### PR TITLE
fix(viewer): fix concurrency select arrow overlap and restrict taskAutoFinalize input

### DIFF
--- a/apps/memos-local-openclaw/src/viewer/html.ts
+++ b/apps/memos-local-openclaw/src/viewer/html.ts
@@ -1818,7 +1818,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
               </div>
               <div class="settings-field">
                 <label data-i18n="settings.taskAutoFinalize">Task Auto-Finalize (hours)</label>
-                <input type="number" id="cfgTaskAutoFinalizeHours" placeholder="4" min="0" step="1" style="max-width:120px">
+                <input type="number" id="cfgTaskAutoFinalizeHours" placeholder="4" min="0" step="1" style="max-width:120px" onkeydown="if(['-','e','E','+'].includes(event.key))event.preventDefault()" oninput="this.value=this.value.replace(/[^0-9]/g,'')">
                 <div class="field-hint" data-i18n="settings.taskAutoFinalize.hint">Active tasks with no new messages beyond this duration will be automatically summarized and completed when the Tasks page is opened. Set to 0 to disable. Default: 4 hours.</div>
               </div>
             </div>
@@ -1906,7 +1906,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
           <button class="btn btn-primary" onclick="migrateStart()" id="migrateStartBtn" style="display:none" data-i18n="migrate.start">Start Import</button>
           <span id="migrateConcurrencyRow" style="display:none;align-items:center;gap:6px">
             <span style="font-size:11px;color:var(--text-muted)" data-i18n="migrate.concurrency.label">Concurrent agents</span>
-            <select id="migrateConcurrency" class="filter-select" style="min-width:auto;padding:3px 10px;font-size:11px">
+            <select id="migrateConcurrency" class="filter-select" style="min-width:auto;padding:3px 28px 3px 10px;font-size:11px">
               <option value="1" selected>1</option>
               <option value="2">2</option>
               <option value="4">4</option>
@@ -1945,7 +1945,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
               <button class="btn btn-sm" id="ppStopBtn" onclick="ppStop()" style="display:none;background:rgba(239,68,68,.12);color:#ef4444;border:1px solid rgba(239,68,68,.3);font-size:12px;padding:5px 16px;font-weight:600" data-i18n="migrate.stop">\u25A0 Stop</button>
               <span style="display:inline-flex;align-items:center;gap:6px">
                 <span style="font-size:11px;color:var(--text-muted)" data-i18n="pp.concurrency.label">Concurrent agents</span>
-                <select id="ppConcurrency" class="filter-select" style="min-width:auto;padding:3px 10px;font-size:11px">
+                <select id="ppConcurrency" class="filter-select" style="min-width:auto;padding:3px 28px 3px 10px;font-size:11px">
                   <option value="1" selected>1</option>
                   <option value="2">2</option>
                   <option value="4">4</option>
@@ -7414,7 +7414,7 @@ async function saveGeneralConfig(){
   const vp=document.getElementById('cfgViewerPort').value.trim();
   if(vp) cfg.viewerPort=Number(vp);
   const tafh=document.getElementById('cfgTaskAutoFinalizeHours').value.trim();
-  cfg.taskAutoFinalizeHours=tafh!==''?Number(tafh):4;
+  cfg.taskAutoFinalizeHours=tafh!==''?Math.max(0,Number(tafh)):4;
   cfg.telemetry={enabled:document.getElementById('cfgTelemetryEnabled').checked};
 
   await doSaveConfig(cfg, saveBtn, 'generalSaved');


### PR DESCRIPTION
## Summary
- **Fix concurrency select dropdown arrow overlap**: The inline `padding:3px 10px` on `migrateConcurrency` and `ppConcurrency` selects was overriding the `.filter-select` class's `padding-right:28px`, causing the custom SVG dropdown arrow to overlap the selected number. Fixed by using `padding:3px 28px 3px 10px`.
- **Restrict taskAutoFinalizeHours to non-negative integers**: The input allowed typing invalid characters like `-`, `e`, `+`, resulting in values like "0-4" which the browser treats as empty, causing silent fallback to default. Fixed with three layers of protection:
  - `onkeydown`: blocks `-`, `e`, `E`, `+` keys
  - `oninput`: strips any non-digit characters (covers paste scenarios)
  - Save handler: `Math.max(0, ...)` clamp as server-side safeguard

## Test plan
- [ ] Open Memory Viewer → Import Memory panel → verify the "并行 Agent 数" select dropdown arrow does not overlap the number
- [ ] Open Memory Viewer → Post-process section → verify the same fix for "并行 Agent 数" select there
- [ ] Open Settings → General Settings → "任务自动完结（小时）" → verify cannot type `-`, `e`, `E`, `+`
- [ ] Try pasting "0-4" or "-3" into the taskAutoFinalize input → verify it gets sanitized to digits only
- [ ] Set taskAutoFinalize to 0 → save → refresh → verify it stays 0
- [ ] Leave taskAutoFinalize empty → save → refresh → verify it defaults to 4

Made with [Cursor](https://cursor.com)