### PR TITLE
fix: update Python version constraints in project files

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -991,7 +991,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "eval"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+markers = "(platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and python_version < \"3.14\""
 files = [
     {file = "greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be"},
     {file = "greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac"},
@@ -5872,5 +5872,5 @@ tree-mem = ["neo4j", "schedule"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.10,<3.14"
-content-hash = "e072d74f80e118b785c887b9724f104868e07af8a5ce9e594420700c18d5806a"
+python-versions = ">=3.10,<4.0"
+content-hash = "8e1eb09dfd7ea2efc6a0e18389fcc4ad5092c861266c7ff82bf3158e5cf12577"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "Intelligence Begins with Memory"
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 authors = [
     {name = "MemTensor", email = "MemTensor@memtensor.cn"}
 ]
@@ -124,6 +124,7 @@ build-backend = "poetry.core.masonry.api"
 
 packages = [{include = "memos", from = "src"}]
 requires-poetry = ">=2.0"
+dependencies = { "python" = ">=3.10,<4.0" }
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
## Description

Summary: 

<img width="1439" height="355" alt="647cd098954c7147ac4d7adee34ffa1d" src="https://github.com/user-attachments/assets/83f236c6-6129-4124-8a94-83973090cc30" />

According to @likeUMR, the current Python version requirement in `pyproject.toml` is `>=3.10,<4.0` (too restrictive), which sometimes causes Poetry to fail version resolution when conducting `poetry add MemoryOS`.  

The current solution follows Poetry's official recommendation: https://python-poetry.org/docs/pyproject#requires-python.

It separates the more lenient `project` section (as per [Python PEP 621](https://peps.python.org/pep-0621/)) from Poetry's stricter `tool.poetry.dependencies` (see: [Poetry documentation](https://python-poetry.org/docs/pyproject#dependencies-and-dependency-groups)). This approach satisfies both cases: managing `poetry add MemoryOS` (requiring looser Python constraints) and adding dependencies for MemoryOS (requiring more precise Python constraints).

Reviewer: @CaralHsi @likeUMR 

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
