### PR TITLE
feat: Add VoyageAI embedder support

### DIFF
--- a/src/memos/api/config.py
+++ b/src/memos/api/config.py
@@ -431,15 +431,30 @@ class APIConfig:
         """Get embedder configuration."""
         embedder_backend = os.getenv("MOS_EMBEDDER_BACKEND", "ollama")
 
-        if embedder_backend == "universal_api":
+        # Map voyageai to universal_api
+        if embedder_backend in ["universal_api", "voyageai"]:
+            # Handle API Key - support VOYAGE_API_KEY for convenience
+            api_key = os.getenv("MOS_EMBEDDER_API_KEY")
+            if not api_key and embedder_backend == "voyageai":
+                api_key = os.getenv("VOYAGE_API_KEY")
+            if not api_key:
+                api_key = "sk-xxxx"
+
+            # Auto-configure VoyageAI base URL
+            base_url = os.getenv("MOS_EMBEDDER_API_BASE")
+            if not base_url and embedder_backend == "voyageai":
+                base_url = "https://api.voyageai.com/v1"
+            if not base_url:
+                base_url = "http://openai.com"
+
             return {
                 "backend": "universal_api",
                 "config": {
                     "provider": os.getenv("MOS_EMBEDDER_PROVIDER", "openai"),
-                    "api_key": os.getenv("MOS_EMBEDDER_API_KEY", "sk-xxxx"),
+                    "api_key": api_key,
                     "model_name_or_path": os.getenv("MOS_EMBEDDER_MODEL", "text-embedding-3-large"),
                     "headers_extra": json.loads(os.getenv("MOS_EMBEDDER_HEADERS_EXTRA", "{}")),
-                    "base_url": os.getenv("MOS_EMBEDDER_API_BASE", "http://openai.com"),
+                    "base_url": base_url,
                     "backup_client": os.getenv("MOS_EMBEDDER_BACKUP_CLIENT", "false").lower()
                     == "true",
                     "backup_base_url": os.getenv(


### PR DESCRIPTION
# feat: Add VoyageAI embedder support

## Overview

Adds support for VoyageAI embeddings via the `universal_api` backend, providing state-of-the-art semantic embeddings for production use.

## Motivation

VoyageAI offers superior embedding quality compared to standard models:
- 📊 **Better retrieval accuracy** on benchmark datasets
- 🚀 **Optimized for semantic search** use cases
- 💰 **Cost-effective** for production workloads
- 🌍 **Multilingual support** out of the box

## Changes

### 1. VoyageAI Backend Mapping

Maps `MOS_EMBEDDER_BACKEND=voyageai` to `universal_api` embedder with VoyageAI-specific defaults:

```python
# Map voyageai to universal_api
if embedder_backend in ["universal_api", "voyageai"]:
    provider = os.getenv("MOS_EMBEDDER_PROVIDER", "openai")

    # Handle API Key - supports VOYAGE_API_KEY for convenience
    api_key = os.getenv("MOS_EMBEDDER_API_KEY")
    if not api_key and embedder_backend == "voyageai":
        api_key = os.getenv("VOYAGE_API_KEY")

    # Auto-configure VoyageAI base URL
    base_url = os.getenv("MOS_EMBEDDER_API_BASE")
    if not base_url and embedder_backend == "voyageai":
        base_url = "https://api.voyageai.com/v1"
```

### 2. Environment Variables

New environment variable support:

- `VOYAGE_API_KEY` - VoyageAI API key (convenience alias)
- `MOS_EMBEDDER_BACKEND=voyageai` - Enables VoyageAI mode

Backward compatible with existing `MOS_EMBEDDER_API_KEY` and `MOS_EMBEDDER_API_BASE`.

### 3. Intelligent Defaults

When `backend=voyageai`:
- ✅ Base URL defaults to `https://api.voyageai.com/v1`
- ✅ Supports `VOYAGE_API_KEY` environment variable
- ✅ Falls back to generic `MOS_EMBEDDER_*` vars if not set

## Usage

### Basic Configuration

```bash
export MOS_EMBEDDER_BACKEND=voyageai
export VOYAGE_API_KEY=pa-your-api-key-here
export MOS_EMBEDDER_MODEL=voyage-3  # or voyage-3-lite, voyage-code-3
```

### Advanced Configuration

```bash
export MOS_EMBEDDER_BACKEND=voyageai
export MOS_EMBEDDER_API_KEY=pa-your-key  # Alternative to VOYAGE_API_KEY
export MOS_EMBEDDER_MODEL=voyage-3-large
export MOS_EMBEDDER_PROVIDER=openai  # OpenAI-compatible client
```

### Docker Compose Example

```yaml
environment:
  MOS_EMBEDDER_BACKEND: voyageai
  VOYAGE_API_KEY: ${VOYAGE_API_KEY}
  MOS_EMBEDDER_MODEL: voyage-3-lite
```

## Available Models

VoyageAI supports multiple models optimized for different use cases:

| Model | Dimensions | Use Case |
|-------|------------|----------|
| `voyage-3-large` | 1024 | Highest quality, general purpose |
| `voyage-3` | 1024 | Balanced quality/speed |
| `voyage-3-lite` | 512 | Fast, cost-effective |
| `voyage-code-3` | 1024 | Optimized for code search |
| `voyage-finance-2` | 1024 | Financial documents |
| `voyage-law-2` | 1024 | Legal documents |

See [VoyageAI docs](https://docs.voyageai.com/docs/embeddings) for latest models.

## Testing

Tested with:
- ✅ `voyage-3-lite` model (production)
- ✅ Environment variable fallbacks
- ✅ Backward compatibility with `universal_api` backend
- ✅ Unicode text handling (with PR #2 sanitization)

## Impact

- **Breaking Changes**: None - purely additive
- **Dependencies**: Uses existing `universal_api` embedder
- **Performance**: Depends on VoyageAI API latency (~50-200ms)
- **Cost**: Pay-per-use VoyageAI API pricing

## Migration

Existing users can continue using `ollama`, `sentence_transformer`, or `universal_api`. VoyageAI is opt-in via `MOS_EMBEDDER_BACKEND=voyageai`.

## Related

- Complements PR #2 (Unicode sanitization) for production-ready cloud embedders
- Uses existing `UniversalAPIEmbedder` infrastructure

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added inline documentation
- [x] Backward compatible (no breaking changes)
- [x] Environment variables documented
- [x] Example usage provided

## References

- [VoyageAI Documentation](https://docs.voyageai.com/)
- [VoyageAI Embeddings API](https://docs.voyageai.com/docs/embeddings)
- [VoyageAI Pricing](https://www.voyageai.com/pricing)
