### PR TITLE
fix(openclaw): prevent duplicate viewer instances on gateway restart

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -2424,7 +2424,7 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
           await instanceToReplace.telemetry.shutdown().catch(() => {});
           instanceToReplace.store.close();
         } catch (err) {
-          api.logger.warn(`memos-local: previous instance cleanup error: ${err}`);
+          api.logger.warn(`memos-local: previous instance cleanup error: ${err instanceof Error ? err.message : String(err)}`);
         }
         api.logger.info("memos-local: previous instance stopped");
       }
@@ -2489,6 +2489,8 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     // service.start() immediately after registration.
     const SELF_START_DELAY_MS = 0;
     setTimeout(() => {
+      // Abort if this instance was already replaced by a newer register() call
+      if (activeInstances.get(stateDir)?.viewer !== viewer) return;
       if (!serviceStarted) {
         api.logger.info("memos-local: service.start() not called by host, self-starting viewer...");
         startServiceCore().catch((err) => {

--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -150,6 +150,19 @@ const pluginConfigSchema = {
   },
 };
 
+// ─── Module-level singleton guard ───
+// Prevents duplicate viewers/stores when OpenClaw calls register() multiple
+// times for the SAME stateDir (e.g. deferred reload, gateway restart).
+// Keyed by stateDir so that truly independent instances (different data dirs,
+// as in tests) are not accidentally torn down.
+const activeInstances = new Map<string, {
+  viewer: InstanceType<typeof ViewerServer>;
+  hubServer: InstanceType<typeof HubServer> | null;
+  worker: InstanceType<typeof IngestWorker>;
+  store: InstanceType<typeof SqliteStore>;
+  telemetry: InstanceType<typeof Telemetry>;
+}>();
+
 const memosLocalPlugin = {
   id: "memos-local-openclaw-plugin",
   name: "MemOS Local Memory",
@@ -160,6 +173,19 @@ const memosLocalPlugin = {
   configSchema: pluginConfigSchema,
 
   register(api: OpenClawPluginApi) {
+    // Resolve stateDir early so we can check for a duplicate instance with the
+    // same data directory (deferred reload / gateway restart scenario).
+    const stateDir = process.env.OPENCLAW_STATE_DIR || api.resolvePath("~/.openclaw");
+
+    // Snapshot the previous instance for this stateDir so startServiceCore()
+    // can tear it down asynchronously (awaiting port release) before starting
+    // the new viewer.  Instances with a different stateDir are left untouched.
+    const instanceToReplace = activeInstances.get(stateDir) ?? null;
+    activeInstances.delete(stateDir);
+    if (instanceToReplace) {
+      api.logger.info("memos-local: previous instance detected, will stop before starting new viewer");
+    }
+
     api.registerMemoryCapability({
       promptBuilder: buildMemoryPromptSection,
     });
@@ -286,7 +312,6 @@ const memosLocalPlugin = {
     }
 
     let pluginCfg = (api.pluginConfig ?? {}) as Record<string, unknown>;
-    const stateDir = process.env.OPENCLAW_STATE_DIR || api.resolvePath("~/.openclaw");
 
     // Fallback: read config from file if not provided by OpenClaw
     const configPath = path.join(stateDir, "state", "memos-local", "config.json");
@@ -2378,6 +2403,9 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
       ? new HubServer({ store, log: ctx.log, config: ctx.config, dataDir: stateDir, embedder, defaultHubPort: derivedHubPort })
       : null;
 
+    // Track this instance so the next register() with the same stateDir can tear it down
+    activeInstances.set(stateDir, { viewer, hubServer, worker, store, telemetry });
+
     // ─── Service lifecycle ───
 
     let serviceStarted = false;
@@ -2385,6 +2413,21 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     const startServiceCore = async () => {
       if (serviceStarted) return;
       serviceStarted = true;
+
+      // Gracefully shut down the previous instance before binding new ports
+      if (instanceToReplace) {
+        api.logger.info("memos-local: stopping previous instance...");
+        try {
+          await instanceToReplace.viewer.stop();
+          await instanceToReplace.hubServer?.stop();
+          await instanceToReplace.worker.flush().catch(() => {});
+          await instanceToReplace.telemetry.shutdown().catch(() => {});
+          instanceToReplace.store.close();
+        } catch (err) {
+          api.logger.warn(`memos-local: previous instance cleanup error: ${err}`);
+        }
+        api.logger.info("memos-local: previous instance stopped");
+      }
 
       if (hubServer) {
         const hubUrl = await hubServer.start();
@@ -2429,10 +2472,11 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
       id: "memos-local-openclaw-plugin",
       start: async () => { await startServiceCore(); },
       stop: async () => {
+        activeInstances.delete(stateDir);
         await worker.flush();
         await telemetry.shutdown();
         await hubServer?.stop();
-        viewer.stop();
+        await viewer.stop();
         store.close();
         api.logger.info("memos-local: stopped");
       },

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -211,13 +211,19 @@ export class ViewerServer {
     }
   }
 
-  stop(): void {
+  stop(): Promise<void> {
     this.stopHubHeartbeat();
     this.stopNotifPoll();
     for (const c of this.notifSSEClients) { try { c.end(); } catch {} }
     this.notifSSEClients = [];
-    this.server?.close();
+    if (!this.server) return Promise.resolve();
+    const srv = this.server;
     this.server = null;
+    return new Promise<void>((resolve) => {
+      srv.close(() => resolve());
+      // Force-close idle keep-alive connections so close() doesn't hang
+      srv.closeAllConnections?.();
+    });
   }
 
   getResetToken(): string {

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -220,9 +220,20 @@ export class ViewerServer {
     const srv = this.server;
     this.server = null;
     return new Promise<void>((resolve) => {
-      srv.close(() => resolve());
-      // Force-close idle keep-alive connections so close() doesn't hang
-      srv.closeAllConnections?.();
+      const timeout = setTimeout(() => resolve(), 3000);
+      srv.close(() => { clearTimeout(timeout); resolve(); });
+      // Force-close idle keep-alive sockets. closeAllConnections is
+      // available from Node 18.2; fall back to destroying tracked sockets.
+      if (typeof srv.closeAllConnections === "function") {
+        srv.closeAllConnections();
+      } else {
+        // Older Node: close idle connections via closeIdleConnections
+        // (18.0+) or just unref so the event loop can exit.
+        if (typeof (srv as any).closeIdleConnections === "function") {
+          (srv as any).closeIdleConnections();
+        }
+        srv.unref();
+      }
     });
   }
 

--- a/apps/memos-local-openclaw/tests/e2e-duplicate-instance.test.ts
+++ b/apps/memos-local-openclaw/tests/e2e-duplicate-instance.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Real integration test: verify that calling register() twice stops the
+ * previous viewer instead of leaking a second HTTP server on a new port.
+ *
+ * Spins up actual HTTP servers (ViewerServer) and verifies:
+ *   1. Old instance is torn down before new one starts
+ *   2. New viewer binds to the same port (not port+1)
+ *   3. Only one HTTP server is running after re-registration
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-dup-test-"));
+fs.mkdirSync(path.join(tmpDir, "memos-local"), { recursive: true });
+fs.mkdirSync(path.join(tmpDir, "workspace", "skills"), { recursive: true });
+fs.mkdirSync(path.join(tmpDir, "skills"), { recursive: true });
+
+/** Find a free port by temporarily binding to port 0 */
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+/** Check if a port is in use by attempting TCP connect */
+function isPortListening(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ host: "127.0.0.1", port }, () => {
+      sock.destroy();
+      resolve(true);
+    });
+    sock.on("error", () => resolve(false));
+    sock.setTimeout(1000, () => { sock.destroy(); resolve(false); });
+  });
+}
+
+function createMockApi(stateDir: string, gatewayPort: number) {
+  const services: Array<{ id: string; start: () => Promise<void>; stop: () => Promise<void> }> = [];
+  const logs: string[] = [];
+  return {
+    api: {
+      id: "memos-local-openclaw-plugin",
+      pluginConfig: {},
+      config: { gateway: { port: gatewayPort } },
+      resolvePath: (p: string) => p.replace("~/.openclaw", stateDir),
+      logger: {
+        info: (msg: string) => logs.push(msg),
+        warn: (msg: string) => logs.push(msg),
+        error: (msg: string) => logs.push(msg),
+        debug: (msg: string) => logs.push(msg),
+      },
+      registerTool: () => {},
+      registerMemoryCapability: () => {},
+      registerService: (svc: any) => { services.push(svc); },
+      registerHook: () => {},
+      on: () => {},
+    },
+    services,
+    logs,
+  };
+}
+
+let lastCleanup: (() => Promise<void>) | null = null;
+
+afterAll(async () => {
+  if (lastCleanup) await lastCleanup();
+  await new Promise((r) => setTimeout(r, 200));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Extract the viewer port from logs like "→ http://127.0.0.1:19799" */
+function extractViewerPort(logs: string[]): number | null {
+  for (const l of logs) {
+    const m = l.match(/→\s*http:\/\/127\.0\.0\.1:(\d+)/);
+    if (m) return parseInt(m[1], 10);
+  }
+  return null;
+}
+
+describe("duplicate instance prevention (real HTTP servers)", () => {
+  it("second register() should stop previous viewer and reuse the same port", async () => {
+    // Pick a random free port to avoid collisions with other processes
+    const freePort = await findFreePort();
+    const gatewayPort = freePort;
+    const expectedViewerPort = gatewayPort + 10;
+
+    // Confirm our ports are actually free
+    expect(await isPortListening(expectedViewerPort)).toBe(false);
+    expect(await isPortListening(expectedViewerPort + 1)).toBe(false);
+
+    const pluginModule = await import("../index");
+    const plugin = pluginModule.default;
+
+    // ─── 1st register + start ───
+    const mock1 = createMockApi(tmpDir, gatewayPort);
+    plugin.register(mock1.api as any);
+    const svc1 = mock1.services[mock1.services.length - 1];
+    await svc1.start();
+
+    const viewerPort1 = extractViewerPort(mock1.logs);
+    expect(viewerPort1).toBe(expectedViewerPort);
+    expect(await isPortListening(expectedViewerPort)).toBe(true);
+
+    // ─── 2nd register (simulates deferred reload / gateway restart) ───
+    const mock2 = createMockApi(tmpDir, gatewayPort);
+    plugin.register(mock2.api as any);
+
+    // Verify the plugin detected the previous instance
+    const detectedMsg = mock2.logs.some((l) => l.includes("previous instance detected"));
+    expect(detectedMsg).toBe(true);
+
+    // Start the 2nd service — cleanup happens inside startServiceCore()
+    const svc2 = mock2.services[mock2.services.length - 1];
+    await svc2.start();
+
+    lastCleanup = async () => { await svc2.stop(); };
+
+    // Verify: stopped previous, then started on the SAME port
+    const stoppedMsg = mock2.logs.some((l) => l.includes("previous instance stopped"));
+    expect(stoppedMsg).toBe(true);
+
+    const viewerPort2 = extractViewerPort(mock2.logs);
+    expect(viewerPort2).toBe(expectedViewerPort);  // Same port, not port+1
+
+    // Verify: only ONE server is running (the expected port), not two
+    expect(await isPortListening(expectedViewerPort)).toBe(true);
+    expect(await isPortListening(expectedViewerPort + 1)).toBe(false);
+
+    // ─── Clean stop ───
+    await svc2.stop();
+    lastCleanup = null;
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(await isPortListening(expectedViewerPort)).toBe(false);
+  });
+});

--- a/apps/memos-local-openclaw/tests/e2e-duplicate-instance.test.ts
+++ b/apps/memos-local-openclaw/tests/e2e-duplicate-instance.test.ts
@@ -24,11 +24,11 @@ fs.mkdirSync(path.join(tmpDir, "skills"), { recursive: true });
 function findFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();
+    srv.on("error", reject);
     srv.listen(0, "127.0.0.1", () => {
       const port = (srv.address() as net.AddressInfo).port;
       srv.close(() => resolve(port));
     });
-    srv.on("error", reject);
   });
 }
 

--- a/apps/memos-local-openclaw/tests/shutdown-lifecycle.test.ts
+++ b/apps/memos-local-openclaw/tests/shutdown-lifecycle.test.ts
@@ -83,7 +83,7 @@ describe("shutdown lifecycle", () => {
 
     class MockViewer {
       async start(): Promise<string> { return "http://127.0.0.1:18799"; }
-      stop(): void { events.push("viewer-stop"); }
+      async stop(): Promise<void> { events.push("viewer-stop"); }
       getResetToken(): string { return "token"; }
     }
 


### PR DESCRIPTION
## Description

OpenClaw 在 gateway restart 或 deferred reload 时会重新调用插件的 `register()`，但旧的 viewer HTTP server 没有关闭。每次重注册都会泄漏一个新的 server 到下一个端口（18799 → 18800 → 18801……），#1471 里的日志就是这样。

问题出在 `serviceStarted` 和 `viewer` 都是 `register()` 闭包里的局部变量。第二次调 `register()` 会创建新闭包，旧闭包里的 viewer 就没人管了。

改法：在模块层面用 Map 追踪活跃实例，以 stateDir 为 key。`register()` 进来先查有没有同 stateDir 的旧实例，有的话在 `startServiceCore()` 里先 await 把旧 viewer 关掉（等端口真正释放），再启动新的。

`ViewerServer.stop()` 改成返回 Promise，这样调用方能等 `server.close()` 回调完成，不会出现端口还没释放就尝试 rebind 的竞态。

用 stateDir 做 key 而不是全局单例，是因为集成测试里会用不同 stateDir 同时跑多个 `register()`，全局单例会误杀别人的实例。

Related Issue: Fixes #1471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script Or Test Steps (please provide)

跑了三层验证：

1. `npm run build` — TypeScript 编译通过
2. `npx vitest run` — 182 个既有测试全绿（排除 main 上已有的 2 个 flaky test）
3. 新增 `e2e-duplicate-instance.test.ts` — 用真实 HTTP server 验证：找一个空闲端口，对同一 stateDir 调两次 `register()` + `start()`，检查：
   - 旧 viewer 被检测并停止
   - 新 viewer 绑到**同一个端口**（不是 port+1）
   - 不存在泄漏的第二个 server
   - stop 后端口完全释放

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
