### PR TITLE
fix(install): handle postinstall node_modules cleanup and remove stale contextEngine slot

### DIFF
--- a/apps/memos-local-openclaw/install.ps1
+++ b/apps/memos-local-openclaw/install.ps1
@@ -184,10 +184,13 @@ if (!config.plugins.allow.includes(pluginId)) {
   config.plugins.allow.push(pluginId);
 }
 
-if (!config.plugins.slots || typeof config.plugins.slots !== "object") {
-  config.plugins.slots = {};
+// Clean up stale contextEngine slot from previous versions
+if (config.plugins.slots && config.plugins.slots.contextEngine) {
+  delete config.plugins.slots.contextEngine;
+  if (Object.keys(config.plugins.slots).length === 0) {
+    delete config.plugins.slots;
+  }
 }
-config.plugins.slots.contextEngine = "memos-local-openclaw-plugin";
 
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 '@
@@ -296,6 +299,20 @@ try {
 finally {
   Remove-Item Env:\MEMOS_SKIP_SETUP -ErrorAction SilentlyContinue
   Pop-Location
+}
+
+$nodeModulesDir = Join-Path $ExtensionDir "node_modules"
+if (-not (Test-Path $nodeModulesDir) -or @(Get-ChildItem -Path $nodeModulesDir -ErrorAction SilentlyContinue).Count -eq 0) {
+  Write-Warn "node_modules was cleaned by postinstall (version upgrade detected), re-installing..."
+  Push-Location $ExtensionDir
+  try {
+    $env:MEMOS_SKIP_SETUP = "1"
+    & npm install --omit=dev --no-fund --no-audit --loglevel=error 2>&1
+  }
+  finally {
+    Remove-Item Env:\MEMOS_SKIP_SETUP -ErrorAction SilentlyContinue
+    Pop-Location
+  }
 }
 
 if (-not (Test-Path $ExtensionDir)) {

--- a/apps/memos-local-openclaw/install.sh
+++ b/apps/memos-local-openclaw/install.sh
@@ -246,10 +246,13 @@ if (!config.plugins.allow.includes(pluginId)) {
   config.plugins.allow.push(pluginId);
 }
 
-if (!config.plugins.slots || typeof config.plugins.slots !== 'object') {
-  config.plugins.slots = {};
+// Clean up stale contextEngine slot from previous versions
+if (config.plugins.slots && config.plugins.slots.contextEngine) {
+  delete config.plugins.slots.contextEngine;
+  if (Object.keys(config.plugins.slots).length === 0) {
+    delete config.plugins.slots;
+  }
 }
-config.plugins.slots.contextEngine = 'memos-local-openclaw-plugin';
 
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 NODE
@@ -304,6 +307,14 @@ info "Install dependencies, 安装依赖..."
   cd "${EXTENSION_DIR}"
   MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error 2>&1
 )
+
+if [[ ! -d "${EXTENSION_DIR}/node_modules" ]] || [[ -z "$(ls -A "${EXTENSION_DIR}/node_modules" 2>/dev/null)" ]]; then
+  warn "node_modules was cleaned by postinstall (version upgrade detected), re-installing..."
+  (
+    cd "${EXTENSION_DIR}"
+    MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error 2>&1
+  )
+fi
 
 if [[ ! -d "$EXTENSION_DIR" ]]; then
   error "Plugin directory not found after install, 安装后未找到插件目录: ${EXTENSION_DIR}"


### PR DESCRIPTION
## Summary

- **Remove stale `contextEngine` slot**: The install scripts no longer write `plugins.slots.contextEngine` into `openclaw.json`. Instead, they clean up this deprecated field left by previous versions.
- **Handle postinstall `node_modules` cleanup**: After `npm install`, if `node_modules` was emptied by a postinstall hook (e.g. during version upgrade), the scripts automatically re-run `npm install`.

## Changed files

- `apps/memos-local-openclaw/install.sh`
- `apps/memos-local-openclaw/install.ps1`

## Test plan

- [ ] Run `bash install.sh --version <version>` on macOS/Linux, verify plugin installs correctly
- [ ] Run `install.ps1 --version <version>` on Windows, verify plugin installs correctly
- [ ] Verify `openclaw.json` no longer contains `plugins.slots.contextEngine` after installation
- [ ] Simulate postinstall clearing `node_modules` — confirm the re-install logic triggers


Made with [Cursor](https://cursor.com)