### PR TITLE
Fix Windows sqlite path check and Gemini embedding defaults

### DIFF
--- a/apps/memos-local-openclaw/README.md
+++ b/apps/memos-local-openclaw/README.md
@@ -178,7 +178,7 @@ Add the plugin config to `~/.openclaw/openclaw.json`:
 | Provider | `provider` value | Example `model` | Notes |
 |---|---|---|---|
 | OpenAI / compatible | `openai_compatible` | `bge-m3`, `text-embedding-3-small` | Any OpenAI-compatible API |
-| Gemini | `gemini` | `text-embedding-004` | Requires `apiKey` |
+| Gemini | `gemini` | `gemini-embedding-001` | Requires `apiKey` |
 | Cohere | `cohere` | `embed-english-v3.0` | Separates document/query embedding |
 | Voyage | `voyage` | `voyage-2` | |
 | Mistral | `mistral` | `mistral-embed` | |

--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -9,6 +9,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { buildContext } from "./src/config";
 import { SqliteStore } from "./src/storage/sqlite";
 import { Embedder } from "./src/embedding";
@@ -76,13 +77,15 @@ const memosLocalPlugin = {
 
   register(api: OpenClawPluginApi) {
     // ─── Ensure better-sqlite3 native module is available ───
-    const pluginDir = path.dirname(new URL(import.meta.url).pathname);
+    const pluginDir = path.dirname(fileURLToPath(import.meta.url));
     let sqliteReady = false;
 
     function trySqliteLoad(): boolean {
       try {
         const resolved = require.resolve("better-sqlite3", { paths: [pluginDir] });
-        if (!resolved.startsWith(pluginDir)) {
+        const normalizedResolved = path.normalize(resolved).toLowerCase();
+        const normalizedPluginDir = path.normalize(pluginDir).toLowerCase();
+        if (!normalizedResolved.startsWith(normalizedPluginDir)) {
           api.logger.warn(`memos-local: better-sqlite3 resolved outside plugin dir: ${resolved}`);
           return false;
         }

--- a/apps/memos-local-openclaw/src/embedding/providers/gemini.ts
+++ b/apps/memos-local-openclaw/src/embedding/providers/gemini.ts
@@ -1,14 +1,25 @@
 import type { EmbeddingConfig, Logger } from "../../types";
 
+function normalizeGeminiEmbeddingEndpoint(endpoint: string, model: string): string {
+  let out = endpoint.trim();
+  if (!out) {
+    return `https://generativelanguage.googleapis.com/v1beta/models/${model}:batchEmbedContents`;
+  }
+  out = out.replace('/v1/models/', '/v1beta/models/');
+  out = out.replace(/:embedContent\b/, ':batchEmbedContents');
+  return out;
+}
+
 export async function embedGemini(
   texts: string[],
   cfg: EmbeddingConfig,
   log: Logger,
 ): Promise<number[][]> {
-  const model = cfg.model ?? "text-embedding-004";
-  const endpoint =
-    cfg.endpoint ??
-    `https://generativelanguage.googleapis.com/v1beta/models/${model}:batchEmbedContents`;
+  const model = cfg.model ?? "gemini-embedding-001";
+  const endpoint = normalizeGeminiEmbeddingEndpoint(
+    cfg.endpoint ?? `https://generativelanguage.googleapis.com/v1beta/models/${model}:batchEmbedContents`,
+    model,
+  );
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

This PR fixes two issues we hit while testing `apps/memos-local-openclaw` on Windows with Gemini:

1. **Windows path handling for `better-sqlite3`**
   - `path.dirname(new URL(import.meta.url).pathname)` produced `/C:/...` on Windows.
   - `require.resolve()` returned `C:\...`, so the plugin incorrectly concluded `better-sqlite3` was outside the plugin directory and failed to load.
   - Switched to `fileURLToPath(import.meta.url)` and normalized both paths before comparison.

2. **Gemini embedding defaults / compatibility**
   - Default embedding model changed from `text-embedding-004` to `gemini-embedding-001`.
   - Gemini embedding endpoint normalization now auto-corrects older `v1/...:embedContent` style values to the current `v1beta/...:batchEmbedContents` style.
   - README example model updated accordingly.

## Validation

- Reproduced on Windows while installing and enabling the plugin under OpenClaw.
- Verified the TypeScript build succeeds locally with:
  - `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
  - `npm run build`
- Verified Gemini embedding requests succeed against the official Gemini API when using `gemini-embedding-001`.

## Notes

The published package we tested also exposed a Viewer-side Gemini test issue, but that code path does not appear in the current repo source tree under `apps/memos-local-openclaw`. This PR only includes the source changes I could trace and validate in the repository itself.