### PR TITLE
fix: skip tools.allow patching when wildcard '*' is present

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -290,7 +290,7 @@ const memosLocalPlugin = {
         const raw = fs.readFileSync(openclawJsonPath, "utf-8");
         const cfg = JSON.parse(raw);
         const allow: string[] | undefined = cfg?.tools?.allow;
-        if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins")) {
+        if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins") && !allow.includes("*")) {
           const lastEntry = JSON.stringify(allow[allow.length - 1]);
           const patched = raw.replace(
             new RegExp(`(${lastEntry})(\\s*\\])`),


### PR DESCRIPTION
## Bug

When `tools.allow` contains `"*"`, the plugin still appends `"group:plugins"` to `tools.allow`. This triggers OpenClaw core to sync `"group:plugins"` to `acp.allowedAgents` **without deduplication**, causing an infinite restart loop:

```
plugin init → append "group:plugins" to tools.allow
→ core syncs to acp.allowedAgents (no dedup)
→ config change detected → gateway restart
→ plugin re-inits → core appends again
→ infinite restart loop
```

In production this resulted in 20+ restarts in ~40 minutes, with `acp.allowedAgents` accumulating 34+ duplicate `"group:plugins"` entries.

## Reproduction

1. Install `@memtensor/memos-local-openclaw-plugin` v1.0.7 on OpenClaw
2. Set `tools.allow` to `["*"]` in `openclaw.json`
3. Start gateway → observe repeated config changes and restarts in logs

## Fix

Skip patching `tools.allow` when it already contains the wildcard `"*"`, since the wildcard already covers all plugin tools.

```diff
- if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins")) {
+ if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins") && !allow.includes("*")) {
```

## Impact

- Users with `tools.allow: ["*"]` (very common) will no longer trigger restart loops
- Users with explicit tool lists still get `"group:plugins"` appended as before
- Zero breaking changes