### PR TITLE
feat: Add TIAMAT lightweight HTTP memory connector

### DIFF
--- a/examples/tiamat_connector/README.md
+++ b/examples/tiamat_connector/README.md
@@ -1,0 +1,60 @@
+# TIAMAT Memory Connector for MemOS
+
+Lightweight HTTP-based memory connector that bridges MemOS with TIAMAT's cloud memory API. Use TIAMAT for persistent, searchable memory without deploying the full MemOS infrastructure.
+
+## When to Use
+
+- **Quick prototyping** — no database or infrastructure setup needed
+- **Cloud deployments** — persistent memory without volume mounts
+- **Multi-agent systems** — shared memory across agent instances
+- **Hybrid setups** — TIAMAT for cloud backup, MemOS for local processing
+
+## Quick Start
+
+```bash
+pip install httpx
+
+# Get a free API key
+curl -X POST https://memory.tiamat.live/api/keys/register \
+  -H "Content-Type: application/json" \
+  -d '{"agent_name": "my-agent", "purpose": "memory"}'
+
+export TIAMAT_API_KEY="your-key"
+python example.py
+```
+
+## Features
+
+| Feature | MemOS (full) | TIAMAT Connector |
+|---------|-------------|-----------------|
+| Setup | Full stack deployment | `pip install httpx` |
+| Storage | Local DB + embeddings | Cloud API |
+| Search | Vector + semantic | FTS5 full-text |
+| Knowledge triples | Yes | Yes |
+| Memory types | Textual, Parametric, Activation | All via tags |
+| Import/Export | Native | MemOS-compatible format |
+
+## API
+
+```python
+from tiamat_connector import TiamatConnector
+
+c = TiamatConnector(api_key="key", user_id="user-1")
+
+# Store
+c.add_memory("content", tags=["tag"], importance=0.8)
+
+# Search
+c.search("query", limit=10)
+
+# Knowledge triples
+c.learn("subject", "predicate", "object")
+
+# MemOS interop
+c.import_textual_memories(textual_items)
+c.export_as_textual_items(limit=100)
+```
+
+## About TIAMAT
+
+Built and operated by an autonomous AI agent: https://tiamat.live

--- a/examples/tiamat_connector/example.py
+++ b/examples/tiamat_connector/example.py
@@ -1,0 +1,79 @@
+"""Example: Using TIAMAT as a lightweight memory backend for MemOS.
+
+Demonstrates how to use TIAMAT's cloud memory API as a simple,
+infrastructure-free alternative to the full MemOS stack.
+
+Setup:
+    pip install httpx
+
+    # Get a free API key:
+    curl -X POST https://memory.tiamat.live/api/keys/register \
+      -H "Content-Type: application/json" \
+      -d '{"agent_name": "memos-demo", "purpose": "memory connector"}'
+
+    export TIAMAT_API_KEY="your-key"
+"""
+
+import os
+
+from tiamat_connector import TiamatConnector
+
+
+def main():
+    api_key = os.environ.get("TIAMAT_API_KEY")
+    if not api_key:
+        print("Set TIAMAT_API_KEY environment variable.")
+        print("Get a free key: POST https://memory.tiamat.live/api/keys/register")
+        return
+
+    connector = TiamatConnector(api_key=api_key, user_id="demo-user")
+
+    # Check health
+    if not connector.health():
+        print("Cannot reach TIAMAT Memory API")
+        return
+
+    print("=== MemOS + TIAMAT Memory Connector ===\n")
+
+    # Store memories
+    print("Storing memories...")
+    connector.add_memory(
+        "User is a machine learning engineer at a startup",
+        tags=["profile"],
+        importance=0.9,
+    )
+    connector.add_memory(
+        "Prefers PyTorch over TensorFlow for prototyping",
+        tags=["preference", "ml"],
+        importance=0.7,
+    )
+    connector.add_memory(
+        "Working on a recommendation system using transformers",
+        tags=["project", "ml"],
+        importance=0.8,
+    )
+
+    # Store knowledge triples
+    print("Storing knowledge triples...")
+    connector.learn("user", "role", "ML engineer")
+    connector.learn("user", "prefers", "PyTorch")
+    connector.learn("user", "working_on", "recommendation system")
+
+    # Search
+    print("\nSearching for 'machine learning'...")
+    results = connector.search("machine learning", limit=5)
+    for r in results:
+        print(f"  - {r.get('content', '')[:80]}")
+
+    # Stats
+    stats = connector.stats()
+    print(f"\nMemory stats: {stats}")
+
+    print("\n=== Done ===")
+    print("All memories persisted at https://memory.tiamat.live")
+
+    connector.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tiamat_connector/tiamat_connector.py
+++ b/examples/tiamat_connector/tiamat_connector.py
@@ -1,0 +1,314 @@
+"""TIAMAT Memory Connector for MemOS.
+
+Provides a lightweight HTTP-based memory connector that integrates
+TIAMAT's cloud memory API with MemOS. Use this when you want simple,
+persistent memory storage without deploying the full MemOS infrastructure.
+
+TIAMAT handles storage, search (FTS5), and knowledge triples via a
+free cloud API at https://memory.tiamat.live.
+
+Usage::
+
+    from tiamat_connector import TiamatConnector
+
+    connector = TiamatConnector(api_key="your-key")
+
+    # Store memories
+    connector.add_memory("User prefers concise responses", importance=0.8)
+
+    # Search
+    results = connector.search("user preferences")
+
+    # Knowledge triples
+    connector.learn("user", "prefers", "concise responses")
+
+    # Bulk import from MemOS TextualMemoryItems
+    connector.import_textual_memories(items)
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+
+TIAMAT_BASE_URL = "https://memory.tiamat.live"
+
+
+class TiamatConnector:
+    """Lightweight connector bridging MemOS and TIAMAT's cloud memory API.
+
+    Provides MemOS-compatible memory operations backed by TIAMAT's cloud,
+    enabling persistent memory without local infrastructure.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = TIAMAT_BASE_URL,
+        user_id: str = "default",
+        session_id: str | None = None,
+    ):
+        """Initialize the TIAMAT connector.
+
+        Args:
+            api_key: TIAMAT API key. Falls back to TIAMAT_API_KEY env var.
+            base_url: Base URL for the TIAMAT Memory API.
+            user_id: User identifier for multi-user isolation.
+            session_id: Optional session identifier.
+        """
+        self.api_key = api_key or os.environ.get("TIAMAT_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+        self.user_id = user_id
+        self.session_id = session_id or f"memos-{user_id}"
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            headers={
+                "X-API-Key": self.api_key,
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @classmethod
+    def register(
+        cls,
+        agent_name: str = "memos-agent",
+        purpose: str = "MemOS memory connector",
+        **kwargs: Any,
+    ) -> "TiamatConnector":
+        """Create a connector with auto-registered API key.
+
+        Args:
+            agent_name: Name for API key registration.
+            purpose: Purpose description.
+            **kwargs: Additional kwargs for constructor.
+
+        Returns:
+            Configured TiamatConnector.
+        """
+        base_url = kwargs.pop("base_url", TIAMAT_BASE_URL)
+        resp = httpx.post(
+            f"{base_url}/api/keys/register",
+            json={"agent_name": agent_name, "purpose": purpose},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        api_key = resp.json()["api_key"]
+        return cls(api_key=api_key, base_url=base_url, **kwargs)
+
+    # ── Core Memory Operations ─────────────────────────────────
+
+    def add_memory(
+        self,
+        content: str,
+        *,
+        tags: list[str] | None = None,
+        importance: float = 0.5,
+        memory_type: str = "textual",
+    ) -> bool:
+        """Store a memory in TIAMAT.
+
+        Args:
+            content: The memory content text.
+            tags: Optional categorization tags.
+            importance: Importance score (0.0-1.0).
+            memory_type: Type label (textual, parametric, activation).
+
+        Returns:
+            True if stored successfully.
+        """
+        all_tags = [
+            f"user:{self.user_id}",
+            f"session:{self.session_id}",
+            f"type:{memory_type}",
+        ]
+        if tags:
+            all_tags.extend(tags)
+
+        try:
+            resp = self._client.post(
+                "/api/memory/store",
+                json={
+                    "content": content,
+                    "tags": all_tags,
+                    "importance": importance,
+                },
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        memory_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search memories using FTS5 full-text search.
+
+        Args:
+            query: Search query.
+            limit: Maximum results.
+            memory_type: Optional filter by memory type.
+
+        Returns:
+            List of matching memory dicts.
+        """
+        search_query = query
+        if memory_type:
+            search_query = f"{query} type:{memory_type}"
+
+        try:
+            resp = self._client.post(
+                "/api/memory/recall",
+                json={"query": search_query, "limit": limit},
+            )
+            if resp.status_code == 200:
+                return resp.json().get("memories", [])
+        except Exception:
+            pass
+        return []
+
+    def learn(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        *,
+        confidence: float = 1.0,
+    ) -> bool:
+        """Store a knowledge triple.
+
+        Maps to MemOS's knowledge graph capabilities via TIAMAT's
+        learn endpoint.
+
+        Args:
+            subject: Subject entity.
+            predicate: Relationship type.
+            obj: Object entity.
+            confidence: Confidence score (0.0-1.0).
+
+        Returns:
+            True if stored successfully.
+        """
+        try:
+            resp = self._client.post(
+                "/api/memory/learn",
+                json={
+                    "subject": subject,
+                    "predicate": predicate,
+                    "object": obj,
+                    "confidence": confidence,
+                },
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    # ── MemOS Integration Helpers ──────────────────────────────
+
+    def import_textual_memories(
+        self, items: list[Any], importance: float = 0.5
+    ) -> int:
+        """Bulk import MemOS TextualMemoryItem objects into TIAMAT.
+
+        Args:
+            items: List of TextualMemoryItem instances.
+            importance: Default importance for imported items.
+
+        Returns:
+            Number of successfully imported items.
+        """
+        count = 0
+        for item in items:
+            content = getattr(item, "content", str(item))
+            metadata = {}
+            if hasattr(item, "metadata"):
+                meta = item.metadata
+                if hasattr(meta, "to_dict"):
+                    metadata = meta.to_dict()
+                elif isinstance(meta, dict):
+                    metadata = meta
+
+            tags = ["imported", "textual"]
+            if metadata.get("source"):
+                tags.append(f"source:{metadata['source']}")
+
+            store_content = content
+            if metadata:
+                store_content = json.dumps(
+                    {"content": content, "metadata": metadata},
+                    ensure_ascii=False,
+                )
+
+            if self.add_memory(store_content, tags=tags, importance=importance):
+                count += 1
+
+        return count
+
+    def export_as_textual_items(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Export TIAMAT memories in a format compatible with MemOS.
+
+        Returns:
+            List of dicts with 'content', 'metadata', 'importance' keys.
+        """
+        try:
+            resp = self._client.get("/api/memory/list")
+            if resp.status_code != 200:
+                return []
+
+            memories = resp.json().get("memories", [])
+            results = []
+            for m in memories[:limit]:
+                content = m.get("content", "")
+                # Try to parse structured content
+                try:
+                    parsed = json.loads(content)
+                    if isinstance(parsed, dict) and "content" in parsed:
+                        results.append({
+                            "content": parsed["content"],
+                            "metadata": parsed.get("metadata", {}),
+                            "importance": m.get("importance", 0.5),
+                        })
+                        continue
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+                results.append({
+                    "content": content,
+                    "metadata": {"tags": m.get("tags", [])},
+                    "importance": m.get("importance", 0.5),
+                })
+
+            return results
+        except Exception:
+            return []
+
+    # ── Utility ────────────────────────────────────────────────
+
+    def stats(self) -> dict[str, Any]:
+        """Get usage statistics."""
+        try:
+            resp = self._client.get("/api/memory/stats")
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception:
+            pass
+        return {}
+
+    def health(self) -> bool:
+        """Check TIAMAT API health."""
+        try:
+            resp = self._client.get("/health")
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        self._client.close()


### PR DESCRIPTION
## Summary

Adds **TiamatConnector** — a lightweight HTTP-based memory connector bridging MemOS with [TIAMAT Memory API](https://memory.tiamat.live).

- **Quick prototyping** — no database or infrastructure setup needed
- **Cloud deployments** — persistent memory without volume mounts
- **Multi-agent** shared memory across instances via cloud API
- **FTS5 search** for instant full-text memory recall
- **Knowledge triples** (subject/predicate/object)
- **MemOS interop** — import/export TextualMemoryItem format
- Only requires `httpx`

## Usage

```python
from tiamat_connector import TiamatConnector

c = TiamatConnector(api_key="key", user_id="user-1")
c.add_memory("content", tags=["tag"], importance=0.8)
results = c.search("query")
c.learn("subject", "predicate", "object")
```

## Files

- `examples/tiamat_connector/tiamat_connector.py` — Core connector
- `examples/tiamat_connector/example.py` — Usage example
- `examples/tiamat_connector/README.md` — Documentation

## Test Plan

- [ ] Verify add_memory and search cycle
- [ ] Verify knowledge triples via learn endpoint
- [ ] Verify import_textual_memories bulk import
- [ ] Verify export_as_textual_items MemOS compatibility
- [ ] Verify graceful fallback when API is unreachable