### PR TITLE
fix(memos-local-openclaw): detect Anthropic provider in OpenClaw fallback config

### DIFF
--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -36,13 +36,33 @@ function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | undefined {
     const apiKey: string | undefined = providerCfg.apiKey;
     if (!baseUrl || !apiKey) return undefined;
 
-    const endpoint = baseUrl.endsWith("/chat/completions")
-      ? baseUrl
-      : baseUrl.replace(/\/+$/, "") + "/chat/completions";
+    // Detect provider type from provider key or base URL
+    const isAnthropic = providerKey?.toLowerCase().includes("anthropic") ||
+      baseUrl.includes("anthropic.com");
+    const isBedrock = providerKey?.toLowerCase().includes("bedrock") ||
+      baseUrl.includes("bedrock");
 
-    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl}`);
+    let provider: SummarizerConfig["provider"];
+    let endpoint: string;
+
+    if (isAnthropic) {
+      provider = "anthropic";
+      endpoint = baseUrl.endsWith("/messages")
+        ? baseUrl
+        : baseUrl.replace(/\/+$/, "") + "/messages";
+    } else if (isBedrock) {
+      provider = "bedrock";
+      endpoint = baseUrl;
+    } else {
+      provider = "openai_compatible";
+      endpoint = baseUrl.endsWith("/chat/completions")
+        ? baseUrl
+        : baseUrl.replace(/\/+$/, "") + "/chat/completions";
+    }
+
+    log.debug(`OpenClaw fallback model: ${modelId} via ${baseUrl} (provider=${provider})`);
     return {
-      provider: "openai_compatible",
+      provider,
       endpoint,
       apiKey,
       model: modelId,

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -959,7 +959,8 @@ export class ViewerServer {
 
   private getOpenClawConfigPath(): string {
     const home = process.env.HOME || process.env.USERPROFILE || "";
-    return path.join(home, ".openclaw", "openclaw.json");
+    const ocHome = process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw");
+    return path.join(ocHome, "openclaw.json");
   }
 
   private serveConfig(res: http.ServerResponse): void {
@@ -1050,7 +1051,7 @@ export class ViewerServer {
 
   private getOpenClawHome(): string {
     const home = process.env.HOME || process.env.USERPROFILE || "";
-    return path.join(home, ".openclaw");
+    return process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw");
   }
 
   private handleMigrateScan(res: http.ServerResponse): void {


### PR DESCRIPTION
Fixes #1254.

When Anthropic is configured as the OpenClaw native model, `loadOpenClawFallbackConfig()` was incorrectly treating it as `openai_compatible`, appending `/chat/completions` to the Anthropic endpoint.

Now detects the provider type from the provider key or base URL and constructs the correct endpoint:
- **Anthropic**: appends `/messages`
- **Bedrock**: uses baseUrl as-is
- **OpenAI-compatible**: appends `/chat/completions` (existing behavior)