### PR TITLE
fix(product): Correctly handle nested memory structure in chat methods

### DIFF
--- a/src/memos/mem_os/product.py
+++ b/src/memos/mem_os/product.py
@@ -844,7 +844,7 @@ class MOSProduct(MOSCore):
         reference = []
         for memories_dict in memories_list:
             for memory_item in memories_dict["memories"]:
-                memory_json = memory_item.model_dump()  
+                memory_json = memory_item.model_dump()
                 memory_json["metadata"]["ref_id"] = f"[{memory_item.id.split('-')[0]}]"
                 memory_json["metadata"]["embedding"] = []
                 memory_json["metadata"]["sources"] = []

--- a/src/memos/mem_os/product.py
+++ b/src/memos/mem_os/product.py
@@ -715,12 +715,13 @@ class MOSProduct(MOSCore):
 
         # Prepare reference data
         reference = []
-        for memories in memories_list:
-            memories_json = memories.model_dump()
-            memories_json["metadata"]["ref_id"] = f"[{memories.id.split('-')[0]}]"
-            memories_json["metadata"]["embedding"] = []
-            memories_json["metadata"]["sources"] = []
-            reference.append(memories_json)
+        for memories_dict in memories_list:
+            for memory_item in memories_dict["memories"]:
+                memory_json = memory_item.model_dump()
+                memory_json["metadata"]["ref_id"] = f"[{memory_item.id.split('-')[0]}]"
+                memory_json["metadata"]["embedding"] = []
+                memory_json["metadata"]["sources"] = []
+                reference.append(memory_json)
 
         yield f"data: {json.dumps({'type': 'reference', 'content': reference})}\n\n"
         total_time = round(float(time_end - time_start), 1)
@@ -841,13 +842,14 @@ class MOSProduct(MOSCore):
 
         # Prepare reference data
         reference = []
-        for memories in memories_list:
-            memories_json = memories.model_dump()
-            memories_json["metadata"]["ref_id"] = f"{memories.id.split('-')[0]}"
-            memories_json["metadata"]["embedding"] = []
-            memories_json["metadata"]["sources"] = []
-            memories_json["metadata"]["memory"] = memories.memory
-            reference.append({"metadata": memories_json["metadata"]})
+        for memories_dict in memories_list:
+            for memory_item in memories_dict["memories"]:
+                memory_json = memory_item.model_dump()  
+                memory_json["metadata"]["ref_id"] = f"[{memory_item.id.split('-')[0]}]"
+                memory_json["metadata"]["embedding"] = []
+                memory_json["metadata"]["sources"] = []
+                memory_json["metadata"]["memory"] = memory_item.memory
+                reference.append({"metadata": memory_json["metadata"]})
 
         yield f"data: {json.dumps({'type': 'reference', 'data': reference})}\n\n"
         total_time = round(float(time_end - time_start), 1)


### PR DESCRIPTION
## Description

Summary: This PR fixes an `AttributeError` that occurred in both `chat()` and `chat_with_references()` when processing memory references for streaming responses. The root cause was an incorrect assumption about the data structure returned from the search method.

Fix: #(no existing issue - bug found during development)

Docs Issue/PR: (not applicable)

Reviewer: @(leave blank)

## Root Cause

The `super().search()` method returns a list of dictionaries, where each dictionary is structured as `{"cube_id": "...", "memories": [TextualMemoryItem, ...]}`.

The code was incorrectly trying to access attributes like `.id` and `.model_dump()` on the outer dictionary instead of on the `TextualMemoryItem` objects contained within the `"memories"` key.

## Solution

A nested loop has been added to correctly iterate through the `TextualMemoryItem` objects. This ensures we are operating on the actual Pydantic models and can access their attributes without error.

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人