### PR TITLE
fix bug when calling _concat_caches in kv.py

### DIFF
--- a/src/memos/memories/activation/kv.py
+++ b/src/memos/memories/activation/kv.py
@@ -211,13 +211,15 @@ class KVCacheMemory(BaseActMemory):
         merged = DynamicCache()
         num_layers = len(caches[0].key_cache)
 
+        merged.append_new_layers(num_layers - 1)
+
         for layer in range(num_layers):
             # gather all K and V for this layer
-            keys = [c.key_cache[layer] for c in caches]
-            vals = [c.value_cache[layer] for c in caches]
+            keys = [c.layers[layer].keys for c in caches]
+            vals = [c.layers[layer].values for c in caches]
             # single concat per layer
-            merged.key_cache.append(torch.cat(keys, dim=-2))
-            merged.value_cache.append(torch.cat(vals, dim=-2))
+            merged.layers[layer].keys = (torch.cat(keys, dim=-2))
+            merged.layers[layer].values = (torch.cat(vals, dim=-2))
 
         return merged
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes below;
Fill in the issue number that this PR addresses (if applicable);
Fill in the related MemOS-Docs repository issue or PR link (if applicable);
Mention the person who will review this PR (if you know who it is);
Replace (summary), (issue), (docs-issue-or-pr-link), and (reviewer) with the appropriate information.

请在下方填写更改的摘要；
填写此 PR 解决的问题编号（如果适用）；
填写相关的 MemOS-Docs 仓库 issue 或 PR 链接（如果适用）；
提及将审查此 PR 的人（如果您知道是谁）；
替换 (summary)、(issue)、(docs-issue-or-pr-link) 和 (reviewer) 为适当的信息。
-->

Summary: (fix a bug when calling _concat_caches function)

BUG Description:
```
Traceback (most recent call last):
  File "/root/Misc/test.py", line 24, in <module>
    merged_cache = mem.get_cache([cache_item_1.id, cache_item_2.id])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/memos/memories/activation/kv.py", line 81, in get_cache
    return self._concat_caches(caches_to_merge)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/lib/python3.12/site-packages/memos/memories/activation/kv.py", line 245, in _concat_caches
    merged.key_cache.append(torch.cat(keys, dim=-2))
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'KeyValuesWrapper' object has no attribute 'append'
```

Solution: 
The solution replaced merged.key_cache.append and merged.value_cache.append with operations on merged.layers[layer].keys and merged.layers[layer].values. This aligns with the DynamicCache structure, where keys and values are stored per layer. Additionally, the code now correctly retrieves keys and values from c.layers[layer].keys and c.layers[layer].values respectively.

Fix: #(not applicable)

Docs Issue/PR: (not applicable)

Reviewer: @(not applicable)

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
