### PR TITLE
feat(openclaw-plugin): add configurable capture skipSessionPatterns

### DIFF
--- a/apps/memos-local-openclaw/src/capture/index.ts
+++ b/apps/memos-local-openclaw/src/capture/index.ts
@@ -62,10 +62,19 @@ export function captureMessages(
   log: Logger,
   owner?: string,
   userSearchTime?: number,
+  skipSessionPatterns?: string[],
 ): ConversationMessage[] {
   const now = Date.now();
   const result: ConversationMessage[] = [];
   let lastTimestamp = 0;
+
+  // Skip capturing sessions matching configured patterns (e.g. [":cron:", "agent:wechat"]).
+  if (sessionKey && skipSessionPatterns && skipSessionPatterns.length > 0) {
+    if (skipSessionPatterns.some(p => sessionKey.includes(p))) {
+      log.debug(`Skipping filtered session capture: ${sessionKey}`);
+      return result;
+    }
+  }
 
   for (const msg of messages) {
     const role = msg.role as Role;

--- a/apps/memos-local-openclaw/src/config.ts
+++ b/apps/memos-local-openclaw/src/config.ts
@@ -72,6 +72,7 @@ export function resolveConfig(raw: Partial<MemosLocalConfig> | undefined, stateD
     },
     capture: {
       evidenceWrapperTag: cfg.capture?.evidenceWrapperTag ?? DEFAULTS.evidenceWrapperTag,
+      skipSessionPatterns: cfg.capture?.skipSessionPatterns ?? [":cron:"],
     },
     telemetry: {
       enabled: telemetryEnabled,

--- a/apps/memos-local-openclaw/src/index.ts
+++ b/apps/memos-local-openclaw/src/index.ts
@@ -92,7 +92,7 @@ export function initPlugin(opts: PluginInitOptions = {}): MemosLocalPlugin {
       const userSearchTime = sharedState.lastSearchTime || 0;
       sharedState.lastSearchTime = 0;
 
-      const captured = captureMessages(messages, session, turnId, tag, ctx.log, owner, userSearchTime);
+      const captured = captureMessages(messages, session, turnId, tag, ctx.log, owner, userSearchTime, ctx.config.capture?.skipSessionPatterns);
       if (captured.length > 0) {
         worker.enqueue(captured);
       }

--- a/apps/memos-local-openclaw/src/types.ts
+++ b/apps/memos-local-openclaw/src/types.ts
@@ -318,6 +318,8 @@ export interface MemosLocalConfig {
   };
   capture?: {
     evidenceWrapperTag?: string;
+    /** Session key substrings to skip capture entirely (e.g. [":cron:", "agent:wechat"]). Default: [":cron:"] */
+    skipSessionPatterns?: string[];
   };
   skillEvolution?: SkillEvolutionConfig;
   telemetry?: TelemetryConfig;


### PR DESCRIPTION
## Summary

Allow users to configure session key substrings to skip memory capture via `capture.skipSessionPatterns` config option.

**Default:** `[":cron:"]` (backward compatible — cron sessions still skipped by default)

## Motivation

Previously, only cron sessions were hard-coded to skip capture. Users who run multiple agents (e.g. a dedicated wechat agent) had to modify source code to exclude specific agents from memory capture.

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `skipSessionPatterns?: string[]` to `MemosLocalConfig.capture` |
| `src/config.ts` | Resolve config with default `[":cron:"]` |
| `src/capture/index.ts` | Add `skipSessionPatterns` parameter to `captureMessages()`, filter before processing |
| `src/index.ts` | Pass config value to `captureMessages()` |

## Example config

```json
{
  "capture": {
    "skipSessionPatterns": [":cron:", "agent:wechat", "agent:bot"]
  }
}
```

This replaces the previous hard-coded cron check and makes session filtering data-driven.