### PR TITLE
fix(openclaw-plugin): self-start viewer + install script improvements

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -2329,48 +2329,54 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
 
     // ─── Service lifecycle ───
 
+    let serviceStarted = false;
+
+    const startServiceCore = async () => {
+      if (serviceStarted) return;
+      serviceStarted = true;
+
+      if (hubServer) {
+        const hubUrl = await hubServer.start();
+        api.logger.info(`memos-local: hub started at ${hubUrl}`);
+      }
+
+      if (ctx.config.sharing?.enabled && ctx.config.sharing.role === "client") {
+        try {
+          const session = await connectToHub(store, ctx.config, ctx.log);
+          api.logger.info(`memos-local: connected to Hub as "${session.username}" (${session.userId})`);
+        } catch (err) {
+          api.logger.warn(`memos-local: Hub connection failed: ${err}`);
+        }
+      }
+
+      try {
+        const viewerUrl = await viewer.start();
+        api.logger.info(`memos-local: started (embedding: ${embedder.provider})`);
+        api.logger.info(`╔══════════════════════════════════════════╗`);
+        api.logger.info(`║  MemOS Memory Viewer                     ║`);
+        api.logger.info(`║  → ${viewerUrl.padEnd(37)}║`);
+        api.logger.info(`║  Open in browser to manage memories       ║`);
+        api.logger.info(`╚══════════════════════════════════════════╝`);
+        api.logger.info(`memos-local: password reset token: ${viewer.getResetToken()}`);
+        api.logger.info(`memos-local: forgot password? Use the reset token on the login page.`);
+        skillEvolver.recoverOrphanedTasks().then((count) => {
+          if (count > 0) api.logger.info(`memos-local: recovered ${count} orphaned skill tasks`);
+        }).catch((err) => {
+          api.logger.warn(`memos-local: skill recovery failed: ${err}`);
+        });
+      } catch (err) {
+        api.logger.warn(`memos-local: viewer failed to start: ${err}`);
+        api.logger.info(`memos-local: started (embedding: ${embedder.provider})`);
+      }
+      telemetry.trackPluginStarted(
+        ctx.config.embedding?.provider ?? "local",
+        ctx.config.summarizer?.provider ?? "none",
+      );
+    };
+
     api.registerService({
       id: "memos-local-openclaw-plugin",
-      start: async () => {
-        if (hubServer) {
-          const hubUrl = await hubServer.start();
-          api.logger.info(`memos-local: hub started at ${hubUrl}`);
-        }
-
-        // Auto-connect to Hub in client mode (handles both existing token and auto-join via teamToken)
-        if (ctx.config.sharing?.enabled && ctx.config.sharing.role === "client") {
-          try {
-            const session = await connectToHub(store, ctx.config, ctx.log);
-            api.logger.info(`memos-local: connected to Hub as "${session.username}" (${session.userId})`);
-          } catch (err) {
-            api.logger.warn(`memos-local: Hub connection failed: ${err}`);
-          }
-        }
-
-        try {
-          const viewerUrl = await viewer.start();
-          api.logger.info(`memos-local: started (embedding: ${embedder.provider})`);
-          api.logger.info(`╔══════════════════════════════════════════╗`);
-          api.logger.info(`║  MemOS Memory Viewer                     ║`);
-          api.logger.info(`║  → ${viewerUrl.padEnd(37)}║`);
-          api.logger.info(`║  Open in browser to manage memories       ║`);
-          api.logger.info(`╚══════════════════════════════════════════╝`);
-          api.logger.info(`memos-local: password reset token: ${viewer.getResetToken()}`);
-          api.logger.info(`memos-local: forgot password? Use the reset token on the login page.`);
-          skillEvolver.recoverOrphanedTasks().then((count) => {
-            if (count > 0) api.logger.info(`memos-local: recovered ${count} orphaned skill tasks`);
-          }).catch((err) => {
-            api.logger.warn(`memos-local: skill recovery failed: ${err}`);
-          });
-        } catch (err) {
-          api.logger.warn(`memos-local: viewer failed to start: ${err}`);
-          api.logger.info(`memos-local: started (embedding: ${embedder.provider})`);
-        }
-        telemetry.trackPluginStarted(
-          ctx.config.embedding?.provider ?? "local",
-          ctx.config.summarizer?.provider ?? "none",
-        );
-      },
+      start: async () => { await startServiceCore(); },
       stop: async () => {
         await worker.flush();
         await telemetry.shutdown();
@@ -2380,6 +2386,19 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
         api.logger.info("memos-local: stopped");
       },
     });
+
+    // Fallback: OpenClaw may load this plugin via deferred reload after
+    // startPluginServices has already run, so service.start() never fires.
+    // Self-start the viewer after a grace period if it hasn't been started.
+    const SELF_START_DELAY_MS = 3000;
+    setTimeout(() => {
+      if (!serviceStarted) {
+        api.logger.info("memos-local: service.start() not called by host, self-starting viewer...");
+        startServiceCore().catch((err) => {
+          api.logger.warn(`memos-local: self-start failed: ${err}`);
+        });
+      }
+    }, SELF_START_DELAY_MS);
   },
 };
 

--- a/apps/memos-local-openclaw/install.ps1
+++ b/apps/memos-local-openclaw/install.ps1
@@ -148,6 +148,8 @@ function Update-OpenClawConfig {
   param(
     [string]$OpenClawHome,
     [string]$ConfigPath,
+    [string]$ExtensionDir,
+    [string]$PackageSpec,
     [string]$PluginId
   )
 
@@ -155,9 +157,12 @@ function Update-OpenClawConfig {
   New-Item -ItemType Directory -Path $OpenClawHome -Force | Out-Null
   $nodeScript = @'
 const fs = require("fs");
+const path = require("path");
 
 const configPath = process.argv[2];
 const pluginId = process.argv[3];
+const installPath = process.argv[4];
+const spec = process.argv[5];
 
 let config = {};
 if (fs.existsSync(configPath)) {
@@ -192,9 +197,48 @@ if (config.plugins.slots && config.plugins.slots.contextEngine) {
   }
 }
 
+// Register memory slot
+if (!config.plugins.slots || typeof config.plugins.slots !== "object") {
+  config.plugins.slots = {};
+}
+config.plugins.slots.memory = pluginId;
+
+// Register plugin entry as enabled
+if (!config.plugins.entries || typeof config.plugins.entries !== "object") {
+  config.plugins.entries = {};
+}
+if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId] !== "object") {
+  config.plugins.entries[pluginId] = {};
+}
+config.plugins.entries[pluginId].enabled = true;
+
+// Register installs entry with pinned version
+if (!config.plugins.installs || typeof config.plugins.installs !== "object") {
+  config.plugins.installs = {};
+}
+let resolvedName = "";
+let resolvedVersion = "";
+const pkgJsonPath = path.join(installPath, "package.json");
+if (fs.existsSync(pkgJsonPath)) {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  resolvedName = pkg.name;
+  resolvedVersion = pkg.version;
+}
+const pinnedSpec = resolvedName && resolvedVersion ? `${resolvedName}@${resolvedVersion}` : spec;
+config.plugins.installs[pluginId] = {
+  source: "npm",
+  spec: pinnedSpec,
+  installPath,
+  ...(resolvedVersion ? { version: resolvedVersion } : {}),
+  ...(resolvedName ? { resolvedName } : {}),
+  ...(resolvedVersion ? { resolvedVersion } : {}),
+  ...(resolvedName && resolvedVersion ? { resolvedSpec: pinnedSpec } : {}),
+  installedAt: new Date().toISOString(),
+};
+
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 '@
-  $nodeScript | & node - $ConfigPath $PluginId
+  $nodeScript | & node - $ConfigPath $PluginId $ExtensionDir $PackageSpec
   Write-Success "OpenClaw config updated: $ConfigPath"
 }
 
@@ -352,7 +396,17 @@ if (-not (Test-Path $NodeModulesDir)) {
   exit 1
 }
 
-Update-OpenClawConfig -OpenClawHome $OpenClawHome -ConfigPath $OpenClawConfigPath -PluginId $PluginId
+Update-OpenClawConfig -OpenClawHome $OpenClawHome -ConfigPath $OpenClawConfigPath -PluginId $PluginId -ExtensionDir $ExtensionDir -PackageSpec $PackageSpec
 
 Write-Success "Restarting OpenClaw Gateway..."
-& npx openclaw gateway run --port $Port --force
+try { & npx openclaw gateway install --port $Port --force 2>&1 } catch {}
+& npx openclaw gateway start 2>&1
+
+Write-Host ""
+Write-Host "=========================================="
+Write-Host "  Installation complete!"
+Write-Host "=========================================="
+Write-Host ""
+Write-Host "  OpenClaw Web UI:      http://localhost:${Port}"
+Write-Host "  Memory Viewer:        http://localhost:18799"
+Write-Host ""

--- a/apps/memos-local-openclaw/install.sh
+++ b/apps/memos-local-openclaw/install.sh
@@ -215,11 +215,14 @@ OPENCLAW_CONFIG_PATH="${OPENCLAW_HOME}/openclaw.json"
 update_openclaw_config() {
   info "Update OpenClaw config, 更新 OpenClaw 配置..."
   mkdir -p "${OPENCLAW_HOME}"
-  node - "${OPENCLAW_CONFIG_PATH}" "${PLUGIN_ID}" <<'NODE'
+  node - "${OPENCLAW_CONFIG_PATH}" "${PLUGIN_ID}" "${EXTENSION_DIR}" "${PACKAGE_SPEC}" <<'NODE'
 const fs = require('fs');
+const path = require('path');
 
 const configPath = process.argv[2];
 const pluginId = process.argv[3];
+const installPath = process.argv[4];
+const spec = process.argv[5];
 
 let config = {};
 if (fs.existsSync(configPath)) {
@@ -253,6 +256,45 @@ if (config.plugins.slots && config.plugins.slots.contextEngine) {
     delete config.plugins.slots;
   }
 }
+
+// Register memory slot
+if (!config.plugins.slots || typeof config.plugins.slots !== 'object') {
+  config.plugins.slots = {};
+}
+config.plugins.slots.memory = pluginId;
+
+// Register plugin entry as enabled
+if (!config.plugins.entries || typeof config.plugins.entries !== 'object') {
+  config.plugins.entries = {};
+}
+if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId] !== 'object') {
+  config.plugins.entries[pluginId] = {};
+}
+config.plugins.entries[pluginId].enabled = true;
+
+// Register installs entry with pinned version
+if (!config.plugins.installs || typeof config.plugins.installs !== 'object') {
+  config.plugins.installs = {};
+}
+let resolvedName = '';
+let resolvedVersion = '';
+const pkgJsonPath = path.join(installPath, 'package.json');
+if (fs.existsSync(pkgJsonPath)) {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  resolvedName = pkg.name;
+  resolvedVersion = pkg.version;
+}
+const pinnedSpec = resolvedName && resolvedVersion ? `${resolvedName}@${resolvedVersion}` : spec;
+config.plugins.installs[pluginId] = {
+  source: 'npm',
+  spec: pinnedSpec,
+  installPath,
+  ...(resolvedVersion ? { version: resolvedVersion } : {}),
+  ...(resolvedName ? { resolvedName } : {}),
+  ...(resolvedVersion ? { resolvedVersion } : {}),
+  ...(resolvedName && resolvedVersion ? { resolvedSpec: pinnedSpec } : {}),
+  installedAt: new Date().toISOString(),
+};
 
 fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 NODE
@@ -346,4 +388,14 @@ fi
 update_openclaw_config
 
 success "Restart OpenClaw Gateway, 重启 OpenClaw Gateway..."
-exec npx openclaw gateway run --port "${PORT}" --force
+npx openclaw gateway install --port "${PORT}" --force 2>&1 || true
+npx openclaw gateway start 2>&1
+
+echo ""
+echo "=========================================="
+echo "  Installation complete! 安装完成!"
+echo "=========================================="
+echo ""
+echo "  OpenClaw Web UI:      http://localhost:${PORT}"
+echo "  Memory Viewer:        http://localhost:18799"
+echo ""


### PR DESCRIPTION
## Summary

- **Viewer self-start fallback**: OpenClaw 4.2 loads third-party plugins via deferred reload *after* `startPluginServices()` has already run. This means the plugin's `service.start()` callback (which starts the ViewerServer on port 18799) is never invoked by the host. Added a 3-second `setTimeout` fallback in `register()` that self-starts the viewer if the host hasn't called `service.start()`.
- **Install script: full plugin registration**: Register the plugin in `plugins.slots.memory`, `plugins.entries`, and `plugins.installs` sections of `openclaw.json`, ensuring the plugin auto-loads correctly on gateway restart.
- **Install script: pin version spec**: Use the exact resolved version (e.g. `@memtensor/memos-local-openclaw-plugin@1.0.7`) instead of `@latest` in the `installs.spec` field, preventing OpenClaw 4.2's security scanner from repeatedly blocking auto-update attempts.
- **Install script: background service**: Replace `exec npx openclaw gateway run` (foreground, blocks shell) with `npx openclaw gateway install/start` (background launchd service), so the script exits cleanly.
- **Install script: completion hints**: Print OpenClaw Web UI and Memory Viewer URLs after successful installation.

## Test plan

- [x] Verified on macOS with OpenClaw 2026.4.2 — Memory Viewer starts on port 18799
- [x] Confirmed self-start log: `memos-local: service.start() not called by host, self-starting viewer...`
- [x] Confirmed `curl -sI http://localhost:18799` returns HTTP 200
- [ ] Test `install.ps1` on Windows

Made with [Cursor](https://cursor.com)