### PR TITLE
fix: fixed list of type in EXTRACTION_PROMPT_PART_1

### DIFF
--- a/src/memos/memories/textual/general.py
+++ b/src/memos/memories/textual/general.py
@@ -214,7 +214,7 @@ EXTRACTION_PROMPT_PART_1 = f"""You are a memory extractor. Your task is to extra
     - "memory": The content of the memory (string). Rephrase the content if necessary.
     - "metadata": A dictionary containing additional information about the memory.
 * The metadata dictionary should include:
-    - "type": The type of memory (string), e.g., "procedure", "fact", "event", "opinion", etc.
+    - "type": The type of memory must be only in: "procedure", "fact", "event", "opinion", "topic", "reasoning".
     - "memory_time": The time the memory occurred or refers to (string). Must be in standard `YYYY-MM-DD` format. Relative expressions such as "yesterday" or "tomorrow" are not allowed.
     - "source": The origin of the memory (string), e.g., `"conversation"`, `"retrieved"`, `"web"`, `"file"`.
     - "confidence": A numeric score (float between 0 and 100) indicating how certain you are about the accuracy or reliability of the memory.


### PR DESCRIPTION
## Description

Corrected the EXTRACTION_PROMPT_PART_1 prompt, the list of TextualMemoryMetadata types only accepts: iteral[‘procedure’, ‘fact’, ‘event’, “opinion”, “topic”, ‘reasoning’] | None.
The LLM must not generate anything else.
Summary: (summary)

Reviewer: @fridayL 

## Checklist:

- [X] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [X] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [X] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
