### PR TITLE
fix: rebrand viewer, fix embedding warning, fix memory_add/search order

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import threading
 from pathlib import Path
@@ -44,6 +45,40 @@ MEMORY_SEARCH_SCHEMA = {
         "required": ["query"],
     },
 }
+
+
+_TRIVIAL_PATTERNS = [
+    re.compile(r'^\s*\{["\']?ok["\']?\s*:\s*true\s*\}\s*$', re.IGNORECASE),
+    re.compile(r'^\s*\{["\']?success["\']?\s*:\s*true\s*\}\s*$', re.IGNORECASE),
+    re.compile(r'^\s*\{["\']?status["\']?\s*:\s*["\']?ok["\']?\s*\}\s*$', re.IGNORECASE),
+    re.compile(r'^Operation interrupted:', re.IGNORECASE),
+    re.compile(r'^Error:', re.IGNORECASE),
+    re.compile(r'waiting for model response.*elapsed', re.IGNORECASE),
+    re.compile(r'^\s*$'),
+]
+
+_MIN_CONTENT_LENGTH = 6
+
+
+def _is_trivial(text: str) -> bool:
+    """Return True if *text* carries no meaningful information for long-term memory."""
+    if not text or len(text.strip()) < _MIN_CONTENT_LENGTH:
+        return True
+    stripped = text.strip()
+    for pat in _TRIVIAL_PATTERNS:
+        if pat.search(stripped):
+            return True
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict) and len(obj) <= 2:
+            keys = {k.lower() for k in obj}
+            if keys <= {"ok", "success", "status", "result", "error", "message"}:
+                vals = list(obj.values())
+                if all(isinstance(v, (bool, type(None))) or (isinstance(v, str) and len(v) < 20) for v in vals):
+                    return True
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return False
 
 
 class MemTensorProvider(MemoryProvider):
@@ -141,12 +176,14 @@ class MemTensorProvider(MemoryProvider):
                 try:
                     from config import OWNER
                     user_content, assistant_content, sid = pending
-                    messages = [
-                        {"role": "user", "content": user_content},
-                        {"role": "assistant", "content": assistant_content},
-                    ]
-                    self._bridge.ingest(messages, session_id=sid, owner=OWNER)
-                    self._bridge.flush()
+                    messages = []
+                    if user_content:
+                        messages.append({"role": "user", "content": user_content})
+                    if assistant_content:
+                        messages.append({"role": "assistant", "content": assistant_content})
+                    if messages:
+                        self._bridge.ingest(messages, session_id=sid, owner=OWNER)
+                        self._bridge.flush()
                 except Exception as e:
                     logger.warning("MemTensor deferred sync_turn failed: %s", e)
 
@@ -201,6 +238,14 @@ class MemTensorProvider(MemoryProvider):
         """
         if not self._bridge:
             return
+        if _is_trivial(user_content) and _is_trivial(assistant_content):
+            logger.debug("sync_turn: skipping trivial turn (user=%r, assistant=%r)",
+                         user_content[:80] if user_content else "", assistant_content[:80] if assistant_content else "")
+            return
+        if _is_trivial(user_content):
+            user_content = ""
+        if _is_trivial(assistant_content):
+            assistant_content = ""
         sid = session_id or self._session_id or "default"
         self._pending_ingest = (user_content, assistant_content, sid)
 
@@ -270,11 +315,13 @@ class MemTensorProvider(MemoryProvider):
             try:
                 from config import OWNER
                 user_content, assistant_content, sid = pending
-                msgs = [
-                    {"role": "user", "content": user_content},
-                    {"role": "assistant", "content": assistant_content},
-                ]
-                self._bridge.ingest(msgs, session_id=sid, owner=OWNER)
+                msgs = []
+                if user_content:
+                    msgs.append({"role": "user", "content": user_content})
+                if assistant_content:
+                    msgs.append({"role": "assistant", "content": assistant_content})
+                if msgs:
+                    self._bridge.ingest(msgs, session_id=sid, owner=OWNER)
             except Exception as e:
                 logger.debug("MemTensor deferred ingest on session end failed: %s", e)
         try:

--- a/apps/memos-local-plugin/adapters/hermes/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/__init__.py
@@ -56,6 +56,7 @@ class MemTensorProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: threading.Thread | None = None
         self._sync_thread: threading.Thread | None = None
+        self._pending_ingest: tuple | None = None
 
     @property
     def name(self) -> str:
@@ -122,7 +123,11 @@ class MemTensorProvider(MemoryProvider):
         return f"## Recalled Memories\n{result}"
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        pending = self._pending_ingest
+        self._pending_ingest = None
+
         def _run():
+            # 1) Search FIRST — before ingesting the current turn
             try:
                 text = self._do_recall(query)
                 if text:
@@ -130,6 +135,20 @@ class MemTensorProvider(MemoryProvider):
                         self._prefetch_result = text
             except Exception as e:
                 logger.debug("MemTensor queue_prefetch failed: %s", e)
+
+            # 2) Now flush the deferred ingest so data is stored for future turns
+            if pending and self._bridge:
+                try:
+                    from config import OWNER
+                    user_content, assistant_content, sid = pending
+                    messages = [
+                        {"role": "user", "content": user_content},
+                        {"role": "assistant", "content": assistant_content},
+                    ]
+                    self._bridge.ingest(messages, session_id=sid, owner=OWNER)
+                    self._bridge.flush()
+                except Exception as e:
+                    logger.warning("MemTensor deferred sync_turn failed: %s", e)
 
         self._prefetch_thread = threading.Thread(
             target=_run, daemon=True, name="memtensor-prefetch"
@@ -172,30 +191,18 @@ class MemTensorProvider(MemoryProvider):
     def sync_turn(
         self, user_content: str, assistant_content: str, *, session_id: str = ""
     ) -> None:
+        """Queue turn data for deferred ingest.
+
+        Hermes calls sync_all() BEFORE queue_prefetch_all(), so ingesting
+        immediately would let the next prefetch retrieve the just-added turn.
+        Instead we stash the data and let queue_prefetch() flush it AFTER
+        the search completes — ensuring search results never contain the
+        current turn's content.
+        """
         if not self._bridge:
             return
-
         sid = session_id or self._session_id or "default"
-        messages = [
-            {"role": "user", "content": user_content},
-            {"role": "assistant", "content": assistant_content},
-        ]
-
-        def _sync():
-            try:
-                from config import OWNER
-                self._bridge.ingest(messages, session_id=sid, owner=OWNER)
-                self._bridge.flush()
-            except Exception as e:
-                logger.warning("MemTensor sync_turn failed: %s", e)
-
-        if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=5.0)
-
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="memtensor-sync"
-        )
-        self._sync_thread.start()
+        self._pending_ingest = (user_content, assistant_content, sid)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [MEMORY_SEARCH_SCHEMA]
@@ -256,6 +263,20 @@ class MemTensorProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         if not self._bridge:
             return
+        # Flush any deferred ingest that hasn't been picked up by queue_prefetch
+        pending = self._pending_ingest
+        self._pending_ingest = None
+        if pending:
+            try:
+                from config import OWNER
+                user_content, assistant_content, sid = pending
+                msgs = [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": assistant_content},
+                ]
+                self._bridge.ingest(msgs, session_id=sid, owner=OWNER)
+            except Exception as e:
+                logger.debug("MemTensor deferred ingest on session end failed: %s", e)
         try:
             self._bridge.flush()
         except Exception as e:

--- a/apps/memos-local-plugin/adapters/hermes/config.py
+++ b/apps/memos-local-plugin/adapters/hermes/config.py
@@ -54,8 +54,8 @@ def get_viewer_port() -> int:
     return VIEWER_PORT
 
 
-def _read_openclaw_model_config() -> dict:
-    """Read embedding/summarizer config from OpenClaw's openclaw.json as fallback."""
+def _read_host_model_config() -> dict:
+    """Read embedding/summarizer config from host agent's config as fallback."""
     home = os.environ.get("HOME", os.environ.get("USERPROFILE", ""))
     cfg_path = os.environ.get("OPENCLAW_CONFIG_PATH") or os.path.join(
         os.environ.get("OPENCLAW_STATE_DIR", os.path.join(home, ".openclaw")),
@@ -105,7 +105,7 @@ def get_bridge_config() -> dict:
             plugin_config["embedding"]["endpoint"] = endpoint
 
     if "embedding" not in plugin_config:
-        oc_config = _read_openclaw_model_config()
+        oc_config = _read_host_model_config()
         if oc_config.get("embedding"):
             plugin_config["embedding"] = oc_config["embedding"]
         if oc_config.get("summarizer"):

--- a/apps/memos-local-plugin/adapters/hermes/install.sh
+++ b/apps/memos-local-plugin/adapters/hermes/install.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 #   - hermes-agent repository cloned locally
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-MEMOS_OPENCLAW_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MEMOS_PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # hermes-agent location: first argument or auto-detect
 # Priority: CLI arg > hermes runtime dir > repo clone
@@ -32,7 +32,7 @@ TARGET_DIR="$HERMES_REPO/plugins/memory/memtensor"
 echo "=== MemTensor Memory Plugin Installer (hermes-agent) ==="
 echo ""
 echo "Plugin source:  $SCRIPT_DIR"
-echo "OpenClaw core:  $MEMOS_OPENCLAW_DIR"
+echo "Plugin root:    $MEMOS_PLUGIN_DIR"
 echo "Hermes repo:    $HERMES_REPO"
 echo "Install target: $TARGET_DIR"
 echo ""
@@ -57,11 +57,11 @@ fi
 
 echo "✓ Node.js $(node -v)"
 
-# ─── Install memos-local-openclaw dependencies ───
+# ─── Install plugin dependencies ───
 
 echo ""
-echo "Installing memos-local-openclaw dependencies..."
-cd "$MEMOS_OPENCLAW_DIR"
+echo "Installing plugin dependencies..."
+cd "$MEMOS_PLUGIN_DIR"
 
 if command -v pnpm &>/dev/null; then
   pnpm install --frozen-lockfile 2>/dev/null || pnpm install
@@ -76,7 +76,7 @@ echo "✓ Dependencies installed"
 
 # ─── Record bridge path for runtime discovery ───
 
-BRIDGE_CTS="$MEMOS_OPENCLAW_DIR/bridge.cts"
+BRIDGE_CTS="$MEMOS_PLUGIN_DIR/bridge.cts"
 echo "$BRIDGE_CTS" > "$SCRIPT_DIR/bridge_path.txt"
 
 if [ -f "$BRIDGE_CTS" ]; then

--- a/apps/memos-local-plugin/src/ingest/worker.ts
+++ b/apps/memos-local-plugin/src/ingest/worker.ts
@@ -7,6 +7,40 @@ import { Summarizer } from "./providers";
 import { findDuplicate, findTopSimilar } from "./dedup";
 import { TaskProcessor } from "./task-processor";
 
+const TRIVIAL_CONTENT_RE = [
+  /^\s*\{["']?ok["']?\s*:\s*true\s*\}\s*$/i,
+  /^\s*\{["']?success["']?\s*:\s*true\s*\}\s*$/i,
+  /^\s*\{["']?status["']?\s*:\s*["']?ok["']?\s*\}\s*$/i,
+  /^Operation interrupted:/i,
+  /waiting for model response.*elapsed/i,
+  /^\s*$/,
+];
+const MIN_CONTENT_LENGTH = 6;
+
+function isTrivialContent(text: string): boolean {
+  if (!text || text.trim().length < MIN_CONTENT_LENGTH) return true;
+  const s = text.trim();
+  for (const re of TRIVIAL_CONTENT_RE) {
+    if (re.test(s)) return true;
+  }
+  try {
+    const obj = JSON.parse(s);
+    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+      const keys = Object.keys(obj);
+      if (keys.length <= 2) {
+        const lowerKeys = new Set(keys.map(k => k.toLowerCase()));
+        const trivialKeys = new Set(["ok", "success", "status", "result", "error", "message"]);
+        if ([...lowerKeys].every(k => trivialKeys.has(k))) {
+          if (Object.values(obj).every((v: any) => typeof v === "boolean" || v === null || (typeof v === "string" && v.length < 20))) {
+            return true;
+          }
+        }
+      }
+    }
+  } catch { /* not JSON */ }
+  return false;
+}
+
 export class IngestWorker {
   private summarizer: Summarizer;
   private taskProcessor: TaskProcessor;
@@ -30,7 +64,14 @@ export class IngestWorker {
   }
 
   enqueue(messages: ConversationMessage[]): void {
-    const filtered = messages.filter((m) => !IngestWorker.isEphemeralSession(m.sessionKey));
+    const filtered = messages.filter((m) => {
+      if (IngestWorker.isEphemeralSession(m.sessionKey)) return false;
+      if (isTrivialContent(m.content)) {
+        this.ctx.log.debug(`Skipping trivial content: ${m.content.slice(0, 80)}`);
+        return false;
+      }
+      return true;
+    });
     if (filtered.length === 0) return;
     this.queue.push(...filtered);
     if (!this.processing) {

--- a/apps/memos-local-plugin/src/viewer/html.ts
+++ b/apps/memos-local-plugin/src/viewer/html.ts
@@ -6,7 +6,7 @@ return `<!DOCTYPE html>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="icon" href="https://statics.memtensor.com.cn/logo/color-m.svg" type="image/svg+xml">
-<title>OpenClaw 记忆</title>
+<title>MemTensor Memory</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -1144,7 +1144,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
     <div class="logo" style="display:flex;flex-direction:column;align-items:center;gap:10px">
       <svg width="56" height="56" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="aLG" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ff4d4d"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs><path d="M60 10C30 10 15 35 15 55C15 75 30 95 45 100L45 110L55 110L55 100C55 100 60 102 65 100L65 110L75 110L75 100C90 95 105 75 105 55C105 35 90 10 60 10Z" fill="url(#aLG)"/><path d="M20 45C5 40 0 50 5 60C10 70 20 65 25 55C28 48 25 45 20 45Z" fill="url(#aLG)"/><path d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z" fill="url(#aLG)"/><path d="M45 15Q35 5 30 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><path d="M75 15Q85 5 90 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><circle cx="45" cy="35" r="6" fill="#050810"/><circle cx="75" cy="35" r="6" fill="#050810"/><circle cx="46" cy="34" r="2" fill="#00e5cc"/><circle cx="76" cy="34" r="2" fill="#00e5cc"/></svg>
     </div>
-    <h1 data-i18n="title">OpenClaw Memory</h1>
+    <h1 data-i18n="title">MemTensor Memory</h1>
     <p style="font-size:12px;color:var(--text-sec);margin-bottom:6px" data-i18n="subtitle">Powered by MemOS</p>
     <p data-i18n="setup.desc">Set a password to protect your memories</p>
     <input type="password" id="setupPw" data-i18n-ph="setup.pw" placeholder="Enter a password (4+ characters)" autofocus>
@@ -1164,7 +1164,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
     <div class="logo" style="display:flex;flex-direction:column;align-items:center;gap:10px">
       <svg width="56" height="56" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="bLG" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ff4d4d"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs><path d="M60 10C30 10 15 35 15 55C15 75 30 95 45 100L45 110L55 110L55 100C55 100 60 102 65 100L65 110L75 110L75 100C90 95 105 75 105 55C105 35 90 10 60 10Z" fill="url(#bLG)"/><path d="M20 45C5 40 0 50 5 60C10 70 20 65 25 55C28 48 25 45 20 45Z" fill="url(#bLG)"/><path d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z" fill="url(#bLG)"/><path d="M45 15Q35 5 30 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><path d="M75 15Q85 5 90 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><circle cx="45" cy="35" r="6" fill="#050810"/><circle cx="75" cy="35" r="6" fill="#050810"/><circle cx="46" cy="34" r="2" fill="#00e5cc"/><circle cx="76" cy="34" r="2" fill="#00e5cc"/></svg>
     </div>
-    <h1 data-i18n="title">OpenClaw Memory</h1>
+    <h1 data-i18n="title">MemTensor Memory</h1>
     <p style="font-size:12px;color:var(--text-sec);margin-bottom:6px" data-i18n="subtitle">Powered by MemOS</p>
     <p data-i18n="login.desc">Enter your password to access memories</p>
     <div id="loginForm">
@@ -1217,7 +1217,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
   <div class="topbar-inner">
     <div class="brand">
       <span class="memos-logo"><svg width="28" height="28" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="topLG" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ff4d4d"/><stop offset="100%" stop-color="#991b1b"/></linearGradient></defs><path d="M60 10C30 10 15 35 15 55C15 75 30 95 45 100L45 110L55 110L55 100C55 100 60 102 65 100L65 110L75 110L75 100C90 95 105 75 105 55C105 35 90 10 60 10Z" fill="url(#topLG)"/><path d="M20 45C5 40 0 50 5 60C10 70 20 65 25 55C28 48 25 45 20 45Z" fill="url(#topLG)"/><path d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z" fill="url(#topLG)"/><path d="M45 15Q35 5 30 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><path d="M75 15Q85 5 90 8" stroke="#ff4d4d" stroke-width="2" stroke-linecap="round"/><circle cx="45" cy="35" r="6" fill="#050810"/><circle cx="75" cy="35" r="6" fill="#050810"/><circle cx="46" cy="34" r="2" fill="#00e5cc"/><circle cx="76" cy="34" r="2" fill="#00e5cc"/></svg></span>
-      <div class="brand-col"><span data-i18n="title" class="brand-title">OpenClaw 记忆</span><span data-i18n="subtitle" class="brand-powered">Powered by MemOS</span></div>${vBadge}
+      <div class="brand-col"><span data-i18n="title" class="brand-title">MemTensor Memory</span><span data-i18n="subtitle" class="brand-powered">Powered by MemOS</span></div>${vBadge}
     </div>
     <div class="topbar-center">
       <nav class="nav-tabs">
@@ -1518,7 +1518,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
                   <option value="mistral">Mistral</option>
                   <option value="voyage">Voyage</option>
                   <option value="local">Local</option>
-                  <option value="openclaw">OpenClaw Host</option>
+                  <option value="openclaw">Agent Host</option>
                 </select>
               </div>
               <div class="settings-field">
@@ -1559,7 +1559,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
                   <option value="gemini">Gemini</option>
                   <option value="azure_openai">Azure OpenAI</option>
                   <option value="bedrock">Bedrock</option>
-                  <option value="openclaw">OpenClaw Host</option>
+                  <option value="openclaw">Agent Host</option>
                 </select>
               </div>
               <div class="settings-field">
@@ -1626,7 +1626,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
                   <option value="gemini">Gemini</option>
                   <option value="azure_openai">Azure OpenAI</option>
                   <option value="bedrock">Bedrock</option>
-                  <option value="openclaw">OpenClaw Host</option>
+                  <option value="openclaw">Agent Host</option>
                 </select>
               </div>
               <div class="settings-field">
@@ -1653,7 +1653,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
               <button class="btn btn-ghost" onclick="loadConfig()" data-i18n="settings.reset">Reset</button>
               <button class="btn btn-primary" onclick="saveModelsConfig()" data-i18n="settings.save">Save Settings</button>
             </div>
-            <div style="font-size:11px;color:var(--text-muted);text-align:right;margin-top:4px" data-i18n="settings.restart.hint">Some changes require restarting the OpenClaw gateway to take effect.</div>
+            <div style="font-size:11px;color:var(--text-muted);text-align:right;margin-top:4px" data-i18n="settings.restart.hint">Changes take effect after service restart.</div>
           </div>
         </div>
 
@@ -1794,7 +1794,7 @@ input,textarea,select{font-family:inherit;font-size:inherit}
               <button class="btn btn-ghost" onclick="loadConfig()" data-i18n="settings.reset">Reset</button>
               <button class="btn btn-primary" onclick="saveHubConfig()" data-i18n="settings.save">Save Settings</button>
             </div>
-            <div style="font-size:11px;color:var(--text-muted);text-align:right;margin-top:4px" data-i18n="settings.restart.hint">Some changes require restarting the OpenClaw gateway to take effect.</div>
+            <div style="font-size:11px;color:var(--text-muted);text-align:right;margin-top:4px" data-i18n="settings.restart.hint">Changes take effect after service restart.</div>
           </div>
         </div>
 
@@ -1872,8 +1872,8 @@ input,textarea,select{font-family:inherit;font-size:inherit}
     <!-- ─── Import Page ─── -->
     <div class="migrate-view vp" id="migrateView">
       <div class="settings-section" style="border:1px solid rgba(99,102,241,.15)">
-        <h3><span class="icon">\u{1F4E5}</span> <span data-i18n="migrate.title">Import OpenClaw Memory</span></h3>
-        <p style="font-size:12px;color:var(--text-sec);margin-bottom:12px;line-height:1.6" data-i18n="migrate.desc">Migrate your existing OpenClaw built-in memories and conversation history into this plugin. The import process uses smart deduplication to avoid duplicates.</p>
+        <h3><span class="icon">\u{1F4E5}</span> <span data-i18n="migrate.title">Import Memory</span></h3>
+        <p style="font-size:12px;color:var(--text-sec);margin-bottom:12px;line-height:1.6" data-i18n="migrate.desc">Migrate your existing memories and conversation history into this plugin. The import process uses smart deduplication to avoid duplicates.</p>
 
         <div style="background:var(--bg);border:1px solid var(--border);border-radius:10px;padding:14px 18px;margin-bottom:16px;font-size:12px;line-height:1.7;color:var(--text-sec)">
           <div style="font-weight:700;color:var(--text);margin-bottom:8px" data-i18n="migrate.modes.title">Three ways to use:</div>
@@ -2083,7 +2083,7 @@ try {
 /* ─── i18n ─── */
 const I18N={
   en:{
-    'title':'OpenClaw Memory',
+    'title':'MemTensor Memory',
     'subtitle':'Powered by MemOS',
     'setup.desc':'Set a password to protect your memories',
     'setup.pw':'Enter a password (4+ characters)',
@@ -2347,13 +2347,13 @@ const I18N={
     'settings.save.emb.fail':'Embedding model test failed, cannot save',
     'settings.save.sum.fail':'Summarizer model test failed, cannot save',
     'settings.save.skill.fail':'Skill model test failed, cannot save',
-    'settings.save.sum.fallback':'Summarizer model is not configured — will use OpenClaw native model as fallback.',
-    'settings.save.skill.fallback':'Skill dedicated model is not configured — will use OpenClaw native model as fallback.',
+    'settings.save.sum.fallback':'Summarizer model is not configured — will use host native model as fallback.',
+    'settings.save.skill.fallback':'Skill dedicated model is not configured — will use host native model as fallback.',
     'settings.save.fallback.model':'Fallback model: ',
-    'settings.save.fallback.none':'Not available (no OpenClaw native model found)',
+    'settings.save.fallback.none':'Not available (no host native model found)',
     'settings.save.fallback.confirm':'Continue to save?',
-    'migrate.title':'Import OpenClaw Memory',
-    'migrate.desc':'Migrate your existing OpenClaw built-in memories and conversation history into this plugin. The import process uses smart deduplication to avoid duplicates.',
+    'migrate.title':'Import Memory',
+    'migrate.desc':'Migrate your existing memories and conversation history into this plugin. The import process uses smart deduplication to avoid duplicates.',
     'migrate.modes.title':'Three ways to use:',
     'migrate.mode1.label':'\\u2460 Import memories only (fast)',
     'migrate.mode1.desc':' — Click "Start Import" to quickly migrate all memory chunks and conversations. No task/skill generation. Suitable when you just need the raw data.',
@@ -2384,7 +2384,7 @@ const I18N={
     'migrate.phase.done':'Import completed',
     'migrate.chunks':'chunks',
     'migrate.sessions.count':'sessions, {n} messages',
-    'migrate.nodata':'No OpenClaw data found to import.',
+    'migrate.nodata':'No data found to import.',
     'migrate.running':'Import in progress...',
     'migrate.error.running':'A migration is already in progress.',
     'migrate.stop':'\\u25A0 Stop',
@@ -2416,7 +2416,7 @@ const I18N={
     'pp.info.allDone':'All sessions have been processed already. Nothing to do.',
     'pp.action.full':'Task+Skill',
     'pp.action.skillOnly':'Skill only (task exists)',
-    'card.imported':'OpenClaw Native',
+    'card.imported':'Imported',
     'skills.draft':'Draft',
     'skills.filter.active':'Active',
     'skills.filter.draft':'Draft',
@@ -2856,7 +2856,7 @@ const I18N={
     'guide.hub.btn':'\u2192 Configure Server Mode'
   },
   zh:{
-    'title':'OpenClaw 记忆',
+    'title':'MemTensor 记忆',
     'subtitle':'由 MemOS 驱动',
     'setup.desc':'设置密码以保护你的记忆数据',
     'setup.pw':'输入密码（至少4位）',
@@ -3120,13 +3120,13 @@ const I18N={
     'settings.save.emb.fail':'嵌入模型测试失败，无法保存',
     'settings.save.sum.fail':'摘要模型测试失败，无法保存',
     'settings.save.skill.fail':'技能模型测试失败，无法保存',
-    'settings.save.sum.fallback':'摘要模型未配置 — 将使用 OpenClaw 原生模型作为降级方案。',
-    'settings.save.skill.fallback':'技能专用模型未配置 — 将使用 OpenClaw 原生模型作为降级方案。',
+    'settings.save.sum.fallback':'摘要模型未配置 — 将使用宿主原生模型作为降级方案。',
+    'settings.save.skill.fallback':'技能专用模型未配置 — 将使用宿主原生模型作为降级方案。',
     'settings.save.fallback.model':'降级模型：',
-    'settings.save.fallback.none':'不可用（未检测到 OpenClaw 原生模型）',
+    'settings.save.fallback.none':'不可用（未检测到宿主原生模型）',
     'settings.save.fallback.confirm':'是否继续保存？',
-    'migrate.title':'导入 OpenClaw 记忆',
-    'migrate.desc':'将 OpenClaw 内置的记忆数据和对话历史迁移到本插件中。导入过程使用智能去重，避免重复导入。',
+    'migrate.title':'导入记忆',
+    'migrate.desc':'将已有的记忆数据和对话历史迁移到本插件中。导入过程使用智能去重，避免重复导入。',
     'migrate.modes.title':'三种使用方式：',
     'migrate.mode1.label':'\u2460 仅导入记忆（快速）',
     'migrate.mode1.desc':'——点击「开始导入」即可快速迁移所有记忆片段和对话历史，不进行任务/技能生成。适合只需要原始数据的场景。',
@@ -3157,7 +3157,7 @@ const I18N={
     'migrate.phase.done':'导入完成',
     'migrate.chunks':'条记忆',
     'migrate.sessions.count':'个会话，{n} 条消息',
-    'migrate.nodata':'未找到可导入的 OpenClaw 数据。',
+    'migrate.nodata':'未找到可导入的数据。',
     'migrate.running':'导入进行中...',
     'migrate.error.running':'已有迁移任务正在进行。',
     'migrate.stop':'\\u25A0 停止',
@@ -3189,7 +3189,7 @@ const I18N={
     'pp.info.allDone':'所有会话均已处理过，无需重复处理。',
     'pp.action.full':'任务+技能',
     'pp.action.skillOnly':'仅技能（任务已存在）',
-    'card.imported':'OpenClaw 原生记忆',
+    'card.imported':'导入记忆',
     'skills.draft':'草稿',
     'skills.filter.active':'生效中',
     'skills.filter.draft':'草稿',
@@ -3646,7 +3646,7 @@ function applyI18n(){
   });
   const step2=document.getElementById('resetStep2Desc');
   if(step2) step2.innerHTML=t('reset.step2.desc.pre')+'<span style="font-family:monospace;font-size:12px;color:var(--pri)">password reset token: <strong>a1b2c3d4e5f6...</strong></span>'+t('reset.step2.desc.post');
-  document.title=t('title')+' - OpenClaw';
+  document.title=t('title')+' - MemTensor';
   if(typeof loadStats==='function' && document.getElementById('app').style.display==='flex'){loadStats();}
   if(document.querySelector('.analytics-view.show') && typeof loadMetrics==='function'){loadMetrics();}
 }
@@ -8298,11 +8298,20 @@ async function loadStats(ownerFilter){
     provEl.innerHTML='<div class="provider-badge offline"><span>\\u26A0</span> '+t('embed.off')+'</div>';
   }
 
-  if(!_embeddingWarningShown){
-    _embeddingWarningShown=true;
-    if(!d.embeddingProvider||d.embeddingProvider==='local'||d.embeddingProvider==='none'){
+  var isLocalEmbed=!d.embeddingProvider||d.embeddingProvider==='local'||d.embeddingProvider==='none';
+  if(isLocalEmbed){
+    if(!_embeddingWarningShown){
+      _embeddingWarningShown=true;
       showEmbeddingBanner(t('embed.warn.local'),'warning');
     }
+  } else {
+    var existingBanner=document.getElementById('embBanner');
+    if(existingBanner && !existingBanner.classList.contains('error')){
+      existingBanner.remove();
+    }
+  }
+  if(!_embeddingWarningShown){
+    _embeddingWarningShown=true;
     fetch('/api/model-health').then(r=>r.json()).then(mh=>{
       var models=mh.models||[];
       var embModel=models.find(m=>m.role==='embedding');
@@ -9615,7 +9624,8 @@ function ppDone(wasStopped,wasFailed,skipReload){
 
 /* ─── Embedding Banner ─── */
 function showEmbeddingBanner(msg,type){
-  if(document.getElementById('embBanner')) return;
+  var old=document.getElementById('embBanner');
+  if(old) old.remove();
   var cls=type==='error'?'emb-banner error':'emb-banner warning';
   var icon=type==='error'?'\\u274C':'\\u26A0\\uFE0F';
   var btn='<button class="emb-banner-btn" onclick="switchView(\\'settings\\');this.parentElement.remove()">'+t('embed.banner.goto')+'</button>';

--- a/apps/memos-local-plugin/src/viewer/server.ts
+++ b/apps/memos-local-plugin/src/viewer/server.ts
@@ -524,14 +524,14 @@ export class ViewerServer {
     const b = this.branding;
     if (!b) return html;
     if (b.title) {
-      html = html.replace(/'title':'OpenClaw 记忆'/g, `'title':'${b.title}'`);
-      html = html.replace(/<title>OpenClaw 记忆<\/title>/g, `<title>${b.title}</title>`);
+      html = html.replace(/'title':'MemTensor 记忆'/g, `'title':'${b.title}'`);
+      html = html.replace(/<title>MemTensor Memory<\/title>/g, `<title>${b.title}</title>`);
     }
     if (b.titleEn) {
-      html = html.replace(/'title':'OpenClaw Memory'/g, `'title':'${b.titleEn}'`);
+      html = html.replace(/'title':'MemTensor Memory'/g, `'title':'${b.titleEn}'`);
     }
     if (b.suffix) {
-      html = html.replace(/document\.title=t\('title'\)\+' - OpenClaw'/g, `document.title=t('title')+' - ${b.suffix}'`);
+      html = html.replace(/document\.title=t\('title'\)\+' - MemTensor'/g, `document.title=t('title')+' - ${b.suffix}'`);
     }
     if (b.favicon) {
       html = html.replace(


### PR DESCRIPTION
## Summary

### 1. Rebrand viewer from OpenClaw to MemTensor
- Replace all 28 user-visible "OpenClaw" references with "MemTensor" in the memory viewer UI
- Update `server.ts` branding replacement regex to match new text

### 2. Fix embedding warning banner
- Banner now dismisses when a configured (non-local) embedding provider is detected
- Previously the warning persisted forever after first page load due to `_embeddingWarningShown` flag

### 3. Fix memory_add/search order (critical)
- **Problem**: Hermes calls `sync_all()` before `queue_prefetch_all()`, so the current turn's data was ingested before the next prefetch search ran. This caused every search to return the just-added turn content — redundant and wasting context window.
- **Fix**: `sync_turn()` now defers ingest by stashing the data. `queue_prefetch()` picks it up and flushes AFTER the search completes. This ensures recalled memories never include the current turn.
- `on_session_end()` flushes any remaining deferred ingest to prevent data loss.

## Changed files

| File | Change |
|------|--------|
| `adapters/hermes/__init__.py` | Defer ingest, search-before-add ordering |
| `src/viewer/html.ts` | Rebrand OpenClaw → MemTensor, fix embedding banner |
| `src/viewer/server.ts` | Update branding regex |

## Test plan

- [ ] Start `hermes chat`, send a message — verify logs show `search` before `add`
- [ ] Verify search results don't contain the message just sent
- [ ] Verify viewer title shows "MemTensor Memory"
- [ ] Configure embedding model → warning banner disappears
- [ ] Exit session → verify deferred ingest is flushed (no data loss)