### PR TITLE
fix(memos-local-openclaw-plugin): integrate stfix(memos-local): report memory status correctly and avoid CLI-spawned viewersatus runtime and gate viewer self-start

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -333,6 +333,86 @@ const memosLocalPlugin = {
     } catch {}
     const telemetry = new Telemetry(ctx.config.telemetry ?? {}, stateDir, pluginVersion, ctx.log, pluginDir);
 
+    api.registerMemoryRuntime({
+      async getMemorySearchManager(params: { agentId: string }) {
+        const ownerFilter = [`agent:${params.agentId}`, "public"];
+        const readCount = (sql: string) => {
+          try {
+            const db = (store as { db?: { prepare: (query: string) => { get: (...args: string[]) => { count?: number } | undefined } } }).db;
+            const row = db?.prepare(sql).get(...ownerFilter);
+            return Number(row?.count ?? 0);
+          } catch {
+            return 0;
+          }
+        };
+
+        return {
+          manager: {
+            async search(query: string, opts?: { maxResults?: number; minScore?: number }) {
+              const result = await engine.search({
+                query,
+                maxResults: opts?.maxResults,
+                minScore: opts?.minScore,
+                ownerFilter,
+              });
+              return result.hits.map((hit) => ({
+                path: `session:${hit.source.sessionKey}`,
+                startLine: 1,
+                endLine: 1,
+                score: hit.score,
+                snippet: hit.original_excerpt || hit.summary,
+                source: "sessions" as const,
+                citation: hit.ref.chunkId,
+              }));
+            },
+            async readFile(params: { relPath: string }) {
+              throw new Error(`file-backed memory read unsupported by memos-local: ${params.relPath}`);
+            },
+            status() {
+              const chunks = readCount("SELECT COUNT(*) as count FROM chunks WHERE owner IN (?, ?)");
+              const files = readCount("SELECT COUNT(DISTINCT session_key) as count FROM chunks WHERE owner IN (?, ?)");
+              const vectorCount = readCount("SELECT COUNT(*) as count FROM embeddings e JOIN chunks c ON c.id = e.chunk_id WHERE c.owner IN (?, ?)");
+              return {
+                backend: "builtin" as const,
+                provider: embedder.provider,
+                model: ctx.config.embedding?.model,
+                files,
+                chunks,
+                dirty: false,
+                workspaceDir: api.resolvePath("~/.openclaw/workspace"),
+                dbPath: ctx.config.storage?.dbPath,
+                sources: ["sessions" as const],
+                vector: {
+                  enabled: true,
+                  available: vectorCount > 0,
+                  dims: embedder.dimensions,
+                },
+                custom: {
+                  plugin: "memos-local-openclaw-plugin",
+                },
+              };
+            },
+            async probeEmbeddingAvailability() {
+              try {
+                await embedder.embedQuery("health check");
+                return { ok: true };
+              } catch (err) {
+                return { ok: false, error: err instanceof Error ? err.message : String(err) };
+              }
+            },
+            async probeVectorAvailability() {
+              return readCount("SELECT COUNT(*) as count FROM embeddings e JOIN chunks c ON c.id = e.chunk_id WHERE c.owner IN (?, ?)") > 0;
+            },
+            async close() {},
+          },
+        };
+      },
+      resolveMemoryBackendConfig() {
+        return { backend: "builtin" as const };
+      },
+      async closeAllMemorySearchManagers() {},
+    });
+
     // Install bundled memory-guide skill so OpenClaw loads it (write from embedded content so it works regardless of deploy layout)
     const workspaceSkillsDir = path.join(workspaceDir, "skills");
     const memosGuideDest = path.join(workspaceSkillsDir, "memos-memory-guide");
@@ -2380,6 +2460,11 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
 
     // ─── Service lifecycle ───
 
+    const registrationMode = (api as { registrationMode?: string }).registrationMode ?? "full";
+    const argv = process.argv.slice(2);
+    const isGatewayProcess = argv.includes("gateway") || process.argv.includes("gateway");
+    const shouldHostViewerService = registrationMode === "full" && isGatewayProcess;
+
     let serviceStarted = false;
 
     const startServiceCore = async () => {
@@ -2425,33 +2510,35 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
       );
     };
 
-    api.registerService({
-      id: "memos-local-openclaw-plugin",
-      start: async () => { await startServiceCore(); },
-      stop: async () => {
-        await worker.flush();
-        await telemetry.shutdown();
-        await hubServer?.stop();
-        viewer.stop();
-        store.close();
-        api.logger.info("memos-local: stopped");
-      },
-    });
+    if (shouldHostViewerService) {
+      api.registerService({
+        id: "memos-local-openclaw-plugin",
+        start: async () => { await startServiceCore(); },
+        stop: async () => {
+          await worker.flush();
+          await telemetry.shutdown();
+          await hubServer?.stop();
+          viewer.stop();
+          store.close();
+          api.logger.info("memos-local: stopped");
+        },
+      });
 
-    // Fallback: OpenClaw may load this plugin via deferred reload after
-    // startPluginServices has already run, so service.start() never fires.
-    // Start on the next tick instead of waiting several seconds; the
-    // serviceStarted guard still prevents duplicate startup if the host calls
-    // service.start() immediately after registration.
-    const SELF_START_DELAY_MS = 0;
-    setTimeout(() => {
-      if (!serviceStarted) {
-        api.logger.info("memos-local: service.start() not called by host, self-starting viewer...");
-        startServiceCore().catch((err) => {
-          api.logger.warn(`memos-local: self-start failed: ${err}`);
-        });
-      }
-    }, SELF_START_DELAY_MS);
+      // Fallback: OpenClaw may load this plugin via deferred reload after
+      // startPluginServices has already run, so service.start() never fires.
+      // Self-start the viewer after a short grace period only in the gateway process.
+      const SELF_START_DELAY_MS = 3000;
+      setTimeout(() => {
+        if (!serviceStarted) {
+          api.logger.info("memos-local: service.start() not called by host, self-starting viewer...");
+          startServiceCore().catch((err) => {
+            api.logger.warn(`memos-local: self-start failed: ${err}`);
+          });
+        }
+      }, SELF_START_DELAY_MS);
+    } else {
+      api.logger.info(`memos-local: skipping viewer service registration (mode=${registrationMode}, argv=${argv.join(" ")})`);
+    }
   },
 };
 


### PR DESCRIPTION
## Summary

This PR fixes two integration issues in the MemOS local OpenClaw plugin:

1. Register an OpenClaw memory runtime adapter so host status probes can read plugin health correctly
2. Gate viewer service registration and self-start logic to real gateway processes only

## Problem
The plugin could still read and write memory correctly, but `openclaw status` reported memory as `unavailable`.

At the same time, CLI processes such as `openclaw status` could accidentally trigger the plugin's viewer self-start fallback, which caused extra viewer instances to be spawned and fallback ports to be consumed.

## Changes

- add `registerMemoryRuntime(...)` so OpenClaw can query memory status through the standard runtime interface
- expose plugin-backed memory status details such as files, chunks, sources, and vector readiness
- restrict viewer service registration to actual gateway processes
- prevent non-gateway CLI runs from triggering viewer self-start
- keep the fix limited to plugin code only

## Result

After this change:
- `openclaw status` reports normal memory status instead of `unavailable`
- memory status can show values such as `files`, `chunks`, `sources sessions`, and `vector ready`
- CLI commands no longer spawn extra viewer instances
- the memory viewer lifecycle stays bound to the gateway process as expected

## Notes

This PR does not include any local machine config workarounds or user-specific environment changes.
It only addresses the plugin-side integration and lifecycle issues.

## Validation

Validated locally by confirming that:
- memory read/write was still working before and after the fix
- `openclaw status` no longer reported `unavailable`
- status output showed plugin-backed memory health information
- non-gateway CLI commands no longer created additional viewer listeners