### PR TITLE
fix(openclaw): detect Anthropic provider and use correct API format

### DIFF
--- a/apps/memos-local-openclaw/scripts/refresh-summaries.ts
+++ b/apps/memos-local-openclaw/scripts/refresh-summaries.ts
@@ -62,36 +62,66 @@ async function main() {
     process.exit(1);
   }
 
+  const isAnthropic = cfg.provider === "anthropic"
+    || cfg.endpoint?.toLowerCase().includes("anthropic");
+
   console.log(`Summarizer: ${cfg.provider} / ${cfg.model}`);
 
   let endpoint = cfg.endpoint.replace(/\/+$/, "");
-  if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions";
+  if (isAnthropic) {
+    if (!endpoint.endsWith("/v1/messages") && !endpoint.endsWith("/messages")) {
+      endpoint += "/v1/messages";
+    }
+  } else {
+    if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions";
+  }
 
   async function callLLM(text: string): Promise<string> {
+    const headers: Record<string, string> = isAnthropic
+      ? {
+          "Content-Type": "application/json",
+          "x-api-key": cfg.apiKey,
+          "anthropic-version": "2023-06-01",
+        }
+      : {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cfg.apiKey}`,
+        };
+
+    const body = isAnthropic
+      ? JSON.stringify({
+          model: cfg.model,
+          temperature: 0.1,
+          max_tokens: 4096,
+          system: TASK_SUMMARY_PROMPT,
+          messages: [{ role: "user", content: text }],
+        })
+      : JSON.stringify({
+          model: cfg.model,
+          temperature: 0.1,
+          max_tokens: 4096,
+          messages: [
+            { role: "system", content: TASK_SUMMARY_PROMPT },
+            { role: "user", content: text },
+          ],
+        });
+
     const resp = await fetch(endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cfg.apiKey}`,
-      },
-      body: JSON.stringify({
-        model: cfg.model,
-        temperature: 0.1,
-        max_tokens: 4096,
-        messages: [
-          { role: "system", content: TASK_SUMMARY_PROMPT },
-          { role: "user", content: text },
-        ],
-      }),
+      headers,
+      body,
       signal: AbortSignal.timeout(60_000),
     });
 
     if (!resp.ok) {
-      const body = await resp.text();
-      throw new Error(`API ${resp.status}: ${body.slice(0, 200)}`);
+      const respBody = await resp.text();
+      throw new Error(`API ${resp.status}: ${respBody.slice(0, 200)}`);
     }
 
     const json = (await resp.json()) as any;
+    if (isAnthropic) {
+      return json.content?.find((c: any) => c.type === "text")?.text?.trim() ?? "";
+    }
     return json.choices[0]?.message?.content?.trim() ?? "";
   }
 

--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -1,12 +1,46 @@
 import * as fs from "fs";
 import * as path from "path";
-import type { SummarizerConfig, Logger } from "../../types";
+import type { SummarizerConfig, SummaryProvider, Logger } from "../../types";
 import { summarizeOpenAI, summarizeTaskOpenAI, judgeNewTopicOpenAI, filterRelevantOpenAI, judgeDedupOpenAI } from "./openai";
 import type { FilterResult, DedupResult } from "./openai";
 export type { FilterResult, DedupResult } from "./openai";
 import { summarizeAnthropic, summarizeTaskAnthropic, judgeNewTopicAnthropic, filterRelevantAnthropic, judgeDedupAnthropic } from "./anthropic";
 import { summarizeGemini, summarizeTaskGemini, judgeNewTopicGemini, filterRelevantGemini, judgeDedupGemini } from "./gemini";
 import { summarizeBedrock, summarizeTaskBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock } from "./bedrock";
+
+/**
+ * Detect provider type from provider key name or base URL.
+ */
+function detectProvider(
+  providerKey: string | undefined,
+  baseUrl: string,
+): SummaryProvider {
+  const key = providerKey?.toLowerCase() ?? "";
+  const url = baseUrl.toLowerCase();
+  if (key.includes("anthropic") || url.includes("anthropic")) return "anthropic";
+  if (key.includes("gemini") || url.includes("generativelanguage.googleapis.com")) {
+    return "gemini";
+  }
+  if (key.includes("bedrock") || url.includes("bedrock")) return "bedrock";
+  return "openai_compatible";
+}
+
+/**
+ * Return the correct endpoint for a given provider and base URL.
+ */
+function normalizeEndpointForProvider(
+  provider: SummaryProvider,
+  baseUrl: string,
+): string {
+  const stripped = baseUrl.replace(/\/+$/, "");
+  if (provider === "anthropic") {
+    if (stripped.endsWith("/v1/messages")) return stripped;
+    return `${stripped}/v1/messages`;
+  }
+  if (stripped.endsWith("/chat/completions")) return stripped;
+  if (stripped.endsWith("/completions")) return stripped;
+  return `${stripped}/chat/completions`;
+}
 
 /**
  * Build a SummarizerConfig from OpenClaw's native model configuration (openclaw.json).
@@ -36,13 +70,12 @@ function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | undefined {
     const apiKey: string | undefined = providerCfg.apiKey;
     if (!baseUrl || !apiKey) return undefined;
 
-    const endpoint = baseUrl.endsWith("/chat/completions")
-      ? baseUrl
-      : baseUrl.replace(/\/+$/, "") + "/chat/completions";
+    const provider = detectProvider(providerKey, baseUrl);
+    const endpoint = normalizeEndpointForProvider(provider, baseUrl);
 
-    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl}`);
+    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl} (${provider})`);
     return {
-      provider: "openai_compatible",
+      provider,
       endpoint,
       apiKey,
       model: modelId,

--- a/apps/memos-local-openclaw/src/shared/llm-call.ts
+++ b/apps/memos-local-openclaw/src/shared/llm-call.ts
@@ -1,6 +1,35 @@
 import * as fs from "fs";
 import * as path from "path";
-import type { SummarizerConfig, Logger, PluginContext } from "../types";
+import type { SummarizerConfig, SummaryProvider, Logger, PluginContext } from "../types";
+
+/**
+ * Detect provider type from provider key name or base URL.
+ */
+function detectProvider(providerKey: string | undefined, baseUrl: string): SummaryProvider {
+  const key = providerKey?.toLowerCase() ?? "";
+  const url = baseUrl.toLowerCase();
+  if (key.includes("anthropic") || url.includes("anthropic")) return "anthropic";
+  if (key.includes("gemini") || url.includes("generativelanguage.googleapis.com")) {
+    return "gemini";
+  }
+  if (key.includes("bedrock") || url.includes("bedrock")) return "bedrock";
+  return "openai_compatible";
+}
+
+/**
+ * Return the correct default endpoint for a given provider.
+ */
+function defaultEndpointForProvider(provider: SummaryProvider, baseUrl: string): string {
+  const stripped = baseUrl.replace(/\/+$/, "");
+  if (provider === "anthropic") {
+    if (stripped.endsWith("/v1/messages")) return stripped;
+    return `${stripped}/v1/messages`;
+  }
+  // OpenAI-compatible providers
+  if (stripped.endsWith("/chat/completions")) return stripped;
+  if (stripped.endsWith("/completions")) return stripped;
+  return `${stripped}/chat/completions`;
+}
 
 /**
  * Build a SummarizerConfig from OpenClaw's native model configuration (openclaw.json).
@@ -30,13 +59,12 @@ export function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | unde
     const apiKey: string | undefined = providerCfg.apiKey;
     if (!baseUrl || !apiKey) return undefined;
 
-    const endpoint = baseUrl.endsWith("/chat/completions")
-      ? baseUrl
-      : baseUrl.replace(/\/+$/, "") + "/chat/completions";
+    const provider = detectProvider(providerKey, baseUrl);
+    const endpoint = defaultEndpointForProvider(provider, baseUrl);
 
-    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl}`);
+    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl} (${provider})`);
     return {
-      provider: "openai_compatible",
+      provider,
       endpoint,
       apiKey,
       model: modelId,
@@ -68,22 +96,84 @@ export interface LLMCallOptions {
   timeoutMs?: number;
 }
 
-function normalizeEndpoint(url: string): string {
+function normalizeOpenAIEndpoint(url: string): string {
   const stripped = url.replace(/\/+$/, "");
   if (stripped.endsWith("/chat/completions")) return stripped;
   if (stripped.endsWith("/completions")) return stripped;
   return `${stripped}/chat/completions`;
 }
 
+function normalizeAnthropicEndpoint(url: string): string {
+  const stripped = url.replace(/\/+$/, "");
+  if (stripped.endsWith("/v1/messages")) return stripped;
+  if (stripped.endsWith("/messages")) return stripped;
+  return `${stripped}/v1/messages`;
+}
+
+function isAnthropicProvider(cfg: SummarizerConfig): boolean {
+  return cfg.provider === "anthropic";
+}
+
 /**
  * Make a single LLM call with the given config. Throws on failure.
+ * Dispatches to Anthropic or OpenAI-compatible format based on provider.
  */
 export async function callLLMOnce(
   cfg: SummarizerConfig,
   prompt: string,
   opts: LLMCallOptions = {},
 ): Promise<string> {
-  const endpoint = normalizeEndpoint(cfg.endpoint ?? "https://api.openai.com/v1/chat/completions");
+  if (isAnthropicProvider(cfg)) {
+    return callLLMOnceAnthropic(cfg, prompt, opts);
+  }
+  return callLLMOnceOpenAI(cfg, prompt, opts);
+}
+
+async function callLLMOnceAnthropic(
+  cfg: SummarizerConfig,
+  prompt: string,
+  opts: LLMCallOptions = {},
+): Promise<string> {
+  const endpoint = normalizeAnthropicEndpoint(
+    cfg.endpoint ?? "https://api.anthropic.com/v1/messages",
+  );
+  const model = cfg.model ?? "claude-3-haiku-20240307";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": cfg.apiKey ?? "",
+    "anthropic-version": "2023-06-01",
+    ...cfg.headers,
+  };
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      temperature: opts.temperature ?? 0.1,
+      max_tokens: opts.maxTokens ?? 1024,
+      messages: [{ role: "user", content: prompt }],
+    }),
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 30_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`LLM call failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { content: Array<{ type: string; text: string }> };
+  return json.content.find((c) => c.type === "text")?.text?.trim() ?? "";
+}
+
+async function callLLMOnceOpenAI(
+  cfg: SummarizerConfig,
+  prompt: string,
+  opts: LLMCallOptions = {},
+): Promise<string> {
+  const endpoint = normalizeOpenAIEndpoint(
+    cfg.endpoint ?? "https://api.openai.com/v1/chat/completions",
+  );
   const model = cfg.model ?? "gpt-4o-mini";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Anthropic API endpoints were incorrectly normalized by appending `/chat/completions` (OpenAI format), causing 404 errors during skill evolution
- Added provider detection logic (from config key name or base URL) to route Anthropic providers to `/v1/messages` with correct headers (`x-api-key`, `anthropic-version`) and response parsing
- Fixed three locations: `src/shared/llm-call.ts`, `src/ingest/providers/index.ts`, and `scripts/refresh-summaries.ts`

Fixes #1254

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] All 101 existing tests pass (`vitest run`)
- [ ] Manual test: configure Anthropic provider in `openclaw.json` and verify skill evolution succeeds
- [ ] Manual test: verify OpenAI-compatible providers continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)