### PR TITLE
fix: preference return results

### DIFF
--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -443,7 +443,28 @@ class SingleCubeView(MemCubeView):
                 },
                 search_filter=search_req.filter,
             )
-            return self._postformat_memories(results, user_context.mem_cube_id)
+            formatted_results = self._postformat_memories(results, user_context.mem_cube_id)
+
+            # For each returned item, tackle with metadata.info project_id /
+            # operation / manager_user_id
+            for item in formatted_results:
+                if not isinstance(item, dict):
+                    continue
+                metadata = item.get("metadata")
+                if not isinstance(metadata, dict):
+                    continue
+                info = metadata.get("info")
+                if not isinstance(info, dict):
+                    continue
+
+                for key in ("project_id", "operation", "manager_user_id"):
+                    if key not in info:
+                        continue
+                    value = info.pop(key)
+                    if key not in metadata:
+                        metadata[key] = value
+
+            return formatted_results
         except Exception as e:
             self.logger.error("Error in _search_pref: %s; traceback: %s", e, traceback.format_exc())
             return []


### PR DESCRIPTION
## Description

In SingleCubeView._search_pref (src/memos/multi_mem_cube/single_cube.py), post-process the formatted preference results.
For each item:
Look at item["metadata"]["info"].
For each of project_id, operation, manager_user_id:
If present in info, pop it from info.
If missing on metadata top-level, copy it to metadata[key].

Related Issue (Required):  Fixes #1089 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test
- [x] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

```python

data = {
  "user_id": user_id,
  "writable_cube_ids": [cube_id],
  "messages": [
        {
          "role": "user",
          "content": "我偏好住贵的酒店 不要再给我推荐全季了",
          "message_id": "u-1"
        },
{
          "role": "assistant",
          "content": "好的 我会记住你的偏好，下次 我就会给你推荐贵的酒店",
          "message_id": "u-1"
        }
      ],
  "info": {"source_type": "batch_import"},
  "include_preference": True,
  "async_mode": "sync",
  "mode": "fine",
  "manager_user_id": "mock_manager_id_xcyyyyyy",
  "project_id": "mock_project_id_xcyyyyyy"
}
call(ADD_URL, data, "conversation")

# Search for the weather query we just added
search_data = {
    "user_id": user_id,
    "mem_cube_id": cube_id,
    "query": "我今天看什么了",
    "top_k": 5,
    "include_preference": True
}
call(SEARCH_URL, search_data, "search_weather_query")

data = {
  "user_id": user_id,
  "mem_cube_id": cube_id,
  "include_preference": True
}
call(GET_URL, data, "get")
```

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
