### PR TITLE
feat: add Dockerfile and Helm chart for Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# MemOS Production Dockerfile
+# Multi-stage build with optimizations
+
+# Stage 1: Install dependencies
+FROM python:3.11-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    build-essential \
+    libffi-dev \
+    python3-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY docker/requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --prefix=/install --no-cache-dir -r requirements.txt
+
+# Stage 2: Runtime image
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -u 1000 memos
+
+WORKDIR /app
+
+ENV HF_ENDPOINT=https://hf-mirror.com
+ENV PYTHONPATH=/app/src
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder /install /usr/local
+COPY src/ ./src
+COPY docker/ ./docker
+
+RUN chown -R memos:memos /app
+
+USER memos
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+CMD ["uvicorn", "memos.api.server_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: memos
+description: MemOS - AI Memory Operating System for LLM and Agent systems
+type: application
+version: 1.0.0
+appVersion: "2.0.9"
+keywords:
+  - memory
+  - llm
+  - agent
+  - ai
+  - vector-database
+  - graph-database
+home: https://memos.openmem.net
+sources:
+  - https://github.com/MemTensor/MemOS
+maintainers:
+  - name: MemTensor
+    url: https://github.com/MemTensor

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,154 @@
+# MemOS Helm Chart
+
+MemOS - AI Memory Operating System for LLM and Agent systems.
+
+## Prerequisites
+
+- Kubernetes 1.20+
+- Helm 3.0+
+- PV provisioner support in the underlying infrastructure
+
+## Components
+
+| Component | Description | Port |
+|-----------|-------------|------|
+| memos-api | Main API service | 8000 |
+| neo4j | Graph database | 7474 (HTTP), 7687 (Bolt) |
+| qdrant | Vector database | 6333 (HTTP), 6334 (gRPC) |
+
+## Quick Start
+
+### 1. Build Docker Image
+
+```bash
+# From repo root
+docker build -t memos:2.0.9 .
+```
+
+### 2. Push to Registry
+
+```bash
+docker tag memos:2.0.9 your-registry/memos:2.0.9
+docker push your-registry/memos:2.0.9
+```
+
+### 3. Configure Values
+
+```bash
+cp deploy/helm/values-example.yaml my-values.yaml
+
+# Edit my-values.yaml with your settings:
+# - OPENAI_API_KEY
+# - MEMRADER_API_KEY
+# - image.repository (your registry)
+```
+
+### 4. Install
+
+```bash
+helm install memos deploy/helm -f my-values.yaml -n memos --create-namespace
+```
+
+## Configuration
+
+### Required Settings
+
+```yaml
+memos:
+  image:
+    repository: your-registry/memos
+    tag: "2.0.9"
+  env:
+    OPENAI_API_KEY: "sk-your-key"
+    MEMRADER_API_KEY: "sk-your-key"
+```
+
+### Enable Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: memos.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+### Use External Neo4j/Qdrant
+
+```yaml
+neo4j:
+  enabled: false
+
+qdrant:
+  enabled: false
+
+memos:
+  env:
+    NEO4J_URI: "bolt://external-neo4j:7687"
+    NEO4J_USER: "neo4j"
+    NEO4J_PASSWORD: "password"
+    QDRANT_HOST: "external-qdrant"
+    QDRANT_PORT: "6333"
+```
+
+## Values Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `memos.replicaCount` | `1` | API replicas |
+| `memos.image.repository` | `memos/memos` | Image repository |
+| `memos.image.tag` | `2.0.9` | Image tag |
+| `memos.service.type` | `ClusterIP` | Service type |
+| `memos.service.port` | `8000` | Service port |
+| `neo4j.enabled` | `true` | Enable Neo4j |
+| `neo4j.auth.password` | `memos123456` | Neo4j password |
+| `neo4j.persistence.size` | `10Gi` | Neo4j data size |
+| `qdrant.enabled` | `true` | Enable Qdrant |
+| `qdrant.persistence.size` | `10Gi` | Qdrant data size |
+| `ingress.enabled` | `false` | Enable Ingress |
+
+## API Endpoints
+
+```bash
+# Add memory
+curl -X POST http://memos-api:8000/product/add \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "test-user",
+    "mem_cube_id": "test-cube",
+    "messages": [{"role": "user", "content": "I like strawberry"}],
+    "async_mode": "sync"
+  }'
+
+# Search memory
+curl -X POST http://memos-api:8000/product/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What do I like",
+    "user_id": "test-user",
+    "mem_cube_id": "test-cube"
+  }'
+```
+
+## Uninstall
+
+```bash
+helm uninstall memos -n memos
+kubectl delete namespace memos
+```
+
+## Troubleshooting
+
+```bash
+# Check logs
+kubectl logs -n memos -l app.kubernetes.io/component=api
+
+# Check Neo4j
+kubectl exec -n memos -it deployment/memos-neo4j -- cypher-shell -u neo4j -p memos123456
+
+# Check Qdrant
+kubectl exec -n memos -it deployment/memos-qdrant -- curl localhost:6333
+```

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "memos.name" -}}
+memos
+{{- end }}
+
+{{- define "memos.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "memos.labels" -}}
+app.kubernetes.io/name: {{ include "memos.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
+
+{{- define "memos.neo4j.fullname" -}}
+{{- printf "%s-neo4j" (include "memos.fullname" .) }}
+{{- end }}
+
+{{- define "memos.qdrant.fullname" -}}
+{{- printf "%s-qdrant" (include "memos.fullname" .) }}
+{{- end }}
+
+{{- define "memos.memos.fullname" -}}
+{{- printf "%s-api" (include "memos.fullname" .) }}
+{{- end }}

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "memos.memos.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+data:
+  TZ: {{ .Values.memos.env.TZ | quote }}
+  MOS_CUBE_PATH: {{ .Values.memos.env.MOS_CUBE_PATH | quote }}
+  MEMOS_BASE_PATH: {{ .Values.memos.env.MEMOS_BASE_PATH | quote }}
+  MOS_ENABLE_DEFAULT_CUBE_CONFIG: {{ .Values.memos.env.MOS_ENABLE_DEFAULT_CUBE_CONFIG | quote }}
+  MOS_ENABLE_REORGANIZE: {{ .Values.memos.env.MOS_ENABLE_REORGANIZE | quote }}
+  MOS_TEXT_MEM_TYPE: {{ .Values.memos.env.MOS_TEXT_MEM_TYPE | quote }}
+  ASYNC_MODE: {{ .Values.memos.env.ASYNC_MODE | quote }}
+  MOS_TOP_K: {{ .Values.memos.env.MOS_TOP_K | quote }}
+  MOS_CHAT_MODEL: {{ .Values.memos.env.MOS_CHAT_MODEL | quote }}
+  MOS_CHAT_TEMPERATURE: {{ .Values.memos.env.MOS_CHAT_TEMPERATURE | quote }}
+  MOS_MAX_TOKENS: {{ .Values.memos.env.MOS_MAX_TOKENS | quote }}
+  MOS_TOP_P: {{ .Values.memos.env.MOS_TOP_P | quote }}
+  MOS_CHAT_MODEL_PROVIDER: {{ .Values.memos.env.MOS_CHAT_MODEL_PROVIDER | quote }}
+  OPENAI_API_BASE: {{ .Values.memos.env.OPENAI_API_BASE | quote }}
+  MEMRADER_MODEL: {{ .Values.memos.env.MEMRADER_MODEL | quote }}
+  MEMRADER_API_BASE: {{ .Values.memos.env.MEMRADER_API_BASE | quote }}
+  MEMRADER_MAX_TOKENS: {{ .Values.memos.env.MEMRADER_MAX_TOKENS | quote }}
+  EMBEDDING_DIMENSION: {{ .Values.memos.env.EMBEDDING_DIMENSION | quote }}
+  MOS_EMBEDDER_BACKEND: {{ .Values.memos.env.MOS_EMBEDDER_BACKEND | quote }}
+  MOS_EMBEDDER_PROVIDER: {{ .Values.memos.env.MOS_EMBEDDER_PROVIDER | quote }}
+  MOS_EMBEDDER_MODEL: {{ .Values.memos.env.MOS_EMBEDDER_MODEL | quote }}
+  MOS_EMBEDDER_API_BASE: {{ .Values.memos.env.MOS_EMBEDDER_API_BASE | quote }}
+  MOS_EMBEDDER_API_KEY: {{ .Values.memos.env.MOS_EMBEDDER_API_KEY | quote }}
+  MOS_RERANKER_BACKEND: {{ .Values.memos.env.MOS_RERANKER_BACKEND | quote }}
+  MOS_RERANKER_URL: {{ .Values.memos.env.MOS_RERANKER_URL | quote }}
+  MOS_RERANKER_MODEL: {{ .Values.memos.env.MOS_RERANKER_MODEL | quote }}
+  MOS_RERANKER_STRATEGY: {{ .Values.memos.env.MOS_RERANKER_STRATEGY | quote }}
+  ENABLE_INTERNET: {{ .Values.memos.env.ENABLE_INTERNET | quote }}
+  ENABLE_PREFERENCE_MEMORY: {{ .Values.memos.env.ENABLE_PREFERENCE_MEMORY | quote }}
+  PREFERENCE_ADDER_MODE: {{ .Values.memos.env.PREFERENCE_ADDER_MODE | quote }}
+  MOS_ENABLE_SCHEDULER: {{ .Values.memos.env.MOS_ENABLE_SCHEDULER | quote }}
+  MOS_SCHEDULER_TOP_K: {{ .Values.memos.env.MOS_SCHEDULER_TOP_K | quote }}
+  NEO4J_BACKEND: {{ .Values.memos.env.NEO4J_BACKEND | quote }}
+  NEO4J_URI: "bolt://{{ include "memos.neo4j.fullname" . }}:7687"
+  NEO4J_USER: {{ .Values.neo4j.auth.user | quote }}
+  NEO4J_PASSWORD: {{ .Values.neo4j.auth.password | quote }}
+  NEO4J_DB_NAME: {{ .Values.memos.env.NEO4J_DB_NAME | quote }}
+  MOS_NEO4J_SHARED_DB: {{ .Values.memos.env.MOS_NEO4J_SHARED_DB | quote }}
+  QDRANT_HOST: {{ include "memos.qdrant.fullname" . }}
+  QDRANT_PORT: "6333"
+  PYTHONPATH: "/app/src"

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "memos.memos.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "memos.memos.fullname" $ }}
+                port:
+                  number: {{ $.Values.memos.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/memos.yaml
+++ b/deploy/helm/templates/memos.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "memos.memos.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.memos.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "memos.labels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "memos.labels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: wait-for-neo4j
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z {{ include "memos.neo4j.fullname" . }} 7687; do echo waiting for neo4j; sleep 2; done;']
+        - name: wait-for-qdrant
+          image: busybox:1.36
+          command: ['sh', '-c', 'until nc -z {{ include "memos.qdrant.fullname" . }} 6333; do echo waiting for qdrant; sleep 2; done;']
+      containers:
+        - name: memos
+          image: "{{ .Values.memos.image.repository }}:{{ .Values.memos.image.tag }}"
+          imagePullPolicy: {{ .Values.memos.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: {{ include "memos.memos.fullname" . }}
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "memos.memos.fullname" . }}-secret
+                  key: openai-api-key
+            - name: MEMRADER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "memos.memos.fullname" . }}-secret
+                  key: memrader-api-key
+          resources:
+            {{- toYaml .Values.memos.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "memos.memos.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.memos.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.memos.service.port }}
+      targetPort: http
+  selector:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "memos.memos.fullname" . }}-secret
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  openai-api-key: {{ .Values.memos.env.OPENAI_API_KEY | quote }}
+  memrader-api-key: {{ .Values.memos.env.MEMRADER_API_KEY | quote }}

--- a/deploy/helm/templates/neo4j.yaml
+++ b/deploy/helm/templates/neo4j.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.neo4j.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "memos.neo4j.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neo4j
+spec:
+  replicas: {{ .Values.neo4j.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "memos.labels" . | nindent 6 }}
+      app.kubernetes.io/component: neo4j
+  template:
+    metadata:
+      labels:
+        {{- include "memos.labels" . | nindent 8 }}
+        app.kubernetes.io/component: neo4j
+    spec:
+      containers:
+        - name: neo4j
+          image: "{{ .Values.neo4j.image.repository }}:{{ .Values.neo4j.image.tag }}"
+          imagePullPolicy: {{ .Values.neo4j.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 7474
+            - name: bolt
+              containerPort: 7687
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: {{ .Values.neo4j.auth.acceptLicense | quote }}
+            - name: NEO4J_AUTH
+              value: "{{ .Values.neo4j.auth.user }}/{{ .Values.neo4j.auth.password }}"
+          {{- if .Values.neo4j.persistence.enabled }}
+          volumeMounts:
+            - name: neo4j-data
+              mountPath: /data
+            - name: neo4j-logs
+              mountPath: /logs
+          {{- end }}
+          resources:
+            {{- toYaml .Values.neo4j.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 7474
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 7474
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      {{- if .Values.neo4j.persistence.enabled }}
+      volumes:
+        - name: neo4j-data
+          persistentVolumeClaim:
+            claimName: {{ include "memos.neo4j.fullname" . }}-data
+        - name: neo4j-logs
+          persistentVolumeClaim:
+            claimName: {{ include "memos.neo4j.fullname" . }}-logs
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "memos.neo4j.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neo4j
+spec:
+  type: {{ .Values.neo4j.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.neo4j.service.httpPort }}
+      targetPort: http
+    - name: bolt
+      port: {{ .Values.neo4j.service.boltPort }}
+      targetPort: bolt
+  selector:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neo4j
+{{- if .Values.neo4j.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memos.neo4j.fullname" . }}-data
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neo4j
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- else if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.neo4j.persistence.size }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memos.neo4j.fullname" . }}-logs
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neo4j
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- else if .Values.neo4j.persistence.storageClass }}
+  storageClassName: {{ .Values.neo4j.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/qdrant.yaml
+++ b/deploy/helm/templates/qdrant.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.qdrant.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "memos.qdrant.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: qdrant
+spec:
+  replicas: {{ .Values.qdrant.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "memos.labels" . | nindent 6 }}
+      app.kubernetes.io/component: qdrant
+  template:
+    metadata:
+      labels:
+        {{- include "memos.labels" . | nindent 8 }}
+        app.kubernetes.io/component: qdrant
+    spec:
+      containers:
+        - name: qdrant
+          image: "{{ .Values.qdrant.image.repository }}:{{ .Values.qdrant.image.tag }}"
+          imagePullPolicy: {{ .Values.qdrant.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 6333
+            - name: grpc
+              containerPort: 6334
+          env:
+            - name: QDRANT__SERVICE__GRPC_PORT
+              value: "6334"
+            - name: QDRANT__SERVICE__HTTP_PORT
+              value: "6333"
+          {{- if .Values.qdrant.persistence.enabled }}
+          volumeMounts:
+            - name: qdrant-data
+              mountPath: /qdrant/storage
+          {{- end }}
+          resources:
+            {{- toYaml .Values.qdrant.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6333
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      {{- if .Values.qdrant.persistence.enabled }}
+      volumes:
+        - name: qdrant-data
+          persistentVolumeClaim:
+            claimName: {{ include "memos.qdrant.fullname" . }}-data
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "memos.qdrant.fullname" . }}
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: qdrant
+spec:
+  type: {{ .Values.qdrant.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.qdrant.service.httpPort }}
+      targetPort: http
+    - name: grpc
+      port: {{ .Values.qdrant.service.grpcPort }}
+      targetPort: grpc
+  selector:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: qdrant
+{{- if .Values.qdrant.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "memos.qdrant.fullname" . }}-data
+  labels:
+    {{- include "memos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: qdrant
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- else if .Values.qdrant.persistence.storageClass }}
+  storageClassName: {{ .Values.qdrant.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.qdrant.persistence.size }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/values-example.yaml
+++ b/deploy/helm/values-example.yaml
@@ -1,0 +1,34 @@
+memos:
+  image:
+    repository: your-registry/memos
+    tag: "2.0.9"
+    pullPolicy: IfNotPresent
+  
+  env:
+    TZ: "Asia/Taipei"
+    MOS_CHAT_MODEL: "gpt-4o-mini"
+    MOS_CHAT_MODEL_PROVIDER: "openai"
+    OPENAI_API_KEY: "sk-your-openai-key"
+    OPENAI_API_BASE: "https://api.openai.com/v1"
+    MEMRADER_MODEL: "gpt-4o-mini"
+    MEMRADER_API_KEY: "sk-your-openai-key"
+    MEMRADER_API_BASE: "https://api.openai.com/v1"
+    EMBEDDING_DIMENSION: "1024"
+    MOS_EMBEDDER_BACKEND: "universal_api"
+    MOS_EMBEDDER_PROVIDER: "openai"
+    MOS_EMBEDDER_MODEL: "text-embedding-3-small"
+    MOS_EMBEDDER_API_BASE: "https://api.openai.com/v1"
+    MOS_EMBEDDER_API_KEY: "sk-your-openai-key"
+
+neo4j:
+  auth:
+    password: "change-this-password"
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: memos.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,134 @@
+global:
+  imagePullSecrets: []
+  storageClass: ""
+
+memos:
+  replicaCount: 1
+  image:
+    repository: memos/memos
+    tag: "2.0.9"
+    pullPolicy: IfNotPresent
+  
+  service:
+    type: ClusterIP
+    port: 8000
+  
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+  
+  env:
+    TZ: "Asia/Taipei"
+    MOS_CUBE_PATH: "/tmp/data_test"
+    MEMOS_BASE_PATH: "."
+    MOS_ENABLE_DEFAULT_CUBE_CONFIG: "true"
+    MOS_ENABLE_REORGANIZE: "false"
+    MOS_TEXT_MEM_TYPE: "general_text"
+    ASYNC_MODE: "sync"
+    MOS_TOP_K: "50"
+    MOS_CHAT_MODEL: "gpt-4o-mini"
+    MOS_CHAT_TEMPERATURE: "0.8"
+    MOS_MAX_TOKENS: "2048"
+    MOS_TOP_P: "0.9"
+    MOS_CHAT_MODEL_PROVIDER: "openai"
+    OPENAI_API_KEY: "sk-xxx"
+    OPENAI_API_BASE: "https://api.openai.com/v1"
+    MEMRADER_MODEL: "gpt-4o-mini"
+    MEMRADER_API_KEY: "sk-xxx"
+    MEMRADER_API_BASE: "http://localhost:3000/v1"
+    MEMRADER_MAX_TOKENS: "5000"
+    EMBEDDING_DIMENSION: "1024"
+    MOS_EMBEDDER_BACKEND: "universal_api"
+    MOS_EMBEDDER_PROVIDER: "openai"
+    MOS_EMBEDDER_MODEL: "bge-m3"
+    MOS_EMBEDDER_API_BASE: "http://localhost:8000/v1"
+    MOS_EMBEDDER_API_KEY: "EMPTY"
+    MOS_RERANKER_BACKEND: "http_bge"
+    MOS_RERANKER_URL: "http://localhost:8001"
+    MOS_RERANKER_MODEL: "bge-reranker-v2-m3"
+    MOS_RERANKER_STRATEGY: "single_turn"
+    ENABLE_INTERNET: "false"
+    ENABLE_PREFERENCE_MEMORY: "true"
+    PREFERENCE_ADDER_MODE: "fast"
+    MOS_ENABLE_SCHEDULER: "false"
+    MOS_SCHEDULER_TOP_K: "10"
+    NEO4J_BACKEND: "neo4j-community"
+    NEO4J_DB_NAME: "neo4j"
+    MOS_NEO4J_SHARED_DB: "false"
+
+neo4j:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: neo4j
+    tag: "5.26.4"
+    pullPolicy: IfNotPresent
+  
+  service:
+    type: ClusterIP
+    httpPort: 7474
+    boltPort: 7687
+  
+  auth:
+    enabled: true
+    user: neo4j
+    password: "memos123456"
+    acceptLicense: "yes"
+  
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+  
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+qdrant:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: qdrant/qdrant
+    tag: "v1.15.3"
+    pullPolicy: IfNotPresent
+  
+  service:
+    type: ClusterIP
+    httpPort: 6333
+    grpcPort: 6334
+  
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+  
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: memos.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary
- Add production-ready Dockerfile with multi-stage build
- Add Helm chart for Kubernetes deployment with:
  - MemOS API service
  - Neo4j graph database
  - Qdrant vector database
  - Ingress configuration
  - Example values file

## Usage
```bash
# Build image
docker build -t your-registry/memos:2.0.9 .

# Deploy
helm install memos deploy/helm -f deploy/helm/values-example.yaml -n memos --create-namespace
```