### PR TITLE
fix(graph_dbs): sanitize nested metadata before Neo4j writes

### DIFF
--- a/src/memos/graph_dbs/neo4j.py
+++ b/src/memos/graph_dbs/neo4j.py
@@ -72,6 +72,27 @@ def _flatten_info_fields(metadata: dict[str, Any]) -> dict[str, Any]:
     return metadata
 
 
+def _sanitize_neo4j_value(value: Any) -> Any:
+    """Convert values unsupported by Neo4j properties into safe serializations."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, list):
+        if all(item is None or isinstance(item, (str, int, float, bool)) for item in value):
+            return value
+        return [json.dumps(item, ensure_ascii=False) if isinstance(item, (dict, list)) else str(item) for item in value]
+
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+    return str(value)
+
+
+def _sanitize_neo4j_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Ensure all metadata values are valid Neo4j property types."""
+    return {key: _sanitize_neo4j_value(value) for key, value in metadata.items()}
+
+
 class Neo4jGraphDB(BaseGraphDB):
     """Neo4j-based implementation of a graph memory store."""
 
@@ -208,6 +229,9 @@ class Neo4jGraphDB(BaseGraphDB):
 
         # Flatten info fields to top level (for Neo4j flat structure)
         metadata = _flatten_info_fields(metadata)
+
+        # Ensure Neo4j property compatibility (no nested map/list-of-map values)
+        metadata = _sanitize_neo4j_metadata(metadata)
 
         # Initialize delete_time and delete_record_id fields
         metadata.setdefault("delete_time", "")

--- a/src/memos/graph_dbs/neo4j_community.py
+++ b/src/memos/graph_dbs/neo4j_community.py
@@ -5,7 +5,12 @@ from datetime import datetime
 from typing import Any
 
 from memos.configs.graph_db import Neo4jGraphDBConfig
-from memos.graph_dbs.neo4j import Neo4jGraphDB, _flatten_info_fields, _prepare_node_metadata
+from memos.graph_dbs.neo4j import (
+    Neo4jGraphDB,
+    _flatten_info_fields,
+    _prepare_node_metadata,
+    _sanitize_neo4j_metadata,
+)
 from memos.log import get_logger
 from memos.vec_dbs.factory import VecDBFactory
 from memos.vec_dbs.item import VecDBItem
@@ -55,6 +60,8 @@ class Neo4jCommunityGraphDB(Neo4jGraphDB):
 
         # Safely process metadata
         metadata = _prepare_node_metadata(metadata)
+        metadata = _flatten_info_fields(metadata)
+        metadata = _sanitize_neo4j_metadata(metadata)
 
         # Initialize delete_time and delete_record_id fields
         metadata.setdefault("delete_time", "")
@@ -134,6 +141,7 @@ class Neo4jCommunityGraphDB(Neo4jGraphDB):
 
                 metadata = _prepare_node_metadata(metadata)
                 metadata = _flatten_info_fields(metadata)
+                metadata = _sanitize_neo4j_metadata(metadata)
 
                 # Initialize delete_time and delete_record_id fields
                 metadata.setdefault("delete_time", "")

--- a/tests/graph_dbs/graph_dbs.py
+++ b/tests/graph_dbs/graph_dbs.py
@@ -105,3 +105,26 @@ def test_get_memory_count(graph_db):
     session_mock.run.return_value.single.return_value = {"count": 42}
     count = graph_db.get_memory_count("WorkingMemory")
     assert count == 42
+
+
+def test_add_node_sanitizes_nested_metadata(graph_db):
+    session_mock = graph_db.driver.session.return_value.__enter__.return_value
+    node_id = str(uuid.uuid4())
+    memory = "skill memory"
+    metadata = {
+        "memory_type": "SkillMemory",
+        "embedding": [0.1, 0.2, 0.3],
+        "tags": ["skill"],
+        "scripts": {"run.py": "print(1)"},
+        "others": {"README.md": "# demo"},
+        "info": {"nested": {"x": 1}, "arr_obj": [{"a": 1}]},
+    }
+
+    graph_db.add_node(node_id, memory, metadata)
+
+    _, kwargs = session_mock.run.call_args
+    sanitized = kwargs["metadata"]
+    assert isinstance(sanitized["scripts"], str)
+    assert isinstance(sanitized["others"], str)
+    assert isinstance(sanitized["nested"], str)
+    assert sanitized["arr_obj"] == ['{"a": 1}']


### PR DESCRIPTION
## Summary
- sanitize nested metadata values before writing Neo4j node properties
- apply the same sanitization in both Neo4j enterprise and community graph DB implementations
- add a regression test covering skill-memory style nested metadata

## Problem
Neo4j node properties only accept primitive values or arrays of primitives. Some MemOS flows (especially SkillMemory and feedback-related flows) can produce nested metadata like:
- `scripts: dict`
- `others: dict`
- nested objects under `info`
- arrays containing dict items

Those values can reach `SET n += $metadata` and trigger errors like:
- `Property values can only be of primitive types or arrays thereof`
- `CypherTypeError: Map{} encountered`

## Fix
This PR adds a small sanitization layer before Neo4j writes:
- keep primitive values as-is
- keep arrays of primitives as-is
- serialize dict values to JSON strings
- serialize nested list items that are dict/list values

This keeps metadata readable while making it safe for Neo4j property storage.

## Validation
- reproduced the issue locally with SkillMemory-style metadata
- verified the sanitized metadata no longer contains Neo4j-invalid map values
- verified a real `/product/add` flow successfully created `SkillMemory` without the previous Neo4j `Map{}` error
