### PR TITLE
fix: migrate auto-recall from before_agent_start to before_prompt_build

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -928,7 +928,7 @@ const memosLocalPlugin = {
 
     // ─── Auto-recall: inject relevant memories before agent starts ───
 
-    api.on("before_agent_start", async (event: { prompt?: string; messages?: unknown[] }, hookCtx?: { agentId?: string; sessionKey?: string }) => {
+    api.on("before_prompt_build", async (event: { prompt?: string; messages?: unknown[] }, hookCtx?: { agentId?: string; sessionKey?: string }) => {
       if (!allowPromptInjection) return {};
       if (!event.prompt || event.prompt.length < 3) return;
 


### PR DESCRIPTION
## Problem

`before_agent_start` is a legacy hook that the OpenClaw framework invokes **twice** per agent run:

1. **Model resolve phase** ([`run.ts` L348](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run.ts#L348)): passes only `{ prompt }` — no `messages` field
2. **Prompt build phase** ([`attempt.ts` L1438](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run/attempt.ts#L1438)): passes `{ prompt, messages }` — messages available

This causes the auto-recall handler to fire twice: the first invocation has no `messages` so topic-aware pre-filtering (if any) is bypassed, and a redundant embedding search + LLM filter call runs on every turn.

## Solution

Use `before_prompt_build` instead ([docs](https://docs.openclaw.ai/tools/plugin#plugin-hooks)), which:
- Fires once per turn, after session load
- Always provides `{ prompt, messages }` — reliable access to conversation history
- Is the framework-recommended hook for prompt injection (per OpenClaw docs: *"legacy compatibility hook... prefer the explicit hooks above"*)
- Returns the same result fields: `prependContext`, `systemPrompt`, `prependSystemContext`, `appendSystemContext`

## Changes

- `before_agent_start` → `before_prompt_build` (single line change in `index.ts` L931)
- No other logic changes; return contract is identical

## References

- OpenClaw agent loop: [`concepts/agent-loop.md`](https://github.com/openclaw/openclaw/blob/main/docs/concepts/agent-loop.md)
- OpenClaw plugin docs: [`tools/plugin.md`](https://github.com/openclaw/openclaw/blob/main/docs/tools/plugin.md)
- Related issue: [openclaw/openclaw#26914](https://github.com/openclaw/openclaw/issues/26914) (ephemeralContext request — same root cause of prependContext accumulation)