### PR TITLE
fix: The "tags" lack the key words related to the memory content.

### DIFF
--- a/src/memos/mem_reader/read_multi_modal/base.py
+++ b/src/memos/mem_reader/read_multi_modal/base.py
@@ -15,6 +15,7 @@ from memos.memories.textual.item import (
     TextualMemoryItem,
     TreeNodeTextualMemoryMetadata,
 )
+from memos.memories.textual.tree_text_memory.retrieve.retrieve_utils import FastTokenizer
 from memos.utils import timed
 
 from .utils import detect_lang, get_text_splitter
@@ -90,6 +91,7 @@ class BaseMessageParser(ABC):
         """
         self.embedder = embedder
         self.llm = llm
+        self.tokenizer = FastTokenizer(use_jieba=True, use_stopwords=True)
 
     @abstractmethod
     def create_source(

--- a/src/memos/mem_reader/read_multi_modal/file_content_parser.py
+++ b/src/memos/mem_reader/read_multi_modal/file_content_parser.py
@@ -412,7 +412,6 @@ class FileContentParser(BaseMessageParser):
         # Extract file parameters (all are optional)
         file_data = file_info.get("file_data", "")
         file_id = file_info.get("file_id", "")
-        filename = file_info.get("filename", "")
         file_url_flag = False
         # Build content string based on available information
         content_parts = []
@@ -433,24 +432,11 @@ class FileContentParser(BaseMessageParser):
                 # Check if it looks like a URL
                 elif file_data.startswith(("http://", "https://", "file://")):
                     file_url_flag = True
-                    content_parts.append(f"[File URL: {file_data}]")
                 else:
                     # TODO: split into multiple memory items
                     content_parts.append(file_data)
             else:
                 content_parts.append(f"[File Data: {type(file_data).__name__}]")
-
-        # Priority 2: If file_id is provided, reference it
-        if file_id:
-            content_parts.append(f"[File ID: {file_id}]")
-
-        # Priority 3: If filename is provided, include it
-        if filename:
-            content_parts.append(f"[Filename: {filename}]")
-
-        # If no content can be extracted, create a placeholder
-        if not content_parts:
-            content_parts.append("[File: unknown]")
 
         # Combine content parts
         content = " ".join(content_parts)

--- a/src/memos/mem_reader/read_multi_modal/file_content_parser.py
+++ b/src/memos/mem_reader/read_multi_modal/file_content_parser.py
@@ -710,7 +710,7 @@ class FileContentParser(BaseMessageParser):
             chunk_idx: int, chunk_text: str, reason: str = "raw"
         ) -> TextualMemoryItem:
             """Create fallback memory item with raw chunk text."""
-            return _make_memory_item(
+            raw_chunk_mem = _make_memory_item(
                 value=chunk_text,
                 tags=[
                     "mode:fine",
@@ -721,6 +721,11 @@ class FileContentParser(BaseMessageParser):
                 chunk_idx=chunk_idx,
                 chunk_content=chunk_text,
             )
+            tags_list = self.tokenizer.tokenize_mixed(raw_chunk_mem.metadata.key)
+            tags_list = [tag for tag in tags_list if len(tag) > 1]
+            tags_list = sorted(tags_list, key=len, reverse=True)
+            raw_chunk_mem.metadata.tags.extend(tags_list[:5])
+            return raw_chunk_mem
 
         # Handle empty chunks case
         if not valid_chunks:


### PR DESCRIPTION
## Description

Please include a summary of the change, the problem it solves, the implementation approach, and relevant context. List any dependencies required for this change.

Related Issue (Required):  Fixes #998 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test
- [x] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

Test Script:
step1:  Insert a line of code at line 741, to simulate the situation where a large model fails to be invoked: ./src/memos/mem_reader/read_multi_modal/file_content_parser.py
<img width="451" height="110" alt="image" src="https://github.com/user-attachments/assets/4866361d-316f-4d49-9cd3-c50110bf3c7e" />

step2: Start the local service and run the following add request
curl --location --request POST 'http://127.0.0.1:8002/product/add' \
--header 'Content-Type: application/json' \
--data-raw '{
  "user_id": "testfile_0202",
  "mem_cube_id": "testfile_0202_cube",
  "async_mode" : "sync", 
  "messages": [
    {
      "file": {
        "file_data": "https://memos-file.oss-cn-shanghai.aliyuncs.com/algorithm/2026/01/13/0544a5cae26f4975b056b4738f34d7da.md",
        "file_id": "0544a5cae26f4975b056b4738f34d7da",
        "filename": "rick.txt"
      },
      "type": "file"
    }
  ],
  "info":{"source_type":"extreme_multimodal"}
}'

step3：Initiate a search request
curl --location --request POST 'http://127.0.0.1:8002/product/search' \
--header 'Content-Type: application/json' \
--data-raw '{
    "user_id": "testfile_0202", 
    "readable_cube_ids": ["testfile_0202_cube"],
    "query": "minddock",
    "top_k":20
}'

step4: Check whether the tags of each item in the recall results contain any words related to the memory topic.
<img width="720" height="366" alt="image" src="https://github.com/user-attachments/assets/6f97eb10-ccaf-4dad-9590-230828c790c0" />
As shown in the example, in the case where the large model fails to access, the tags still retain the relevant words for proposing.

step5: Don't forget to restore the code after the test is completed.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
