### PR TITLE
feat: prevent repeated memories via archival and activated-only retrieval

### DIFF
--- a/src/memos/api/handlers/component_init.py
+++ b/src/memos/api/handlers/component_init.py
@@ -183,7 +183,8 @@ def init_server() -> dict[str, Any]:
         else None
     )
     embedder = EmbedderFactory.from_config(embedder_config)
-    mem_reader = MemReaderFactory.from_config(mem_reader_config)
+    # Pass graph_db to mem_reader for recall operations (deduplication, conflict detection)
+    mem_reader = MemReaderFactory.from_config(mem_reader_config, graph_db=graph_db)
     reranker = RerankerFactory.from_config(reranker_config)
     feedback_reranker = RerankerFactory.from_config(feedback_reranker_config)
     internet_retriever = InternetRetrieverFactory.from_config(

--- a/src/memos/graph_dbs/base.py
+++ b/src/memos/graph_dbs/base.py
@@ -82,7 +82,7 @@ class BaseGraphDB(ABC):
 
     @abstractmethod
     def get_nodes(
-        self, id: str, include_embedding: bool = False, **kwargs
+        self, ids: list, include_embedding: bool = False, **kwargs
     ) -> dict[str, Any] | None:
         """
         Retrieve the metadata and memory of a list of nodes.

--- a/src/memos/graph_dbs/base.py
+++ b/src/memos/graph_dbs/base.py
@@ -160,13 +160,17 @@ class BaseGraphDB(ABC):
         """
 
     @abstractmethod
-    def get_by_metadata(self, filters: list[dict[str, Any]]) -> list[str]:
+    def get_by_metadata(
+        self, filters: list[dict[str, Any]], status: str | None = None
+    ) -> list[str]:
         """
         Retrieve node IDs that match given metadata filters.
 
         Args:
             filters (dict[str, Any]): A dictionary of attribute-value filters.
                 Example: {"topic": "psychology", "importance": 2}
+            status (str, optional): Filter by status (e.g., 'activated', 'archived').
+                If None, no status filter is applied.
 
         Returns:
             list[str]: Node IDs whose metadata match the filter conditions.
@@ -239,13 +243,17 @@ class BaseGraphDB(ABC):
         """
 
     @abstractmethod
-    def get_all_memory_items(self, scope: str, include_embedding: bool = False) -> list[dict]:
+    def get_all_memory_items(
+        self, scope: str, include_embedding: bool = False, status: str | None = None
+    ) -> list[dict]:
         """
         Retrieve all memory items of a specific memory_type.
 
         Args:
             scope (str): Must be one of 'WorkingMemory', 'LongTermMemory', or 'UserMemory'.
             include_embedding: with/without embedding
+            status (str, optional): Filter by status (e.g., 'activated', 'archived').
+                If None, no status filter is applied.
 
         Returns:
             list[dict]: Full list of memory items under this scope.

--- a/src/memos/graph_dbs/base.py
+++ b/src/memos/graph_dbs/base.py
@@ -19,12 +19,13 @@ class BaseGraphDB(ABC):
         """
 
     @abstractmethod
-    def update_node(self, id: str, fields: dict[str, Any]) -> None:
+    def update_node(self, id: str, fields: dict[str, Any], user_name: str | None = None) -> None:
         """
         Update attributes of an existing node.
         Args:
             id: Node identifier to be updated.
             fields: Dictionary of fields to update.
+            user_name: given user_name
         """
 
     @abstractmethod
@@ -70,7 +71,7 @@ class BaseGraphDB(ABC):
 
     # Graph Query & Reasoning
     @abstractmethod
-    def get_node(self, id: str, include_embedding: bool = False) -> dict[str, Any] | None:
+    def get_node(self, id: str, include_embedding: bool = False, **kwargs) -> dict[str, Any] | None:
         """
         Retrieve the metadata and content of a node.
         Args:

--- a/src/memos/graph_dbs/neo4j.py
+++ b/src/memos/graph_dbs/neo4j.py
@@ -916,6 +916,7 @@ class Neo4jGraphDB(BaseGraphDB):
         filter: dict | None = None,
         knowledgebase_ids: list[str] | None = None,
         user_name_flag: bool = True,
+        status: str | None = None,
     ) -> list[str]:
         """
         TODO:
@@ -933,6 +934,8 @@ class Neo4jGraphDB(BaseGraphDB):
                 {"field": "tags", "op": "contains", "value": "AI"},
                 ...
             ]
+        status (str, optional): Filter by status (e.g., 'activated', 'archived').
+            If None, no status filter is applied.
 
         Returns:
             list[str]: Node IDs whose metadata match the filter conditions. (AND logic).
@@ -942,14 +945,19 @@ class Neo4jGraphDB(BaseGraphDB):
             - Can be used for faceted recall or prefiltering before embedding rerank.
         """
         logger.info(
-            f"[get_by_metadata] filters: {filters},user_name: {user_name},filter: {filter},knowledgebase_ids: {knowledgebase_ids}"
+            f"[get_by_metadata] filters: {filters},user_name: {user_name},filter: {filter},knowledgebase_ids: {knowledgebase_ids},status: {status}"
         )
         print(
-            f"[get_by_metadata] filters: {filters},user_name: {user_name},filter: {filter},knowledgebase_ids: {knowledgebase_ids}"
+            f"[get_by_metadata] filters: {filters},user_name: {user_name},filter: {filter},knowledgebase_ids: {knowledgebase_ids},status: {status}"
         )
         user_name = user_name if user_name else self.config.user_name
         where_clauses = []
         params = {}
+
+        # Add status filter if provided
+        if status:
+            where_clauses.append("n.status = $status")
+            params["status"] = status
 
         for i, f in enumerate(filters):
             field = f["field"]
@@ -1272,8 +1280,10 @@ class Neo4jGraphDB(BaseGraphDB):
     def get_all_memory_items(
         self,
         scope: str,
+        include_embedding: bool = False,
         filter: dict | None = None,
         knowledgebase_ids: list[str] | None = None,
+        status: str | None = None,
         **kwargs,
     ) -> list[dict]:
         """
@@ -1281,18 +1291,21 @@ class Neo4jGraphDB(BaseGraphDB):
 
         Args:
             scope (str): Must be one of 'WorkingMemory', 'LongTermMemory', or 'UserMemory'.
+            include_embedding (bool): Whether to include embedding in results.
             filter (dict, optional): Filter conditions with 'and' or 'or' logic for search results.
                 Example: {"and": [{"id": "xxx"}, {"A": "yyy"}]} or {"or": [{"id": "xxx"}, {"A": "yyy"}]}
-        Returns:
+            knowledgebase_ids (list[str], optional): List of knowledgebase IDs to filter by.
+            status (str, optional): Filter by status (e.g., 'activated', 'archived').
+                If None, no status filter is applied.
 
         Returns:
             list[dict]: Full list of memory items under this scope.
         """
         logger.info(
-            f"[get_all_memory_items] scope: {scope},filter: {filter},knowledgebase_ids: {knowledgebase_ids}"
+            f"[get_all_memory_items] scope: {scope},filter: {filter},knowledgebase_ids: {knowledgebase_ids},status: {status}"
         )
         print(
-            f"[get_all_memory_items] scope: {scope},filter: {filter},knowledgebase_ids: {knowledgebase_ids}"
+            f"[get_all_memory_items] scope: {scope},filter: {filter},knowledgebase_ids: {knowledgebase_ids},status: {status}"
         )
 
         user_name = kwargs.get("user_name") if kwargs.get("user_name") else self.config.user_name
@@ -1301,6 +1314,11 @@ class Neo4jGraphDB(BaseGraphDB):
 
         where_clauses = ["n.memory_type = $scope"]
         params = {"scope": scope}
+
+        # Add status filter if provided
+        if status:
+            where_clauses.append("n.status = $status")
+            params["status"] = status
 
         # Build user_name filter with knowledgebase_ids support (OR relationship) using common method
         user_name_conditions, user_name_params = self._build_user_name_and_kb_ids_conditions_cypher(

--- a/src/memos/graph_dbs/polardb.py
+++ b/src/memos/graph_dbs/polardb.py
@@ -2823,6 +2823,7 @@ class PolarDBGraphDB(BaseGraphDB):
         user_name: str | None = None,
         filter: dict | None = None,
         knowledgebase_ids: list | None = None,
+        status: str | None = None,
     ) -> list[dict]:
         """
         Retrieve all memory items of a specific memory_type.
@@ -2831,12 +2832,16 @@ class PolarDBGraphDB(BaseGraphDB):
             scope (str): Must be one of 'WorkingMemory', 'LongTermMemory', or 'UserMemory'.
             include_embedding: with/without embedding
             user_name (str, optional): User name for filtering in non-multi-db mode
+            filter (dict, optional): Filter conditions with 'and' or 'or' logic for search results.
+            knowledgebase_ids (list, optional): List of knowledgebase IDs to filter by.
+            status (str, optional): Filter by status (e.g., 'activated', 'archived').
+                If None, no status filter is applied.
 
         Returns:
             list[dict]: Full list of memory items under this scope.
         """
         logger.info(
-            f"[get_all_memory_items] filter: {filter}, knowledgebase_ids: {knowledgebase_ids}"
+            f"[get_all_memory_items] filter: {filter}, knowledgebase_ids: {knowledgebase_ids}, status: {status}"
         )
 
         user_name = user_name if user_name else self._get_config_value("user_name")
@@ -2867,6 +2872,8 @@ class PolarDBGraphDB(BaseGraphDB):
         if include_embedding:
             # Build WHERE clause with user_name/knowledgebase_ids and filter
             where_parts = [f"n.memory_type = '{scope}'"]
+            if status:
+                where_parts.append(f"n.status = '{status}'")
             if user_name_where:
                 # user_name_where already contains parentheses if it's an OR condition
                 where_parts.append(user_name_where)
@@ -2927,6 +2934,8 @@ class PolarDBGraphDB(BaseGraphDB):
         else:
             # Build WHERE clause with user_name/knowledgebase_ids and filter
             where_parts = [f"n.memory_type = '{scope}'"]
+            if status:
+                where_parts.append(f"n.status = '{status}'")
             if user_name_where:
                 # user_name_where already contains parentheses if it's an OR condition
                 where_parts.append(user_name_where)

--- a/src/memos/mem_feedback/feedback.py
+++ b/src/memos/mem_feedback/feedback.py
@@ -76,7 +76,8 @@ class MemFeedback(BaseMemFeedback):
         self.llm: OpenAILLM | OllamaLLM | AzureLLM = LLMFactory.from_config(config.extractor_llm)
         self.embedder: OllamaEmbedder = EmbedderFactory.from_config(config.embedder)
         self.graph_store: PolarDBGraphDB = GraphStoreFactory.from_config(config.graph_db)
-        self.mem_reader = MemReaderFactory.from_config(config.mem_reader)
+        # Pass graph_store to mem_reader for recall operations (deduplication, conflict detection)
+        self.mem_reader = MemReaderFactory.from_config(config.mem_reader, graph_db=self.graph_store)
 
         self.is_reorganize = config.reorganize
         self.memory_manager: MemoryManager = MemoryManager(

--- a/src/memos/mem_reader/base.py
+++ b/src/memos/mem_reader/base.py
@@ -1,16 +1,37 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from memos.configs.mem_reader import BaseMemReaderConfig
 from memos.memories.textual.item import TextualMemoryItem
 
 
+if TYPE_CHECKING:
+    from memos.graph_dbs.base import BaseGraphDB
+
+
 class BaseMemReader(ABC):
     """MemReader interface class for reading information."""
+
+    # Optional graph database for recall operations (for deduplication, conflict
+    # detection .etc)
+    graph_db: "BaseGraphDB | None" = None
 
     @abstractmethod
     def __init__(self, config: BaseMemReaderConfig):
         """Initialize the MemReader with the given configuration."""
+
+    @abstractmethod
+    def set_graph_db(self, graph_db: "BaseGraphDB | None") -> None:
+        """
+        Set the graph database instance for recall operations.
+
+        This enables the mem-reader to perform:
+        - Semantic deduplication: avoid storing duplicate memories
+        - Conflict detection: detect contradictions with existing memories
+
+        Args:
+            graph_db: The graph database instance, or None to disable recall operations.
+        """
 
     @abstractmethod
     def get_memory(

--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -316,6 +316,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         custom_tags: list[str] | None = None,
         sources: list | None = None,
         prompt_type: str = "chat",
+        related_memories: str | None = None,
     ) -> dict:
         """
         Override parent method to improve language detection by using actual text content
@@ -326,6 +327,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             custom_tags: Optional custom tags
             sources: Optional list of SourceMessage objects to extract text content from
             prompt_type: Type of prompt to use ("chat" or "doc")
+            related_memories: related_memories in the graph
 
         Returns:
             LLM response dictionary
@@ -360,7 +362,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         else:
             template = PROMPT_DICT["chat"][lang]
             examples = PROMPT_DICT["chat"][f"{lang}_example"]
-            prompt = template.replace("${conversation}", mem_str)
+            prompt = template.replace("${conversation}", mem_str).replace(
+                "${reference}", related_memories
+            )
 
         custom_tags_prompt = (
             PROMPT_DICT["custom_tags"][lang].replace("{custom_tags}", str(custom_tags))
@@ -418,6 +422,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         fast_memory_items: list[TextualMemoryItem],
         info: dict[str, Any],
         custom_tags: list[str] | None = None,
+        **kwargs,
     ) -> list[TextualMemoryItem]:
         """
         Process fast mode memory items through LLM to generate fine mode memories.
@@ -454,8 +459,40 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             # Determine prompt type based on sources
             prompt_type = self._determine_prompt_type(sources)
 
+            # recall related memories
+            related_memories = None
+            memory_ids = []
+            if self.graph_db:
+                if "user_name" in kwargs:
+                    memory_ids = self.graph_db.search_by_embedding(
+                        vector=self.embedder.embed(mem_str)[0],
+                        top_k=20,
+                        status="activated",
+                        user_name=kwargs.get("user_name"),
+                        filter={
+                            "or": [
+                                {"memory_type": "LongTermMemory"},
+                                {"memory_type": "UserMemory"},
+                                {"memory_type": "WorkingMemory"},
+                            ]
+                        },
+                    )
+                    memory_ids = set({r["id"] for r in memory_ids if r.get("id")})
+                    related_memories_list = self.graph_db.get_nodes(
+                        list(memory_ids),
+                        include_embedding=False,
+                        user_name=kwargs.get("user_name"),
+                    )
+                    related_memories = "\n".join(
+                        ["{}: {}".format(mem["id"], mem["memory"]) for mem in related_memories_list]
+                    )
+                else:
+                    logger.warning("user_name is null when graph_db exists")
+
             try:
-                resp = self._get_llm_response(mem_str, custom_tags, sources, prompt_type)
+                resp = self._get_llm_response(
+                    mem_str, custom_tags, sources, prompt_type, related_memories
+                )
             except Exception as e:
                 logger.error(f"[MultiModalFine] Error calling LLM: {e}")
                 return fine_items
@@ -469,6 +506,11 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                             .replace("长期记忆", "LongTermMemory")
                             .replace("用户记忆", "UserMemory")
                         )
+                        if "merged_from" in m:
+                            for merged_id in m["merged_from"]:
+                                if merged_id not in memory_ids:
+                                    logger.warning("merged id not valid!!!!!")
+                            info_per_item["merged_from"] = m["merged_from"]
                         # Create fine mode memory item (same as simple_struct)
                         node = self._make_memory_item(
                             value=m.get("value", ""),
@@ -485,6 +527,11 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                         logger.error(f"[MultiModalFine] parse error: {e}")
             elif resp.get("value") and resp.get("key"):
                 try:
+                    if "merged_from" in resp:
+                        for merged_id in resp["merged_from"]:
+                            if merged_id not in memory_ids:
+                                logger.warning("merged id not valid!!!!!")
+                        info_per_item["merged_from"] = resp["merged_from"]
                     # Create fine mode memory item (same as simple_struct)
                     node = self._make_memory_item(
                         value=resp.get("value", "").strip(),
@@ -533,9 +580,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             return []
 
     def _process_tool_trajectory_fine(
-        self,
-        fast_memory_items: list[TextualMemoryItem],
-        info: dict[str, Any],
+        self, fast_memory_items: list[TextualMemoryItem], info: dict[str, Any], **kwargs
     ) -> list[TextualMemoryItem]:
         """
         Process tool trajectory memory items through LLM to generate fine mode memories.
@@ -618,10 +663,10 @@ class MultiModalStructMemReader(SimpleStructMemReader):
 
             with ContextThreadPoolExecutor(max_workers=2) as executor:
                 future_string = executor.submit(
-                    self._process_string_fine, fast_memory_items, info, custom_tags
+                    self._process_string_fine, fast_memory_items, info, custom_tags, **kwargs
                 )
                 future_tool = executor.submit(
-                    self._process_tool_trajectory_fine, fast_memory_items, info
+                    self._process_tool_trajectory_fine, fast_memory_items, info, **kwargs
                 )
 
                 # Collect results
@@ -710,7 +755,12 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         return scene_data
 
     def _read_memory(
-        self, messages: list[MessagesType], type: str, info: dict[str, Any], mode: str = "fine"
+        self,
+        messages: list[MessagesType],
+        type: str,
+        info: dict[str, Any],
+        mode: str = "fine",
+        **kwargs,
     ) -> list[list[TextualMemoryItem]]:
         list_scene_data_info = self.get_scene_data_info(messages, type)
 
@@ -718,7 +768,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         # Process Q&A pairs concurrently with context propagation
         with ContextThreadPoolExecutor() as executor:
             futures = [
-                executor.submit(self._process_multi_modal_data, scene_data_info, info, mode=mode)
+                executor.submit(
+                    self._process_multi_modal_data, scene_data_info, info, mode=mode, **kwargs
+                )
                 for scene_data_info in list_scene_data_info
             ]
             for future in concurrent.futures.as_completed(futures):

--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -362,8 +362,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         else:
             template = PROMPT_DICT["chat"][lang]
             examples = PROMPT_DICT["chat"][f"{lang}_example"]
+            related_memories_str = related_memories if related_memories is not None else ""
             prompt = template.replace("${conversation}", mem_str).replace(
-                "${reference}", related_memories
+                "${reference}", related_memories_str
             )
 
         custom_tags_prompt = (

--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -13,6 +13,7 @@ from memos.mem_reader.read_multi_modal.base import _derive_key
 from memos.mem_reader.simple_struct import PROMPT_DICT, SimpleStructMemReader
 from memos.mem_reader.utils import parse_json_result
 from memos.memories.textual.item import TextualMemoryItem, TreeNodeTextualMemoryMetadata
+from memos.templates.mem_reader_prompts import MEMORY_MERGE_PROMPT_EN, MEMORY_MERGE_PROMPT_ZH
 from memos.templates.tool_mem_prompts import TOOL_TRAJECTORY_PROMPT_EN, TOOL_TRAJECTORY_PROMPT_ZH
 from memos.types import MessagesType
 from memos.utils import timed
@@ -316,7 +317,6 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         custom_tags: list[str] | None = None,
         sources: list | None = None,
         prompt_type: str = "chat",
-        related_memories: str | None = None,
     ) -> dict:
         """
         Override parent method to improve language detection by using actual text content
@@ -327,7 +327,6 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             custom_tags: Optional custom tags
             sources: Optional list of SourceMessage objects to extract text content from
             prompt_type: Type of prompt to use ("chat" or "doc")
-            related_memories: related_memories in the graph
 
         Returns:
             LLM response dictionary
@@ -362,10 +361,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         else:
             template = PROMPT_DICT["chat"][lang]
             examples = PROMPT_DICT["chat"][f"{lang}_example"]
-            related_memories_str = related_memories if related_memories is not None else ""
-            prompt = template.replace("${conversation}", mem_str).replace(
-                "${reference}", related_memories_str
-            )
+            prompt = template.replace("${conversation}", mem_str)
 
         custom_tags_prompt = (
             PROMPT_DICT["custom_tags"][lang].replace("{custom_tags}", str(custom_tags))
@@ -398,6 +394,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                 ],
                 "summary": mem_str,
             }
+        logger.info(f"[MultiModalFine] Task {messages}, Result {response_json}")
         return response_json
 
     def _determine_prompt_type(self, sources: list) -> str:
@@ -417,6 +414,182 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                 prompt_type = "chat"
 
         return prompt_type
+
+    def _get_maybe_merged_memory(
+        self,
+        extracted_memory_dict: dict,
+        mem_text: str,
+        sources: list,
+        **kwargs,
+    ) -> dict:
+        """
+        Check if extracted memory should be merged with similar existing memories.
+        If merge is needed, return merged memory dict with merged_from field.
+        Otherwise, return original memory dict.
+
+        Args:
+            extracted_memory_dict: The extracted memory dict from LLM response
+            mem_text: The memory text content
+            sources: Source messages for language detection
+            **kwargs: Additional parameters (merge_similarity_threshold, etc.)
+
+        Returns:
+            Memory dict (possibly merged) with merged_from field if merged
+        """
+        # If no graph_db or user_name, return original
+        if not self.graph_db or "user_name" not in kwargs:
+            return extracted_memory_dict
+        user_name = kwargs.get("user_name")
+
+        # Detect language
+        lang = "en"
+        if sources:
+            for source in sources:
+                if hasattr(source, "lang") and source.lang:
+                    lang = source.lang
+                    break
+                elif isinstance(source, dict) and source.get("lang"):
+                    lang = source.get("lang")
+                    break
+        if lang is None:
+            lang = detect_lang(mem_text)
+
+        # Search for similar memories
+        merge_threshold = kwargs.get("merge_similarity_threshold", 0.3)
+
+        try:
+            search_results = self.graph_db.search_by_embedding(
+                vector=self.embedder.embed(mem_text)[0],
+                top_k=20,
+                status="activated",
+                threshold=merge_threshold,
+                user_name=user_name,
+                filter={
+                    "or": [
+                        {"memory_type": "LongTermMemory"},
+                        {"memory_type": "UserMemory"},
+                        {"memory_type": "WorkingMemory"},
+                    ]
+                },
+            )
+
+            if not search_results:
+                # No similar memories found, return original
+                return extracted_memory_dict
+
+            # Get full memory details
+            similar_memory_ids = [r["id"] for r in search_results if r.get("id")]
+            similar_memories_list = [
+                self.graph_db.get_node(mem_id, include_embedding=False)
+                for mem_id in similar_memory_ids
+            ]
+
+            # Filter out None and mode:fast memories
+            filtered_similar = []
+            for mem in similar_memories_list:
+                if not mem:
+                    continue
+                mem_metadata = mem.get("metadata", {})
+                tags = mem_metadata.get("tags", [])
+                if isinstance(tags, list) and "mode:fast" in tags:
+                    continue
+                filtered_similar.append(
+                    {
+                        "id": mem.get("id"),
+                        "memory": mem.get("memory", ""),
+                    }
+                )
+            logger.info(
+                f"Valid similar memories for {mem_text} is "
+                f"{len(filtered_similar)}: {filtered_similar}"
+            )
+
+            if not filtered_similar:
+                # No valid similar memories, return original
+                return extracted_memory_dict
+
+            # Create a temporary TextualMemoryItem for merge check
+            temp_memory_item = TextualMemoryItem(
+                memory=mem_text,
+                metadata=TreeNodeTextualMemoryMetadata(
+                    user_id="",
+                    session_id="",
+                    memory_type=extracted_memory_dict.get("memory_type", "LongTermMemory"),
+                    status="activated",
+                    tags=extracted_memory_dict.get("tags", []),
+                    key=extracted_memory_dict.get("key", ""),
+                ),
+            )
+
+            # Try to merge with LLM
+            merge_result = self._merge_memories_with_llm(
+                temp_memory_item, filtered_similar, lang=lang
+            )
+
+            if merge_result:
+                # Return merged memory dict
+                merged_dict = extracted_memory_dict.copy()
+                merged_dict["value"] = merge_result.get("value", mem_text)
+                merged_dict["merged_from"] = merge_result.get("merged_from", [])
+                logger.info(
+                    f"[MultiModalFine] Merged memory with {len(merged_dict['merged_from'])} existing memories"
+                )
+                return merged_dict
+            else:
+                # No merge needed, return original
+                return extracted_memory_dict
+
+        except Exception as e:
+            logger.error(f"[MultiModalFine] Error in get_maybe_merged_memory: {e}")
+            # On error, return original
+            return extracted_memory_dict
+
+    def _merge_memories_with_llm(
+        self,
+        new_memory: TextualMemoryItem,
+        similar_memories: list[dict],
+        lang: str = "en",
+    ) -> dict | None:
+        """
+        Use LLM to merge new memory with similar existing memories.
+
+        Args:
+            new_memory: The newly extracted memory item
+            similar_memories: List of similar memories from graph_db (with id and memory fields)
+            lang: Language code ("en" or "zh")
+
+        Returns:
+            Merged memory dict with merged_from field, or None if no merge needed
+        """
+        if not similar_memories:
+            return None
+
+        # Build merge prompt using template
+        similar_memories_text = "\n".join(
+            [f"[{mem['id']}]: {mem['memory']}" for mem in similar_memories]
+        )
+
+        merge_prompt_template = MEMORY_MERGE_PROMPT_ZH if lang == "zh" else MEMORY_MERGE_PROMPT_EN
+        merge_prompt = merge_prompt_template.format(
+            new_memory=new_memory.memory,
+            similar_memories=similar_memories_text,
+        )
+
+        try:
+            response_text = self.llm.generate([{"role": "user", "content": merge_prompt}])
+            merge_result = parse_json_result(response_text)
+
+            if merge_result.get("should_merge", False):
+                return {
+                    "value": merge_result.get("value", new_memory.memory),
+                    "merged_from": merge_result.get(
+                        "merged_from", [mem["id"] for mem in similar_memories]
+                    ),
+                }
+        except Exception as e:
+            logger.error(f"[MultiModalFine] Error in merge LLM call: {e}")
+
+        return None
 
     def _process_string_fine(
         self,
@@ -460,40 +633,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             # Determine prompt type based on sources
             prompt_type = self._determine_prompt_type(sources)
 
-            # recall related memories
-            related_memories = None
-            memory_ids = []
-            if self.graph_db:
-                if "user_name" in kwargs:
-                    memory_ids = self.graph_db.search_by_embedding(
-                        vector=self.embedder.embed(mem_str)[0],
-                        top_k=20,
-                        status="activated",
-                        user_name=kwargs.get("user_name"),
-                        filter={
-                            "or": [
-                                {"memory_type": "LongTermMemory"},
-                                {"memory_type": "UserMemory"},
-                                {"memory_type": "WorkingMemory"},
-                            ]
-                        },
-                    )
-                    memory_ids = set({r["id"] for r in memory_ids if r.get("id")})
-                    related_memories_list = self.graph_db.get_nodes(
-                        list(memory_ids),
-                        include_embedding=False,
-                        user_name=kwargs.get("user_name"),
-                    )
-                    related_memories = "\n".join(
-                        ["{}: {}".format(mem["id"], mem["memory"]) for mem in related_memories_list]
-                    )
-                else:
-                    logger.warning("user_name is null when graph_db exists")
-
+            # ========== Stage 1: Normal extraction (without reference) ==========
             try:
-                resp = self._get_llm_response(
-                    mem_str, custom_tags, sources, prompt_type, related_memories
-                )
+                resp = self._get_llm_response(mem_str, custom_tags, sources, prompt_type)
             except Exception as e:
                 logger.error(f"[MultiModalFine] Error calling LLM: {e}")
                 return fine_items
@@ -501,49 +643,59 @@ class MultiModalStructMemReader(SimpleStructMemReader):
             if resp.get("memory list", []):
                 for m in resp.get("memory list", []):
                     try:
+                        # Check and merge with similar memories if needed
+                        m_maybe_merged = self._get_maybe_merged_memory(
+                            extracted_memory_dict=m,
+                            mem_text=m.get("value", ""),
+                            sources=sources,
+                            **kwargs,
+                        )
                         # Normalize memory_type (same as simple_struct)
                         memory_type = (
-                            m.get("memory_type", "LongTermMemory")
+                            m_maybe_merged.get("memory_type", "LongTermMemory")
                             .replace("长期记忆", "LongTermMemory")
                             .replace("用户记忆", "UserMemory")
                         )
-                        if "merged_from" in m:
-                            for merged_id in m["merged_from"]:
-                                if merged_id not in memory_ids:
-                                    logger.warning("merged id not valid!!!!!")
-                            info_per_item["merged_from"] = m["merged_from"]
-                        # Create fine mode memory item (same as simple_struct)
                         node = self._make_memory_item(
-                            value=m.get("value", ""),
+                            value=m_maybe_merged.get("value", ""),
                             info=info_per_item,
                             memory_type=memory_type,
-                            tags=m.get("tags", []),
-                            key=m.get("key", ""),
+                            tags=m_maybe_merged.get("tags", []),
+                            key=m_maybe_merged.get("key", ""),
                             sources=sources,  # Preserve sources from fast item
                             background=resp.get("summary", ""),
                             **extra_kwargs,
                         )
+                        # Add merged_from to info if present
+                        if "merged_from" in m_maybe_merged:
+                            node.metadata.info = node.metadata.info or {}
+                            node.metadata.info["merged_from"] = m_maybe_merged["merged_from"]
                         fine_items.append(node)
                     except Exception as e:
                         logger.error(f"[MultiModalFine] parse error: {e}")
             elif resp.get("value") and resp.get("key"):
                 try:
-                    if "merged_from" in resp:
-                        for merged_id in resp["merged_from"]:
-                            if merged_id not in memory_ids:
-                                logger.warning("merged id not valid!!!!!")
-                        info_per_item["merged_from"] = resp["merged_from"]
-                    # Create fine mode memory item (same as simple_struct)
+                    # Check and merge with similar memories if needed
+                    resp_maybe_merged = self._get_maybe_merged_memory(
+                        extracted_memory_dict=resp,
+                        mem_text=resp.get("value", "").strip(),
+                        sources=sources,
+                        **kwargs,
+                    )
                     node = self._make_memory_item(
-                        value=resp.get("value", "").strip(),
+                        value=resp_maybe_merged.get("value", "").strip(),
                         info=info_per_item,
                         memory_type="LongTermMemory",
-                        tags=resp.get("tags", []),
-                        key=resp.get("key", None),
+                        tags=resp_maybe_merged.get("tags", []),
+                        key=resp_maybe_merged.get("key", None),
                         sources=sources,  # Preserve sources from fast item
                         background=resp.get("summary", ""),
                         **extra_kwargs,
                     )
+                    # Add merged_from to info if present
+                    if "merged_from" in resp_maybe_merged:
+                        node.metadata.info = node.metadata.info or {}
+                        node.metadata.info["merged_from"] = resp_maybe_merged["merged_from"]
                     fine_items.append(node)
                 except Exception as e:
                     logger.error(f"[MultiModalFine] parse error: {e}")
@@ -694,9 +846,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
 
     @timed
     def _process_transfer_multi_modal_data(
-        self,
-        raw_node: TextualMemoryItem,
-        custom_tags: list[str] | None = None,
+        self, raw_node: TextualMemoryItem, custom_tags: list[str] | None = None, **kwargs
     ) -> list[TextualMemoryItem]:
         """
         Process transfer for multimodal data.
@@ -720,9 +870,11 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         # Part A: call llm in parallel using thread pool
         with ContextThreadPoolExecutor(max_workers=2) as executor:
             future_string = executor.submit(
-                self._process_string_fine, [raw_node], info, custom_tags
+                self._process_string_fine, [raw_node], info, custom_tags, **kwargs
             )
-            future_tool = executor.submit(self._process_tool_trajectory_fine, [raw_node], info)
+            future_tool = executor.submit(
+                self._process_tool_trajectory_fine, [raw_node], info, **kwargs
+            )
 
             # Collect results
             fine_memory_items_string_parser = future_string.result()
@@ -789,6 +941,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         input_memories: list[TextualMemoryItem],
         type: str,
         custom_tags: list[str] | None = None,
+        **kwargs,
     ) -> list[list[TextualMemoryItem]]:
         if not input_memories:
             return []
@@ -799,7 +952,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         with ContextThreadPoolExecutor() as executor:
             futures = [
                 executor.submit(
-                    self._process_transfer_multi_modal_data, scene_data_info, custom_tags
+                    self._process_transfer_multi_modal_data, scene_data_info, custom_tags, **kwargs
                 )
                 for scene_data_info in input_memories
             ]

--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -228,7 +228,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         lang = detect_lang(mem_str)
         template = PROMPT_DICT["chat"][lang]
         examples = PROMPT_DICT["chat"][f"{lang}_example"]
-        prompt = template.replace("${conversation}", mem_str).replace("${reference}", "")
+        prompt = template.replace("${conversation}", mem_str)
 
         custom_tags_prompt = (
             PROMPT_DICT["custom_tags"][lang].replace("{custom_tags}", str(custom_tags))
@@ -361,7 +361,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
             return chat_read_nodes
 
     def _process_transfer_chat_data(
-        self, raw_node: TextualMemoryItem, custom_tags: list[str] | None = None
+        self, raw_node: TextualMemoryItem, custom_tags: list[str] | None = None, **kwargs
     ):
         raw_memory = raw_node.memory
         response_json = self._get_llm_response(raw_memory, custom_tags)
@@ -669,6 +669,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         input_memories: list[TextualMemoryItem],
         type: str,
         custom_tags: list[str] | None = None,
+        **kwargs,
     ) -> list[list[TextualMemoryItem]]:
         if not input_memories:
             return []
@@ -685,7 +686,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         # Process Q&A pairs concurrently with context propagation
         with ContextThreadPoolExecutor() as executor:
             futures = [
-                executor.submit(processing_func, scene_data_info, custom_tags)
+                executor.submit(processing_func, scene_data_info, custom_tags, **kwargs)
                 for scene_data_info in input_memories
             ]
             for future in concurrent.futures.as_completed(futures):
@@ -889,6 +890,6 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         return doc_nodes
 
     def _process_transfer_doc_data(
-        self, raw_node: TextualMemoryItem, custom_tags: list[str] | None = None
+        self, raw_node: TextualMemoryItem, custom_tags: list[str] | None = None, **kwargs
     ):
         raise NotImplementedError

--- a/src/memos/mem_scheduler/general_modules/init_components_for_scheduler.py
+++ b/src/memos/mem_scheduler/general_modules/init_components_for_scheduler.py
@@ -305,7 +305,8 @@ def init_components() -> dict[str, Any]:
     )
     llm = LLMFactory.from_config(llm_config)
     embedder = EmbedderFactory.from_config(embedder_config)
-    mem_reader = MemReaderFactory.from_config(mem_reader_config)
+    # Pass graph_db to mem_reader for recall operations (deduplication, conflict detection)
+    mem_reader = MemReaderFactory.from_config(mem_reader_config, graph_db=graph_db)
     reranker = RerankerFactory.from_config(reranker_config)
     feedback_reranker = RerankerFactory.from_config(feedback_reranker_config)
     internet_retriever = InternetRetrieverFactory.from_config(

--- a/src/memos/mem_scheduler/general_scheduler.py
+++ b/src/memos/mem_scheduler/general_scheduler.py
@@ -899,7 +899,7 @@ class GeneralScheduler(BaseScheduler):
                     )
 
                     # Mark merged_from memories as archived when provided in memory metadata
-                    if self.mem_reader and self.mem_reader.graph_db:
+                    if self.mem_reader.graph_db:
                         for memory in flattened_memories:
                             merged_from = (memory.metadata.info or {}).get("merged_from")
                             if merged_from:

--- a/src/memos/mem_scheduler/general_scheduler.py
+++ b/src/memos/mem_scheduler/general_scheduler.py
@@ -877,6 +877,7 @@ class GeneralScheduler(BaseScheduler):
                     memory_items,
                     type="chat",
                     custom_tags=custom_tags,
+                    user_name=user_name,
                 )
             except Exception as e:
                 logger.warning(f"{e}: Fail to transfer mem: {memory_items}")
@@ -896,6 +897,38 @@ class GeneralScheduler(BaseScheduler):
                     logger.info(
                         f"Added {len(enhanced_mem_ids)} enhanced memories: {enhanced_mem_ids}"
                     )
+
+                    # Mark merged_from memories as archived when provided in memory metadata
+                    if self.mem_reader and self.mem_reader.graph_db:
+                        for memory in flattened_memories:
+                            merged_from = (memory.metadata.info or {}).get("merged_from")
+                            if merged_from:
+                                old_ids = (
+                                    merged_from
+                                    if isinstance(merged_from, (list | tuple | set))
+                                    else [merged_from]
+                                )
+                                for old_id in old_ids:
+                                    try:
+                                        self.mem_reader.graph_db.update_node(
+                                            str(old_id), {"status": "archived"}, user_name=user_name
+                                        )
+                                        logger.info(
+                                            f"[Scheduler] Archived merged_from memory: {old_id}"
+                                        )
+                                    except Exception as e:
+                                        logger.warning(
+                                            f"[Scheduler] Failed to archive merged_from memory {old_id}: {e}"
+                                        )
+                    else:
+                        # Check if any memory has merged_from but graph_db is unavailable
+                        has_merged_from = any(
+                            (m.metadata.info or {}).get("merged_from") for m in flattened_memories
+                        )
+                        if has_merged_from:
+                            logger.warning(
+                                "[Scheduler] merged_from provided but graph_db is unavailable; skip archiving."
+                            )
 
                     # LOGGING BLOCK START
                     # This block is replicated from _add_message_consumer to ensure consistent logging

--- a/src/memos/memories/textual/tree_text_memory/retrieve/recall.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/recall.py
@@ -77,6 +77,7 @@ class GraphMemoryRetriever:
                 include_embedding=self.include_embedding,
                 user_name=user_name,
                 filter=search_filter,
+                status="activated",
             )
             return [TextualMemoryItem.from_dict(record) for record in working_memories[:top_k]]
 
@@ -247,7 +248,7 @@ class GraphMemoryRetriever:
 
             # Load nodes and post-filter
             node_dicts = self.graph_store.get_nodes(
-                list(candidate_ids), include_embedding=self.include_embedding
+                list(candidate_ids), include_embedding=self.include_embedding, user_name=user_name
             )
 
             final_nodes = []
@@ -277,7 +278,9 @@ class GraphMemoryRetriever:
                     {"field": "key", "op": "in", "value": parsed_goal.keys},
                     {"field": "memory_type", "op": "=", "value": memory_scope},
                 ]
-                key_ids = self.graph_store.get_by_metadata(key_filters, user_name=user_name)
+                key_ids = self.graph_store.get_by_metadata(
+                    key_filters, user_name=user_name, status="activated"
+                )
                 candidate_ids.update(key_ids)
 
             # 2) tag-based OR branch
@@ -286,7 +289,9 @@ class GraphMemoryRetriever:
                     {"field": "tags", "op": "contains", "value": parsed_goal.tags},
                     {"field": "memory_type", "op": "=", "value": memory_scope},
                 ]
-                tag_ids = self.graph_store.get_by_metadata(tag_filters, user_name=user_name)
+                tag_ids = self.graph_store.get_by_metadata(
+                    tag_filters, user_name=user_name, status="activated"
+                )
                 candidate_ids.update(tag_ids)
 
             # No matches → return empty
@@ -422,9 +427,11 @@ class GraphMemoryRetriever:
                 value = search_filter[key]
                 key_filters.append({"field": key, "op": "=", "value": value})
             corpus_name += "".join(list(search_filter.values()))
-        candidate_ids = self.graph_store.get_by_metadata(key_filters, user_name=user_name)
+        candidate_ids = self.graph_store.get_by_metadata(
+            key_filters, user_name=user_name, status="activated"
+        )
         node_dicts = self.graph_store.get_nodes(
-            list(candidate_ids), include_embedding=self.include_embedding
+            list(candidate_ids), include_embedding=self.include_embedding, user_name=user_name
         )
 
         bm25_query = " ".join(list({query, *parsed_goal.keys}))

--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -833,29 +833,32 @@ class SingleCubeView(MemCubeView):
         )
 
         # Mark merged_from memories as archived when provided in add_req.info
-        for memory in flattened_local:
-            merged_from = (memory.metadata.info or {}).get("merged_from")
-            if merged_from:
-                old_ids = (
-                    merged_from if isinstance(merged_from, (list | tuple | set)) else [merged_from]
-                )
-                if self.mem_reader and self.mem_reader.graph_db:
-                    for old_id in old_ids:
-                        try:
-                            self.mem_reader.graph_db.update_node(
-                                str(old_id), {"status": "archived"}
-                            )
-                            self.logger.info(
-                                f"[SingleCubeView] Archived merged_from memory: {old_id}"
-                            )
-                        except Exception as e:
-                            self.logger.warning(
-                                f"[SingleCubeView] Failed to archive merged_from memory {old_id}: {e}"
-                            )
-                else:
-                    self.logger.warning(
-                        "[SingleCubeView] merged_from provided but graph_db is unavailable; skip archiving."
+        if sync_mode == "sync" and extract_mode == "fine":
+            for memory in flattened_local:
+                merged_from = (memory.metadata.info or {}).get("merged_from")
+                if merged_from:
+                    old_ids = (
+                        merged_from
+                        if isinstance(merged_from, (list | tuple | set))
+                        else [merged_from]
                     )
+                    if self.mem_reader and self.mem_reader.graph_db:
+                        for old_id in old_ids:
+                            try:
+                                self.mem_reader.graph_db.update_node(
+                                    str(old_id), {"status": "archived"}
+                                )
+                                self.logger.info(
+                                    f"[SingleCubeView] Archived merged_from memory: {old_id}"
+                                )
+                            except Exception as e:
+                                self.logger.warning(
+                                    f"[SingleCubeView] Failed to archive merged_from memory {old_id}: {e}"
+                                )
+                    else:
+                        self.logger.warning(
+                            "[SingleCubeView] merged_from provided but graph_db is unavailable; skip archiving."
+                        )
 
         text_memories = [
             {

--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -846,7 +846,9 @@ class SingleCubeView(MemCubeView):
                         for old_id in old_ids:
                             try:
                                 self.mem_reader.graph_db.update_node(
-                                    str(old_id), {"status": "archived"}
+                                    str(old_id),
+                                    {"status": "archived"},
+                                    user_name=user_context.mem_cube_id,
                                 )
                                 self.logger.info(
                                     f"[SingleCubeView] Archived merged_from memory: {old_id}"

--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -802,6 +802,7 @@ class SingleCubeView(MemCubeView):
                 "session_id": target_session_id,
             },
             mode=extract_mode,
+            user_name=user_context.mem_cube_id,
         )
         flattened_local = [mm for m in memories_local for mm in m]
 
@@ -830,6 +831,31 @@ class SingleCubeView(MemCubeView):
             mem_ids=mem_ids_local,
             sync_mode=sync_mode,
         )
+
+        # Mark merged_from memories as archived when provided in add_req.info
+        for memory in flattened_local:
+            merged_from = (memory.metadata.info or {}).get("merged_from")
+            if merged_from:
+                old_ids = (
+                    merged_from if isinstance(merged_from, (list | tuple | set)) else [merged_from]
+                )
+                if self.mem_reader and self.mem_reader.graph_db:
+                    for old_id in old_ids:
+                        try:
+                            self.mem_reader.graph_db.update_node(
+                                str(old_id), {"status": "archived"}
+                            )
+                            self.logger.info(
+                                f"[SingleCubeView] Archived merged_from memory: {old_id}"
+                            )
+                        except Exception as e:
+                            self.logger.warning(
+                                f"[SingleCubeView] Failed to archive merged_from memory {old_id}: {e}"
+                            )
+                else:
+                    self.logger.warning(
+                        "[SingleCubeView] merged_from provided but graph_db is unavailable; skip archiving."
+                    )
 
         text_memories = [
             {

--- a/src/memos/templates/mem_reader_prompts.py
+++ b/src/memos/templates/mem_reader_prompts.py
@@ -28,8 +28,7 @@ Return a single valid JSON object with the following structure:
       "key": <string, a unique, concise memory title>,
       "memory_type": <string, Either "LongTermMemory" or "UserMemory">,
       "value": <A detailed, self-contained, and unambiguous memory statement — written in English if the input conversation is in English, or in Chinese if the conversation is in Chinese>,
-      "tags": <A list of relevant thematic keywords (e.g., ["deadline", "team", "planning"])>,
-      "merged_from": <a list of reference memory IDs to be merged; omit this field if no reference memories are provided>
+      "tags": <A list of relevant thematic keywords (e.g., ["deadline", "team", "planning"])>
     },
     ...
   ],
@@ -42,7 +41,7 @@ Language rules:
 
 ${custom_tags_prompt}
 
-Example 1 — No reference memories:
+Example:
 Conversation:
 user: [June 26, 2025 at 3:00 PM]: Hi Jerry! Yesterday at 3 PM I had a meeting with my team about the new project.
 assistant: Oh Tom! Do you think the team can finish by December 15?
@@ -70,7 +69,7 @@ Output:
   "summary": "Tom is currently focused on managing a new project with a tight schedule. After a team meeting on June 25, 2025, he realized the original deadline of December 15 might not be feasible due to backend delays. Concerned about insufficient testing time, he welcomed Jerry’s suggestion of proposing an extension. Tom plans to raise the idea of shifting the deadline to January 5, 2026 in the next morning’s meeting. His actions reflect both stress about timelines and a proactive, team-oriented problem-solving approach."
 }
 
-Example 2 — No reference memories:
+Dialogue:
 assistant: [10:30 AM, August 15, 2025]: The book Deep Work you mentioned is
 indeed very suitable for your current situation. The book explains … (omitted). The author suggests setting aside 2–3 hours of focused work blocks each day and turning off all notifications during that time. Considering that you need to submit a report next week, you could try using the 9:00–11:00 AM time slot for focused work.
 
@@ -90,7 +89,7 @@ Output:
 Note: When the dialogue contains only assistant messages, phrasing such as
 “assistant recommended” or “assistant suggested” should be used, rather than incorrectly attributing the content to the user’s statements or plans.
 
-Example 3 — No reference memories (note: if the user’s language is Chinese, output must also be Chinese):
+Another Example in Chinese (注意: 当user的语言为中文时，你就需要也输出中文)：
 {
   "memory list": [
     {
@@ -104,53 +103,10 @@ Example 3 — No reference memories (note: if the user’s language is Chinese, 
   "summary": "Tom 目前专注于管理一个进度紧张的新项目..."
 }
 
-Note: We may provide partial reference memories. If newly extracted memories substantially overlap with reference memories, merge them and include a `merged_from` field indicating the merged memory IDs.
-If newly extracted memories are strongly related to reference memories, you may appropriately reference them during extraction (but never fabricate memories — only reference them when you are very confident).
-If no reference memories are provided, or if they are unrelated to the new memories, simply ignore them.
-
-Example 4 — With reference memories:
-Dialogue:
-user: [January 13, 2026] Winter skiing is so much fun! I’m planning to go skiing again with friends this weekend!
-assistant: [January 13, 2026] That sounds great!
-user: [January 14, 2026] You remember my ski buddy, right? His name is Tom. We ski together every year — including this week!
-
-Reference memories:
-[xxxx-xxxx-xxxx-xxxx-01]: The user expressed a strong passion for skiing on December 29, 2025
-[xxxx-xxxx-xxxx-xxxx-06]: The user’s ski buddy is named Tom
-[xxxx-xxxx-xxxx-xxxx-11]: Niseko is a ski destination the user has visited multiple times; the user met Tom at Hirafu Ski Resort and became close friends
-[xxxx-xxxx-xxxx-xxxx-12]: On January 1, 2025, the user discussed skiing equipment with the assistant and planned to buy a new ski backpack
-
-Output:
-{
-  "memory list": [
-    {
-      "key": "User's winter skiing plan",
-      "memory_type": "UserMemory",
-      "value": "On January 13, 2026, the user planned to go skiing again over the weekend with their friend Tom.",
-      "tags": ["skiing", "sports preference", "plan", "winter activity"]
-    },
-    {
-      "key": "User's ski partner is named Tom",
-      "memory_type": "UserMemory",
-      "value": "On January 14, 2026, the user again mentioned their ski partner Tom and further explained that they ski together every year. This statement reinforces their long-term and stable skiing partnership and adds new information about its regular annual pattern.",
-      "tags": ["interpersonal relationship", "ski partner", "long-term habit"],
-      "merged_from": [
-        "xxxx-xxxx-xxxx-xxxx-06",
-        "xxxx-xxxx-xxxx-xxxx-11"
-      ]
-    }
-  ],
-  "summary": "The user recently reinforced their strong passion for skiing and, on January 13, 2026, explicitly stated that winter skiing brings them great joy and that they planned to ski again with a friend over the weekend. This indicates that skiing remains a highly significant activity in the user’s life. Additionally, on January 14, 2026, the user elaborated on their long-term relationship with their ski partner Tom, emphasizing that they ski together every year. This further solidifies the importance of this interpersonal relationship in the user’s personal experiences."
-}
-
-Your task:
-Dialogue to be extracted:
-${conversation}
-
-Reference memories:
-${reference}
-
 Always respond in the same language as the conversation.
+
+Conversation:
+${conversation}
 
 Your Output:"""
 
@@ -187,8 +143,7 @@ SIMPLE_STRUCT_MEM_READER_PROMPT_ZH = """您是记忆提取专家。
       "key": <字符串，唯一且简洁的记忆标题>,
       "memory_type": <字符串，"LongTermMemory" 或 "UserMemory">,
       "value": <详细、独立且无歧义的记忆陈述——若输入对话为英文，则用英文；若为中文，则用中文>,
-      "tags": <相关主题关键词列表（例如，["截止日期", "团队", "计划"]）>,
-      "merged_from": <需要被合并的参考记忆列表，当没有提供参考记忆时，不需要输出这个字段 >
+      "tags": <相关主题关键词列表（例如，["截止日期", "团队", "计划"]）>
     },
     ...
   ],
@@ -201,7 +156,7 @@ SIMPLE_STRUCT_MEM_READER_PROMPT_ZH = """您是记忆提取专家。
 
 ${custom_tags_prompt}
 
-示例1-无参考记忆：
+示例：
 对话：
 user: [2025年6月26日下午3:00]：嗨Jerry！昨天下午3点我和团队开了个会，讨论新项目。
 assistant: 哦Tom！你觉得团队能在12月15日前完成吗？
@@ -228,7 +183,7 @@ user: [2025年6月26日下午4:21]：好主意。我明天上午9:30的会上提
   "summary": "Tom目前正专注于管理一个进度紧张的新项目。在2025年6月25日的团队会议后，他意识到原定2025年12月15日的截止日期可能无法实现，因为后端会延迟。由于担心测试时间不足，他接受了Jerry提出的延期建议。Tom计划在次日早上的会议上提出将截止日期推迟至2026年1月5日。他的行为反映出对时间线的担忧，以及积极、以团队为导向的问题解决方式。"
 }
 
-示例2-无参考记忆：
+对话：
 assistant: [2025年8月15日上午10:30]:
 你提到的那本《深度工作》确实很适合你现在的情况。这本书讲了......(略),作者建议每天留出2-3
 小时的专注时间块，期间关闭所有通知。考虑到你下周要交的报告，可以试试早上9点到11点这个时段。
@@ -247,72 +202,27 @@ assistant: [2025年8月15日上午10:30]:
 }
 注意：当对话仅有助手消息时，应使用"助手推荐"、"助手建议"等表述，而非将其错误归因为用户的陈述或计划。
 
-示例3-无参考记忆（注意：当用户语言为中文时，您也需输出中文）：
+另一个中文示例（注意：当用户语言为中文时，您也需输出中文）：
 {
   "memory list": [
     {
       "key": "项目会议",
       "memory_type": "LongTermMemory",
       "value": "在2025年6月25日下午3点，Tom与团队开会讨论了新项目，涉及时间表，并提出了对12月15日截止日期可行性的担忧。",
-      "tags": ["项目", "时间表", "会议", "截止日期"],
-      "merged_from": [
-        "xxxx-xxxx-xxxx-xxxx-xxx",
-        "xxxx-xxxx-xxxx-xxxx-xx",
-      ],
+      "tags": ["项目", "时间表", "会议", "截止日期"]
     },
     ...
   ],
   "summary": "Tom 目前专注于管理一个进度紧张的新项目..."
 }
 
-注意，我们可能给出部分参考记忆，这部分记忆如果和新添加的记忆大量重复，合并记忆，并在输入中多一个`merged_from`字段指明合并的记忆；
-新添加的记忆如果和参考记忆有强关联，可以在提取时适当参考（但一定不要捏造记忆，十分有把握再进行参考）；
-如果没有给出参考记忆、或参考记忆和新添加的记忆无关，直接忽略就好。
+请始终使用与对话相同的语言进行回复。
 
-示例4-带参考记忆：
 对话：
-user: [2026年1月13日] 冬天滑雪真的太快乐了！我打算这周末和朋友再滑一次！
-assistant：[2026年1月13日] 听起来就很棒！
-user: [2026年1月14日] 你还记得我的滑雪搭子吧？他叫Tom，我们每年都一起滑雪！这周也是！
-
-参考记忆：
-[xxxx-xxxx-xxxx-xxxx-01]: 用户在2025年12月29日表达了对滑雪的狂热喜爱
-[xxxx-xxxx-xxxx-xxxx-06]: 用户的滑雪搭子叫Tom
-[xxxx-xxxx-xxxx-xxxx-11]: 二世谷是用户多次去过的滑雪胜地，用户在比罗夫滑雪场认识了Tom并成为好朋友
-[xxxx-xxxx-xxxx-xxxx-12]: 用户2025年1月1日和助手讨论了滑雪装备，打算新买一个滑雪背包。
-
-输出：
-{
-  "memory list": [
-    {
-      "key": "用户冬季滑雪计划",
-      "memory_type": "UserMemory",
-      "value": "用户在2026年1月13日计划在周末与朋友Tom再次进行滑雪活动。",
-      "tags": ["滑雪", "运动偏好", "计划", "冬季活动"],
-    },
-    {
-      "key": "用户的滑雪伙伴叫Tom",
-      "memory_type": "UserMemory",
-      "value": "用户在2026年1月14日再次提到其滑雪搭子Tom，并进一步说明他们每年都会一起滑雪。这一描述强化了双方长期稳定的滑雪伙伴关系，在原有记忆基础上补充了新的时间规律性信息。",
-      "tags": ["人际关系", "滑雪搭子", "长期习惯"],
-      "merged_from": [
-        "xxxx-xxxx-xxxx-xxxx-06",
-        "xxxx-xxxx-xxxx-xxxx-11",
-      ],
-    }
-  ],
-  "summary": "用户近期再次强化了自己对滑雪的热爱，并在2026年1月13日明确表示冬季滑雪带来极大的快乐，同时计划于当周周末与朋友再度滑雪。这表明滑雪对用户而言仍然是一项高度重要的活动。此外，用户在2026年1月14日补充了关于其滑雪伙伴Tom的长期关系细节，强调两人每年都会结伴滑雪，进一步巩固了此人际关系在用户生活中的重要性。"
-}
-
-您的任务：
-待提取的对话：
 ${conversation}
 
-参考记忆：
-${reference}
-
-请始终使用与对话相同的语言进行回复。
 您的输出："""
+
 
 SIMPLE_STRUCT_DOC_READER_PROMPT = """You are an expert text analyst for a search and retrieval system.
 Your task is to process a document chunk and generate a single, structured JSON object.
@@ -957,10 +867,103 @@ Output Format:
 Important: Output **only** the JSON. No extra text.
 """
 
+MEMORY_MERGE_PROMPT_EN = """You are a memory consolidation expert. Given a new memory and similar existing memories, decide if they should be merged.
+
+Example:
+New memory:
+The user’s name is Tom, the user likes skiing, and plans to go skiing this weekend
+
+Similar existing memories:
+xxxx-xxxx-xxxx-xxxx-01: The user’s name is Tom
+xxxx-xxxx-xxxx-xxxx-10: The user likes skiing
+xxxx-xxxx-xxxx-xxxx-11: The user lives by the sea
+
+Expected output:
+{{
+“value”: “The user’s name is Tom, the user likes skiing”,
+“merged_from”: [“xxxx-xxxx-xxxx-xxxx-01”, “xxxx-xxxx-xxxx-xxxx-10”],
+“should_merge”: true
+}}
+
+New memory:
+The user is going to attend a party on Sunday
+
+Similar existing memories:
+xxxx-xxxx-xxxx-xxxx-01: The user read a book yesterday
+
+Expected output:
+{{
+“should_merge”: false
+}}
+
+If the new memory substantially overlaps with or complements the existing memories, merge them into a single consolidated memory and return a JSON object with:
+- "value": the merged memory content (preserving all unique information)
+- "merged_from": list of IDs from similar_memories that were merged
+- "should_merge": true
+
+If the new memory is distinct and should remain separate, return:
+- "should_merge": false
+
+New Memory:
+{new_memory}
+
+Similar Existing Memories:
+{similar_memories}
+
+Return ONLY a valid JSON object, nothing else."""
+
+MEMORY_MERGE_PROMPT_ZH = """你是一个记忆整合专家。给定一个新记忆和相似的现有记忆，判断它们是否应该合并。
+
+示例：
+新记忆：
+用户的名字是Tom，用户喜欢滑雪，并计划周末去滑雪
+
+相似的现有记忆：
+xxxx-xxxx-xxxx-xxxx-01: 用户的名字是Tom
+xxxx-xxxx-xxxx-xxxx-10: 用户喜欢滑雪
+xxxx-xxxx-xxxx-xxxx-11: 用户住在海边
+
+应该的返回值：
+{{
+    "value": "用户的名字是Tom，用户喜欢滑雪",
+    "merged_from": ["xxxx-xxxx-xxxx-xxxx-01", "xxxx-xxxx-xxxx-xxxx-10"],
+    "should_merge": true
+}}
+
+新记忆：
+用户周天要参加一个聚会
+
+相似的现有记忆：
+xxxx-xxxx-xxxx-xxxx-01: 用户昨天读了一本书
+
+应该的返回值：
+{{
+    "should_merge": false
+}}
+
+
+如果新记忆与现有记忆大量重叠或互补，将它们合并为一个整合的记忆，并返回一个JSON列表：
+- "value": 合并后的记忆内容（保留所有独特信息）
+- "merged_from": 被合并的相似记忆ID列表
+- "should_merge": true
+
+如果新记忆是独特的，应该保持独立，返回：
+- "should_merge": false
+
+新记忆：
+{new_memory}
+
+相似的现有记忆：
+{similar_memories}
+
+只返回有效的JSON对象，不要其他内容。"""
+
 # Prompt mapping for specialized tasks (e.g., hallucination filtering)
 PROMPT_MAPPING = {
     "hallucination_filter": SIMPLE_STRUCT_HALLUCINATION_FILTER_PROMPT,
     "rewrite": SIMPLE_STRUCT_REWRITE_MEMORY_PROMPT,
     "rewrite_user_only": SIMPLE_STRUCT_REWRITE_MEMORY_USER_ONLY_PROMPT,
     "add_before_search": SIMPLE_STRUCT_ADD_BEFORE_SEARCH_PROMPT,
+    "memory_merge_en": MEMORY_MERGE_PROMPT_EN,
+    "memory_merge_zh": MEMORY_MERGE_PROMPT_ZH,
 }

--- a/src/memos/templates/mem_reader_prompts.py
+++ b/src/memos/templates/mem_reader_prompts.py
@@ -867,52 +867,120 @@ Output Format:
 Important: Output **only** the JSON. No extra text.
 """
 
-MEMORY_MERGE_PROMPT_EN = """You are a memory consolidation expert. Given a new memory and similar existing memories, decide if they should be merged.
+MEMORY_MERGE_PROMPT_EN = """You are a memory consolidation expert. Given a new memory and a set of similar existing memories, determine whether they should be merged.
+
+Before generating the value, you must complete the following reasoning steps (done in internal reasoning, no need to output them):
+1.	Identify the “fact units” contained in the new memory, for example:
+•	Identity-type facts: name, occupation, place of residence, etc.
+•	Stable preference-type facts: things the user likes/dislikes long-term, frequently visited places, etc.
+•	Relationship-type facts: relationships with someone (friend, colleague, fixed activity partner, etc.)
+•	One-off event/plan-type facts: events on a specific day, temporary plans for this weekend, etc.
+2.	For each fact unit, determine:
+•	Which existing memories are expressing “the same kind of fact”
+•	Whether the corresponding fact in the new memory is just a “repeated confirmation” of that fact, rather than “new factual content”
+
+Merge rules (must be followed when generating value):
+•	The merged value:
+•	Must not repeat the same meaning (each fact should be described only once)
+•	Must not repeat the same fact just because it was mentioned multiple times or at different times
+•	Unless time itself changes the meaning (for example, “used to dislike → now likes”), do not keep specific time information
+•	If the new memory contains multiple different types of facts (for example: “name + hobby + plan for this weekend”):
+•	You may output multiple merge results; each merge result should focus on only one type of fact (for example: one about “name”, one about “hobby”)
+•	Do not force unrelated facts into the same value
+•	One-off events/plans (such as “going skiing this weekend”, “attending a party on Sunday”):
+•	If there is no directly related and complementary event memory in the existing memories, treat it as an independent memory and do not merge it with identity/stable preference-type memories
+•	Do not merge a “temporary plan” and a “long-term preference” into the same value just because they are related (e.g. a plan to ski vs. a long-term preference for skiing)
+
+Output format requirements:
+•	You must return a single JSON object.
+•	If a merge occurred:
+•	“value”: The merged memory content (only describe the final conclusion, preserving all “semantically unique” information, without repetition)
+•	“merged_from”: A list of IDs of the similar memories that were merged
+•	“should_merge”: true
+•	If the new memory cannot be merged with any existing memories, return:
+•	“should_merge”: false
 
 Example:
 New memory:
-The user’s name is Tom, the user likes skiing, and plans to go skiing this weekend
+The user’s name is Tom, the user likes skiing, and plans to go skiing this weekend.
 
 Similar existing memories:
 xxxx-xxxx-xxxx-xxxx-01: The user’s name is Tom
 xxxx-xxxx-xxxx-xxxx-10: The user likes skiing
 xxxx-xxxx-xxxx-xxxx-11: The user lives by the sea
 
-Expected output:
+Expected return value:
 {{
-“value”: “The user’s name is Tom, the user likes skiing”,
-“merged_from”: [“xxxx-xxxx-xxxx-xxxx-01”, “xxxx-xxxx-xxxx-xxxx-10”],
-“should_merge”: true
+"value": "The user's name is Tom and the user likes skiing",
+"merged_from": ["xxxx-xxxx-xxxx-xxxx-01", "xxxx-xxxx-xxxx-xxxx-10"],
+"should_merge": true
 }}
 
 New memory:
-The user is going to attend a party on Sunday
+The user is going to attend a party on Sunday.
 
 Similar existing memories:
-xxxx-xxxx-xxxx-xxxx-01: The user read a book yesterday
+xxxx-xxxx-xxxx-xxxx-01: The user read a book yesterday.
 
-Expected output:
+Expected return value:
 {{
-“should_merge”: false
+"should_merge": false
 }}
 
-If the new memory substantially overlaps with or complements the existing memories, merge them into a single consolidated memory and return a JSON object with:
-- "value": the merged memory content (preserving all unique information)
-- "merged_from": list of IDs from similar_memories that were merged
-- "should_merge": true
+If the new memory largely overlaps with or complements the existing memories, merge them into an integrated memory and return a JSON object:
+•	“value”: The merged memory content
+•	“merged_from”: A list of IDs of the similar memories that were merged
+•	“should_merge”: true
 
-If the new memory is distinct and should remain separate, return:
-- "should_merge": false
+If the new memory is unique and should remain independent, return:
+{{
+"should_merge": false
+}}
 
-New Memory:
+You must only return a valid JSON object in the final output, and no additional content (no natural language explanations, no extra fields).
+
+New memory:
 {new_memory}
 
-Similar Existing Memories:
+Similar existing memories:
 {similar_memories}
 
-Return ONLY a valid JSON object, nothing else."""
+Only return a valid JSON object, and do not include any other content.
+"""
 
-MEMORY_MERGE_PROMPT_ZH = """你是一个记忆整合专家。给定一个新记忆和相似的现有记忆，判断它们是否应该合并。
+MEMORY_MERGE_PROMPT_ZH = """
+你是一个记忆整合专家。给定一个新记忆和相似的现有记忆，判断它们是否应该合并。
+
+在生成 value 之前，必须先完成以下判断步骤（在内在推理中完成，不需要输出）：
+1. 识别新记忆中包含的「事实单元」，例如：
+   - 身份信息类：名字、职业、居住地等
+   - 稳定偏好类：长期喜欢/不喜欢的事物、常去地点等
+   - 关系类：与某人的关系（朋友、同事、固定搭子等）
+   - 一次性事件/计划类：某天要参加的活动、本周末的临时安排等
+2. 对每个事实单元，判断：
+   - 哪些 existing memories 在表达“同一类事实”，
+   - 新记忆中对应的事实是否只是对该事实的「重复确认」，而不是“新的事实内容”
+
+合并规则（生成 value 时必须遵守）：
+- 合并后的 value：
+  - 不要重复表达同一语义（同一事实只描述一次）
+  - 不要因为多次提及或不同时间而重复同一事实
+  - 除非时间本身改变了语义（例如“从不喜欢 → 现在开始喜欢”），否则不要保留具体时间信息
+- 如果新记忆中包含多个不同类型的事实（例如“名字 + 爱好 + 本周计划”）：
+  - 不要合并就好
+  - 不要把彼此无关的事实硬塞进同一个 value 中
+- 一次性事件/计划（如“本周末去滑雪”“周天参加聚会”）：
+  - 如果 existing memories 中没有与之直接相关、可互补的事件记忆，则视为独立记忆，不要与身份/长期偏好类记忆合并
+  - 不要因为它和某个长期偏好有关（例如喜欢滑雪），就把“临时计划”和“长期偏好”合在一个 value 里
+
+输出格式要求：
+- 你需要返回一个 JSON 对象。
+- 若发生了合并：
+  - "value": 合并后的记忆内容（只描述最终结论，保留所有「语义上独特」的信息，不重复）
+  - "merged_from": 被合并的相似记忆 ID 列表
+  - "should_merge": true
+- 若新记忆无法与现有记忆合并，返回：
+  - "should_merge": false
 
 示例：
 新记忆：
@@ -941,14 +1009,17 @@ xxxx-xxxx-xxxx-xxxx-01: 用户昨天读了一本书
     "should_merge": false
 }}
 
-
-如果新记忆与现有记忆大量重叠或互补，将它们合并为一个整合的记忆，并返回一个JSON列表：
-- "value": 合并后的记忆内容（保留所有独特信息）
+如果新记忆与现有记忆大量重叠或互补，将它们合并为一个整合的记忆，并返回一个JSON对象：
+- "value": 合并后的记忆内容
 - "merged_from": 被合并的相似记忆ID列表
 - "should_merge": true
 
 如果新记忆是独特的，应该保持独立，返回：
-- "should_merge": false
+{{
+    "should_merge": false
+}}
+
+最终只返回有效的 JSON 对象，不要任何额外内容（不要自然语言解释、不要多余字段）。
 
 新记忆：
 {new_memory}


### PR DESCRIPTION
## Summary

This PR closes the loop on the **“repeated memory” problem at the add stage**.

Previously, when adding new memories, the system could:
- create a new node that is semantically identical to an existing one,
- continue to return both the old and the new memory during recall,
- allow `merged_from` memories to keep influencing downstream reasoning.

Now, when a new memory is added, we:
1. search for similar existing memories,
2. let a dedicated “memory merge” prompt decide whether they should be merged,
3. archive any `merged_from` nodes so they no longer participate in recall.

Combined with stricter filtering on `status="activated"`, this ensures that:
- stable facts are stored once,
- merged-away memories are cleanly retired,
- recall results are less noisy and more consistent.

---

## What’s changed

### 1. Mem-reader: detect & merge repeated memories on add

- Inject `graph_db` into `MemReader` via `MemReaderFactory.from_config(..., graph_db=...)`, so readers can:
  - look up similar memories before writing,
  - perform semantic deduplication and conflict detection.
- Add dedicated **memory merge prompts** (`MEMORY_MERGE_PROMPT_EN` / `MEMORY_MERGE_PROMPT_ZH`) to:
  - split the new input into fact units (identity, stable preferences, relationships, one-off plans),
  - distinguish “repeated confirmation of the same fact” from genuinely new information,
  - decide whether to:
    - merge and return `{ value, merged_from, should_merge: true }`, or
    - skip merging with `{ should_merge: false }`.
- When merging, the new memory:
  - keeps a single, non-redundant `value`,
  - records the source IDs in `merged_from` for later archival.

### 2. Graph DB & recall: only `activated` memories, plus archival

- Extend the graph DB base and implementations (Neo4j / PolarDB) to support:
  - `update_node(id, fields, user_name=None)` with tenant context,
  - `get_node(..., **kwargs)` and `get_nodes(ids, ..., **kwargs)` for user-scoped queries,
  - `get_by_metadata(filters, status=None)` and `get_all_memory_items(scope, ..., status=None)` with optional `status` filtering.
- In TreeText retrieval:
  - all metadata-based lookups now filter with `status="activated"`,
  - all bulk node loads pass `user_name` to respect multi-tenant isolation.
- In scheduler & single-cube flows:
  - whenever a memory carries `merged_from` in `metadata.info`, the referenced IDs are updated to:
    ```python
    {"status": "archived"}
    ```
    with the proper `user_name` / `mem_cube_id`,
  - archived nodes are thus excluded from future recall.

### 3. Prompt & behavior: make “repeat vs. new” explicit

- Introduce explicit, language-level rules for memory merging:
  - do **not** repeat the same fact multiple times or just because it was mentioned at different timestamps,
  - avoid mixing long-term preferences with one-off plans in the same merged value,
  - only include time information when it changes the meaning (e.g. “used to dislike → now likes”).
- This makes the add-path behavior much more predictable:
  - stable user facts converge into a single clean memory,
  - purely one-off events are not mistakenly merged into long-term profiles,
  - downstream components see a de-duplicated, clearer memory graph.


Fix: #881 

Docs Issue/PR: (docs-issue-or-pr-link)

Reviewer: @(reviewer)

## Checklist:

- [ ] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
