### PR TITLE
fix: sync Qdrant payload on update_node in Neo4j community edition and add schedule dep

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -98,6 +98,7 @@ rich-toolkit==0.15.1
 rignore==0.7.6
 rpds-py==0.28.0
 safetensors==0.6.2
+schedule==1.2.2
 scikit-learn==1.7.2
 scipy==1.16.3
 sentry-sdk==2.44.0

--- a/src/memos/graph_dbs/neo4j_community.py
+++ b/src/memos/graph_dbs/neo4j_community.py
@@ -225,6 +225,28 @@ class Neo4jCommunityGraphDB(Neo4jGraphDB):
             logger.error(f"[add_nodes_batch] Failed to add nodes: {e}", exc_info=True)
             raise
 
+    def update_node(self, id: str, fields: dict[str, Any], user_name: str | None = None) -> None:
+        """
+        Update node in Neo4j and sync key fields to Qdrant payload.
+
+        The parent implementation only updates Neo4j. For the community edition, which
+        relies on an external vector DB (Qdrant), key status/metadata fields must also
+        be propagated to the Qdrant payload so that vector searches reflect the latest
+        node state (e.g. archived memories are excluded correctly).
+        """
+        super().update_node(id, fields, user_name)
+
+        sync_fields = {"status", "tags", "memory_type", "content", "sources"}
+        payload_updates = {k: v for k, v in fields.items() if k in sync_fields}
+        if payload_updates and self.vec_db:
+            try:
+                self.vec_db.update(id, VecDBItem(id=id, vector=None, payload=payload_updates))
+            except Exception as e:
+                logger.warning(
+                    f"[update_node] Failed to sync fields {list(payload_updates)} "
+                    f"to Qdrant for node {id}: {e}"
+                )
+
     def get_children_with_embeddings(
         self, id: str, user_name: str | None = None
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
Fixes #1469

## Problem

Two bugs affecting users of Neo4j Community Edition:

**1. `update_node` not syncing Qdrant payload (High severity)**

`Neo4jCommunityGraphDB` inherits `update_node` from the parent `Neo4jGraphDB`, which only updates Neo4j. The community edition stores vectors in an external Qdrant database, so key metadata fields (`status`, `tags`, `memory_type`, `content`, `sources`) were never propagated to Qdrant when a node was updated. This caused Neo4j and Qdrant to diverge — for example, archived memories would remain visible in vector searches because Qdrant still had the old `status: activated` payload.

**2. Missing `schedule` dependency in `docker/requirements.txt` (Critical severity)**

`reorganizer.py` (Thread-3, which handles conflict detection and memory archiving) imports the `schedule` library. While `schedule>=1.2.2` is declared in `pyproject.toml` and present in `requirements-full.txt`, it was absent from `docker/requirements.txt`. This caused an `ImportError` on Thread-3 startup when deploying with the standard Docker requirements, silently disabling conflict detection and memory archiving.

## Solution

- **`neo4j_community.py`**: Override `update_node` in `Neo4jCommunityGraphDB` to first call the parent's Neo4j update, then sync the relevant fields to Qdrant via `vec_db.update()`. Sync failures are logged as warnings and do not abort the Neo4j update.

- **`docker/requirements.txt`**: Add `schedule==1.2.2` (matching the version already pinned in `requirements-full.txt`).

## Testing

- The `update_node` override follows the same Qdrant interaction pattern used in `add_node` and `add_nodes_batch`.
- The `schedule` version matches the constraint in `pyproject.toml` (`>=1.2.2,<2.0.0`) and the pin in `requirements-full.txt`.