### PR TITLE
fix(feedback): handle empty added_ids in _single_add_operation

### DIFF
--- a/src/memos/mem_feedback/feedback.py
+++ b/src/memos/mem_feedback/feedback.py
@@ -250,6 +250,9 @@ class MemFeedback(BaseMemFeedback):
         )
 
         logger.info(f"[Memory Feedback ADD] memory id: {added_ids!s}")
+        if not added_ids:
+            logger.error("[Memory Feedback ADD] No memory was added, added_ids is empty")
+            return {"id": None, "text": to_add_memory.memory, "source_doc_id": None}
         return {
             "id": added_ids[0],
             "text": to_add_memory.memory,

--- a/tests/mem_feedback/test_feedback_empty_added_ids.py
+++ b/tests/mem_feedback/test_feedback_empty_added_ids.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for issue #1122 (Part 2):
+feedback.py _single_add_operation must handle empty added_ids gracefully
+instead of raising IndexError.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestFeedbackEmptyAddedIds:
+    """Regression: _single_add_operation should not crash when added_ids is empty."""
+
+    def test_single_add_returns_none_id_when_added_ids_empty(self):
+        """
+        When memory_manager.add() returns an empty list (e.g. due to a
+        silent graph DB failure), _single_add_operation should return
+        {"id": None, ...} instead of raising IndexError.
+        """
+        from memos.mem_feedback.feedback import MemFeedback
+
+        core = object.__new__(MemFeedback)
+        core.memory_manager = MagicMock()
+        core.memory_manager.add.return_value = []  # simulate silent failure
+
+        # Build a minimal mock memory item
+        mock_memory = MagicMock()
+        mock_memory.memory = "test memory"
+        mock_memory.metadata.key = "test_key"
+        mock_memory.metadata.tags = []
+        mock_memory.metadata.embedding = [0.1, 0.2]
+        mock_memory.metadata.user_id = "user1"
+        mock_memory.metadata.background = ""
+        mock_memory.metadata.sources = []
+        mock_memory.metadata.created_at = "2025-01-01T00:00:00"
+        mock_memory.metadata.updated_at = "2025-01-01T00:00:00"
+        mock_memory.metadata.file_ids = None
+        mock_memory.model_copy.return_value = mock_memory
+
+        result = core._single_add_operation(
+            old_memory_item=None,
+            new_memory_item=mock_memory,
+            user_id="user1",
+            user_name="test-user",
+        )
+
+        assert result["id"] is None
+        assert result["text"] == "test memory"
+
+    def test_single_add_returns_id_when_added_ids_present(self):
+        """Normal case: added_ids has one element, should return it."""
+        from memos.mem_feedback.feedback import MemFeedback
+
+        core = object.__new__(MemFeedback)
+        core.memory_manager = MagicMock()
+        core.memory_manager.add.return_value = ["mem-id-123"]
+
+        mock_memory = MagicMock()
+        mock_memory.memory = "test memory"
+        mock_memory.metadata.key = "test_key"
+        mock_memory.metadata.tags = []
+        mock_memory.metadata.embedding = [0.1, 0.2]
+        mock_memory.metadata.user_id = "user1"
+        mock_memory.metadata.background = ""
+        mock_memory.metadata.sources = []
+        mock_memory.metadata.created_at = "2025-01-01T00:00:00"
+        mock_memory.metadata.updated_at = "2025-01-01T00:00:00"
+        mock_memory.metadata.file_ids = ["doc-1"]
+        mock_memory.model_copy.return_value = mock_memory
+
+        result = core._single_add_operation(
+            old_memory_item=None,
+            new_memory_item=mock_memory,
+            user_id="user1",
+            user_name="test-user",
+        )
+
+        assert result["id"] == "mem-id-123"
+        assert result["text"] == "test memory"
+        assert result["source_doc_id"] == "doc-1"


### PR DESCRIPTION
## Summary

- **Bug**: `IndexError` in `_single_add_operation` when `memory_manager.add()` returns empty list
- **Root cause**: `feedback.py:254` accesses `added_ids[0]` without checking if the list is empty
- **Fix**: Add empty-list guard that returns `{"id": None, ...}` gracefully

Fixes #1122 (Part 2 of 2 — the IndexError on empty added_ids)

## Problem

When the graph DB silently fails (e.g. due to the CypherTypeError in Part 1), `_add_memories_parallel()` catches the exception, logs it, but returns an empty list. Then `_single_add_operation` crashes:

```python
added_ids = self._retry_db_operation(
    lambda: self.memory_manager.add([to_add_memory], user_name=user_name, use_batch=False)
)
return {
    "id": added_ids[0],  # IndexError: list index out of range
    ...
}
```

**Before fix:**
```
added_ids = []
added_ids[0]  ->  IndexError: list index out of range
```

## Changes

- `src/memos/mem_feedback/feedback.py` — Add empty-list guard before accessing `added_ids[0]`
- `tests/mem_feedback/test_feedback_empty_added_ids.py` — Regression tests

**After fix:**
```
added_ids = []
-> returns {"id": None, "text": "...", "source_doc_id": None}  (no crash)
```

## Test plan

- [x] New test: `test_single_add_returns_none_id_when_added_ids_empty` — verifies graceful handling
- [x] New test: `test_single_add_returns_id_when_added_ids_present` — verifies normal path

## Effect on User Experience

**Before:** `/product/feedback` endpoint crashes with 500 Internal Server Error when the underlying graph DB add fails silently.
**After:** The endpoint returns a response with `"id": null`, allowing the caller to detect and handle the failure.