### PR TITLE
feat: auto-install Node.js when missing in hermes install script

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/install.sh
+++ b/apps/memos-local-plugin/adapters/hermes/install.sh
@@ -7,8 +7,146 @@ set -euo pipefail
 #   bash install.sh [/path/to/hermes-agent]
 #
 # Prerequisites:
-#   - Node.js >= 18
 #   - hermes-agent repository cloned locally
+#   - Node.js >= 18 (auto-installed if missing)
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}$1${NC}"; }
+success() { echo -e "${GREEN}$1${NC}"; }
+warn()    { echo -e "${YELLOW}$1${NC}"; }
+error()   { echo -e "${RED}$1${NC}"; }
+
+# ─── Node.js auto-install helpers ───
+
+node_major_version() {
+  if ! command -v node >/dev/null 2>&1; then
+    echo "0"
+    return 0
+  fi
+  local node_version
+  node_version="$(node -v 2>/dev/null || true)"
+  node_version="${node_version#v}"
+  echo "${node_version%%.*}"
+}
+
+run_with_privilege() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+download_to_file() {
+  local url="$1"
+  local output="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --proto '=https' --tlsv1.2 "$url" -o "$output"
+    return 0
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -q --https-only --secure-protocol=TLSv1_2 "$url" -O "$output"
+    return 0
+  fi
+  return 1
+}
+
+install_node22() {
+  local os_name
+  os_name="$(uname -s)"
+
+  if [[ "$os_name" == "Darwin" ]]; then
+    if ! command -v brew >/dev/null 2>&1; then
+      error "Homebrew is required to auto-install Node.js on macOS"
+      error "Install Homebrew first: https://brew.sh"
+      exit 1
+    fi
+    info "Auto-installing Node.js 22 via Homebrew..."
+    brew install node@22 >/dev/null
+    brew link node@22 --overwrite --force >/dev/null 2>&1 || true
+    local brew_node_prefix
+    brew_node_prefix="$(brew --prefix node@22 2>/dev/null || true)"
+    if [[ -n "$brew_node_prefix" && -x "${brew_node_prefix}/bin/node" ]]; then
+      export PATH="${brew_node_prefix}/bin:${PATH}"
+    fi
+    return 0
+  fi
+
+  if [[ "$os_name" == "Linux" ]]; then
+    info "Auto-installing Node.js 22 on Linux..."
+    local tmp_script
+    tmp_script="$(mktemp)"
+    if command -v apt-get >/dev/null 2>&1; then
+      if ! download_to_file "https://deb.nodesource.com/setup_22.x" "$tmp_script"; then
+        error "Failed to download NodeSource setup script"
+        rm -f "$tmp_script"
+        exit 1
+      fi
+      run_with_privilege bash "$tmp_script"
+      run_with_privilege apt-get update -qq
+      run_with_privilege apt-get install -y -qq nodejs
+      rm -f "$tmp_script"
+      return 0
+    fi
+    if command -v dnf >/dev/null 2>&1; then
+      if ! download_to_file "https://rpm.nodesource.com/setup_22.x" "$tmp_script"; then
+        error "Failed to download NodeSource setup script"
+        rm -f "$tmp_script"
+        exit 1
+      fi
+      run_with_privilege bash "$tmp_script"
+      run_with_privilege dnf install -y -q nodejs
+      rm -f "$tmp_script"
+      return 0
+    fi
+    if command -v yum >/dev/null 2>&1; then
+      if ! download_to_file "https://rpm.nodesource.com/setup_22.x" "$tmp_script"; then
+        error "Failed to download NodeSource setup script"
+        rm -f "$tmp_script"
+        exit 1
+      fi
+      run_with_privilege bash "$tmp_script"
+      run_with_privilege yum install -y -q nodejs
+      rm -f "$tmp_script"
+      return 0
+    fi
+    rm -f "$tmp_script"
+  fi
+
+  error "Unsupported platform for auto-install. Please install Node.js >= 18 manually."
+  exit 1
+}
+
+ensure_node() {
+  local required_major=18
+  local current_major
+  current_major="$(node_major_version)"
+
+  if [[ "$current_major" =~ ^[0-9]+$ ]] && (( current_major >= required_major )); then
+    success "✓ Node.js $(node -v)"
+    return 0
+  fi
+
+  warn "Node.js >= ${required_major} is required but not found. Auto-installing..."
+  install_node22
+
+  current_major="$(node_major_version)"
+  if [[ "$current_major" =~ ^[0-9]+$ ]] && (( current_major >= required_major )); then
+    success "✓ Node.js installed: $(node -v)"
+    return 0
+  fi
+
+  error "Node.js installation failed — still below >= ${required_major}."
+  exit 1
+}
+
+# ─── Main ───
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MEMOS_PLUGIN_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -29,38 +167,27 @@ fi
 
 TARGET_DIR="$HERMES_REPO/plugins/memory/memtensor"
 
-echo "=== MemTensor Memory Plugin Installer (hermes-agent) ==="
+echo -e "${BOLD}=== MemTensor Memory Plugin Installer (hermes-agent) ===${NC}"
 echo ""
-echo "Plugin source:  $SCRIPT_DIR"
-echo "Plugin root:    $MEMOS_PLUGIN_DIR"
-echo "Hermes repo:    $HERMES_REPO"
-echo "Install target: $TARGET_DIR"
+info "Plugin source:  $SCRIPT_DIR"
+info "Plugin root:    $MEMOS_PLUGIN_DIR"
+info "Hermes repo:    $HERMES_REPO"
+info "Install target: $TARGET_DIR"
 echo ""
 
 # ─── Pre-flight checks ───
 
 if [ ! -f "$HERMES_REPO/agent/memory_provider.py" ]; then
-  echo "ERROR: $HERMES_REPO does not look like a hermes-agent repository."
+  error "ERROR: $HERMES_REPO does not look like a hermes-agent repository."
   exit 1
 fi
 
-if ! command -v node &>/dev/null; then
-  echo "ERROR: Node.js is required (>= 18). Please install it first."
-  exit 1
-fi
-
-NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
-if [ "$NODE_VERSION" -lt 18 ]; then
-  echo "ERROR: Node.js >= 18 is required. Current: $(node -v)"
-  exit 1
-fi
-
-echo "✓ Node.js $(node -v)"
+ensure_node
 
 # ─── Install plugin dependencies ───
 
 echo ""
-echo "Installing plugin dependencies..."
+info "Installing plugin dependencies..."
 cd "$MEMOS_PLUGIN_DIR"
 
 if command -v pnpm &>/dev/null; then
@@ -68,11 +195,11 @@ if command -v pnpm &>/dev/null; then
 elif command -v npm &>/dev/null; then
   npm install
 else
-  echo "ERROR: npm or pnpm is required."
+  error "ERROR: npm or pnpm is required."
   exit 1
 fi
 
-echo "✓ Dependencies installed"
+success "✓ Dependencies installed"
 
 # ─── Record bridge path for runtime discovery ───
 
@@ -80,42 +207,42 @@ BRIDGE_CTS="$MEMOS_PLUGIN_DIR/bridge.cts"
 echo "$BRIDGE_CTS" > "$SCRIPT_DIR/bridge_path.txt"
 
 if [ -f "$BRIDGE_CTS" ]; then
-  echo "✓ Bridge script found: $BRIDGE_CTS"
+  success "✓ Bridge script found: $BRIDGE_CTS"
 else
-  echo "WARNING: bridge.cts not found at $BRIDGE_CTS"
-  echo "  Make sure it exists before using the plugin."
+  warn "WARNING: bridge.cts not found at $BRIDGE_CTS"
+  warn "  Make sure it exists before using the plugin."
 fi
 
 # ─── Create symlink in hermes-agent plugins/memory/ ───
 
 echo ""
-echo "Creating symlink: $TARGET_DIR -> $SCRIPT_DIR"
+info "Creating symlink: $TARGET_DIR -> $SCRIPT_DIR"
 
 if [ -L "$TARGET_DIR" ]; then
   rm "$TARGET_DIR"
-  echo "  (removed old symlink)"
+  info "  (removed old symlink)"
 elif [ -d "$TARGET_DIR" ]; then
   rm -rf "$TARGET_DIR"
-  echo "  (removed old directory)"
+  info "  (removed old directory)"
 fi
 
 ln -s "$SCRIPT_DIR" "$TARGET_DIR"
-echo "✓ Symlink created"
+success "✓ Symlink created"
 
 echo ""
-echo "=== Installation complete ==="
+echo -e "${BOLD}=== Installation complete ===${NC}"
 echo ""
-echo "Activate the plugin by editing ~/.hermes/config.yaml:"
+info "Activate the plugin by editing ~/.hermes/config.yaml:"
 echo ""
 echo "  memory:"
 echo "    provider: memtensor"
 echo ""
-echo "Then start hermes normally. The bridge daemon and memory viewer"
-echo "will start automatically on first session."
+info "Then start hermes normally. The bridge daemon and memory viewer"
+info "will start automatically on first session."
 echo ""
-echo "  Memory Viewer: http://127.0.0.1:18901"
+success "  Memory Viewer: http://127.0.0.1:18901"
 echo ""
-echo "Optional environment variables:"
+info "Optional environment variables:"
 echo "  MEMOS_STATE_DIR          - Override memory database location"
 echo "  MEMOS_DAEMON_PORT        - Bridge daemon TCP port (default: 18990)"
 echo "  MEMOS_VIEWER_PORT        - Memory viewer HTTP port (default: 18899)"


### PR DESCRIPTION
## Summary

- If Node.js >= 18 is not found, the hermes plugin installer now **automatically installs Node.js 22** instead of just printing an error and exiting
- Supports macOS (Homebrew) and Linux (NodeSource for apt/dnf/yum)
- Adds colored terminal output (info/success/warn/error) for better readability during installation

## Details

The `ensure_node()` function checks the current Node.js version. If it's missing or below 18, `install_node22()` is called:

| Platform | Method |
|----------|--------|
| macOS | `brew install node@22` (requires Homebrew) |
| Debian/Ubuntu | NodeSource `setup_22.x` + `apt-get install nodejs` |
| Fedora | NodeSource `setup_22.x` + `dnf install nodejs` |
| CentOS/RHEL | NodeSource `setup_22.x` + `yum install nodejs` |
| Other | Error with manual install instructions |

After installation, the version is re-checked to confirm success.

## Test plan

- [ ] Run `install.sh` on macOS with Node.js already installed — should print green checkmark and continue
- [ ] Run `install.sh` on a clean environment without Node.js — should auto-install and proceed
- [ ] Run `install.sh` with Node.js < 18 — should upgrade and proceed
- [ ] Verify colored output renders correctly in terminal