### PR TITLE
feat: add memreader to tackle with internet

### DIFF
--- a/src/memos/configs/internet_retriever.py
+++ b/src/memos/configs/internet_retriever.py
@@ -7,6 +7,7 @@ from pydantic import Field, field_validator, model_validator
 from memos.chunkers.factory import ChunkerConfigFactory
 from memos.configs.base import BaseConfig
 from memos.exceptions import ConfigurationError
+from memos.mem_reader.factory import MemReaderConfigFactory
 
 
 class BaseInternetRetrieverConfig(BaseConfig):
@@ -52,6 +53,11 @@ class XinyuSearchConfig(BaseInternetRetrieverConfig):
         ...,
         default_factory=ChunkerConfigFactory,
         description="Chunker configuration",
+    )
+    reader: MemReaderConfigFactory = Field(
+        ...,
+        default_factory=MemReaderConfigFactory,
+        description="Reader configuration",
     )
 
 

--- a/src/memos/configs/internet_retriever.py
+++ b/src/memos/configs/internet_retriever.py
@@ -4,7 +4,6 @@ from typing import Any, ClassVar
 
 from pydantic import Field, field_validator, model_validator
 
-from memos.chunkers.factory import ChunkerConfigFactory
 from memos.configs.base import BaseConfig
 from memos.exceptions import ConfigurationError
 from memos.mem_reader.factory import MemReaderConfigFactory
@@ -48,11 +47,6 @@ class XinyuSearchConfig(BaseInternetRetrieverConfig):
     max_results: int = Field(default=20, description="Maximum number of results to retrieve")
     num_per_request: int = Field(
         default=10, description="Number of results per API request (not used for Xinyu)"
-    )
-    chunker: ChunkerConfigFactory = Field(
-        ...,
-        default_factory=ChunkerConfigFactory,
-        description="Chunker configuration",
     )
     reader: MemReaderConfigFactory = Field(
         ...,

--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -180,8 +180,12 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         elif type == "doc":
             for item in scene_data:
                 try:
-                    parsed_text = parser.parse(item)
-                    results.append({"file": item, "text": parsed_text})
+                    if not isinstance(item, str):
+                        parsed_text = parser.parse(item)
+                        results.append({"file": "pure_text", "text": parsed_text})
+                    else:
+                        parsed_text = item
+                        results.append({"file": item, "text": parsed_text})
                 except Exception as e:
                     print(f"Error parsing file {item}: {e!s}")
 

--- a/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever.py
@@ -127,7 +127,7 @@ class InternetGoogleRetriever:
         self.embedder = embedder
 
     def retrieve_from_internet(
-        self, query: str, top_k: int = 10, parsed_goal=None
+        self, query: str, top_k: int = 10, parsed_goal=None, info=None
     ) -> list[TextualMemoryItem]:
         """
         Retrieve information from the internet and convert to TextualMemoryItem format
@@ -136,6 +136,7 @@ class InternetGoogleRetriever:
             query: Search query
             top_k: Number of results to return
             parsed_goal: Parsed task goal (optional)
+            info (dict): Leave a record of memory consumption.
 
         Returns:
             List of TextualMemoryItem
@@ -157,8 +158,8 @@ class InternetGoogleRetriever:
             memory_content = f"Title: {title}\nSummary: {snippet}\nSource: {link}"
             # Create metadata
             metadata = TreeNodeTextualMemoryMetadata(
-                user_id=None,
-                session_id=None,
+                user_id=info.get("user_id", ""),
+                session_id=info.get("session_id", ""),
                 status="activated",
                 type="fact",  # Internet search results are usually factual information
                 memory_time=datetime.now().strftime("%Y-%m-%d"),

--- a/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever_factory.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever_factory.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from memos.chunkers.factory import ChunkerFactory
 from memos.configs.internet_retriever import InternetRetrieverConfigFactory
 from memos.embedders.base import BaseEmbedder
+from memos.mem_reader.factory import MemReaderFactory
 from memos.memories.textual.tree_text_memory.retrieve.internet_retriever import (
     InternetGoogleRetriever,
 )
@@ -68,6 +69,7 @@ class InternetRetrieverFactory:
                 search_engine_id=config.search_engine_id,
                 embedder=embedder,
                 chunker=ChunkerFactory.from_config(config.chunker),
+                reader=MemReaderFactory.from_config(config.reader),
                 max_results=config.max_results,
             )
         else:

--- a/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever_factory.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever_factory.py
@@ -2,7 +2,6 @@
 
 from typing import Any, ClassVar
 
-from memos.chunkers.factory import ChunkerFactory
 from memos.configs.internet_retriever import InternetRetrieverConfigFactory
 from memos.embedders.base import BaseEmbedder
 from memos.mem_reader.factory import MemReaderFactory
@@ -68,7 +67,6 @@ class InternetRetrieverFactory:
                 access_key=config.api_key,  # Use api_key as access_key for xinyu
                 search_engine_id=config.search_engine_id,
                 embedder=embedder,
-                chunker=ChunkerFactory.from_config(config.chunker),
                 reader=MemReaderFactory.from_config(config.reader),
                 max_results=config.max_results,
             )

--- a/src/memos/memories/textual/tree_text_memory/retrieve/searcher.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/searcher.py
@@ -141,7 +141,7 @@ class Searcher:
             if memory_type not in ["All"]:
                 return []
             internet_items = self.internet_retriever.retrieve_from_internet(
-                query=query, top_k=top_k, parsed_goal=parsed_goal
+                query=query, top_k=top_k, parsed_goal=parsed_goal, info=info
             )
 
             # Convert to the format expected by reranker

--- a/src/memos/memories/textual/tree_text_memory/retrieve/xinyusearch.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/xinyusearch.py
@@ -8,7 +8,6 @@ from datetime import datetime
 
 import requests
 
-from memos.chunkers.base import BaseChunker
 from memos.embedders.factory import OllamaEmbedder
 from memos.log import get_logger
 from memos.mem_reader.base import BaseMemReader
@@ -115,7 +114,6 @@ class XinyuSearchRetriever:
         access_key: str,
         search_engine_id: str,
         embedder: OllamaEmbedder,
-        chunker: BaseChunker,
         reader: BaseMemReader,
         max_results: int = 20,
     ):
@@ -126,10 +124,10 @@ class XinyuSearchRetriever:
             access_key: Xinyu API access key
             embedder: Embedder instance for generating embeddings
             max_results: Maximum number of results to retrieve
+            reader: MemReader Moduel to deal with internet contents
         """
         self.xinyu_api = XinyuSearchAPI(access_key, search_engine_id, max_results=max_results)
         self.embedder = embedder
-        self.chunker = chunker
         self.reader = reader
 
     def retrieve_from_internet(

--- a/src/memos/memories/textual/tree_text_memory/retrieve/xinyusearch.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/xinyusearch.py
@@ -11,7 +11,8 @@ import requests
 from memos.chunkers.base import BaseChunker
 from memos.embedders.factory import OllamaEmbedder
 from memos.log import get_logger
-from memos.memories.textual.item import TextualMemoryItem, TreeNodeTextualMemoryMetadata
+from memos.mem_reader.base import BaseMemReader
+from memos.memories.textual.item import TextualMemoryItem
 
 
 logger = get_logger(__name__)
@@ -115,6 +116,7 @@ class XinyuSearchRetriever:
         search_engine_id: str,
         embedder: OllamaEmbedder,
         chunker: BaseChunker,
+        reader: BaseMemReader,
         max_results: int = 20,
     ):
         """
@@ -128,9 +130,10 @@ class XinyuSearchRetriever:
         self.xinyu_api = XinyuSearchAPI(access_key, search_engine_id, max_results=max_results)
         self.embedder = embedder
         self.chunker = chunker
+        self.reader = reader
 
     def retrieve_from_internet(
-        self, query: str, top_k: int = 10, parsed_goal=None
+        self, query: str, top_k: int = 10, parsed_goal=None, info=None
     ) -> list[TextualMemoryItem]:
         """
         Retrieve information from Xinyu search and convert to TextualMemoryItem format
@@ -139,7 +142,7 @@ class XinyuSearchRetriever:
             query: Search query
             top_k: Number of results to return
             parsed_goal: Parsed task goal (optional)
-
+            info (dict): Leave a record of memory consumption.
         Returns:
             List of TextualMemoryItem
         """
@@ -151,7 +154,7 @@ class XinyuSearchRetriever:
 
         with ThreadPoolExecutor(max_workers=8) as executor:
             futures = [
-                executor.submit(self._process_result, result, query, parsed_goal)
+                executor.submit(self._process_result, result, query, parsed_goal, info)
                 for result in search_results
             ]
             for future in as_completed(futures):
@@ -301,7 +304,7 @@ class XinyuSearchRetriever:
         return list(set(tags))[:15]  # Limit to 15 tags
 
     def _process_result(
-        self, result: dict, query: str, parsed_goal: str
+        self, result: dict, query: str, parsed_goal: str, info: dict
     ) -> list[TextualMemoryItem]:
         title = result.get("title", "")
         content = result.get("content", "")
@@ -318,55 +321,19 @@ class XinyuSearchRetriever:
                 publish_time = datetime.now().strftime("%Y-%m-%d")
         else:
             publish_time = datetime.now().strftime("%Y-%m-%d")
-        source = result.get("source", "")
-        site = result.get("site", "")
-        if site:
-            site = site.split("|")[0]
 
-        qualified_chunks = self._chunk(content)
+        read_items = self.reader.get_memory([content], type="doc", info=info)
 
         memory_items = []
-        for chunk_text, chunk_emb, score in qualified_chunks:
-            memory_content = (
+        for read_item_i in read_items[0]:
+            read_item_i.memory = (
                 f"Title: {title}\nNewsTime: {publish_time}\nSummary: {summary}\n"
-                f"Content: {chunk_text}\nSource: {url}"
+                f"Content: {read_item_i.memory}"
             )
-            metadata = TreeNodeTextualMemoryMetadata(
-                user_id=None,
-                session_id=None,
-                status="activated",
-                type="fact",
-                source="web",
-                confidence=score,
-                entities=self._extract_entities(title, content, summary),
-                tags=self._extract_tags(title, content, summary, parsed_goal),
-                visibility="public",
-                memory_type="OuterMemory",
-                key=f"[{source}]" + title,
-                sources=[url] if url else [],
-                embedding=chunk_emb,
-                created_at=datetime.now().isoformat(),
-                usage=[],
-                background=f"Xinyu search result from {site or source}",
-            )
-            memory_items.append(
-                TextualMemoryItem(id=str(uuid.uuid4()), memory=memory_content, metadata=metadata)
-            )
+            read_item_i.metadata.source = "web"
+            read_item_i.metadata.memory_type = "OuterMemory"
+            read_item_i.metadata.sources = [url] if url else []
+            read_item_i.metadata.visibility = "public"
 
+            memory_items.append(read_item_i)
         return memory_items
-
-    def _chunk(self, content: str) -> list[tuple[str, list[float], float]]:
-        """
-        Use SentenceChunker to split content into chunks and embed each.
-
-        Returns:
-            List of (chunk_text, chunk_embedding, dummy_score)
-        """
-        chunks = self.chunker.chunk(content)
-        if not chunks:
-            return []
-
-        chunk_texts = [c.text for c in chunks]
-        chunk_embeddings = self.embedder.embed(chunk_texts)
-
-        return [(text, emb, 1.0) for text, emb in zip(chunk_texts, chunk_embeddings, strict=False)]

--- a/tests/mem_reader/test_simple_structure.py
+++ b/tests/mem_reader/test_simple_structure.py
@@ -124,7 +124,7 @@ class TestSimpleStructMemReader(unittest.TestCase):
         parser_instance.parse.return_value = "Parsed document text.\n"
         mock_parser_factory.from_config.return_value = parser_instance
 
-        scene_data = ["tests/mem_reader/test.txt"]
+        scene_data = [{"fake_file_like": "should trigger parse"}]
         result = self.reader.get_scene_data_info(scene_data, type="doc")
 
         self.assertIsInstance(result, list)

--- a/tests/mem_reader/test_simple_structure.py
+++ b/tests/mem_reader/test_simple_structure.py
@@ -128,7 +128,7 @@ class TestSimpleStructMemReader(unittest.TestCase):
         result = self.reader.get_scene_data_info(scene_data, type="doc")
 
         self.assertIsInstance(result, list)
-        self.assertEqual(result[0]["text"], "Parsed document text\n")
+        self.assertEqual(result[0]["text"], "Parsed document text.\n")
 
     def test_parse_json_result_success(self):
         """Test successful JSON parsing."""

--- a/tests/mem_reader/test_simple_structure.py
+++ b/tests/mem_reader/test_simple_structure.py
@@ -117,7 +117,7 @@ class TestSimpleStructMemReader(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][0], "user: [3 May 2025]: I'm feeling a bit down today.")
 
-    @patch("memos.parsers.factory.ParserFactory")
+    @patch("memos.mem_reader.simple_struct.ParserFactory")
     def test_get_scene_data_info_with_doc(self, mock_parser_factory):
         """Test parsing document files."""
         parser_instance = MagicMock()


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes below;
Fill in the issue number that this PR addresses (if applicable);
Fill in the related MemOS-Docs repository issue or PR link (if applicable);
Mention the person who will review this PR (if you know who it is);
Replace (summary), (issue), (docs-issue-or-pr-link), and (reviewer) with the appropriate information.

请在下方填写更改的摘要；
填写此 PR 解决的问题编号（如果适用）；
填写相关的 MemOS-Docs 仓库 issue 或 PR 链接（如果适用）；
提及将审查此 PR 的人（如果您知道是谁）；
替换 (summary)、(issue)、(docs-issue-or-pr-link) 和 (reviewer) 为适当的信息。
-->

Summary:
- Replaced custom chunk/tag/embedding logic in XinyuSearchRetriever with standardized MemReader pipeline
- Injected MemReader into Xinyu retriever via config and factory
- Updated `get_scene_data_info()` to parse both str and non-str doc entries with ParserFactory
- Added `info` support in all internet retriever signatures to track memory usage metadata
- Simplified `_process_result()` by reusing extracted memory items from MemReader
- Adjusted test for `get_scene_data_info_with_doc` to correctly trigger parser with non-string mock input

Fix: #153 

Docs Issue/PR: (docs-issue-or-pr-link)

Reviewer: @fridayL @Nyakult 

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
