### PR TITLE
fix(memos-local-openclaw): resolve SecretRef apiKey in OpenClaw fallb…

### DIFF
--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -9,6 +9,19 @@ import { summarizeGemini, summarizeTaskGemini, generateTaskTitleGemini, judgeNew
 import { summarizeBedrock, summarizeTaskBedrock, generateTaskTitleBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock } from "./bedrock";
 
 /**
+ * Resolve a SecretInput (string | SecretRef) to a plain string.
+ * Supports env-sourced SecretRef from OpenClaw's credential system.
+ */
+function resolveApiKey(
+  input: string | { source: string; provider?: string; id: string } | undefined,
+): string | undefined {
+  if (!input) return undefined;
+  if (typeof input === "string") return input;
+  if (input.source === "env") return process.env[input.id];
+  return undefined;
+}
+
+/**
  * Detect provider type from provider key name or base URL.
  */
 function detectProvider(
@@ -68,7 +81,7 @@ function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | undefined {
     if (!providerCfg) return undefined;
 
     const baseUrl: string | undefined = providerCfg.baseUrl;
-    const apiKey: string | undefined = providerCfg.apiKey;
+    const apiKey = resolveApiKey(providerCfg.apiKey);
     if (!baseUrl || !apiKey) return undefined;
 
     const provider = detectProvider(providerKey, baseUrl);

--- a/apps/memos-local-openclaw/src/shared/llm-call.ts
+++ b/apps/memos-local-openclaw/src/shared/llm-call.ts
@@ -3,6 +3,19 @@ import * as path from "path";
 import type { SummarizerConfig, SummaryProvider, Logger, PluginContext, OpenClawAPI } from "../types";
 
 /**
+ * Resolve a SecretInput (string | SecretRef) to a plain string.
+ * Supports env-sourced SecretRef from OpenClaw's credential system.
+ */
+function resolveApiKey(
+  input: string | { source: string; provider?: string; id: string } | undefined,
+): string | undefined {
+  if (!input) return undefined;
+  if (typeof input === "string") return input;
+  if (input.source === "env") return process.env[input.id];
+  return undefined;
+}
+
+/**
  * Detect provider type from provider key name or base URL.
  */
 function detectProvider(providerKey: string | undefined, baseUrl: string): SummaryProvider {
@@ -56,7 +69,7 @@ export function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | unde
     if (!providerCfg) return undefined;
 
     const baseUrl: string | undefined = providerCfg.baseUrl;
-    const apiKey: string | undefined = providerCfg.apiKey;
+    const apiKey = resolveApiKey(providerCfg.apiKey);
     if (!baseUrl || !apiKey) return undefined;
 
     const provider = detectProvider(providerKey, baseUrl);

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -3258,7 +3258,8 @@ export class ViewerServer {
       const providerCfg = providerKey
         ? raw?.models?.providers?.[providerKey]
         : Object.values(raw?.models?.providers ?? {})[0] as Record<string, unknown> | undefined;
-      if (!providerCfg || !providerCfg.baseUrl || !providerCfg.apiKey) {
+      const resolvedKey = ViewerServer.resolveApiKeyValue(providerCfg?.apiKey);
+      if (!providerCfg || !providerCfg.baseUrl || !resolvedKey) {
         this.jsonResponse(res, { available: false });
         return;
       }
@@ -3266,6 +3267,17 @@ export class ViewerServer {
     } catch {
       this.jsonResponse(res, { available: false });
     }
+  }
+
+  private static resolveApiKeyValue(
+    input: unknown,
+  ): string | undefined {
+    if (!input) return undefined;
+    if (typeof input === "string") return input;
+    if (typeof input === "object" && input !== null && (input as any).source === "env") {
+      return process.env[(input as any).id];
+    }
+    return undefined;
   }
 
   private findPluginPackageJson(): string | null {

--- a/apps/memos-local-openclaw/tests/openclaw-fallback.test.ts
+++ b/apps/memos-local-openclaw/tests/openclaw-fallback.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { buildContext } from "../src/config";
 import { Embedder } from "../src/embedding";
 import { Summarizer } from "../src/ingest/providers";
+import { loadOpenClawFallbackConfig } from "../src/shared/llm-call";
 import * as os from "os";
 import * as fs from "fs";
 import * as path from "path";
@@ -282,6 +283,152 @@ describe("OpenClaw Fallback Configuration", () => {
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
+  });
+
+  describe("SecretRef apiKey resolution in loadOpenClawFallbackConfig", () => {
+    const noopLog = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    let tmpDir: string;
+    let savedConfigPath: string | undefined;
+    let savedStateDir: string | undefined;
+
+    afterEach(() => {
+      if (savedConfigPath !== undefined) process.env.OPENCLAW_CONFIG_PATH = savedConfigPath;
+      else delete process.env.OPENCLAW_CONFIG_PATH;
+      if (savedStateDir !== undefined) process.env.OPENCLAW_STATE_DIR = savedStateDir;
+      else delete process.env.OPENCLAW_STATE_DIR;
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function setupFakeConfig(openclawJson: object): string {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-secretref-"));
+      const cfgPath = path.join(tmpDir, "openclaw.json");
+      fs.writeFileSync(cfgPath, JSON.stringify(openclawJson), "utf-8");
+      savedConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      savedStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_CONFIG_PATH = cfgPath;
+      return cfgPath;
+    }
+
+    it("should resolve plain string apiKey", () => {
+      setupFakeConfig({
+        agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } },
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              apiKey: "sk-ant-plain-key-123",
+            },
+          },
+        },
+      });
+      const cfg = loadOpenClawFallbackConfig(noopLog);
+      expect(cfg).toBeDefined();
+      expect(cfg!.apiKey).toBe("sk-ant-plain-key-123");
+      expect(cfg!.provider).toBe("anthropic");
+      expect(cfg!.model).toBe("claude-3-haiku");
+    });
+
+    it("should resolve env-sourced SecretRef apiKey", () => {
+      const testKey = "sk-ant-secretref-test-" + Date.now();
+      process.env.__MEMOS_TEST_ANTHROPIC_KEY = testKey;
+      try {
+        setupFakeConfig({
+          agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } },
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: "https://api.anthropic.com",
+                apiKey: { source: "env", provider: "anthropic", id: "__MEMOS_TEST_ANTHROPIC_KEY" },
+              },
+            },
+          },
+        });
+        const cfg = loadOpenClawFallbackConfig(noopLog);
+        expect(cfg).toBeDefined();
+        expect(cfg!.apiKey).toBe(testKey);
+        expect(cfg!.provider).toBe("anthropic");
+      } finally {
+        delete process.env.__MEMOS_TEST_ANTHROPIC_KEY;
+      }
+    });
+
+    it("should return undefined when SecretRef env var is not set", () => {
+      delete process.env.__MEMOS_TEST_MISSING_KEY;
+      setupFakeConfig({
+        agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } },
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              apiKey: { source: "env", provider: "anthropic", id: "__MEMOS_TEST_MISSING_KEY" },
+            },
+          },
+        },
+      });
+      const cfg = loadOpenClawFallbackConfig(noopLog);
+      expect(cfg).toBeUndefined();
+    });
+
+    it("should return undefined when apiKey is missing entirely", () => {
+      setupFakeConfig({
+        agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } },
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+            },
+          },
+        },
+      });
+      const cfg = loadOpenClawFallbackConfig(noopLog);
+      expect(cfg).toBeUndefined();
+    });
+
+    it("should return undefined for unsupported SecretRef source", () => {
+      setupFakeConfig({
+        agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } },
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              apiKey: { source: "vault", provider: "anthropic", id: "some-vault-id" },
+            },
+          },
+        },
+      });
+      const cfg = loadOpenClawFallbackConfig(noopLog);
+      expect(cfg).toBeUndefined();
+    });
+
+    it("should resolve SecretRef apiKey for OpenAI-compatible provider", () => {
+      const testKey = "sk-openai-test-" + Date.now();
+      process.env.__MEMOS_TEST_OPENAI_KEY = testKey;
+      try {
+        setupFakeConfig({
+          agents: { defaults: { model: { primary: "custom-provider/gpt-4o-mini" } } },
+          models: {
+            providers: {
+              "custom-provider": {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: { source: "env", provider: "openai", id: "__MEMOS_TEST_OPENAI_KEY" },
+              },
+            },
+          },
+        });
+        const cfg = loadOpenClawFallbackConfig(noopLog);
+        expect(cfg).toBeDefined();
+        expect(cfg!.apiKey).toBe(testKey);
+        expect(cfg!.provider).toBe("openai_compatible");
+        expect(cfg!.model).toBe("gpt-4o-mini");
+      } finally {
+        delete process.env.__MEMOS_TEST_OPENAI_KEY;
+      }
+    });
   });
 
   it("should use rule fallback when summarizer openclaw provider fails", async () => {


### PR DESCRIPTION
## Description

`loadOpenClawFallbackConfig` reads `openclaw.json` to build the final fallback LLM config when the plugin's configured summarizer model fails. Previously, it assumed `apiKey` in `models.providers` is always a plain string. However, OpenClaw's credential system also supports `SecretRef` format (`{ source: "env", id: "ENV_VAR_NAME" }`), which was not resolved — causing either silent fallback skip (when treated as truthy object passing the check but failing HTTP auth) or incorrect availability detection in the viewer.

This PR adds `resolveApiKey()` to properly handle both plain string and env-sourced `SecretRef` API keys in three locations:

- `src/ingest/providers/index.ts` — Summarizer fallback chain
- `src/shared/llm-call.ts` — Skill pipeline fallback chain
- `src/viewer/server.ts` — Viewer fallback model availability check

The implementation mirrors the existing `resolveApiKey` in `src/openclaw-api.ts` (used by the host model proxy path).

Related Issue (Required): Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Unit Test
- [x] Test Script Or Test Steps (please provide)

1. Configure `openclaw.json` with a SecretRef-style apiKey in `models.providers`:
   ```json
   {
     "agents": { "defaults": { "model": { "primary": "anthropic/claude-3-haiku-20240307" } } },
     "models": {
       "providers": {
         "anthropic": {
           "baseUrl": "https://api.anthropic.com",
           "apiKey": { "source": "env", "id": "ANTHROPIC_API_KEY" }
         }
       }
     }
   }
   ```
2. Set `ANTHROPIC_API_KEY` in environment.
3. Configure the plugin summarizer with an intentionally invalid OpenAI-compatible endpoint so it fails.
4. Verify the fallback chain correctly resolves the Anthropic API key from env and completes summarization via Anthropic format.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided