### PR TITLE
chore: The Poetry virtualenv issue persists; another temporary workaround is ok

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,6 +39,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
+
     - name: Install virtualenv with specific version
       # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
       # Relevant issues:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install poetry
+      # This is a temporary fix to ensure compatibility with Poetry & virtualenv
+      # Revert to the original installation method once the poetry==2.1.4 is released
       run: |
         echo "virtualenv==20.32.0" > constraints.txt
         pipx install poetry==2.1.3 --pip-args="--constraint=constraints.txt"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,17 +39,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-
-    - name: Install virtualenv with specific version
-      # This is only a temporary fix to ensure compatibility with Poetry & virtualenv
-      # Relevant issues:
-      # - https://github.com/pypa/virtualenv/issues/2931
-      # - https://github.com/python-poetry/poetry/issues/10490
-      # - https://github.com/actions/setup-python/issues/1167
-      run: pip install virtualenv==20.32
     - uses: actions/checkout@v4
     - name: Install poetry
-      run: pipx install poetry
+      run: |
+        echo "virtualenv==20.32.0" > constraints.txt
+        pipx install poetry==2.1.3 --pip-args="--constraint=constraints.txt"
+        rm constraints.txt
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Description

Summary:

PR #213 does not resolve the Poetry virtualenv issue.

A temporary workaround copied from PR moneymeets/action-setup-python-poetry#40 has been implemented.

> [!note]
> Revert PR #213 and #215 to the original installation method once Poetry 2.1.4 is released.

Reviewer: @fridayL 

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
