### PR TITLE
Add plugin.yaml for agent discovery & registry

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -4,7 +4,7 @@
 
 name: memos
 display_name: MemOS
-version: "0.1.0"
+manifest_version: "1.0"
 description: >
   AI memory operating system for LLM and Agent systems. Enables persistent
   memory, cross-task skill reuse, and memory evolution — giving agents
@@ -45,7 +45,7 @@ runtime:
   language: python
   min_python: "3.9"
 
-discovery:
+protocols:
   protocol: api
-  transport:
+transport:
     - http

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,51 @@
+# plugin.yaml — MemOS Agent Plugin Manifest
+# This file makes MemOS discoverable as an agent plugin.
+# Learn more: https://list.agenium.net/plugins
+
+name: memos
+display_name: MemOS
+version: "0.1.0"
+description: >
+  AI memory operating system for LLM and Agent systems. Enables persistent
+  memory, cross-task skill reuse, and memory evolution — giving agents
+  long-term memory that improves over time.
+
+author:
+  name: MemTensor
+  url: https://github.com/MemTensor
+
+repository: https://github.com/MemTensor/MemOS
+license: Apache-2.0
+
+categories:
+  - agent-infrastructure
+  - memory-systems
+  - developer-tools
+
+tags:
+  - memory
+  - persistent-memory
+  - skill-reuse
+  - llm-memory
+  - agent-memory
+  - knowledge-graph
+  - rag
+
+capabilities:
+  - persistent-memory
+  - skill-memory
+  - cross-task-reuse
+  - memory-evolution
+  - knowledge-management
+
+install:
+  pip: memos-ai
+
+runtime:
+  language: python
+  min_python: "3.9"
+
+discovery:
+  protocol: api
+  transport:
+    - http


### PR DESCRIPTION
## What

Adds a `plugin.yaml` manifest file that describes MemOS as a discoverable agent plugin.

## Why

The AI agent ecosystem needs a standard way for infrastructure tools to declare their capabilities in a machine-readable format. A `plugin.yaml` at the repo root lets registries and other agents automatically discover and understand what MemOS offers.

## What it includes

- **Metadata**: name, description, author, license
- **Capabilities**: persistent memory, skill memory, cross-task reuse, memory evolution
- **Install info**: `pip install memos-ai`
- **Discovery**: protocol and transport info
- **Categories & tags**: for search and filtering

## Impact

- Zero code changes — metadata file only
- No dependencies added
- Makes MemOS discoverable by agent orchestration tools
- Standard format other agent infrastructure projects are also adopting

---

*Part of an effort to standardize agent plugin discovery. [Learn more](https://list.agenium.net/plugins)*