### PR TITLE
fix: Use env exchange overrides for all scheduler messages

### DIFF
--- a/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
+++ b/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
@@ -14,7 +14,6 @@ from memos.log import get_logger
 from memos.mem_scheduler.general_modules.base import BaseSchedulerModule
 from memos.mem_scheduler.general_modules.misc import AutoDroppingQueue
 from memos.mem_scheduler.schemas.general_schemas import DIRECT_EXCHANGE_TYPE, FANOUT_EXCHANGE_TYPE
-from memos.mem_scheduler.utils.misc_utils import is_cloud_env
 
 
 logger = get_logger(__name__)
@@ -131,6 +130,19 @@ class RabbitMQSchedulerModule(BaseSchedulerModule):
                 ):
                     self.rabbitmq_exchange_type = self.rabbitmq_config.exchange_type
                     logger.info(f"Using configured exchange type: {self.rabbitmq_exchange_type}")
+
+            env_exchange_name = os.getenv("MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME")
+            env_exchange_type = os.getenv("MEMSCHEDULER_RABBITMQ_EXCHANGE_TYPE")
+            if env_exchange_name:
+                self.rabbitmq_exchange_name = env_exchange_name
+                logger.info(
+                    f"Using env exchange name override: {self.rabbitmq_exchange_name}"
+                )
+            if env_exchange_type:
+                self.rabbitmq_exchange_type = env_exchange_type
+                logger.info(
+                    f"Using env exchange type override: {self.rabbitmq_exchange_type}"
+                )
 
                 # Start connection process
             parameters = self.get_rabbitmq_connection_param()
@@ -313,15 +325,12 @@ class RabbitMQSchedulerModule(BaseSchedulerModule):
         if label == "knowledgeBaseUpdate":
             routing_key = ""
 
-        # Cloud environment override: applies to specific message types if MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME is set
+        # Env override: apply to all message types when MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME is set
         env_exchange_name = os.getenv("MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME")
-        if is_cloud_env() and env_exchange_name and label in ["taskStatus", "knowledgeBaseUpdate"]:
+        if env_exchange_name:
             exchange_name = env_exchange_name
-            routing_key = ""  # Routing key is always empty in cloud environment for these types
-
-            # Specific diagnostic logging for messages affected by cloud environment settings
             logger.info(
-                f"[DIAGNOSTIC] Publishing {label} message in Cloud Env. "
+                f"[DIAGNOSTIC] Publishing {label} message with env exchange override. "
                 f"Exchange: {exchange_name}, Routing Key: '{routing_key}'."
             )
             logger.info(f"  - Message Content: {json.dumps(message, indent=2, ensure_ascii=False)}")

--- a/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
+++ b/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
@@ -135,14 +135,10 @@ class RabbitMQSchedulerModule(BaseSchedulerModule):
             env_exchange_type = os.getenv("MEMSCHEDULER_RABBITMQ_EXCHANGE_TYPE")
             if env_exchange_name:
                 self.rabbitmq_exchange_name = env_exchange_name
-                logger.info(
-                    f"Using env exchange name override: {self.rabbitmq_exchange_name}"
-                )
+                logger.info(f"Using env exchange name override: {self.rabbitmq_exchange_name}")
             if env_exchange_type:
                 self.rabbitmq_exchange_type = env_exchange_type
-                logger.info(
-                    f"Using env exchange type override: {self.rabbitmq_exchange_type}"
-                )
+                logger.info(f"Using env exchange type override: {self.rabbitmq_exchange_type}")
 
                 # Start connection process
             parameters = self.get_rabbitmq_connection_param()

--- a/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
+++ b/src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py
@@ -327,8 +327,12 @@ class RabbitMQSchedulerModule(BaseSchedulerModule):
 
         # Env override: apply to all message types when MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME is set
         env_exchange_name = os.getenv("MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME")
+        env_routing_key = os.getenv("MEMSCHEDULER_RABBITMQ_ROUTING_KEY")
         if env_exchange_name:
             exchange_name = env_exchange_name
+            routing_key = (
+                env_routing_key if env_routing_key is not None and env_routing_key != "" else ""
+            )
             logger.info(
                 f"[DIAGNOSTIC] Publishing {label} message with env exchange override. "
                 f"Exchange: {exchange_name}, Routing Key: '{routing_key}'."


### PR DESCRIPTION
  Summary

  - Apply MEMSCHEDULER_RABBITMQ_EXCHANGE_NAME to all message types, regardless of environment or label.
  - Apply MEMSCHEDULER_RABBITMQ_EXCHANGE_TYPE when set.
  - Default routing key to "" when using env exchange override; allow override via MEMSCHEDULER_RABBITMQ_ROUTING_KEY.

  Why

  - Ensures consistent routing when an exchange name is explicitly configured via env.
  - Removes label-scoped behavior that prevented non‑cloud messages from using the configured exchange.
  - Matches deployment reality where cloud/non‑cloud are on isolated infrastructure.

  Changes

  - src/memos/mem_scheduler/webservice_modules/rabbitmq_service.py: env overrides now apply to all messages; routing key default behavior updated; exchange type env override applied during initialization.