### PR TITLE
fix: parallel chunk large memory items and process those chunks, but …

### DIFF
--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -838,8 +838,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
         if isinstance(scene_data_info, list):
             # Parse each message in the list
             all_memory_items = []
-            # Use thread pool to parse each message in parallel
+            # Use thread pool to parse each message in parallel, but keep the original order
             with ContextThreadPoolExecutor(max_workers=30) as executor:
+                # submit tasks and keep the original order
                 futures = [
                     executor.submit(
                         self.multi_modal_parser.parse,
@@ -851,7 +852,8 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                     )
                     for msg in scene_data_info
                 ]
-                for future in concurrent.futures.as_completed(futures):
+                # collect results in original order
+                for future in futures:
                     try:
                         items = future.result()
                         all_memory_items.extend(items)


### PR DESCRIPTION
…keep the original order

## Description

For those large memory items that MemReader extracts, MemOS will first split them into small memory items. But in the current process, the segmentation and recombination of memory items are not order-preserving. This pull request is fixing that problem and make the process order-preserving.

Related Issue (Required):  Fixes #1010 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
