### PR TITLE
fix: keep query embedding for fine search

### DIFF
--- a/src/memos/memories/textual/tree_text_memory/retrieve/recall.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/recall.py
@@ -338,7 +338,20 @@ class GraphMemoryRetriever:
         # TODO: tackle with post-filter and pre-filter(5.18+) better.
         """
         if not query_embedding:
+            logger.info(
+                "[VECTOR_RECALL] skipped empty query embedding, scope=%s, user_name=%s",
+                memory_scope,
+                user_name,
+            )
             return []
+
+        logger.info(
+            "[VECTOR_RECALL] start scope=%s, user_name=%s, top_k=%s, embedding_count=%s",
+            memory_scope,
+            user_name,
+            top_k,
+            min(len(query_embedding), max_num),
+        )
 
         def search_single(vec, search_priority=None, search_filter=None):
             return (
@@ -390,6 +403,13 @@ class GraphMemoryRetriever:
             all_hits.extend(path_a_future.result())
             all_hits.extend(path_b_future.result())
 
+        logger.info(
+            "[VECTOR_RECALL] raw hits scope=%s, user_name=%s, count=%s",
+            memory_scope,
+            user_name,
+            len(all_hits),
+        )
+
         if not all_hits:
             return []
 
@@ -436,6 +456,13 @@ class GraphMemoryRetriever:
                     node["metadata"] = {}
                 node["metadata"]["relativity"] = id_to_score.get(rid, 0.0)
                 ordered_nodes.append(node)
+
+        logger.info(
+            "[VECTOR_RECALL] loaded nodes scope=%s, user_name=%s, count=%s",
+            memory_scope,
+            user_name,
+            len(ordered_nodes),
+        )
 
         return [TextualMemoryItem.from_dict(n) for n in ordered_nodes]
 

--- a/src/memos/memories/textual/tree_text_memory/retrieve/searcher.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/searcher.py
@@ -320,10 +320,13 @@ class Searcher:
         )
 
         query = parsed_goal.rephrased_query or query
-        # if goal has extra memories, embed them too
-        if parsed_goal.memories:
-            embed_texts = list(dict.fromkeys([query, *parsed_goal.memories]))
-            query_embedding = self.embedder.embed(embed_texts)
+        embed_texts = [
+            text.strip()
+            for text in [query, *parsed_goal.memories]
+            if isinstance(text, str) and text.strip()
+        ]
+        if embed_texts:
+            query_embedding = self.embedder.embed(list(dict.fromkeys(embed_texts)))
         return parsed_goal, query_embedding, context, query
 
     @timed

--- a/tests/memories/textual/test_tree_searcher.py
+++ b/tests/memories/textual/test_tree_searcher.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from memos.memories.textual.item import TextualMemoryItem, TreeNodeTextualMemoryMetadata
+from memos.memories.textual.tree_text_memory.retrieve.retrieval_mid_structs import ParsedTaskGoal
 from memos.memories.textual.tree_text_memory.retrieve.searcher import Searcher
 from memos.reranker.base import BaseReranker
 
@@ -24,13 +25,14 @@ def mock_searcher():
     return s
 
 
-def make_item(content: str, score: float):
+def make_item(content: str, score: float, memory_type: str = "WorkingMemory"):
     # Simulate a TextualMemoryItem with usage list for update test
     return (
         TextualMemoryItem(
             memory=content,
             metadata=TreeNodeTextualMemoryMetadata(
                 embedding=[0.1] * 5,
+                memory_type=memory_type,
                 usage=[],
             ),
         ),
@@ -102,6 +104,90 @@ def test_searcher_fine_mode_triggers_reasoner(mock_searcher):
         mode="fine",
     )
     assert len(result) == 1
+
+
+def test_fine_search_embeds_query_when_parser_returns_no_memory_expansions(mock_searcher):
+    query = "我喜欢什么"
+    user_memory = make_item("我喜欢草莓", 0.9, memory_type="UserMemory")[0]
+
+    mock_searcher.task_goal_parser.parse.return_value = ParsedTaskGoal(
+        keys=["喜欢", "偏好", "兴趣"],
+        tags=["personal preference", "user interest", "taste"],
+        memories=[],
+        rephrased_query="",
+    )
+    mock_searcher.embedder.embed.return_value = [[0.1] * 5]
+
+    def retrieve_side_effect(*args, **kwargs):
+        if kwargs.get("memory_scope") == "UserMemory":
+            assert kwargs["query_embedding"] == [[0.1] * 5]
+            return [user_memory]
+        return []
+
+    mock_searcher.graph_retriever.retrieve.side_effect = retrieve_side_effect
+    mock_searcher.reranker.rerank.return_value = [(user_memory, 0.9)]
+
+    result = mock_searcher.search(query=query, top_k=1, mode="fine", memory_type="UserMemory")
+
+    mock_searcher.embedder.embed.assert_called_once_with([query])
+    assert len(result) == 1
+    assert result[0].memory == "我喜欢草莓"
+
+
+def test_fine_search_runs_vector_recall_when_metadata_recall_misses():
+    query = "What do I like"
+    dispatcher_llm = MagicMock()
+    graph_store = MagicMock()
+    embedder = MagicMock()
+    reranker = MagicMock(spec=BaseReranker)
+    searcher = Searcher(dispatcher_llm, graph_store, embedder, reranker)
+
+    searcher.task_goal_parser = MagicMock()
+    searcher.task_goal_parser.parse.return_value = ParsedTaskGoal(
+        keys=["likes", "preferences", "interests"],
+        tags=["personal preferences", "user profile", "taste"],
+        memories=[],
+        rephrased_query="",
+    )
+    embedder.embed.return_value = [[0.1] * 5]
+
+    memory_id = "abfd6604-3f73-4c0c-bdfa-d100834f0596"
+    graph_store.get_by_metadata.side_effect = [[], []]
+    graph_store.search_by_embedding.return_value = [{"id": memory_id, "score": 0.82}]
+    graph_store.get_nodes.return_value = [
+        {
+            "id": memory_id,
+            "memory": "On April 14, 2026 at 1:48 PM, the user expressed that they like strawberries.",
+            "metadata": {
+                "memory_type": "UserMemory",
+                "embedding": [0.2] * 5,
+                "key": "Preference for strawberries",
+                "tags": ["food preference", "fruit", "personal taste"],
+            },
+        }
+    ]
+
+    def rerank_side_effect(*, graph_results, **kwargs):
+        return [(item, item.metadata.relativity or 0.82) for item in graph_results]
+
+    reranker.rerank.side_effect = rerank_side_effect
+
+    result = searcher.search(
+        query=query,
+        top_k=1,
+        mode="fine",
+        memory_type="UserMemory",
+        user_name="b32d0977-435d-4828-a86f-4f47f8b55bca",
+    )
+
+    embedder.embed.assert_called_once_with([query])
+    graph_store.search_by_embedding.assert_called_once()
+    assert graph_store.search_by_embedding.call_args.kwargs["scope"] == "UserMemory"
+    assert graph_store.search_by_embedding.call_args.kwargs["user_name"] == (
+        "b32d0977-435d-4828-a86f-4f47f8b55bca"
+    )
+    assert len(result) == 1
+    assert "strawberries" in result[0].memory
 
 
 def test_searcher_respects_memory_type(mock_searcher):


### PR DESCRIPTION
## What changed

Fine search now embeds the user query even when the task parser returns keys or tags but no memory expansions.

Before this change, `_parse_task` only called the embedder when `parsed_goal.memories` was non-empty. That made fine search fragile for prompts like `What do I like` or `我喜欢什么`: the parser can produce useful keys/tags while leaving `memories=[]`, and retrieval then depends on exact metadata filters. Fast-added `UserMemory` often has a full sentence as `key` and tags that do not exactly match the parser output, so metadata recall misses even though the vector point exists.

The patch keeps metadata recall as-is, but always embeds the normalized query plus any parser-provided memory expansions. Empty strings are ignored and duplicates are removed.

I also added explicit vector recall logs. They make the next failure point visible:

- empty query embedding
- no Qdrant/vector hits
- vector hits that cannot be loaded from Neo4j
- successful vector load followed by later filtering

## Why this shape

I did not map `UserMemory` into `pref_mem`. The current response formatter treats `PreferenceMemory` as preference memory and returns `UserMemory` through `text_mem`. Changing that here would mix two memory types and make the API behavior harder to reason about.

## Validation

- `uv run pytest tests/memories/textual/test_tree_searcher.py tests/memories/textual/test_tree_retriever.py` -> 9 passed
- `uv run ruff check src/memos/memories/textual/tree_text_memory/retrieve/searcher.py src/memos/memories/textual/tree_text_memory/retrieve/recall.py tests/memories/textual/test_tree_searcher.py` -> passed
- `git diff --check` -> passed

I also ran a local end-to-end check with the product API, qwen-flash, `az-ut-on/text-embedding-3-small`, Docker Qdrant, and Docker Neo4j:

- `/product/add` wrote `我喜欢草莓` as `UserMemory`.
- Qdrant contained the point with `memory_type=UserMemory`, `tags=["mode:fast"]`, and the expected cube id as `user_name`.
- Neo4j contained the same `Memory` node.
- A direct Qdrant vector search for `我喜欢什么`, using the same embedding model and filtering by `user_name` plus `memory_type=UserMemory`, hit the stored strawberry memory.
- `/product/search` with `mode=fine` and `search_memory_type=UserMemory` returned the relevant memory under `text_mem`.

Closes #1448
