### PR TITLE
fix(memos-local-openclaw): prevent viewer startup during non-gateway commands

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -2391,7 +2391,20 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
 
     let serviceStarted = false;
 
+    function isGatewayStartCommand(): boolean {
+      const args = process.argv.map(a => String(a || "").toLowerCase());
+      const gIdx = args.lastIndexOf("gateway");
+      if (gIdx === -1) return false;
+      const next = args[gIdx + 1];
+      return !next || next.startsWith("-") || next === "start" || next === "restart";
+    }
+
     const startServiceCore = async () => {
+      if (!isGatewayStartCommand()) {
+        api.logger.info("memos-local: not a gateway start command, skipping service startup.");
+        return;
+      }
+
       if (globalRef.__memosLocalPluginStopPromise) {
         await globalRef.__memosLocalPluginStopPromise;
         globalRef.__memosLocalPluginStopPromise = undefined;
@@ -2470,25 +2483,15 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     // Start on a delay instead of next tick so the host has time to call
     // service.start() during normal startup if this is a fresh launch.
     const SELF_START_DELAY_MS = 2000;
-    setTimeout(() => {
-      const args = process.argv.map(arg => String(arg || "").toLowerCase());
-      const gatewayIndex = args.lastIndexOf("gateway");
-      let shouldStart = false;
-
-      if (gatewayIndex !== -1) {
-        const nextArg = args[gatewayIndex + 1];
-        if (!nextArg || nextArg.startsWith("-") || nextArg === "start" || nextArg === "restart") {
-          shouldStart = true;
-        }
-      }
-
-      if (!serviceStarted && shouldStart) {
+    const selfStartTimer = setTimeout(() => {
+      if (!serviceStarted && isGatewayStartCommand()) {
         api.logger.info("memos-local: service.start() not called by host, self-starting viewer...");
         startServiceCore().catch((err) => {
           api.logger.warn(`memos-local: self-start failed: ${err}`);
         });
       }
     }, SELF_START_DELAY_MS);
+    if (selfStartTimer.unref) selfStartTimer.unref();
   },
 };
 


### PR DESCRIPTION
## Summary

- `openclaw plugin list` was incorrectly triggering the full MemOS service startup (ViewerServer + HubServer), causing an extra memory panel to open, the process to hang indefinitely, and the plugin list output to not display in the terminal.
- Root cause: `startServiceCore()` had no guard against non-gateway commands. The OpenClaw host framework calls `service.start()` on all registered services even for read-only CLI commands like `plugin list`.
- Fix: extract `isGatewayStartCommand()` helper (reusing the existing argv-checking logic from the setTimeout fallback) and add it as a guard at the top of `startServiceCore()`. Also `.unref()` the fallback timer so it doesn't prevent process exit.

## What changed

**`apps/memos-local-openclaw/index.ts`** — Service lifecycle section:

1. **New `isGatewayStartCommand()` function** — checks `process.argv` for `gateway start|restart` patterns. Returns `false` for commands like `plugin list`, `gateway stop`, `gateway install`, etc.
2. **Guard at top of `startServiceCore()`** — early-returns when not a gateway start command, preventing ViewerServer/HubServer from starting during `plugin list` and similar CLI commands.
3. **Simplified setTimeout fallback** — reuses `isGatewayStartCommand()` instead of duplicating the argv-parsing logic. Calls `.unref()` on the timer so it doesn't block process exit.

## Scenario verification

| Command | `isGatewayStartCommand()` | Viewer starts? | Expected? |
|---|---|---|---|
| `openclaw gateway start` | ✅ true | ✅ Yes | ✅ |
| `openclaw gateway restart` | ✅ true | ✅ Yes | ✅ |
| `openclaw gateway` | ✅ true | ✅ Yes | ✅ |
| `openclaw gateway --daemon` | ✅ true | ✅ Yes | ✅ |
| `openclaw plugin list` | ❌ false | ❌ No | ✅ |
| `openclaw gateway stop` | ❌ false | ❌ No | ✅ |
| `openclaw gateway install` | ❌ false | ❌ No | ✅ |
| Deferred reload (gateway running) | ✅ true | ✅ Yes | ✅ |

## Test plan

- [ ] Run `openclaw plugin list` — should display installed plugins and exit immediately without opening the memory viewer
- [ ] Run `openclaw gateway start` — Memory Viewer should start normally on port 18799
- [ ] Run `openclaw gateway restart` — Memory Viewer should restart normally
- [ ] Install/update plugin while gateway is running — deferred reload should start the viewer correctly