### PR TITLE
Detect allowPromptInjection and optimize auto-recall handling

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -211,6 +211,18 @@ const memosLocalPlugin = {
 
     api.logger.info(`memos-local: initialized (db: ${ctx.config.storage!.dbPath})`);
 
+    // ─── Check allowPromptInjection policy ───
+    // When allowPromptInjection=false, the prompt mutation fields (such as prependContext) in the hook return value
+    // will be stripped by the framework. Skip auto-recall to avoid unnecessary LLM/embedding calls.
+    const pluginEntry = (api.config as any)?.plugins?.entries?.[api.id];
+    const allowPromptInjection = pluginEntry?.hooks?.allowPromptInjection !== false;
+    if (!allowPromptInjection) {
+      api.logger.info("memos-local: allowPromptInjection=false, auto-recall disabled");
+    }
+    else {
+      api.logger.info("memos-local: allowPromptInjection=true, auto-recall enabled");
+    }
+
     const trackTool = (toolName: string, fn: (...args: any[]) => Promise<any>) =>
       async (...args: any[]) => {
         const t0 = performance.now();
@@ -860,6 +872,7 @@ const memosLocalPlugin = {
     let lastRecalledSummaries: string[] = [];
 
     api.on("before_agent_start", async (event: { prompt?: string; messages?: unknown[]; agentId?: string }) => {
+      if (!allowPromptInjection) return {};
       lastRecalledChunkIds = new Set();
       lastRecalledSummaries = [];
       if (!event.prompt || event.prompt.length < 3) return;


### PR DESCRIPTION
## Description

When allowPromptInjection=false, the OpenClaw framework strips prompt mutation fields from before_agent_start results, leaving undefined. The ?? fallback in attempt.ts then invokes the hook a second time. MemOS's auto-recall (LLM + embedding search) runs twice per message, and both results are discarded.

Related Issue (Required):  Fixes  #1276

## Fix (workaround at plugin level): Detect allowPromptInjection in the plugin and skip auto-recall early.

```
// In register(): read policy
const pluginEntry = (api.config as any)?.plugins?.entries?.[api.id];
const allowPromptInjection = pluginEntry?.hooks?.allowPromptInjection !== false;

// In before_agent_start handler: early return
if (!allowPromptInjection) return {};
```

Returning {} (truthy) prevents the ?? fallback from triggering a second call.

Note: This is a workaround for an openclaw framework issue. The framework-level fix would be in constrainLegacyPromptInjectionHook to return {} instead of undefined.
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
