### PR TITLE
fix(memos-local-plugin): Node.js v23 built-in TypeScript breaks bridge.cts

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/daemon_manager.py
@@ -123,6 +123,20 @@ def start_daemon(
     env["MEMOS_BRIDGE_CONFIG"] = json.dumps(get_bridge_config())
     env["OPENCLAW_STATE_DIR"] = str(get_daemon_dir().parent)
 
+    # Node.js v23.6+ enables --experimental-strip-types by default, which
+    # causes its native .cts handler to take precedence over tsx.  The native
+    # handler only strips types without transforming ESM imports to require(),
+    # breaking bridge.cts.  Disable it so tsx handles the compilation.
+    try:
+        node_ver = subprocess.check_output(["node", "-v"], text=True).strip()
+        major = int(node_ver.lstrip("v").split(".")[0])
+        if major >= 23:
+            existing = env.get("NODE_OPTIONS", "")
+            if "--no-experimental-strip-types" not in existing:
+                env["NODE_OPTIONS"] = f"--no-experimental-strip-types {existing}".strip()
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+        pass
+
     log_dir = get_daemon_dir()
 
     logger.info("Starting daemon: %s", " ".join(bridge_cmd))

--- a/apps/memos-local-plugin/adapters/openharness/scripts/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/openharness/scripts/daemon_manager.py
@@ -126,6 +126,20 @@ def start_daemon(
     # Isolate viewer: prevent migration scan from showing OpenClaw data
     env["OPENCLAW_STATE_DIR"] = str(get_daemon_dir().parent)
 
+    # Node.js v23.6+ enables --experimental-strip-types by default, which
+    # causes its native .cts handler to take precedence over tsx.  The native
+    # handler only strips types without transforming ESM imports to require(),
+    # breaking bridge.cts.  Disable it so tsx handles the compilation.
+    try:
+        node_ver = subprocess.check_output(["node", "-v"], text=True).strip()
+        major = int(node_ver.lstrip("v").split(".")[0])
+        if major >= 23:
+            existing = env.get("NODE_OPTIONS", "")
+            if "--no-experimental-strip-types" not in existing:
+                env["NODE_OPTIONS"] = f"--no-experimental-strip-types {existing}".strip()
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError):
+        pass
+
     log_dir = get_daemon_dir()
 
     logger.info("Starting daemon: %s", " ".join(bridge_cmd))

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -122,6 +122,10 @@ else
     error "需要 Node.js >= 18，当前: $(node -v)"
     exit 1
   fi
+  if [[ "$NODE_VERSION" -ge 23 ]]; then
+    info "Node.js >= 23 detected — disabling built-in TypeScript to avoid tsx conflict"
+    export NODE_OPTIONS="--no-experimental-strip-types ${NODE_OPTIONS:-}"
+  fi
   success "Node.js $(node -v)"
 fi
 


### PR DESCRIPTION
## Summary

- Node.js v23.6+ enables `--experimental-strip-types` by default, causing its native `.cts` handler (`Object.loadCTS`) to take precedence over `tsx`. The native handler only strips type annotations without transforming ESM `import` to `require()`, resulting in `SyntaxError: Cannot use import statement outside a module` when loading `bridge.cts`.
- Set `NODE_OPTIONS='--no-experimental-strip-types'` when Node >= 23 is detected in both `daemon_manager.py` (hermes + openharness adapters) and `install.sh`, so `tsx` fully handles the compilation.

## Error reproduced

```
(node:70572) Warning: Failed to load the ES module: bridge.cts
SyntaxError: Cannot use import statement outside a module
    at Object.loadCTS [as .cts] (node:internal/modules/cjs/loader:1797:10)
```

## Files changed

| File | Change |
|------|--------|
| `adapters/hermes/daemon_manager.py` | Detect Node >= 23, set `--no-experimental-strip-types` in env before launching daemon |
| `adapters/openharness/scripts/daemon_manager.py` | Same fix for openharness adapter |
| `install.sh` | Export `NODE_OPTIONS` in environment check when Node >= 23 detected |

## Test plan

- [ ] Install plugin on Node.js v23.x — daemon should start without `SyntaxError`
- [ ] Install plugin on Node.js v22.x (LTS) — no regression, `NODE_OPTIONS` not set
- [ ] Verify memory viewer accessible at `http://127.0.0.1:18901` after install on Node 23