### PR TITLE
fix(openclaw-plugin): read allowPromptInjection from plugin config

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -392,8 +392,12 @@ const memosLocalPlugin = {
     // ─── Check allowPromptInjection policy ───
     // When allowPromptInjection=false, the prompt mutation fields (such as prependContext) in the hook return value
     // will be stripped by the framework. Skip auto-recall to avoid unnecessary LLM/embedding calls.
+    // Reads from both the framework hook config (plugins.entries.<id>.hooks.allowPromptInjection)
+    // and the plugin's own config (allowPromptInjection), so users can set it in either place.
     const pluginEntry = (api.config as any)?.plugins?.entries?.[api.id];
-    const allowPromptInjection = pluginEntry?.hooks?.allowPromptInjection !== false;
+    const allowPromptInjection =
+      pluginEntry?.hooks?.allowPromptInjection !== false &&
+      ctx.config.allowPromptInjection !== false;
     if (!allowPromptInjection) {
       api.logger.info("memos-local: allowPromptInjection=false, auto-recall disabled");
     }

--- a/apps/memos-local-openclaw/openclaw.plugin.json
+++ b/apps/memos-local-openclaw/openclaw.plugin.json
@@ -16,6 +16,10 @@
       "viewerPort": {
         "type": "number",
         "description": "Memory Viewer HTTP port (default 18799)"
+      },
+      "allowPromptInjection": {
+        "type": "boolean",
+        "description": "Set to false to disable automatic memory recall injection into prompts (default true)"
       }
     }
   },

--- a/apps/memos-local-openclaw/src/types.ts
+++ b/apps/memos-local-openclaw/src/types.ts
@@ -324,6 +324,8 @@ export interface MemosLocalConfig {
   sharing?: SharingConfig;
   /** Hours of inactivity after which an active task is automatically finalized. 0 = disabled. Default 4. */
   taskAutoFinalizeHours?: number;
+  /** Set to false to disable automatic memory recall injection into prompts (default true). */
+  allowPromptInjection?: boolean;
 }
 
 // ─── Defaults ───


### PR DESCRIPTION
## Problem

Bug 3 from #1383: setting `allowPromptInjection: false` in the plugin config has no effect — auto-recall continues to inject memories into prompts.

### Root Cause

The code only reads from `plugins.entries.<id>.hooks.allowPromptInjection` (the OpenClaw framework hook config), but users naturally set it in the plugin's own config block:

```json
{
  "plugins": {
    "entries": {
      "memos-local-openclaw-plugin": {
        "config": {
          "allowPromptInjection": false  // ← this was ignored
        }
      }
    }
  }
}
```

### Fix

Now reads from **both** locations — the framework hook config AND the plugin's own config. Setting `allowPromptInjection: false` in either place disables auto-recall.

### Changes

- **index.ts**: Check both `pluginEntry.hooks.allowPromptInjection` and `ctx.config.allowPromptInjection`
- **types.ts**: Add `allowPromptInjection` to `MemosLocalConfig` interface
- **openclaw.plugin.json**: Add `allowPromptInjection` to configSchema so it appears in plugin settings UI

### Testing

- Verified the config read path: when `ctx.config.allowPromptInjection` is `false`, the `allowPromptInjection` variable evaluates to `false`, disabling both the context engine injection and the `before_prompt_build` hook
- Backward compatible: existing users with `hooks.allowPromptInjection` config continue to work

Related: #1383 (Bug 3)