### PR TITLE
fix(hermes-plugin): add telemetry credentials generation to CI publish

### DIFF
--- a/.github/workflows/hermes-plugin-publish.yml
+++ b/.github/workflows/hermes-plugin-publish.yml
@@ -92,6 +92,13 @@ jobs:
       - name: Install dependencies (skip native build)
         run: npm install --ignore-scripts
 
+      - name: Generate telemetry credentials
+        run: node scripts/generate-telemetry-credentials.cjs
+        env:
+          MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
+          MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
+          MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
+
       - name: Bump version
         run: npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 

--- a/apps/memos-local-plugin/scripts/generate-telemetry-credentials.cjs
+++ b/apps/memos-local-plugin/scripts/generate-telemetry-credentials.cjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Generate telemetry.credentials.json from environment variables.
+ *
+ * Called by CI before `npm publish` so the npm package ships with
+ * working telemetry credentials while the git repo stays clean.
+ *
+ * Required env vars:
+ *   MEMOS_ARMS_ENDPOINT  — full ARMS RUM endpoint URL
+ *   MEMOS_ARMS_PID       — ARMS application PID
+ *   MEMOS_ARMS_ENV       — environment tag (default: "prod")
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const endpoint = process.env.MEMOS_ARMS_ENDPOINT || "";
+const pid = process.env.MEMOS_ARMS_PID || "";
+const env = process.env.MEMOS_ARMS_ENV || "prod";
+
+if (!endpoint) {
+  console.warn(
+    "[generate-telemetry-credentials] MEMOS_ARMS_ENDPOINT not set — " +
+      "skipping. Telemetry will be disabled in this build.",
+  );
+  process.exit(0);
+}
+
+const out = path.resolve(__dirname, "..", "telemetry.credentials.json");
+fs.writeFileSync(out, JSON.stringify({ endpoint, pid, env }, null, 2) + "\n", "utf-8");
+console.log("[generate-telemetry-credentials] wrote " + out);


### PR DESCRIPTION
## Summary
- Add `scripts/generate-telemetry-credentials.cjs` to `apps/memos-local-plugin/` (same script that openclaw already uses)
- Add the "Generate telemetry credentials" step to `hermes-plugin-publish.yml`, injecting `MEMOS_ARMS_*` secrets so published npm packages ship with a working `telemetry.credentials.json`

Without this fix, hermes plugin builds have no credentials file and ARMS telemetry is silently disabled. Both plugins now write to the same ARMS app, differentiated by the `platform` tag (`"hermes"` vs `"openclaw"`).

## Test plan
- [ ] Verify `hermes-plugin-publish.yml` workflow runs successfully with the new step
- [ ] Confirm published hermes npm package contains `telemetry.credentials.json`
- [ ] Validate telemetry events from hermes have `platform: "hermes"` in ARMS console