### PR TITLE
fix: install.sh auto-resolve npm version & update download URL

### DIFF
--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -5,9 +5,13 @@ set -euo pipefail
 #
 # Usage (remote):
 #   curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash
+#   curl ... | bash -s -- --version 1.0.0-beta.1
 #
 # Usage (local, after extracting the npm package):
 #   bash install.sh
+#
+# Options:
+#   --version <ver>            - Install a specific version (default: latest from npm)
 #
 # Environment variables:
 #   MEMOS_INSTALL_DIR          - Override install directory (default: ~/.hermes/memos-plugin)
@@ -20,6 +24,21 @@ set -euo pipefail
 
 NPM_PACKAGE="@memtensor/memos-local-hermes-plugin"
 INSTALL_DIR="${MEMOS_INSTALL_DIR:-$HOME/.hermes/memos-plugin}"
+PKG_VERSION=""
+
+# ─── Parse arguments ───
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      PKG_VERSION="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
 
 # ─── Colors ───
 
@@ -171,8 +190,22 @@ else
   trap "rm -rf '$TMP_DIR'" EXIT
 
   cd "$TMP_DIR"
-  info "Downloading from npm..."
-  npm pack "$NPM_PACKAGE" --loglevel=error 2>/dev/null
+
+  # Resolve version: use --version if given, otherwise query npm for latest
+  if [[ -z "$PKG_VERSION" ]]; then
+    PKG_VERSION=$(npm view "$NPM_PACKAGE" dist-tags.latest 2>/dev/null || true)
+    if [[ -z "$PKG_VERSION" ]]; then
+      PKG_VERSION=$(npm view "$NPM_PACKAGE" version 2>/dev/null || true)
+    fi
+    if [[ -z "$PKG_VERSION" ]]; then
+      error "Cannot determine latest version of $NPM_PACKAGE"
+      error "Use --version to specify: bash install.sh --version 1.0.0-beta.1"
+      exit 1
+    fi
+  fi
+
+  info "Downloading $NPM_PACKAGE@$PKG_VERSION from npm..."
+  npm pack "$NPM_PACKAGE@$PKG_VERSION" --loglevel=error 2>/dev/null
   TARBALL=$(ls -1 memtensor-memos-local-hermes-plugin-*.tgz 2>/dev/null | head -1)
 
   if [[ -z "$TARBALL" || ! -f "$TARBALL" ]]; then

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # ─── MemTensor Memory for Hermes Agent — One-line Installer ───
 #
 # Usage (remote):
-#   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install-memory.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash
 #
 # Usage (local, after extracting the npm package):
 #   bash install.sh

--- a/apps/memos-local-plugin/www/docs/index.html
+++ b/apps/memos-local-plugin/www/docs/index.html
@@ -306,8 +306,8 @@ body.lang-zh .lang-en{display:none !important}
     <div class="install-note"><span class="lang-zh"># 自动下载、安装依赖、配置 Hermes、启动记忆面板</span><span class="lang-en"># Auto-downloads, installs deps, configures Hermes, starts memory panel</span></div>
     <div class="install-row">
       <span class="prompt">$</span>
-      <span class="cmd">curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install-memory.sh | bash</span>
-      <button type="button" class="install-copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install-memory.sh | bash" title="Copy" aria-label="Copy"><svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg><svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg></button>
+      <span class="cmd">curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash</span>
+      <button type="button" class="install-copy-btn" data-copy="curl -fsSL https://raw.githubusercontent.com/MemTensor/MemOS/openclaw-local-plugin-20260408/apps/memos-local-plugin/install.sh | bash" title="Copy" aria-label="Copy"><svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg><svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- **Auto-resolve latest npm version**: `install.sh` now queries `npm view` for the latest published version before downloading, fixing the issue where `npm pack` fails for prerelease versions (e.g. `1.0.0-beta.1`) without an explicit version specifier
- **`--version` flag**: Users can pin a specific version via `bash install.sh --version 1.0.0-beta.1` or `curl ... | bash -s -- --version <ver>`
- **Update download URL**: Point the curl one-liner in `install.sh` and `www/docs/index.html` to the actual GitHub raw path (`MemTensor/MemOS/openclaw-local-plugin-20260408`)

## Changed files

| File | Change |
|------|--------|
| `apps/memos-local-plugin/install.sh` | Add `--version` arg parsing, auto-resolve latest version via `npm view` |
| `apps/memos-local-plugin/www/docs/index.html` | Update curl URL in docs |

## Test plan

- [ ] `curl -fsSL <raw-url>/install.sh | bash` — auto-downloads `1.0.0-beta.1`
- [ ] `curl ... | bash -s -- --version 1.0.0-beta.1` — explicit version works
- [ ] Verify docs page shows correct install command