### PR TITLE
fix: handle string-type message in suggestion handler

### DIFF
--- a/src/memos/api/handlers/suggestion_handler.py
+++ b/src/memos/api/handlers/suggestion_handler.py
@@ -17,7 +17,7 @@ from memos.templates.mos_prompts import (
     SUGGESTION_QUERY_PROMPT_EN,
     SUGGESTION_QUERY_PROMPT_ZH,
 )
-from memos.types import MessageList
+from memos.types import MessageList, MessagesType
 
 
 logger = get_logger(__name__)
@@ -25,20 +25,29 @@ logger = get_logger(__name__)
 
 def _get_further_suggestion(
     llm: Any,
-    message: MessageList,
+    message: MessageList | str,
 ) -> list[str]:
     """
     Get further suggestion based on recent dialogue.
 
     Args:
         llm: LLM instance for generating suggestions
-        message: Recent chat messages
+        message: Recent chat messages (can be a list of message dicts or a plain string)
 
     Returns:
         List of suggestion queries
     """
     try:
-        dialogue_info = "\n".join([f"{msg['role']}: {msg['content']}" for msg in message[-2:]])
+        if isinstance(message, str):
+            dialogue_info = message
+        else:
+            dialogue_info = "\n".join(
+                [
+                    f"{msg['role']}: {msg['content']}"
+                    for msg in message[-2:]
+                    if isinstance(msg, dict)
+                ]
+            )
         further_suggestion_prompt = FURTHER_SUGGESTION_PROMPT.format(dialogue=dialogue_info)
         message_list = [{"role": "system", "content": further_suggestion_prompt}]
         response = llm.generate(message_list)
@@ -53,7 +62,7 @@ def _get_further_suggestion(
 def handle_get_suggestion_queries(
     user_id: str,
     language: str,
-    message: MessageList | None,
+    message: MessagesType | None,
     llm: Any,
     naive_mem_cube: Any,
 ) -> SuggestionResponse:


### PR DESCRIPTION
## Description

- Handle `str` input by using it directly as dialogue context
- Guard against `RawMessageList` elements missing `role`/`content` keys
- Fallback `str()` conversion for non-string `content` fields
- Align type annotations with `MessagesType`

Related Issue (Required):  Fixes #1215 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

- `/suggestions` with string `message` returns normally
- `/suggestions` with `list[dict]` message works as before
- `/suggestions` with `message=None` falls back to recent memories


## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
