### PR TITLE
fix: detect and rebuild better-sqlite3 on Node.js ABI mismatch

### DIFF
--- a/apps/memos-local-openclaw/scripts/postinstall.cjs
+++ b/apps/memos-local-openclaw/scripts/postinstall.cjs
@@ -226,7 +226,35 @@ function sqliteBindingsExist() {
   return false;
 }
 
-if (sqliteBindingsExist()) {
+/**
+ * Check whether better-sqlite3 can actually be loaded by the current
+ * Node.js runtime.  A binding file may exist on disk but still fail
+ * with NODE_MODULE_VERSION mismatch after a Node.js or plugin update.
+ */
+function sqliteLoadsSuccessfully() {
+  try {
+    require(path.join(sqliteModulePath, "lib", "index.js"));
+    return true;
+  } catch (e) {
+    if (e && e.message && e.message.includes("NODE_MODULE_VERSION")) {
+      warn("ABI version mismatch — native module was built for a different Node.js version.");
+      return false;
+    }
+    // For any other load error fall through to the rebuild path as well.
+    return false;
+  }
+}
+
+let needsRebuild = false;
+
+if (!sqliteBindingsExist()) {
+  warn("better-sqlite3 native bindings not found in plugin dir.");
+  log(`Searched in: ${DIM}${sqliteModulePath}/build/${RESET}`);
+  needsRebuild = true;
+} else if (!sqliteLoadsSuccessfully()) {
+  log("Native binding file exists but cannot be loaded by current Node.js.");
+  needsRebuild = true;
+} else {
   ok("better-sqlite3 is ready.");
   console.log(`
 ${GREEN}${BOLD}  ┌──────────────────────────────────────────────────┐
@@ -237,11 +265,9 @@ ${GREEN}${BOLD}  ┌────────────────────
   └──────────────────────────────────────────────────┘${RESET}
 `);
   process.exit(0);
-} else {
-  warn("better-sqlite3 native bindings not found in plugin dir.");
-  log(`Searched in: ${DIM}${sqliteModulePath}/build/${RESET}`);
-  log("Running: npm rebuild better-sqlite3 (may take 30-60s)...");
 }
+
+log("Running: npm rebuild better-sqlite3 (may take 30-60s)...");
 
 const startMs = Date.now();
 


### PR DESCRIPTION
## Summary

- Fixes the `NODE_MODULE_VERSION` mismatch that prevents `memos-local-openclaw-plugin` from loading after a Node.js or plugin update on Windows (and other platforms)
- The `postinstall.cjs` script previously only checked whether the `.node` binary file existed on disk; it now also attempts to `require()` the module and catches ABI mismatch errors
- When an incompatible binary is detected, `npm rebuild better-sqlite3` runs automatically — no manual intervention needed

## Details

The root cause: `openclaw plugins update` installs new JS files but may reuse the existing native binary built for an older Node.js ABI. The postinstall script saw the binary existed and short-circuited with "ready", even though it would fail at runtime.

The fix adds a `sqliteLoadsSuccessfully()` function that does a trial `require()` of the module. If it throws a `NODE_MODULE_VERSION` error, the script proceeds to rebuild instead of reporting success.

Closes #1343

## Test plan

- [ ] On a machine with better-sqlite3 already built, run `node scripts/postinstall.cjs` — should report "ready" without rebuilding
- [ ] Swap to a different Node.js version (e.g. via nvm), run `node scripts/postinstall.cjs` — should detect ABI mismatch and trigger rebuild automatically
- [ ] Delete the `build/` directory, run `node scripts/postinstall.cjs` — should detect missing bindings and rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)