### PR TITLE
fix: a temporal workaround for the "virtualenv 20.33.0 breaks Poetry in GitHub Actions"

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,9 +42,9 @@ jobs:
     - name: Install virtualenv with specific version
       # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
       # Relevant issues:
-      # - https://github.com/actions/setup-python/issues/1167
       # - https://github.com/pypa/virtualenv/issues/2931
       # - https://github.com/python-poetry/poetry/issues/10490
+      # - https://github.com/actions/setup-python/issues/1167
       run: pip install virtualenv==20.32
     - uses: actions/checkout@v4
     - name: Install poetry

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,12 +41,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install poetry
-      run: pipx install --python python3.10 poetry
+      run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
+    - name: Install virtualenv with specific version
+      # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
+      # Relevant issues:
+      # - https://github.com/actions/setup-python/issues/1167
+      # - https://github.com/pypa/virtualenv/issues/2931
+      # - https://github.com/python-poetry/poetry/issues/10490
+      run: pip install virtualenv==20.32
 
     # Dependency and building tests
     - name: Install main dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install poetry
-      run: pipx install poetry
+      run: pipx install --python python3.10 poetry
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,6 +39,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
+    - name: Install virtualenv with specific version
+      # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
+      # Relevant issues:
+      # - https://github.com/actions/setup-python/issues/1167
+      # - https://github.com/pypa/virtualenv/issues/2931
+      # - https://github.com/python-poetry/poetry/issues/10490
+      run: pip install virtualenv==20.32
     - uses: actions/checkout@v4
     - name: Install poetry
       run: pipx install poetry
@@ -47,13 +54,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
-    - name: Install virtualenv with specific version
-      # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
-      # Relevant issues:
-      # - https://github.com/actions/setup-python/issues/1167
-      # - https://github.com/pypa/virtualenv/issues/2931
-      # - https://github.com/python-poetry/poetry/issues/10490
-      run: pip install virtualenv==20.32
 
     # Dependency and building tests
     - name: Install main dependencies


### PR DESCRIPTION
## Description

Summary: 

The upstream dependency `virtualenv` was upgraded to version 20.33.0, causing `poetry` to fail in executing commands based on the Python version in the virtual environment. This also likely caused the failure in locating the cache during the `Set up Python ${{ matrix.python-version }}` workflow step.

Related issues:
- https://github.com/pypa/virtualenv/issues/2931
- https://github.com/python-poetry/poetry/issues/10490
- https://github.com/actions/setup-python/issues/1167

Currently, the temporary workaround is to downgrade `virtualenv` from 20.33.0 to 20.32.

Reviewer: @fridayL @CaralHsi @J1awei-Yang 

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have added necessary documentation (if applicable) | 我已添加必要的文档（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
