### PR TITLE
fix(openclaw): strip <think/> tags from assistant messages

### DIFF
--- a/apps/memos-local-openclaw/src/capture/index.ts
+++ b/apps/memos-local-openclaw/src/capture/index.ts
@@ -70,6 +70,7 @@ export function captureMessages(
     if (role === "user") {
       content = stripInboundMetadata(content);
     } else {
+      content = stripThinkingTags(content);
       content = stripEvidenceWrappers(content, evidenceTag);
     }
     if (!content.trim()) continue;
@@ -146,6 +147,13 @@ export function stripInboundMetadata(text: string): string {
   }
 
   return stripEnvelopePrefix(result.join("\n")).trim();
+}
+
+/** Strip <think…>…</think⟩ blocks emitted by DeepSeek-style reasoning models. */
+const THINKING_TAG_RE = /<think[\s>][\s\S]*?<\/think>\s*/gi;
+
+function stripThinkingTags(text: string): string {
+  return text.replace(THINKING_TAG_RE, "");
 }
 
 function stripEnvelopePrefix(text: string): string {


### PR DESCRIPTION
Closes #1268

## Summary

Strips `<think…>…</think⟩` tags from assistant messages before downstream processing in the OpenClaw local plugin.

## Problem

When using models that emit thinking tags (e.g. DeepSeek), the `<think…>` … `</think⟩` blocks were being passed through to capture/storage, cluttering the actual assistant response content.

## Fix

- Added `stripThinkingTags()` utility in `apps/memos-local-openclaw/src/capture/index.ts`
- Applies regex-based stripping of thinking blocks before processing assistant messages