### PR TITLE
Support customized system prompt base

### DIFF
--- a/tests/mem_os/test_memos.py
+++ b/tests/mem_os/test_memos.py
@@ -100,3 +100,76 @@ def test_mos_has_core_methods(mock_llm, mock_reader, mock_user_manager, simple_c
     assert callable(mos.chat)
     assert callable(mos.search)
     assert callable(mos.add)
+
+
+@patch("memos.mem_os.core.UserManager")
+@patch("memos.mem_os.core.MemReaderFactory")
+@patch("memos.mem_os.core.LLMFactory")
+@patch("memos.mem_os.main.MOSCore.chat")
+def test_mos_chat_with_custom_prompt_no_cot(
+    mock_core_chat, mock_llm, mock_reader, mock_user_manager, simple_config
+):
+    """Test that MOS.chat passes base_prompt to MOSCore.chat when CoT is disabled."""
+    # Mock all dependencies
+    mock_llm.from_config.return_value = MagicMock()
+    mock_reader.from_config.return_value = MagicMock()
+    user_manager_instance = MagicMock()
+    user_manager_instance.validate_user.return_value = True
+    mock_user_manager.return_value = user_manager_instance
+
+    # Disable CoT
+    simple_config.PRO_MODE = False
+    mos = MOS(simple_config)
+
+    # Call chat with a custom prompt
+    custom_prompt = "You are a helpful bot."
+    mos.chat("Hello", user_id="test_user", base_prompt=custom_prompt)
+
+    # Assert that the core chat method was called with the custom prompt
+    mock_core_chat.assert_called_once_with("Hello", "test_user", base_prompt=custom_prompt)
+
+
+@patch("memos.mem_os.core.UserManager")
+@patch("memos.mem_os.core.MemReaderFactory")
+@patch("memos.mem_os.core.LLMFactory")
+@patch("memos.mem_os.main.MOS._generate_enhanced_response_with_context")
+@patch("memos.mem_os.main.MOS.cot_decompose")
+@patch("memos.mem_os.main.MOS.get_sub_answers")
+def test_mos_chat_with_custom_prompt_with_cot(
+    mock_get_sub_answers,
+    mock_cot_decompose,
+    mock_generate_enhanced_response,
+    mock_llm,
+    mock_reader,
+    mock_user_manager,
+    simple_config,
+):
+    """Test that MOS.chat passes base_prompt correctly when CoT is enabled."""
+    # Mock dependencies
+    mock_llm.from_config.return_value = MagicMock()
+    mock_reader.from_config.return_value = MagicMock()
+    user_manager_instance = MagicMock()
+    user_manager_instance.validate_user.return_value = True
+    user_manager_instance.get_user_cubes.return_value = [MagicMock(cube_id="test_cube")]
+    mock_user_manager.return_value = user_manager_instance
+
+    # Mock CoT process
+    mock_cot_decompose.return_value = {"is_complex": True, "sub_questions": ["Sub-question 1"]}
+    mock_get_sub_answers.return_value = (["Sub-question 1"], ["Sub-answer 1"])
+
+    # Enable CoT
+    simple_config.PRO_MODE = True
+    mos = MOS(simple_config)
+
+    # Mock the search engine to avoid errors
+    mos.mem_cubes["test_cube"] = MagicMock()
+    mos.mem_cubes["test_cube"].text_mem = MagicMock()
+
+    # Call chat with a custom prompt
+    custom_prompt = "You are a super helpful bot. Context: {memories}"
+    mos.chat("Complex question", user_id="test_user", base_prompt=custom_prompt)
+
+    # Assert that the enhanced response generator was called with the prompt
+    mock_generate_enhanced_response.assert_called_once()
+    call_args = mock_generate_enhanced_response.call_args[1]
+    assert call_args.get("base_prompt") == custom_prompt


### PR DESCRIPTION
## Description
Added parameter to mos.chat(base_prompt=) to enable base_prompt to be customised on a per-query basis.

base_prompt (str, optional): A custom base prompt to use for the chat.
 - It can be a template string with a `{memories}` placeholder.
 - If not provided, a default prompt is used.

Issue: https://github.com/MemTensor/MemOS/issues/90

Summary: (Support customized system prompt base)

Fix: #(90)

Reviewer: @fridayL 

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have added necessary documentation (if applicable) | 我已添加必要的文档（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
