### PR TITLE
fix: Stop throwing error when embedding is missing in add_nodes_batch…

### DIFF
--- a/src/memos/graph_dbs/neo4j_community.py
+++ b/src/memos/graph_dbs/neo4j_community.py
@@ -140,8 +140,6 @@ class Neo4jCommunityGraphDB(Neo4jGraphDB):
                 metadata.setdefault("delete_record_id", "")
 
                 embedding = metadata.pop("embedding", None)
-                if embedding is None:
-                    raise ValueError(f"Missing 'embedding' in metadata for node {node_id}")
 
                 vector_sync_status = "success"
                 vec_items.append(


### PR DESCRIPTION
## Description

fix: Stop throwing error when embedding is missing in add_nodes_batch function for Neo4j Community graphdb backend

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Not tested temporarily

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided