### PR TITLE
fix(memos-local-openclaw): normalize Windows paths when resolving better-sqlite3

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -9,6 +9,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
 import { buildContext } from "./src/config";
 import { SqliteStore } from "./src/storage/sqlite";
 import { Embedder } from "./src/embedding";
@@ -76,13 +77,20 @@ const memosLocalPlugin = {
 
   register(api: OpenClawPluginApi) {
     // ─── Ensure better-sqlite3 native module is available ───
-    const pluginDir = path.dirname(new URL(import.meta.url).pathname);
+    const pluginDir = path.dirname(fileURLToPath(import.meta.url));
+
+    function normalizeFsPath(p: string): string {
+      return path.resolve(p).replace(/\\/g, "/").toLowerCase();
+    }
+
     let sqliteReady = false;
 
     function trySqliteLoad(): boolean {
       try {
         const resolved = require.resolve("better-sqlite3", { paths: [pluginDir] });
-        if (!resolved.startsWith(pluginDir)) {
+        const resolvedNorm = normalizeFsPath(resolved);
+        const pluginNorm = normalizeFsPath(pluginDir);
+        if (!resolvedNorm.startsWith(pluginNorm + "/") && resolvedNorm !== pluginNorm) {
           api.logger.warn(`memos-local: better-sqlite3 resolved outside plugin dir: ${resolved}`);
           return false;
         }


### PR DESCRIPTION
Fixes #1192.

On Windows, the plugin incorrectly reported `better-sqlite3 resolved outside plugin dir` because of path format mismatches (`C:\Users\...` vs `C:/Users/...`).

Changes:
- Use `fileURLToPath(import.meta.url)` instead of `new URL().pathname`
- Add `normalizeFsPath()` to normalize both paths before comparison
- Handles `\` vs `/`, case sensitivity, and relative/absolute path differences