### PR TITLE
fix: align MOSProduct._build_system_prompt signature with MOSCore

### DIFF
--- a/src/memos/mem_os/product.py
+++ b/src/memos/mem_os/product.py
@@ -327,7 +327,7 @@ class MOSProduct(MOSCore):
 
         return self._create_user_config(user_id, user_config)
 
-    def _build_system_prompt(self, user_id: str, memories_all: list[TextualMemoryItem]) -> str:
+    def _build_system_prompt(self, memories_all: list[TextualMemoryItem], base_prompt: str | None = None) -> str:
         """
         Build custom system prompt for the user with memory references.
 
@@ -759,7 +759,7 @@ class MOSProduct(MOSCore):
             memories_list = memories_result[0]["memories"]
 
         # Build custom system prompt with relevant memories
-        system_prompt = self._build_system_prompt(user_id, memories_list)
+        system_prompt = self._build_system_prompt(memories_list, base_prompt=None)
 
         # Get chat history
         target_user_id = user_id if user_id is not None else self.user_id

--- a/src/memos/mem_os/product.py
+++ b/src/memos/mem_os/product.py
@@ -327,7 +327,9 @@ class MOSProduct(MOSCore):
 
         return self._create_user_config(user_id, user_config)
 
-    def _build_system_prompt(self, memories_all: list[TextualMemoryItem], base_prompt: str | None = None) -> str:
+    def _build_system_prompt(
+        self, memories_all: list[TextualMemoryItem], base_prompt: str | None = None
+    ) -> str:
         """
         Build custom system prompt for the user with memory references.
 


### PR DESCRIPTION
## Description

Summary: Fix MOSProduct._build_system_prompt method signature mismatch that caused TypeError when calling MOSProduct.chat(). The child class method signature didn't match what the parent MOSCore class expected, breaking inheritance contract.

Fix: #(no existing issue - this was discovered during development)

Docs Issue/PR: (not applicable - internal bug fix)

Reviewer: @(leave blank if you don't know who reviews PRs in this repo)

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人