### PR TITLE
fix(openclaw): strip <think/> tags from assistant messages

### DIFF
--- a/apps/memos-local-openclaw/src/capture/index.ts
+++ b/apps/memos-local-openclaw/src/capture/index.ts
@@ -70,6 +70,7 @@ export function captureMessages(
     if (role === "user") {
       content = stripInboundMetadata(content);
     } else {
+      content = stripThinkingTags(content);
       content = stripEvidenceWrappers(content, evidenceTag);
     }
     if (!content.trim()) continue;
@@ -146,6 +147,13 @@ export function stripInboundMetadata(text: string): string {
   }
 
   return stripEnvelopePrefix(result.join("\n")).trim();
+}
+
+/** Strip <think…>…</think⟩ blocks emitted by DeepSeek-style reasoning models. */
+const THINKING_TAG_RE = /<think[\s>][\s\S]*?<\/think>\s*/gi;
+
+function stripThinkingTags(text: string): string {
+  return text.replace(THINKING_TAG_RE, "");
 }
 
 function stripEnvelopePrefix(text: string): string {


### PR DESCRIPTION
## Problem

DeepSeek-style reasoning models emit `<think…>…</think⟩` blocks when entering reasoning mode. The memos-local plugin does not recognize these tags, causing parse errors that trigger retry loops. This rapid retry cycle overloads OpenClaw and the AI model, eventually leading to timeouts.

## Fix

Strip `<think/>` blocks early in the message capture pipeline (`capture/index.ts`), before any downstream parsing occurs. This is a minimal, non-breaking change — the thinking content is never stored or processed.

Closes #1268