### PR TITLE
fix(viewer): singleton guard prevents port drift on reactivation

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -33,6 +33,11 @@ import { MEMORY_GUIDE_SKILL_MD } from "./src/skill/bundled-memory-guide";
 import { Telemetry } from "./src/telemetry";
 
 
+// Module-level singleton tracking for viewer/hub to prevent port drift on re-registration
+let _previousViewer: ViewerServer | null = null;
+let _previousHubServer: HubServer | null = null;
+let _previousStore: import('./src/storage/sqlite').SqliteStore | null = null;
+
 /** Remove near-duplicate hits based on summary word overlap (>70%). Keeps first (highest-scored) hit. */
 function deduplicateHits<T extends { summary: string }>(hits: T[]): T[] {
   const kept: T[] = [];
@@ -2365,6 +2370,20 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
 
     const derivedHubPort = gatewayPort + 11;
 
+    // Cleanup previous instances to prevent port drift (issue #1430)
+    if (_previousViewer) {
+      try { _previousViewer.stop(); } catch (e) { api.logger.warn(`memos-local: previous viewer cleanup: ${e}`); }
+      _previousViewer = null;
+    }
+    if (_previousHubServer) {
+      try { _previousHubServer.stop(); } catch (e) { api.logger.warn(`memos-local: previous hub cleanup: ${e}`); }
+      _previousHubServer = null;
+    }
+    if (_previousStore) {
+      try { _previousStore.close(); } catch (e) { api.logger.warn(`memos-local: previous store cleanup: ${e}`); }
+      _previousStore = null;
+    }
+
     const viewer = new ViewerServer({
       store,
       embedder,
@@ -2377,6 +2396,10 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     const hubServer = ctx.config.sharing?.enabled && ctx.config.sharing.role === "hub"
       ? new HubServer({ store, log: ctx.log, config: ctx.config, dataDir: stateDir, embedder, defaultHubPort: derivedHubPort })
       : null;
+
+    _previousViewer = viewer;
+    _previousHubServer = hubServer;
+    _previousStore = store;
 
     // ─── Service lifecycle ───
 

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -211,13 +211,18 @@ export class ViewerServer {
     }
   }
 
-  stop(): void {
+  stop(): Promise<void> {
     this.stopHubHeartbeat();
     this.stopNotifPoll();
     for (const c of this.notifSSEClients) { try { c.end(); } catch {} }
     this.notifSSEClients = [];
-    this.server?.close();
-    this.server = null;
+    if (!this.server) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.server!.close(() => {
+        this.server = null;
+        resolve();
+      });
+    });
   }
 
   getResetToken(): string {


### PR DESCRIPTION
## Summary

Fixes #1430 — viewer self-starts repeatedly under host lifecycle mismatch, causing port drift (18799→18800+) and "Memory unavailable".

## Root Cause

When the gateway restarts or reloads, `register()` is called again. Each call creates a new `ViewerServer` instance, but the previous one may still hold the port. The new instance hits `EADDRINUSE` and falls back to port+1, eventually drifting away from the expected 18799.

## Fix

- **Module-level singleton**: Track the active viewer, hub server, and store instances outside `register()` scope
- **Cleanup on re-registration**: `stop()` the previous viewer/hub and `close()` the previous store before creating new ones
- **Reliable stop**: `ViewerServer.stop()` now returns a `Promise<void>` that resolves only after `server.close()` callback fires, ensuring the port is fully released

## Scope

This PR addresses the **plugin side** of the lifecycle mismatch. The host-side gap (deferred `service.start()` call path) would need a separate OpenClaw upstream fix.

## Testing

- `npm run build` passes