### PR TITLE
fix(memos-local-openclaw): respect OPENCLAW_STATE_DIR in viewer migrate

### DIFF
--- a/apps/memos-local-openclaw/src/storage/sqlite.ts
+++ b/apps/memos-local-openclaw/src/storage/sqlite.ts
@@ -1307,7 +1307,7 @@ export class SqliteStore {
  */
 function sanitizeFtsQuery(raw: string): string {
   const tokens = raw
-    .replace(/[."""(){}[\]*:^~!@#$%&\\/<>,;'`]/g, " ")
+    .replace(/[."""(){}[\]*:^~!@#$%&\\/<>,;'`-]/g, " ")
     .split(/\s+/)
     .map((t) => t.trim().replace(/^-+|-+$/g, ""))
     .filter((t) => t.length > 1)

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -959,7 +959,8 @@ export class ViewerServer {
 
   private getOpenClawConfigPath(): string {
     const home = process.env.HOME || process.env.USERPROFILE || "";
-    return path.join(home, ".openclaw", "openclaw.json");
+    const ocHome = process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw");
+    return path.join(ocHome, "openclaw.json");
   }
 
   private serveConfig(res: http.ServerResponse): void {
@@ -1050,7 +1051,7 @@ export class ViewerServer {
 
   private getOpenClawHome(): string {
     const home = process.env.HOME || process.env.USERPROFILE || "";
-    return path.join(home, ".openclaw");
+    return process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw");
   }
 
   private handleMigrateScan(res: http.ServerResponse): void {

--- a/apps/memos-local-openclaw/tests/storage.test.ts
+++ b/apps/memos-local-openclaw/tests/storage.test.ts
@@ -98,6 +98,13 @@ describe("SqliteStore", () => {
     expect(Array.isArray(results)).toBe(true);
   });
 
+  it("should handle FTS query containing date with hyphens", () => {
+    store.insertChunk(makeChunk({ id: "c-date", content: "Release date is 2026-03-14", summary: "release note" }));
+
+    const results = store.ftsSearch("2026-03-14", 10);
+    expect(Array.isArray(results)).toBe(true);
+  });
+
   it("should get neighbor chunks", () => {
     const now = Date.now();
     store.insertChunk(makeChunk({ id: "c1", turnId: "t1", seq: 0, createdAt: now }));


### PR DESCRIPTION
Fixes #1234.

- Use OPENCLAW_STATE_DIR when resolving OpenClaw home
- Ensure openclaw.json is read from the active profile
