### PR TITLE
fix: remove field name will cause error for org-memscheduler config 

### DIFF
--- a/src/memos/configs/mem_scheduler.py
+++ b/src/memos/configs/mem_scheduler.py
@@ -43,6 +43,7 @@ class BaseSchedulerConfig(BaseConfig):
 
 
 class GeneralSchedulerConfig(BaseSchedulerConfig):
+    model_config = ConfigDict(extra="ignore", strict=True)
     act_mem_update_interval: int | None = Field(
         default=300, description="Interval in seconds for updating activation memory"
     )


### PR DESCRIPTION
## Description
 remove field name will cause error for org-memscheduler config 
 change extra config for ignore

Reviewer: @(reviewer)

## Checklist:

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
