### PR TITLE
fix: support minimax-portal provider across all Anthropic handler functions

### DIFF
--- a/apps/memos-local-openclaw/src/ingest/providers/anthropic.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/anthropic.ts
@@ -339,7 +339,13 @@ export async function judgeDedupAnthropic(
   cfg: SummarizerConfig,
   log: Logger,
 ): Promise<DedupResult> {
-  const endpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  // Normalize endpoint: ensure /v1/messages path for Anthropic API
+  const rawEndpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  let endpoint = rawEndpoint;
+  if (!rawEndpoint.includes("/v1/messages")) {
+    const stripped = rawEndpoint.replace(/\/$/, "");
+    endpoint = stripped.endsWith("/v1/messages") ? stripped : `${stripped}/v1/messages`;
+  }
   const model = cfg.model ?? "claude-3-haiku-20240307";
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -360,7 +366,7 @@ export async function judgeDedupAnthropic(
       system: DEDUP_JUDGE_PROMPT,
       messages: [{ role: "user", content: `NEW MEMORY:\n${newSummary}\n\nEXISTING MEMORIES:\n${candidateText}` }],
     }),
-    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 120_000),
   });
 
   if (!resp.ok) {

--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -325,6 +325,7 @@ function callSummarize(cfg: SummarizerConfig, text: string, log: Logger): Promis
     case "voyage":
       return summarizeOpenAI(text, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return summarizeAnthropic(text, cfg, log);
     case "gemini":
       return summarizeGemini(text, cfg, log);
@@ -348,6 +349,7 @@ function callSummarizeTask(cfg: SummarizerConfig, text: string, log: Logger): Pr
     case "voyage":
       return summarizeTaskOpenAI(text, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return summarizeTaskAnthropic(text, cfg, log);
     case "gemini":
       return summarizeTaskGemini(text, cfg, log);
@@ -371,6 +373,7 @@ function callGenerateTaskTitle(cfg: SummarizerConfig, text: string, log: Logger)
     case "voyage":
       return generateTaskTitleOpenAI(text, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return generateTaskTitleAnthropic(text, cfg, log);
     case "gemini":
       return generateTaskTitleGemini(text, cfg, log);
@@ -394,6 +397,7 @@ function callTopicJudge(cfg: SummarizerConfig, currentContext: string, newMessag
     case "voyage":
       return judgeNewTopicOpenAI(currentContext, newMessage, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return judgeNewTopicAnthropic(currentContext, newMessage, cfg, log);
     case "gemini":
       return judgeNewTopicGemini(currentContext, newMessage, cfg, log);
@@ -417,6 +421,7 @@ function callFilterRelevant(cfg: SummarizerConfig, query: string, candidates: Ar
     case "voyage":
       return filterRelevantOpenAI(query, candidates, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return filterRelevantAnthropic(query, candidates, cfg, log);
     case "gemini":
       return filterRelevantGemini(query, candidates, cfg, log);
@@ -440,6 +445,7 @@ function callJudgeDedup(cfg: SummarizerConfig, newSummary: string, candidates: A
     case "voyage":
       return judgeDedupOpenAI(newSummary, candidates, cfg, log);
     case "anthropic":
+    case "minimax-portal":
       return judgeDedupAnthropic(newSummary, candidates, cfg, log);
     case "gemini":
       return judgeDedupGemini(newSummary, candidates, cfg, log);


### PR DESCRIPTION
## Problem

The `minimax-portal` provider uses Anthropic-format API, but all switch cases only had explicit `anthropic` entries.

## Solution

Add `minimax-portal` to all 6 Anthropic handler functions in index.ts + fix anthropic.ts endpoint normalization + increase judgeDedup timeout to 120s.