### PR TITLE
fix(install): use gateway service instead of foreground run, add completion hints

### DIFF
--- a/apps/memos-local-openclaw/install.ps1
+++ b/apps/memos-local-openclaw/install.ps1
@@ -361,5 +361,18 @@ if (-not (Test-Path $ExtensionDir)) {
 
 Update-OpenClawConfig -OpenClawHome $OpenClawHome -ConfigPath $OpenClawConfigPath -PluginId $PluginId -InstallPath $ExtensionDir -Spec $PackageSpec
 
-Write-Success "Restarting OpenClaw Gateway..."
-& npx openclaw gateway run --port $Port --force
+Write-Info "Installing OpenClaw Gateway service..."
+& npx openclaw gateway install --port $Port --force 2>&1
+if (-not $?) { Write-Warn "Gateway service install returned a warning; continuing..." }
+
+Write-Success "Starting OpenClaw Gateway service..."
+& npx openclaw gateway start 2>&1
+
+Write-Host ""
+Write-Success "=========================================="
+Write-Success "  Installation complete!"
+Write-Success "=========================================="
+Write-Host ""
+Write-Info "  OpenClaw Web UI:      http://localhost:$Port"
+Write-Info "  Memory Viewer:        http://localhost:18799"
+Write-Host ""

--- a/apps/memos-local-openclaw/install.sh
+++ b/apps/memos-local-openclaw/install.sh
@@ -360,5 +360,17 @@ fi
 
 update_openclaw_config
 
-success "Restart OpenClaw Gateway, 重启 OpenClaw Gateway..."
-exec npx openclaw gateway run --port "${PORT}" --force
+info "Install OpenClaw Gateway service, 安装 OpenClaw Gateway 服务..."
+npx openclaw gateway install --port "${PORT}" --force 2>&1 || true
+
+success "Start OpenClaw Gateway service, 启动 OpenClaw Gateway 服务..."
+npx openclaw gateway start 2>&1
+
+echo ""
+success "=========================================="
+success "  Installation complete! 安装完成!"
+success "=========================================="
+echo ""
+info "  OpenClaw Web UI:      http://localhost:${PORT}"
+info "  Memory Viewer:        http://localhost:18799"
+echo ""


### PR DESCRIPTION
## Summary

- **Replace foreground `gateway run` with background service**: Use `openclaw gateway install` + `openclaw gateway start` instead of `exec npx openclaw gateway run`. The gateway now runs as a system background service (launchd/systemd/schtasks), so the install script exits cleanly and Ctrl+C won't kill the gateway.
- **Add post-install hints**: Show the user OpenClaw Web UI (`http://localhost:<port>`) and Memory Viewer (`http://localhost:18799`) URLs after installation completes.

## Files changed

- `apps/memos-local-openclaw/install.sh`
- `apps/memos-local-openclaw/install.ps1`

## Test plan

- [ ] Run `bash install.sh --version <version>` — verify script exits after installation
- [ ] Verify gateway is running as a background service after script exits
- [ ] Verify Web UI and Memory Viewer URLs are displayed at the end
- [ ] Ctrl+C during the install process does not leave gateway in a broken state


Made with [Cursor](https://cursor.com)