### PR TITLE
fix: improve API validation error messages with request context

### DIFF
--- a/src/memos/api/exceptions.py
+++ b/src/memos/api/exceptions.py
@@ -14,13 +14,26 @@ class APIExceptionHandler:
     @staticmethod
     async def validation_error_handler(request: Request, exc: RequestValidationError):
         """Handle request validation errors."""
-        logger.error(f"Validation error: {exc.errors()}")
+        errors = exc.errors()
+        path = request.url.path
+        method = request.method
+
+        readable_errors = []
+        for err in errors:
+            loc = " -> ".join(str(loc_i) for loc_i in err.get("loc", []))
+            readable_errors.append(
+                f"[{loc}] {err.get('msg', 'unknown error')} (type: {err.get('type', 'unknown')})"
+            )
+
+        logger.error(
+            f"Validation error on {method} {path}: {readable_errors}, raw errors: {errors}"
+        )
         return JSONResponse(
             status_code=422,
             content={
                 "code": 422,
-                "message": "Parameter validation error",
-                "detail": exc.errors(),
+                "message": f"Parameter validation error on {method} {path}: {'; '.join(readable_errors)}",
+                "detail": errors,
                 "data": None,
             },
         )


### PR DESCRIPTION
## Summary
- Enhanced `validation_error_handler` in `exceptions.py` to include request method, path, and human-readable error descriptions in both the response message and server logs
- Callers can now immediately identify which endpoint failed and what fields are missing, without needing to check server logs

Closes #1349

## Test Plan
- [x] Send POST `/product/get_memory` with empty body → response message includes `POST /product/get_memory: [body] Field required (type: missing)`
- [x] Send POST `/product/get_memory` with body missing `mem_cube_id` → response message includes `[body -> mem_cube_id] Field required (type: missing)`
- [x] Normal valid requests are not affected