### PR TITLE
fix(install): register plugin in slots, entries and installs of openclaw.json

### DIFF
--- a/apps/memos-local-openclaw/install.ps1
+++ b/apps/memos-local-openclaw/install.ps1
@@ -148,16 +148,21 @@ function Update-OpenClawConfig {
   param(
     [string]$OpenClawHome,
     [string]$ConfigPath,
-    [string]$PluginId
+    [string]$PluginId,
+    [string]$InstallPath,
+    [string]$Spec
   )
 
   Write-Info "Updating OpenClaw config..."
   New-Item -ItemType Directory -Path $OpenClawHome -Force | Out-Null
   $nodeScript = @'
 const fs = require("fs");
+const path = require("path");
 
 const configPath = process.argv[2];
 const pluginId = process.argv[3];
+const installPath = process.argv[4];
+const spec = process.argv[5];
 
 let config = {};
 if (fs.existsSync(configPath)) {
@@ -187,14 +192,48 @@ if (!config.plugins.allow.includes(pluginId)) {
 // Clean up stale contextEngine slot from previous versions
 if (config.plugins.slots && config.plugins.slots.contextEngine) {
   delete config.plugins.slots.contextEngine;
-  if (Object.keys(config.plugins.slots).length === 0) {
-    delete config.plugins.slots;
-  }
 }
+
+// Register plugin in memory slot
+if (!config.plugins.slots || typeof config.plugins.slots !== "object") {
+  config.plugins.slots = {};
+}
+config.plugins.slots.memory = pluginId;
+
+// Ensure plugin entry is enabled (preserve existing config if present)
+if (!config.plugins.entries || typeof config.plugins.entries !== "object") {
+  config.plugins.entries = {};
+}
+if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId] !== "object") {
+  config.plugins.entries[pluginId] = {};
+}
+config.plugins.entries[pluginId].enabled = true;
+
+// Register plugin in installs so gateway auto-loads it on restart
+if (!config.plugins.installs || typeof config.plugins.installs !== "object") {
+  config.plugins.installs = {};
+}
+const pkgJsonPath = path.join(installPath, "package.json");
+let resolvedName, resolvedVersion;
+if (fs.existsSync(pkgJsonPath)) {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  resolvedName = pkg.name;
+  resolvedVersion = pkg.version;
+}
+config.plugins.installs[pluginId] = {
+  source: "npm",
+  spec,
+  installPath,
+  ...(resolvedVersion ? { version: resolvedVersion } : {}),
+  ...(resolvedName ? { resolvedName } : {}),
+  ...(resolvedVersion ? { resolvedVersion } : {}),
+  ...(resolvedName && resolvedVersion ? { resolvedSpec: `${resolvedName}@${resolvedVersion}` } : {}),
+  installedAt: new Date().toISOString(),
+};
 
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 '@
-  $nodeScript | & node - $ConfigPath $PluginId
+  $nodeScript | & node - $ConfigPath $PluginId $InstallPath $Spec
   Write-Success "OpenClaw config updated: $ConfigPath"
 }
 
@@ -320,7 +359,7 @@ if (-not (Test-Path $ExtensionDir)) {
   exit 1
 }
 
-Update-OpenClawConfig -OpenClawHome $OpenClawHome -ConfigPath $OpenClawConfigPath -PluginId $PluginId
+Update-OpenClawConfig -OpenClawHome $OpenClawHome -ConfigPath $OpenClawConfigPath -PluginId $PluginId -InstallPath $ExtensionDir -Spec $PackageSpec
 
 Write-Success "Restarting OpenClaw Gateway..."
 & npx openclaw gateway run --port $Port --force

--- a/apps/memos-local-openclaw/install.sh
+++ b/apps/memos-local-openclaw/install.sh
@@ -215,11 +215,14 @@ OPENCLAW_CONFIG_PATH="${OPENCLAW_HOME}/openclaw.json"
 update_openclaw_config() {
   info "Update OpenClaw config, 更新 OpenClaw 配置..."
   mkdir -p "${OPENCLAW_HOME}"
-  node - "${OPENCLAW_CONFIG_PATH}" "${PLUGIN_ID}" <<'NODE'
+  node - "${OPENCLAW_CONFIG_PATH}" "${PLUGIN_ID}" "${EXTENSION_DIR}" "${PACKAGE_SPEC}" <<'NODE'
 const fs = require('fs');
+const path = require('path');
 
 const configPath = process.argv[2];
 const pluginId = process.argv[3];
+const installPath = process.argv[4];
+const spec = process.argv[5];
 
 let config = {};
 if (fs.existsSync(configPath)) {
@@ -249,10 +252,44 @@ if (!config.plugins.allow.includes(pluginId)) {
 // Clean up stale contextEngine slot from previous versions
 if (config.plugins.slots && config.plugins.slots.contextEngine) {
   delete config.plugins.slots.contextEngine;
-  if (Object.keys(config.plugins.slots).length === 0) {
-    delete config.plugins.slots;
-  }
 }
+
+// Register plugin in memory slot
+if (!config.plugins.slots || typeof config.plugins.slots !== 'object') {
+  config.plugins.slots = {};
+}
+config.plugins.slots.memory = pluginId;
+
+// Ensure plugin entry is enabled (preserve existing config if present)
+if (!config.plugins.entries || typeof config.plugins.entries !== 'object') {
+  config.plugins.entries = {};
+}
+if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId] !== 'object') {
+  config.plugins.entries[pluginId] = {};
+}
+config.plugins.entries[pluginId].enabled = true;
+
+// Register plugin in installs so gateway auto-loads it on restart
+if (!config.plugins.installs || typeof config.plugins.installs !== 'object') {
+  config.plugins.installs = {};
+}
+const pkgJsonPath = path.join(installPath, 'package.json');
+let resolvedName, resolvedVersion;
+if (fs.existsSync(pkgJsonPath)) {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  resolvedName = pkg.name;
+  resolvedVersion = pkg.version;
+}
+config.plugins.installs[pluginId] = {
+  source: 'npm',
+  spec,
+  installPath,
+  ...(resolvedVersion ? { version: resolvedVersion } : {}),
+  ...(resolvedName ? { resolvedName } : {}),
+  ...(resolvedVersion ? { resolvedVersion } : {}),
+  ...(resolvedName && resolvedVersion ? { resolvedSpec: `${resolvedName}@${resolvedVersion}` } : {}),
+  installedAt: new Date().toISOString(),
+};
 
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 NODE


### PR DESCRIPTION
## Summary

The install scripts (`install.sh` / `install.ps1`) previously only wrote `plugins.allow` and `plugins.enabled` to `openclaw.json`, but missed three critical registrations. This caused the OpenClaw gateway to **not auto-load the memos-local plugin on restart**.

### Changes

- **`plugins.slots.memory`**: Register the plugin in the `memory` slot so OpenClaw knows which plugin handles memory operations
- **`plugins.entries[pluginId].enabled = true`**: Enable the plugin entry (preserves existing user config like embedding/summarizer settings)
- **`plugins.installs[pluginId]`**: Write full npm install metadata (source, spec, installPath, version, resolvedName, resolvedVersion, resolvedSpec, installedAt) so the gateway can track and auto-load the plugin
- **Clean up stale `contextEngine` slot**: Remove deprecated slot from previous versions

### Files changed

- `apps/memos-local-openclaw/install.sh`
- `apps/memos-local-openclaw/install.ps1`

## Test plan

- [ ] Fresh install via `bash install.sh --version <version>` — verify `openclaw.json` contains `slots.memory`, `entries`, and `installs` for the plugin
- [ ] Restart OpenClaw gateway — verify plugin loads automatically without manual config
- [ ] Re-install over existing config — verify user's existing `entries[pluginId].config` (embedding, summarizer, etc.) is preserved


Made with [Cursor](https://cursor.com)