### PR TITLE
Feature/add optional api key para for qdrant

### DIFF
--- a/src/memos/configs/vec_db.py
+++ b/src/memos/configs/vec_db.py
@@ -27,6 +27,7 @@ class QdrantVecDBConfig(BaseVecDBConfig):
     host: str | None = Field(default=None, description="Host for Qdrant")
     port: int | None = Field(default=None, description="Port for Qdrant")
     path: str | None = Field(default=None, description="Path for Qdrant")
+    api_key: str | None = Field(default=None, description="Optional API key for Qdrant authentication")
 
     @model_validator(mode="after")
     def set_default_path(self):

--- a/src/memos/vec_dbs/qdrant.py
+++ b/src/memos/vec_dbs/qdrant.py
@@ -33,9 +33,15 @@ class QdrantVecDB(BaseVecDB):
                 "(e.g., via Docker: https://qdrant.tech/documentation/quickstart/)."
             )
 
-        self.client = QdrantClient(
-            host=self.config.host, port=self.config.port, path=self.config.path
-        )
+        client_kwargs = {
+            "host": self.config.host,
+            "port": self.config.port,
+            "path": self.config.path,
+        }
+        if self.config.api_key:
+            client_kwargs["api_key"] = self.config.api_key
+
+        self.client = QdrantClient(**client_kwargs)
         self.create_collection()
 
     def create_collection(self) -> None:

--- a/tests/configs/test_vec_db.py
+++ b/tests/configs/test_vec_db.py
@@ -40,7 +40,7 @@ def test_qdrant_vec_db_config():
         required_fields=[
             "collection_name",
         ],
-        optional_fields=["vector_dimension", "distance_metric", "host", "port", "path"],
+        optional_fields=["vector_dimension", "distance_metric", "host", "port", "path", "api_key"],
     )
 
     check_config_instantiation_valid(

--- a/tests/vec_dbs/test_qdrant.py
+++ b/tests/vec_dbs/test_qdrant.py
@@ -137,7 +137,7 @@ def test_client_receives_api_key():
         )
         _ = VecDBFactory.from_config(cfg)
 
-        # 断言 QdrantClient 被以 api_key 关键字参数调用
+        # Assert that QdrantClient was called with api_key keyword argument
         assert mock_client.called
         kwargs = mock_client.call_args.kwargs
         assert kwargs.get("api_key") == api_key


### PR DESCRIPTION
## Description

Summary: (summary)
  - add optional `api-key` parameter for Qdrant
 
Tested with:
 - `pytest -q MemOS/tests/configs/test_vec_db.py::test_qdrant_vec_db_config`
 - `pytest -q MemOS/tests/vec_dbs/test_qdrant.py::test_client_receives_api_key`

## Checklist:

- [Y] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [Y] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [Y] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
