### PR TITLE
fix(plugin): update tools.allow via parsed object instead of raw string replacement

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -250,7 +250,7 @@ const memosLocalPlugin = {
     try {
       const pkg = JSON.parse(fs.readFileSync(path.join(pluginDir, "package.json"), "utf-8"));
       pluginVersion = pkg.version ?? pluginVersion;
-    } catch {}
+    } catch { }
     const telemetry = new Telemetry(ctx.config.telemetry ?? {}, stateDir, pluginVersion, ctx.log, pluginDir);
 
     // Install bundled memory-guide skill so OpenClaw loads it (write from embedded content so it works regardless of deploy layout)
@@ -279,15 +279,9 @@ const memosLocalPlugin = {
         const cfg = JSON.parse(raw);
         const allow: string[] | undefined = cfg?.tools?.allow;
         if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins")) {
-          const lastEntry = JSON.stringify(allow[allow.length - 1]);
-          const patched = raw.replace(
-            new RegExp(`(${lastEntry})(\\s*\\])`),
-            `$1,\n      "group:plugins"$2`,
-          );
-          if (patched !== raw && patched.includes("group:plugins")) {
-            fs.writeFileSync(openclawJsonPath, patched, "utf-8");
-            ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
-          }
+          cfg.tools.allow.push("group:plugins");
+          fs.writeFileSync(openclawJsonPath, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+          ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
         }
       }
     } catch (e) {
@@ -607,9 +601,9 @@ const memosLocalPlugin = {
             };
             const localText = filteredHits.length > 0
               ? filteredHits.map((h, i) => {
-                  const excerpt = h.original_excerpt.length > 220 ? h.original_excerpt.slice(0, 217) + "..." : h.original_excerpt;
-                  return `${i + 1}. [${h.source.role}]${originLabel(h)} ${excerpt}`;
-                }).join("\n")
+                const excerpt = h.original_excerpt.length > 220 ? h.original_excerpt.slice(0, 217) + "..." : h.original_excerpt;
+                return `${i + 1}. [${h.source.role}]${originLabel(h)} ${excerpt}`;
+              }).join("\n")
               : "(none)";
             const hubText = filteredHubHits.length > 0
               ? filteredHubHits.map((h, i) => `${i + 1}. [${h.ownerName}] [团队] ${h.summary}${h.groupName ? ` (${h.groupName})` : ""}`).join("\n")


### PR DESCRIPTION
## Summary
This PR simplifies how the plugin updates `tools.allow` in `openclaw.json` by modifying the parsed JSON object directly instead of patching the raw file content with string replacement.
In addition, it:
- removes unnecessary string manipulation in the config patching flow
- improves readability of the update logic
- normalizes indentation/style in the search result formatting code
Fixes #1377
## Problem
The previous implementation parsed `openclaw.json`, but then used a regex-based string replacement on the raw file content to append `"group:plugins"` to `tools.allow`.
Because the replacement was performed on the full raw JSON string without being scoped to `tools.allow`, it could accidentally match another array that ended with the same last value. In practice, this could inject `"group:plugins"` into unrelated config fields such as:
```json
models.providers.xxxx.models[0].input
```
which then caused config validation failures.

Solution
This PR updates the logic to work on the parsed object directly:

parse openclaw.json
ensure cfg.tools.allow exists and is an array
append "group:plugins" only if it is not already present
write the updated object back using JSON.stringify(...)
This avoids accidental modification of unrelated arrays and makes the code easier to understand and maintain.

Additional cleanup
unified indentation/style in search result formatting code
removed unnecessary string-based operations to improve readability
Dependencies
No new dependencies were added.

Related Issue
Fixes #1377

---
# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update
How Has This Been Tested?
如果你现在还没有单元测试，可以先写成手工复现测试步骤：


- [ ] Unit Test
- [x] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)
### Test Steps
1. Prepare an `openclaw.json` where:
   - `tools.allow` does not contain `"group:plugins"`
   - another array (for example `models.providers.vvvapi.models[0].input`) ends with the same last value as `tools.allow`
2. Run the plugin initialization / config patching logic.
3. Verify that:
   - `"group:plugins"` is appended only to `tools.allow`
   - unrelated arrays such as `models.providers.vvvapi.models[0].input` remain unchanged
   - the resulting `openclaw.json` is valid and can be loaded successfully
### Verified Result
After this change, the plugin updates only `cfg.tools.allow` and no longer corrupts other arrays in `openclaw.json`.
Checklist
如果你暂时没加测试，就别勾那一项。可以先这样：


- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人