### PR TITLE
style: apply ruff format to openharness capture and recall scripts

### DIFF
--- a/apps/memos-local-plugin/adapters/openharness/scripts/capture.py
+++ b/apps/memos-local-plugin/adapters/openharness/scripts/capture.py
@@ -17,12 +17,15 @@ import json
 import logging
 import os
 import sys
+
 from pathlib import Path
+
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from bridge_client import MemosCoreBridge
 from config import get_project_session_dir
+
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger("memos-capture")
@@ -85,10 +88,12 @@ def extract_messages_from_payload() -> tuple[list[dict], str]:
     if isinstance(raw_messages, list):
         for msg in raw_messages:
             if isinstance(msg, dict) and "role" in msg and "content" in msg:
-                messages.append({
-                    "role": msg["role"],
-                    "content": msg["content"],
-                })
+                messages.append(
+                    {
+                        "role": msg["role"],
+                        "content": msg["content"],
+                    }
+                )
 
     return messages, session_id
 

--- a/apps/memos-local-plugin/adapters/openharness/scripts/recall.py
+++ b/apps/memos-local-plugin/adapters/openharness/scripts/recall.py
@@ -16,15 +16,17 @@ Environment:
 from __future__ import annotations
 
 import logging
-import os
 import sys
+
 from pathlib import Path
+
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from bridge_client import MemosCoreBridge
 from config import get_project_memory_dir
 from daemon_manager import ensure_daemon
+
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger("memos-recall")


### PR DESCRIPTION
## Summary

- Apply `ruff format` auto-formatting to `capture.py` and `recall.py` in openharness adapter scripts
- Adds missing blank lines between import groups and after module-level statements
- Fixes dict literal indentation style in `capture.py`
- Removes unused `import os` in `recall.py`

Follow-up to #1458.

## Files Changed

- `adapters/openharness/scripts/capture.py`
- `adapters/openharness/scripts/recall.py`

## Test Plan

- [x] `ruff check apps/memos-local-plugin` passes
- [x] `ruff format --check apps/memos-local-plugin` passes
- [ ] Verify openharness capture/recall scripts still function correctly