### PR TITLE
fix: downgrade AuthConfig partial-init log from WARNING to INFO

### DIFF
--- a/src/memos/configs/mem_scheduler.py
+++ b/src/memos/configs/mem_scheduler.py
@@ -250,8 +250,12 @@ class AuthConfig(BaseConfig, DictConversionMixin):
                 "All configuration components are None. This may indicate missing environment variables or configuration files."
             )
         elif failed_components:
-            logger.warning(
-                f"Failed to initialize components: {', '.join(failed_components)}. Successfully initialized: {', '.join(initialized_components)}"
+            # Use info level: individual from_local_env() methods already log
+            # warnings for actual initialization failures. Components that are
+            # simply not configured (no env vars) are not errors.
+            logger.info(
+                f"Components not configured: {', '.join(failed_components)}. "
+                f"Successfully initialized: {', '.join(initialized_components)}"
             )
 
         return self


### PR DESCRIPTION
## Summary

`AuthConfig.validate_partial_initialization()` logs a `WARNING` on **every startup** when some auth components (openai, graph_db, rabbitmq) are not configured:

```
WARNING - Failed to initialize components: openai, graph_db. Successfully initialized: rabbitmq
```

This is noisy because partial configuration is intentional and common — most deployments only configure the components they need. The individual `from_local_env()` methods already log appropriate per-component messages (INFO for skipped, WARNING for actual failures).

## Fix

- Change the partial-init log from `WARNING` to `INFO` (with clearer wording: "not configured" instead of "Failed to initialize")
- Keep `WARNING` only for the edge case where **all** components are None (likely a real misconfiguration)

## Test plan

- [ ] Start scheduler with only RabbitMQ configured — no WARNING in logs, just INFO
- [ ] Start scheduler with no auth components — WARNING still logged
- [ ] Start scheduler with all components configured — no partial-init message at all