### PR TITLE
fix(delete): accept singular+plural params and return distinct status codes

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,79 @@
+# Security & Tuning Patches
+
+This fork maintains a set of patches on top of upstream `MemTensor/MemOS` for
+production deployment inside the Hermes multi-agent system.
+
+## Why a fork
+
+Upstream is a reference implementation. We need:
+- Per-agent API key auth with spoof detection and cube-level ACL
+- Hardened defaults (localhost binding, required passwords, secret encryption)
+- Search recall tuning (was returning 1/12 relevant results on vague queries)
+- Memory extraction quality fixes (English enforcement, granularity rule)
+
+See the full audit history at
+`memos-setup/learnings/` in the [hermes-multi-agent](https://github.com/sergiocoding96/hermes-multi-agent)
+repo.
+
+## Patched Files
+
+| File | Category | What changed |
+|------|----------|-------------|
+| `src/memos/api/middleware/agent_auth.py` | **NEW** | Per-agent Bearer-key auth middleware, bcrypt v2 format, auth-failure rate limit, auto-reload on config mtime change |
+| `src/memos/api/middleware/request_context.py` | Security | Strip `Authorization` + `Cookie` headers from logs |
+| `src/memos/api/server_api.py` | Security | Register `RateLimitMiddleware` + `AgentAuthMiddleware` + admin router; bind to `MEMOS_BIND_HOST` (default 127.0.0.1) |
+| `src/memos/api/routers/server_router.py` | Authorization | `_enforce_cube_access()` helper; auth on 11 previously-unprotected endpoints; scheduler caps (300s max timeout, cross-agent checks) |
+| `src/memos/api/routers/admin_router.py` | Admin API | Full rewrite for bcrypt v2 key management via `agents-auth.json`; list/create/revoke/rotate |
+| `src/memos/api/handlers/search_handler.py` | Security + tuning | Spoof check + cube isolation; env-configurable search params (`MOS_SEARCH_TOP_K_FACTOR`, `MOS_MMR_TEXT_THRESHOLD`, `MOS_MMR_PENALTY_THRESHOLD`) |
+| `src/memos/api/handlers/add_handler.py` | Security | Spoof check + cube isolation; empty content rejection; log request summary instead of full body |
+| `src/memos/api/handlers/component_init.py` | Security | Inject `UserManager` into `HandlerDependencies` for ACL checks |
+| `src/memos/api/product_models.py` | Tuning | Relativity default 0.20 → 0.05 (was filtering vague but valid queries) |
+| `src/memos/mem_user/user_manager.py` | Authorization | `validate_user_cube_access` resolves cubes by `cube_id` → `cube_name` → `owner_id` (agents address cubes by `user_id`, not `cube_id`) |
+| `src/memos/vec_dbs/qdrant.py` | Bug fix | Pass `api_key` with host+port mode (upstream only supported url mode); force `https=False` for localhost |
+| `src/memos/templates/mem_reader_prompts.py` | Quality | Granularity rule (split by idea, not sentence); English output enforcement (prevents Chinese leakage on English input) |
+| `src/memos/multi_mem_cube/single_cube.py` | Quality | Write-time dedup via cosine similarity ≥ 0.90 |
+
+## Rebasing on Upstream
+
+When pulling new upstream changes:
+
+```bash
+git fetch upstream
+git merge upstream/main
+# Or: git rebase upstream/main
+# Resolve conflicts in the patched files above, prefer keeping our logic
+```
+
+## Environment Variables
+
+Security-sensitive vars this fork requires:
+
+| Var | Purpose |
+|-----|---------|
+| `MEMOS_AUTH_REQUIRED` | Set to `true` in production (otherwise the auth middleware is a no-op) |
+| `MEMOS_AGENT_AUTH_CONFIG` | Path to `agents-auth.json` (bcrypt v2 format) |
+| `MEMOS_ADMIN_KEY` | Separate key for `/admin/*` routes — NOT an agent key |
+| `MEMOS_BIND_HOST` | Default 127.0.0.1. Set `0.0.0.0` only when behind a reverse proxy |
+| `QDRANT_API_KEY` | Required — Qdrant has no default auth |
+| `NEO4J_PASSWORD` | Required — no default fallback accepted |
+| `MEMRADER_API_KEY` | DeepSeek V3 key for memory extraction (MiniMax's `<think>` tags break extraction) |
+
+Tuning vars (optional):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `MOS_SEARCH_TOP_K_FACTOR` | 5 | Expansion factor before MMR dedup (was 3x hardcoded) |
+| `MOS_MMR_TEXT_THRESHOLD` | 0.85 | Text similarity threshold for dedup (was 0.92 — too strict) |
+| `MOS_MMR_PENALTY_THRESHOLD` | 0.70 | MMR exponential penalty start (was 0.90) |
+
+## Secrets Management
+
+Secrets are encrypted with `age` at `~/.memos/secrets.env.age` and decrypted
+at boot by `start-memos.sh`. See that script for details.
+
+Contains:
+- `MINIMAX_API_KEY` (primary LLM)
+- `MEMRADER_API_KEY` (DeepSeek, for memory extraction)
+- `NEO4J_PASSWORD`
+- `QDRANT_API_KEY`
+- `MEMOS_ADMIN_KEY`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     ports:
-      - "8000:8000"
+      # Bind to localhost only — use a reverse proxy to expose externally
+      - "127.0.0.1:8000:8000"
     env_file:
       - ../.env
     depends_on:
@@ -18,7 +19,9 @@ services:
       - HF_ENDPOINT=https://hf-mirror.com
       - QDRANT_HOST=qdrant-docker
       - QDRANT_PORT=6333
+      - QDRANT_API_KEY=${QDRANT_API_KEY}
       - NEO4J_URI=bolt://neo4j-docker:7687
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
     volumes:
       - ../src:/app/src
       - .:/app/docker
@@ -29,8 +32,9 @@ services:
     image: neo4j:5.26.6
     container_name: neo4j-docker
     ports:
-      - "7474:7474"   # HTTP
-      - "7687:7687"   # Bolt
+      # Bind to localhost only
+      - "127.0.0.1:7474:7474"   # HTTP
+      - "127.0.0.1:7687:7687"   # Bolt
     healthcheck:
       test: wget http://localhost:7474 || exit 1
       interval: 1s
@@ -39,7 +43,9 @@ services:
       start_period: 3s
     environment:
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
-      NEO4J_AUTH: "neo4j/12345678"
+      # Require NEO4J_PASSWORD in env (no default). Keep strong — this is the
+      # graph layer of all agent memories.
+      NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}"
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
@@ -50,13 +56,17 @@ services:
     image: qdrant/qdrant:v1.15.3
     container_name: qdrant-docker
     ports:
-      - "6333:6333"  # REST API
-      - "6334:6334"  # gRPC API
+      # Bind to localhost only
+      - "127.0.0.1:6333:6333"  # REST API
+      - "127.0.0.1:6334:6334"  # gRPC API
     volumes:
       - qdrant_data:/qdrant/storage
     environment:
       QDRANT__SERVICE__GRPC_PORT: 6334
       QDRANT__SERVICE__HTTP_PORT: 6333
+      # Require QDRANT_API_KEY in env. Without it, anyone who reaches the
+      # port can read/delete all vectors.
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:?QDRANT_API_KEY must be set}
     restart: unless-stopped
     networks:
       - memos_network

--- a/learnings/2026-04-06-blind-functionality-audit.md
+++ b/learnings/2026-04-06-blind-functionality-audit.md
@@ -1,0 +1,92 @@
+# MemOS Blind Functionality Audit — Session Summary
+
+**Date:** 2026-04-06 to 2026-04-08
+**Scope:** Autonomous blind audit of MemOS API (localhost:8001) — testing all documented capabilities against actual behavior.
+**Full report:** `/home/openclaw/Coding/Hermes/tests/blind-audit-report.md`
+
+---
+
+## What Was Done
+
+1. **Ran a full autonomous audit** — an agent read the OpenAPI spec and source code, then designed and executed its own test suite against a live MemOS instance. Created isolated test users (audit-alpha, audit-beta, audit-gamma) with their own cubes.
+
+2. **Tested 14 areas** across write path, extraction, search, dedup, long content, cross-cube isolation, memory types, feedback, scheduler, chat, auth, delete, persistence, and edge cases.
+
+3. **Root-cause analysis** — after the audit report, we traced each bug to exact source file + line number by reading the installed package at `/home/openclaw/.local/lib/python3.12/site-packages/memos/`.
+
+---
+
+## Overall Score: 6.8/10
+
+### What Works Well
+- **Write persistence** — Qdrant + Neo4j dual storage, survives restarts
+- **Fine-mode extraction** — third-person perspective (10/10), pronoun resolution (10/10), timestamp resolution from `chat_time` (9/10)
+- **Write-time dedup** — 90% similarity threshold correctly blocks exact and near-duplicates
+- **Search** — relativity threshold and top_k work exactly as documented
+- **Cross-cube isolation** — strict 403 enforcement, spoof protection works
+- **Edge cases** — URLs, JSON, HTML, code, short/long content all handled correctly
+
+### Critical Bugs Found
+
+#### Bug 1: BCrypt Auth Overhead (~1.2s per request)
+- **File:** `memos/api/middleware/agent_auth.py:176-183`
+- **Cause:** `_authenticate_key()` iterates ALL agent bcrypt hashes sequentially. With 6 agents and bcrypt cost=12, worst case is ~1.2s pure auth overhead before any memory work.
+- **Fix needed:** Add a prefix-based lookup. Each key starts with `ak_XXXX...` — build a dict mapping `key_prefix` to the agent entry, then only bcrypt-check the one matching prefix instead of all N.
+
+#### Bug 2: Search-Time Dedup Modes (no/sim/mmr) Non-Functional
+- **Files:**
+  - `memos/api/handlers/search_handler.py:90-107` — handler-level sim/mmr dedup exists and works
+  - `memos/memories/textual/tree_text_memory/retrieve/searcher.py:1020-1026` — tree searcher only does exact-text dedup, ignores mode
+- **Cause:** The tree searcher's `_deduplicate_results()` treats dedup as a boolean (on/off), not modal. It always does exact-text dedup regardless of sim/mmr. The handler-level sim/mmr code runs after, but operates on already-deduped results.
+- **Fix needed:** Either pass the dedup mode through to the tree searcher properly, or ensure embeddings are included in results so handler-level sim/mmr dedup has data to work with.
+
+#### Bug 3: Custom Tags/Info Stripped on Write
+- **File:** `memos/mem_reader/simple_struct.py:340-342, 359`
+- **Cause:** `custom_tags` is popped from info dict (line 340) but never used in fast mode. Line 359 hardcodes `tags = ["mode:fast"]`. In fine mode, custom_tags are passed to the LLM prompt but not persisted as memory tags either.
+- **Fix needed:** In fast mode, merge custom_tags into the tags list: `tags = ["mode:fast"] + (custom_tags or [])`. In fine mode, append custom_tags to whatever the LLM returns.
+
+#### Bug 4: Feedback & Delete Endpoints Default to Wrong Cube ID
+- **Files:**
+  - `memos/api/routers/server_router.py:431` — feedback defaults `cube_ids = [user_id]`
+  - `memos/api/routers/server_router.py:411` — delete does the same
+  - `memos/api/handlers/feedback_handler.py:61` — handler also defaults to `[user_id]`
+- **Cause:** Cube naming convention is `{user_id}-cube` but fallback uses raw `user_id`. Results in 403 because no cube named just `user_id` exists.
+- **Fix needed:** Either change default to `[f"{user_id}-cube"]` or (better) require `writable_cube_ids` and return 400 if missing.
+
+#### Bug 5: Scheduler Monitoring Broken Without Redis
+- **Symptom:** `task_queue_status` returns 503, `allstatus` shows all zeros.
+- **Cause:** Local queue mode works for processing but has no status API.
+- **Fix needed:** Implement in-memory task status tracking as fallback when Redis is unavailable.
+
+#### Bug 6: Chat Endpoint Non-Functional
+- **Cause:** `ENABLE_CHAT_API=false` by default, and the request model expects `query` not `messages`.
+- **Low priority** — not used in Hermes architecture.
+
+---
+
+## Fixes Not Yet Applied
+
+We completed root-cause analysis for all bugs but were interrupted before implementing fixes. The priority order for fixing:
+
+1. **BCrypt auth** (Bug 1) — biggest UX impact, every request is slow
+2. **Custom tags** (Bug 3) — blocks metadata-based filtering
+3. **Feedback/delete cube default** (Bug 4) — simple one-line fixes
+4. **Search dedup modes** (Bug 2) — more complex, needs careful threading of mode parameter
+5. **Scheduler monitoring** (Bug 5) — nice-to-have
+6. **Chat endpoint** (Bug 6) — not needed currently
+
+---
+
+## Key Source Paths Referenced
+
+| Component | Path |
+|-----------|------|
+| Auth middleware | `memos/api/middleware/agent_auth.py` |
+| Search handler (dedup) | `memos/api/handlers/search_handler.py` |
+| Tree searcher (dedup) | `memos/memories/textual/tree_text_memory/retrieve/searcher.py` |
+| Add handler (tags/info) | `memos/api/handlers/add_handler.py` |
+| Memory reader (fast/fine) | `memos/mem_reader/simple_struct.py` |
+| Feedback handler | `memos/api/handlers/feedback_handler.py` |
+| Server router | `memos/api/routers/server_router.py` |
+| Installed package root | `/home/openclaw/.local/lib/python3.12/site-packages/memos/` |
+| MemOS source repo | `/home/openclaw/Coding/MemOS/` |

--- a/learnings/2026-04-08-disk-and-memory-audit.md
+++ b/learnings/2026-04-08-disk-and-memory-audit.md
@@ -1,0 +1,95 @@
+# Disk & Memory Audit — 2026-04-08
+
+## Context
+Session with Sergio to investigate why the system appeared to have only ~45 GB available, and why RAM/swap was under pressure.
+
+---
+
+## System Hardware
+
+- **Storage**: Toshiba Q300 SSD, 111.8 GB total (NOT an HDD — it's solid-state)
+- **RAM**: 15 GB total
+- **Swap**: 4 GB
+
+---
+
+## Root Cause: Disk Was 96% Full
+
+At the start of the session, disk was nearly full:
+```
+108G total | 99G used | 4.2G free (96% used)
+```
+
+The "45 GB" shown in the file manager was the size of the `/home/openclaw` folder — not a disk quota or partition limit.
+
+---
+
+## User Account Structure (important context)
+
+There are **two real user accounts** on the same machine, same person:
+
+| User | Home | Size |
+|---|---|---|
+| `sergio` (desktop GUI login) | `/home/sergio` | 14 GB |
+| `openclaw` (Hermes/AI system user) | `/home/openclaw` | 31 GB |
+| `linuxbrew` | `/home/linuxbrew` | 2 GB |
+| `root` | `/root` | ~950 MB |
+
+No per-user disk quota is in place. The full SSD is shared.
+
+---
+
+## Biggest Disk Consumers Found
+
+| Path | Size | Notes |
+|---|---|---|
+| `~/.cache/uv` | 7.8 GB | Python package cache |
+| `~/.cache/pip` | 5.5 GB | pip download cache |
+| `polymarket-predicti...` (project) | 7.8 GB | Deleted by user |
+| Docker build cache | 4.1 GB | Build layer cache |
+| `~/.cache/whisper` | 3.6 GB | Whisper AI model weights |
+| `~/.cache/camoufox` | 1.4 GB | Camoufox browser binaries |
+| `~/.cache/ms-playwright` | 1.3 GB | Playwright browser binaries |
+| `~/.cache/huggingface` | 1.3 GB | Sentence-transformers model |
+| Docker images (unused) | 1.3 GB | Prunable |
+| `~/.cache/puppeteer` | 626 MB | Puppeteer browser |
+
+---
+
+## Cleanup Performed (~14 GB reclaimed)
+
+```bash
+uv cache clean               # 7.6 GB
+pip cache purge              # 5.5 GB
+sudo docker builder prune -f # 4.0 GB
+sudo docker volume prune -f  # 300 MB
+# polymarket folder deleted manually by user: ~7.8 GB
+```
+
+**Result:** 15 GB free (was 4.2 GB). Disk now at 86% used.
+
+---
+
+## RAM / Swap Situation
+
+- **Cache (6 GB)**: Normal Linux behavior — kernel fills idle RAM with disk cache, reclaimed instantly when apps need it. Not a problem.
+- **Swap (4 GB, 100% used)**: Real pressure. Docker + MemOS (Qdrant + Neo4j) + other services are exhausting physical RAM.
+  - Mitigation: restart unused services to free RAM.
+
+---
+
+## Do NOT Delete (would break system)
+
+- `~/.cache/whisper` — Whisper model weights
+- `~/.cache/huggingface` — sentence-transformers embedding model (used by MemOS)
+- `~/.cache/camoufox` — needed for anti-bot browsing (Camofox)
+- `~/.cache/ms-playwright` — needed by Firecrawl/Playwright scraping
+
+---
+
+## Next Cleanup Candidates (if space needed again)
+
+- `~/.hermes` (7.7 GB) — inspect contents before touching
+- `~/.npm` (2.5 GB) — npm cache, safe to clear with `npm cache clean --force`
+- `~/.local/share/pnpm` (1.9 GB) — pnpm store, check if needed
+- `~/.cache/go-build` (290 MB) — Go build cache, safe to clear

--- a/src/memos/api/handlers/add_handler.py
+++ b/src/memos/api/handlers/add_handler.py
@@ -7,7 +7,10 @@ using dependency injection for better modularity and testability.
 
 from pydantic import validate_call
 
+from fastapi import HTTPException
+
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.product_models import APIADDRequest, APIFeedbackRequest, MemoryResponse
 from memos.memories.textual.item import (
     list_all_fields,
@@ -51,8 +54,38 @@ class AddHandler(BaseHandler):
             MemoryResponse with added memory information
         """
         self.logger.info(
-            f"[DIAGNOSTIC] server_router -> add_handler.handle_add_memories called (Modified at 2025-11-29 18:46). Full request: {add_req.model_dump_json(indent=2)}"
+            f"[AddHandler] add_memories called: user_id={add_req.user_id}, cubes={add_req.writable_cube_ids}, async_mode={add_req.async_mode}"
         )
+
+        # Auth spoof check: if a key was presented, user_id must match what the key says
+        authenticated = get_authenticated_user()
+        if authenticated is not None and authenticated != add_req.user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Key authenticated as '{authenticated}' but request claims user_id='{add_req.user_id}'. Spoofing not allowed."
+            )
+
+        # Cube isolation: verify user has write access to all requested cubes
+        user_manager = getattr(self.deps, "user_manager", None)
+        if user_manager:
+            cube_ids = self._resolve_cube_ids(add_req)
+            for cube_id in cube_ids:
+                if not user_manager.validate_user_cube_access(add_req.user_id, cube_id):
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"Access denied: user '{add_req.user_id}' cannot write to cube '{cube_id}'"
+                    )
+
+        # Reject empty or whitespace-only content early
+        if add_req.messages is not None:
+            all_empty = all(
+                not str(msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")).strip()
+                for msg in add_req.messages
+            )
+            if all_empty:
+                raise HTTPException(status_code=400, detail="Message content must not be empty.")
+        elif add_req.memory_content is not None and not str(add_req.memory_content).strip():
+            raise HTTPException(status_code=400, detail="memory_content must not be empty.")
 
         if add_req.info:
             exclude_fields = list_all_fields()

--- a/src/memos/api/handlers/component_init.py
+++ b/src/memos/api/handlers/component_init.py
@@ -28,6 +28,7 @@ from memos.llms.factory import LLMFactory
 from memos.log import get_logger
 from memos.mem_cube.navie import NaiveMemCube
 from memos.mem_feedback.simple_feedback import SimpleMemFeedback
+from memos.mem_user.user_manager import UserManager
 from memos.mem_reader.factory import MemReaderFactory
 from memos.mem_scheduler.orm_modules.base_model import BaseDBManager
 from memos.mem_scheduler.scheduler_factory import SchedulerFactory
@@ -305,4 +306,5 @@ def init_server() -> dict[str, Any]:
         "deepsearch_agent": deepsearch_agent,
         "nli_client": nli_client,
         "memory_history_manager": memory_history_manager,
+        "user_manager": UserManager(),
     }

--- a/src/memos/api/handlers/memory_handler.py
+++ b/src/memos/api/handlers/memory_handler.py
@@ -386,26 +386,36 @@ def handle_delete_memories(delete_mem_req: DeleteMemoryRequest, naive_mem_cube: 
     )
     quick_constraints = _build_quick_delete_constraints(delete_mem_req)
     has_non_empty_filter = bool(delete_mem_req.filter)
-    has_filter_mode = has_non_empty_filter or bool(quick_constraints)
+    # Explicit id modes take precedence over filter/user_id/session_id, which then act as
+    # identity context rather than extra scope. This lets callers send user_id alongside
+    # memory_ids without hitting the "multiple modes" rejection.
+    has_explicit_id_mode = (
+        delete_mem_req.memory_ids is not None or delete_mem_req.file_ids is not None
+    )
+    has_filter_mode = not has_explicit_id_mode and (has_non_empty_filter or bool(quick_constraints))
 
     # Reject empty filter dict when no quick constraints are provided.
-    if delete_mem_req.filter is not None and not has_non_empty_filter and not quick_constraints:
+    if (
+        delete_mem_req.filter is not None
+        and not has_non_empty_filter
+        and not quick_constraints
+        and not has_explicit_id_mode
+    ):
         return DeleteMemoryResponse(
             message="filter cannot be empty. Provide a non-empty filter or user_id/session_id.",
             data={"status": "failure"},
         )
 
-    # Validate that only one mode is provided: memory_ids, file_ids, or filter-mode.
-    provided_params = [
-        delete_mem_req.memory_ids is not None,
-        delete_mem_req.file_ids is not None,
-        has_filter_mode,
-    ]
-    if sum(provided_params) != 1:
+    # memory_ids and file_ids are mutually exclusive; beyond that, require at least one mode.
+    if delete_mem_req.memory_ids is not None and delete_mem_req.file_ids is not None:
+        return DeleteMemoryResponse(
+            message="memory_ids and file_ids cannot be used together.",
+            data={"status": "failure"},
+        )
+    if not has_explicit_id_mode and not has_filter_mode:
         return DeleteMemoryResponse(
             message=(
-                "Exactly one delete mode must be provided: "
-                "memory_ids, file_ids, or filter/user_id/session_id."
+                "No delete mode provided: supply memory_ids, file_ids, or filter/user_id/session_id."
             ),
             data={"status": "failure"},
         )

--- a/src/memos/api/handlers/search_handler.py
+++ b/src/memos/api/handlers/search_handler.py
@@ -7,11 +7,15 @@ using dependency injection for better modularity and testability.
 
 import copy
 import math
+import os
 
 from typing import Any
 
+from fastapi import HTTPException
+
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
 from memos.api.handlers.formatters_handler import rerank_knowledge_mem
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.product_models import APISearchRequest, SearchResponse
 from memos.log import get_logger
 from memos.memories.textual.tree_text_memory.retrieve.retrieve_utils import (
@@ -59,12 +63,32 @@ class SearchHandler(BaseHandler):
         """
         self.logger.info(f"[SearchHandler] Search Req is: {search_req}")
 
+        # Auth spoof check: if a key was presented, user_id must match what the key says
+        authenticated = get_authenticated_user()
+        if authenticated is not None and authenticated != search_req.user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Key authenticated as '{authenticated}' but request claims user_id='{search_req.user_id}'. Spoofing not allowed."
+            )
+
+        # Cube isolation: verify user has access to all requested cubes
+        user_manager = getattr(self.deps, "user_manager", None)
+        if user_manager:
+            cube_ids = self._resolve_cube_ids(search_req)
+            for cube_id in cube_ids:
+                if not user_manager.validate_user_cube_access(search_req.user_id, cube_id):
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"Access denied: user '{search_req.user_id}' cannot read cube '{cube_id}'"
+                    )
+
         # Use deepcopy to avoid modifying the original request object
         search_req_local = copy.deepcopy(search_req)
 
-        # Expand top_k for deduplication (5x to ensure enough candidates)
+        # Expand top_k for deduplication (env-configurable, default 5x)
+        _top_k_factor = int(os.getenv("MOS_SEARCH_TOP_K_FACTOR", "5"))
         if search_req_local.dedup in ("sim", "mmr"):
-            search_req_local.top_k = search_req_local.top_k * 3
+            search_req_local.top_k = search_req_local.top_k * _top_k_factor
 
         # Search and deduplicate
         cube_view = self._build_cube_view(search_req_local)
@@ -297,8 +321,9 @@ class SearchHandler(BaseHandler):
                 continue
 
             # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
+            _mmr_text_threshold = float(os.getenv("MOS_MMR_TEXT_THRESHOLD", "0.85"))
             if SearchHandler._is_text_highly_similar_optimized(
-                idx, mem_text, selected_global, similarity_matrix, flat, threshold=0.92
+                idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
             ):
                 continue
 
@@ -314,7 +339,7 @@ class SearchHandler(BaseHandler):
 
         # Phase 2: MMR selection for remaining slots
         lambda_relevance = 0.8
-        similarity_threshold = 0.9  # Start exponential penalty from 0.9 (lowered from 0.9)
+        similarity_threshold = float(os.getenv("MOS_MMR_PENALTY_THRESHOLD", "0.7"))  # Exponential penalty start
         alpha_exponential = 10.0  # Exponential penalty coefficient
         remaining = set(range(len(flat))) - set(selected_global)
 
@@ -341,7 +366,7 @@ class SearchHandler(BaseHandler):
 
                 # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
                 if SearchHandler._is_text_highly_similar_optimized(
-                    idx, mem_text, selected_global, similarity_matrix, flat, threshold=0.92
+                    idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
                 ):
                     continue  # Skip highly similar text, don't participate in MMR competition
 

--- a/src/memos/api/middleware/agent_auth.py
+++ b/src/memos/api/middleware/agent_auth.py
@@ -1,0 +1,250 @@
+"""
+Agent authentication middleware for MemOS.
+
+Validates per-agent API keys loaded from a JSON config file.
+On a valid key, stores the authenticated user_id in a contextvar so
+handlers can verify the caller isn't spoofing a different user_id.
+
+Config file format (MEMOS_AGENT_AUTH_CONFIG env var):
+{
+  "version": 2,
+  "agents": [
+    {"key_hash": "$2b$12$...", "key_prefix": "ak_244c", "user_id": "ceo", "description": "CEO Agent"},
+    ...
+  ]
+}
+
+Legacy format (version 1, auto-detected):
+{
+  "version": 1,
+  "agents": [
+    {"key": "ak_...", "user_id": "ceo", "description": "CEO Agent"},
+    ...
+  ]
+}
+
+Usage:
+  Header: Authorization: Bearer ak_<32-hex-chars>
+
+Env vars:
+  MEMOS_AGENT_AUTH_CONFIG  — path to agents-auth.json (required to enable auth)
+  MEMOS_AUTH_REQUIRED      — if "true", requests without a valid key are rejected (401)
+                             if "false" (default), unauthenticated requests pass through
+                             but cannot spoof an authenticated user
+"""
+
+import json
+import os
+import time
+from collections import defaultdict
+from contextvars import ContextVar
+
+import bcrypt
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from memos.log import get_logger
+
+logger = get_logger(__name__)
+
+# Thread-safe contextvar: holds the user_id the key authenticated as, or None
+_authenticated_user: ContextVar[str | None] = ContextVar("authenticated_user", default=None)
+
+
+def get_authenticated_user() -> str | None:
+    """Return the user_id bound to the current request's API key, or None if unauthenticated."""
+    return _authenticated_user.get()
+
+
+class AgentAuthMiddleware(BaseHTTPMiddleware):
+    """
+    Starlette middleware that validates per-agent API keys.
+
+    - Reads key registry from MEMOS_AGENT_AUTH_CONFIG on startup.
+    - Only applies to /product/* endpoints (skips /health, /download, etc).
+    - Stores authenticated user_id in a contextvar for handler-level spoof checks.
+    - Rate-limits failed auth attempts per IP (10 failures / 60s → 429 for 60s).
+    - Auto-reloads config when the file changes on disk.
+    """
+
+    # Paths that skip agent auth entirely (admin router has its own auth)
+    SKIP_PATHS = {"/health", "/docs", "/openapi.json", "/redoc"}
+    SKIP_PREFIXES = ("/download", "/admin")
+
+    # Rate limiting constants
+    RATE_LIMIT_MAX_FAILURES = 10
+    RATE_LIMIT_WINDOW_SECONDS = 60
+
+    def __init__(self, app, config_path: str | None = None):
+        super().__init__(app)
+        self.config_path = config_path or os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+        self._agents: list[dict] = []  # [{"key_hash": bytes, "user_id": str}, ...] for v2
+        self._keys: dict[str, str] = {}  # raw_key → user_id (v1 legacy fallback)
+        self._is_hashed = False
+        self.auth_required = os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() == "true"
+        self._config_mtime: float = 0.0
+        self._fail_tracker: dict[str, list[float]] = defaultdict(list)
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load key registry from JSON file. Supports both hashed (v2) and plaintext (v1) formats."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            logger.warning(
+                f"[AgentAuth] Config not found at '{self.config_path}'. "
+                "Auth disabled — set MEMOS_AGENT_AUTH_CONFIG to enable."
+            )
+            return
+
+        try:
+            self._config_mtime = os.path.getmtime(self.config_path)
+            with open(self.config_path) as f:
+                data = json.load(f)
+
+            agents = data.get("agents", [])
+            version = data.get("version", 1)
+
+            if version >= 2 or any("key_hash" in a for a in agents):
+                # Hashed format (v2)
+                self._agents = []
+                self._keys = {}
+                self._is_hashed = True
+                for entry in agents:
+                    if entry.get("key_hash"):
+                        self._agents.append({
+                            "key_hash": entry["key_hash"].encode("utf-8"),
+                            "user_id": entry["user_id"],
+                            "key_prefix": entry.get("key_prefix", "??"),
+                        })
+                logger.info(
+                    f"[AgentAuth] Loaded {len(self._agents)} hashed agent key(s) from {self.config_path}"
+                )
+            else:
+                # Legacy plaintext format (v1)
+                self._agents = []
+                self._is_hashed = False
+                self._keys = {entry["key"]: entry["user_id"] for entry in agents if entry.get("key")}
+                logger.info(
+                    f"[AgentAuth] Loaded {len(self._keys)} plaintext agent key(s) from {self.config_path} "
+                    "(legacy v1 format — run setup-memos-agents.py to migrate to hashed keys)"
+                )
+        except Exception as e:
+            logger.error(f"[AgentAuth] Failed to load config: {e}")
+
+    def _check_reload(self) -> None:
+        """Reload config if the file has been modified since last load."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            return
+        try:
+            mtime = os.path.getmtime(self.config_path)
+            if mtime != self._config_mtime:
+                logger.info("[AgentAuth] Config file changed on disk — reloading.")
+                self._agents = []
+                self._keys = {}
+                self._load_config()
+        except OSError:
+            pass
+
+    def reload(self) -> None:
+        """Hot-reload key registry without restarting the server."""
+        self._agents = []
+        self._keys.clear()
+        self._load_config()
+
+    def _should_skip(self, path: str) -> bool:
+        if path in self.SKIP_PATHS:
+            return True
+        return any(path.startswith(p) for p in self.SKIP_PREFIXES)
+
+    def _is_rate_limited(self, client_ip: str) -> bool:
+        """Check if a client IP has exceeded the auth failure rate limit."""
+        now = time.monotonic()
+        window_start = now - self.RATE_LIMIT_WINDOW_SECONDS
+        # Prune old entries
+        failures = self._fail_tracker[client_ip]
+        self._fail_tracker[client_ip] = [t for t in failures if t > window_start]
+        return len(self._fail_tracker[client_ip]) >= self.RATE_LIMIT_MAX_FAILURES
+
+    def _record_failure(self, client_ip: str) -> None:
+        """Record an auth failure for rate limiting."""
+        self._fail_tracker[client_ip].append(time.monotonic())
+
+    def _clear_failures(self, client_ip: str) -> None:
+        """Clear failure history on successful auth."""
+        self._fail_tracker.pop(client_ip, None)
+
+    def _authenticate_key(self, key: str) -> str | None:
+        """Validate an API key. Returns user_id on success, None on failure."""
+        if self._is_hashed:
+            key_bytes = key.encode("utf-8")
+            for agent in self._agents:
+                if bcrypt.checkpw(key_bytes, agent["key_hash"]):
+                    return agent["user_id"]
+            return None
+        else:
+            return self._keys.get(key)
+
+    async def dispatch(self, request: Request, call_next):
+        if self._should_skip(request.url.path):
+            return await call_next(request)
+
+        # Auto-reload config if file changed
+        self._check_reload()
+
+        client_ip = request.client.host if request.client else "unknown"
+        rate_limited = self._is_rate_limited(client_ip)
+
+        auth_header = request.headers.get("Authorization", "").strip()
+
+        # No auth header
+        if not auth_header:
+            if self.auth_required:
+                return JSONResponse(
+                    {"detail": "Authorization header required. Use: Authorization: Bearer <agent-key>"},
+                    status_code=401,
+                )
+            # Unauthenticated passthrough — handlers will still enforce cube permissions
+            token = _authenticated_user.set(None)
+            try:
+                return await call_next(request)
+            finally:
+                _authenticated_user.reset(token)
+
+        # Parse Bearer token
+        parts = auth_header.split(None, 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            self._record_failure(client_ip)
+            if rate_limited:
+                return JSONResponse(
+                    {"detail": "Too many failed authentication attempts. Try again later."},
+                    status_code=429,
+                )
+            return JSONResponse(
+                {"detail": "Invalid Authorization format. Expected: Bearer <agent-key>"},
+                status_code=401,
+            )
+
+        key = parts[1].strip()
+        user_id = self._authenticate_key(key)
+
+        if user_id is None:
+            self._record_failure(client_ip)
+            if rate_limited:
+                return JSONResponse(
+                    {"detail": "Too many failed authentication attempts. Try again later."},
+                    status_code=429,
+                )
+            return JSONResponse(
+                {"detail": "Invalid or unknown agent key."},
+                status_code=401,
+            )
+
+        # Successful auth — clear failure history
+        self._clear_failures(client_ip)
+
+        logger.debug(f"[AgentAuth] Authenticated: user_id={user_id}")
+        token = _authenticated_user.set(user_id)
+        try:
+            return await call_next(request)
+        finally:
+            _authenticated_user.reset(token)

--- a/src/memos/api/middleware/request_context.py
+++ b/src/memos/api/middleware/request_context.py
@@ -67,9 +67,11 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         )
         set_request_context(context)
 
+        # Log request start without sensitive headers (Authorization, cookies)
+        safe_headers = {k: v for k, v in request.headers.items() if k.lower() not in ("authorization", "cookie")}
         logger.info(
             f"Request started, source: {self.source}, method: {request.method}, path: {request.url.path}, "
-            f"headers: {request.headers}"
+            f"headers: {safe_headers}"
         )
 
         response = await call_next(request)

--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -99,12 +99,12 @@ class ChatRequest(BaseRequest):
     manager_user_id: str | None = Field(None, description="Manager User ID")
     project_id: str | None = Field(None, description="Project ID")
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 
@@ -339,12 +339,12 @@ class APISearchRequest(BaseRequest):
     )
 
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 
@@ -785,12 +785,12 @@ class APIChatCompleteRequest(BaseRequest):
     manager_user_id: str | None = Field(None, description="Manager User ID")
     project_id: str | None = Field(None, description="Project ID")
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 

--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -855,7 +855,21 @@ class DeleteMemoryRequest(BaseRequest):
     """Request model for deleting memories."""
 
     writable_cube_ids: list[str] | None = Field(None, description="Writable cube IDs")
+    mem_cube_id: str | None = Field(
+        None,
+        description=(
+            "Singular alias for writable_cube_ids. If writable_cube_ids is omitted, "
+            "mem_cube_id is wrapped into a single-element list."
+        ),
+    )
     memory_ids: list[str] | None = Field(None, description="Memory IDs")
+    memory_id: str | None = Field(
+        None,
+        description=(
+            "Singular alias for memory_ids. If memory_ids is omitted, "
+            "memory_id is wrapped into a single-element list."
+        ),
+    )
     file_ids: list[str] | None = Field(None, description="File IDs")
     filter: dict[str, Any] | None = Field(None, description="Filter for the memory")
     user_id: str | None = Field(
@@ -880,11 +894,23 @@ class DeleteMemoryRequest(BaseRequest):
 
     @model_validator(mode="after")
     def normalize_session_alias(self) -> "DeleteMemoryRequest":
-        """Normalize conversation_id to session_id."""
+        """Normalize singular/plural aliases.
+
+        Rules:
+        - conversation_id aliases session_id (legacy).
+        - mem_cube_id (singular) coerces into writable_cube_ids when the plural is absent;
+          plural wins if both are provided.
+        - memory_id (singular) coerces into memory_ids under the same rule.
+        """
         if self.conversation_id and self.session_id and self.conversation_id != self.session_id:
             raise ValueError("conversation_id and session_id must be the same when both are set")
         if self.session_id is None and self.conversation_id is not None:
             self.session_id = self.conversation_id
+
+        if self.writable_cube_ids is None and self.mem_cube_id:
+            self.writable_cube_ids = [self.mem_cube_id]
+        if self.memory_ids is None and self.memory_id:
+            self.memory_ids = [self.memory_id]
         return self
 
 

--- a/src/memos/api/routers/admin_router.py
+++ b/src/memos/api/routers/admin_router.py
@@ -1,55 +1,105 @@
 """
-Admin Router for API Key Management.
+Admin Router for Agent Key Management.
 
-Protected by master key or admin scope.
+Manages agent API keys via the agents-auth.json file that AgentAuthMiddleware reads.
+Protected by a dedicated admin key (MEMOS_ADMIN_KEY env var).
+
+Produces v2 hashed entries (bcrypt) compatible with AgentAuthMiddleware.
 """
 
+import json
 import os
+import secrets
+from datetime import datetime
+from pathlib import Path
 
-from typing import Any
-
-from fastapi import APIRouter, Depends, HTTPException
+import bcrypt
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-import memos.log
-
-from memos.api.middleware.auth import require_scope, verify_api_key
-from memos.api.utils.api_keys import (
-    create_api_key_in_db,
-    generate_master_key,
-    list_api_keys,
-    revoke_api_key,
-)
+from memos.log import get_logger
 
 
-logger = memos.log.get_logger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
-
-# Request/Response models
-class CreateKeyRequest(BaseModel):
-    user_name: str = Field(..., min_length=1, max_length=255)
-    scopes: list[str] = Field(default=["read"])
-    description: str | None = Field(default=None, max_length=500)
-    expires_in_days: int | None = Field(default=None, ge=1, le=365)
+# Admin auth: a separate env-var key that only the operator knows.
+_ADMIN_KEY = os.getenv("MEMOS_ADMIN_KEY", "")
 
 
-class CreateKeyResponse(BaseModel):
+def _require_admin(request: Request):
+    """Dependency: reject requests without a valid admin key."""
+    if not _ADMIN_KEY:
+        raise HTTPException(status_code=503, detail="Admin API not configured (MEMOS_ADMIN_KEY not set)")
+    auth = request.headers.get("Authorization", "").strip()
+    if not auth:
+        raise HTTPException(status_code=401, detail="Admin key required: Authorization: Bearer <admin-key>")
+    parts = auth.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1].strip() != _ADMIN_KEY:
+        raise HTTPException(status_code=401, detail="Invalid admin key")
+
+
+def _get_config_path() -> str:
+    path = os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+    if not path:
+        raise HTTPException(status_code=503, detail="MEMOS_AGENT_AUTH_CONFIG not set")
+    return path
+
+
+def _read_config(path: str) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"version": 2, "agents": []}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read config: {e}")
+
+
+def _write_config(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to write config: {e}")
+
+
+def _hash_key(raw_key: str) -> str:
+    """Bcrypt-hash a raw API key."""
+    return bcrypt.hashpw(raw_key.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+# --- Request / Response models ---
+
+class CreateAgentKeyRequest(BaseModel):
+    user_id: str = Field(..., min_length=1, max_length=255)
+    description: str = Field("", max_length=500)
+
+
+class CreateAgentKeyResponse(BaseModel):
     message: str
-    key: str  # Only returned once!
+    key: str
+    user_id: str
+    description: str
+
+
+class AgentKeyInfo(BaseModel):
+    user_id: str
     key_prefix: str
-    user_name: str
-    scopes: list[str]
+    description: str
 
 
-class KeyListResponse(BaseModel):
+class ListKeysResponse(BaseModel):
     message: str
-    keys: list[dict[str, Any]]
+    agents: list[AgentKeyInfo]
 
 
 class RevokeKeyRequest(BaseModel):
-    key_id: str
+    user_id: str = Field(..., description="user_id of the agent whose key to revoke")
 
 
 class SimpleResponse(BaseModel):
@@ -57,159 +107,137 @@ class SimpleResponse(BaseModel):
     success: bool = True
 
 
-def _get_db_connection():
-    """Get database connection for admin operations."""
-    import psycopg2
+class RotateKeyResponse(BaseModel):
+    message: str
+    key: str
+    user_id: str
 
-    return psycopg2.connect(
-        host=os.getenv("POSTGRES_HOST", "postgres"),
-        port=int(os.getenv("POSTGRES_PORT", "5432")),
-        user=os.getenv("POSTGRES_USER", "memos"),
-        password=os.getenv("POSTGRES_PASSWORD", ""),
-        dbname=os.getenv("POSTGRES_DB", "memos"),
-    )
 
+# --- Endpoints ---
 
 @router.post(
     "/keys",
-    response_model=CreateKeyResponse,
-    summary="Create a new API key",
-    dependencies=[Depends(require_scope("admin"))],
+    response_model=CreateAgentKeyResponse,
+    summary="Create a new agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def create_key(
-    request: CreateKeyRequest,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Create a new API key for a user.
+def create_key(request: Request, body: CreateAgentKeyRequest):
+    """Create a new agent API key. The key is only returned once — store it securely."""
+    path = _get_config_path()
+    config = _read_config(path)
+    config.setdefault("version", 2)
+    agents = config.get("agents", [])
 
-    Requires admin scope or master key.
+    if any(a["user_id"] == body.user_id for a in agents):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Agent key for user_id '{body.user_id}' already exists. Use /admin/keys/rotate to replace it.",
+        )
 
-    **WARNING**: The API key is only returned once. Store it securely!
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            api_key = create_api_key_in_db(
-                conn=conn,
-                user_name=request.user_name,
-                scopes=request.scopes,
-                description=request.description,
-                expires_in_days=request.expires_in_days,
-                created_by=auth.get("user_name", "unknown"),
-            )
+    new_key = f"ak_{secrets.token_hex(16)}"
+    agents.append({
+        "key_hash": _hash_key(new_key),
+        "key_prefix": new_key[:12],
+        "user_id": body.user_id,
+        "description": body.description or f"Agent {body.user_id}",
+        "created_at": datetime.utcnow().isoformat(),
+    })
+    config["agents"] = agents
+    _write_config(path, config)
 
-            logger.info(
-                f"API key created for user '{request.user_name}' by '{auth.get('user_name')}'"
-            )
-
-            return CreateKeyResponse(
-                message="API key created successfully. Store this key securely - it won't be shown again!",
-                key=api_key.key,
-                key_prefix=api_key.key_prefix,
-                user_name=request.user_name,
-                scopes=request.scopes,
-            )
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.error(f"Failed to create API key: {e}")
-        raise HTTPException(status_code=500, detail="Failed to create API key") from e
+    logger.info(f"[Admin] Created agent key for user_id='{body.user_id}'")
+    return CreateAgentKeyResponse(
+        message="Agent key created. Store it securely — it won't be shown again.",
+        key=new_key,
+        user_id=body.user_id,
+        description=body.description,
+    )
 
 
 @router.get(
     "/keys",
-    response_model=KeyListResponse,
-    summary="List API keys",
-    dependencies=[Depends(require_scope("admin"))],
+    response_model=ListKeysResponse,
+    summary="List all agent keys",
+    dependencies=[Depends(_require_admin)],
 )
-def list_keys(
-    user_name: str | None = None,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    List all API keys (admin) or keys for a specific user.
+def list_keys():
+    """List all agent keys (prefixes only — full keys are never returned)."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    Note: Actual key values are never returned, only prefixes.
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            keys = list_api_keys(conn, user_name=user_name)
-            return KeyListResponse(
-                message=f"Found {len(keys)} key(s)",
-                keys=keys,
+    return ListKeysResponse(
+        message=f"Found {len(agents)} agent key(s)",
+        agents=[
+            AgentKeyInfo(
+                user_id=a["user_id"],
+                key_prefix=a.get("key_prefix", "???") + "...",
+                description=a.get("description", ""),
             )
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.error(f"Failed to list API keys: {e}")
-        raise HTTPException(status_code=500, detail="Failed to list API keys") from e
+            for a in agents
+        ],
+    )
 
 
 @router.delete(
-    "/keys/{key_id}",
+    "/keys",
     response_model=SimpleResponse,
-    summary="Revoke an API key",
-    dependencies=[Depends(require_scope("admin"))],
+    summary="Revoke an agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def revoke_key(
-    key_id: str,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Revoke an API key by ID.
+def revoke_key(request: Request, body: RevokeKeyRequest):
+    """Revoke an agent key by user_id. The agent will lose API access immediately."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    The key will be deactivated but not deleted (for audit purposes).
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            success = revoke_api_key(conn, key_id)
-            if success:
-                logger.info(f"API key {key_id} revoked by '{auth.get('user_name')}'")
-                return SimpleResponse(message="API key revoked successfully")
-            else:
-                raise HTTPException(status_code=404, detail="API key not found or already revoked")
-        finally:
-            conn.close()
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to revoke API key: {e}")
-        raise HTTPException(status_code=500, detail="Failed to revoke API key") from e
+    original_count = len(agents)
+    agents = [a for a in agents if a["user_id"] != body.user_id]
+
+    if len(agents) == original_count:
+        raise HTTPException(status_code=404, detail=f"No agent key found for user_id '{body.user_id}'")
+
+    config["agents"] = agents
+    _write_config(path, config)
+
+    logger.info(f"[Admin] Revoked agent key for user_id='{body.user_id}'")
+    return SimpleResponse(message=f"Agent key for '{body.user_id}' revoked")
 
 
 @router.post(
-    "/generate-master-key",
-    response_model=dict,
-    summary="Generate a new master key",
-    dependencies=[Depends(require_scope("admin"))],
+    "/keys/rotate",
+    response_model=RotateKeyResponse,
+    summary="Rotate an agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def generate_new_master_key(
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Generate a new master key.
+def rotate_key(request: Request, body: RevokeKeyRequest):
+    """Replace an agent's key with a new one. The old key stops working immediately."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    **WARNING**: Store the key securely! Add MASTER_KEY_HASH to your .env file.
-    """
-    if not auth.get("is_master_key"):
-        raise HTTPException(
-            status_code=403,
-            detail="Only master key can generate new master keys",
-        )
+    found = False
+    new_key = f"ak_{secrets.token_hex(16)}"
+    for agent in agents:
+        if agent["user_id"] == body.user_id:
+            agent["key_hash"] = _hash_key(new_key)
+            agent["key_prefix"] = new_key[:12]
+            agent.pop("key", None)  # Remove any plaintext key from previous rotation
+            agent["rotated_at"] = datetime.utcnow().isoformat()
+            found = True
+            break
 
-    key, key_hash = generate_master_key()
+    if not found:
+        raise HTTPException(status_code=404, detail=f"No agent key found for user_id '{body.user_id}'")
 
-    logger.warning("New master key generated - update MASTER_KEY_HASH in .env")
+    _write_config(path, config)
 
-    return {
-        "message": "Master key generated. Add MASTER_KEY_HASH to your .env file!",
-        "key": key,
-        "key_hash": key_hash,
-        "env_line": f"MASTER_KEY_HASH={key_hash}",
-    }
+    logger.info(f"[Admin] Rotated agent key for user_id='{body.user_id}'")
+    return RotateKeyResponse(
+        message="Agent key rotated. Store the new key securely — it won't be shown again.",
+        key=new_key,
+        user_id=body.user_id,
+    )
 
 
 @router.get(
@@ -218,11 +246,12 @@ def generate_new_master_key(
 )
 def admin_health():
     """Health check for admin endpoints."""
-    auth_enabled = os.getenv("AUTH_ENABLED", "false").lower() == "true"
-    master_key_configured = bool(os.getenv("MASTER_KEY_HASH"))
+    config_path = os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+    config_exists = bool(config_path) and Path(config_path).exists()
 
     return {
         "status": "ok",
-        "auth_enabled": auth_enabled,
-        "master_key_configured": master_key_configured,
+        "admin_key_configured": bool(_ADMIN_KEY),
+        "auth_config_exists": config_exists,
+        "auth_config_path": config_path if config_exists else None,
     }

--- a/src/memos/api/routers/server_router.py
+++ b/src/memos/api/routers/server_router.py
@@ -15,9 +15,10 @@ import os
 import random as _random
 import socket
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from memos.api import handlers
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.handlers.add_handler import AddHandler
 from memos.api.handlers.base_handler import HandlerDependencies
 from memos.api.handlers.chat_handler import ChatHandler
@@ -60,7 +61,20 @@ from memos.mem_scheduler.utils.status_tracker import TaskStatusTracker
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/product", tags=["Server API"])
+
+def _require_auth():
+    """Router-level dependency: reject all unauthenticated requests when MEMOS_AUTH_REQUIRED=true."""
+    if os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() != "true":
+        return  # Auth not enforced — passthrough
+    authenticated = get_authenticated_user()
+    if authenticated is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization required. Include header: Authorization: Bearer <agent-key>",
+        )
+
+
+router = APIRouter(prefix="/product", tags=["Server API"], dependencies=[Depends(_require_auth)])
 
 # Instance ID for identifying this server instance in logs and responses
 INSTANCE_ID = f"{socket.gethostname()}:{os.getpid()}:{_random.randint(1000, 9999)}"
@@ -94,6 +108,22 @@ naive_mem_cube = components["naive_mem_cube"]
 redis_client = components["redis_client"]
 status_tracker = TaskStatusTracker(redis_client=redis_client)
 graph_db = components["graph_db"]
+user_manager = components.get("user_manager")
+
+
+def _enforce_cube_access(user_id: str, cube_id: str) -> None:
+    """Verify authenticated caller matches user_id and has cube access. Raises 403 on violation."""
+    authenticated = get_authenticated_user()
+    if authenticated is not None and authenticated != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Key authenticated as '{authenticated}' but request claims user_id='{user_id}'.",
+        )
+    if user_manager and not user_manager.validate_user_cube_access(user_id, cube_id):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Access denied: user '{user_id}' cannot access cube '{cube_id}'",
+        )
 
 
 # =============================================================================
@@ -173,6 +203,9 @@ def scheduler_task_queue_status(
     )
 
 
+_MAX_WAIT_TIMEOUT = 300.0  # 5 minutes max for scheduler wait endpoints
+
+
 @router.post("/scheduler/wait", summary="Wait until scheduler is idle for a specific user")
 def scheduler_wait(
     user_name: str,
@@ -180,6 +213,11 @@ def scheduler_wait(
     poll_interval: float = 0.5,
 ):
     """Wait until scheduler is idle for a specific user."""
+    authenticated = get_authenticated_user()
+    if authenticated and authenticated != user_name:
+        raise HTTPException(status_code=403, detail=f"Cannot wait on scheduler for user '{user_name}'")
+    timeout_seconds = min(timeout_seconds, _MAX_WAIT_TIMEOUT)
+    poll_interval = max(poll_interval, 0.25)
     return handlers.scheduler_handler.handle_scheduler_wait(
         user_name=user_name,
         status_tracker=status_tracker,
@@ -195,6 +233,11 @@ def scheduler_wait_stream(
     poll_interval: float = 0.5,
 ):
     """Stream scheduler progress via Server-Sent Events (SSE)."""
+    authenticated = get_authenticated_user()
+    if authenticated and authenticated != user_name:
+        raise HTTPException(status_code=403, detail=f"Cannot stream scheduler for user '{user_name}'")
+    timeout_seconds = min(timeout_seconds, _MAX_WAIT_TIMEOUT)
+    poll_interval = max(poll_interval, 0.25)
     return handlers.scheduler_handler.handle_scheduler_wait_stream(
         user_name=user_name,
         status_tracker=status_tracker,
@@ -287,6 +330,8 @@ def get_all_memories(memory_req: GetMemoryPlaygroundRequest):
     If search_query is provided, returns a subgraph based on the query.
     Otherwise, returns all memories of the specified type.
     """
+    target_cube = memory_req.mem_cube_ids[0] if memory_req.mem_cube_ids else memory_req.user_id
+    _enforce_cube_access(memory_req.user_id, target_cube)
     if memory_req.search_query:
         return handlers.memory_handler.handle_get_subgraph(
             user_id=memory_req.user_id,
@@ -311,6 +356,7 @@ def get_all_memories(memory_req: GetMemoryPlaygroundRequest):
 
 @router.post("/get_memory", summary="Get memories for user", response_model=GetMemoryResponse)
 def get_memories(memory_req: GetMemoryRequest):
+    _enforce_cube_access(memory_req.user_id or memory_req.mem_cube_id, memory_req.mem_cube_id)
     return handlers.memory_handler.handle_get_memories(
         get_mem_req=memory_req,
         naive_mem_cube=naive_mem_cube,
@@ -319,6 +365,16 @@ def get_memories(memory_req: GetMemoryRequest):
 
 @router.get("/get_memory/{memory_id}", summary="Get memory by id", response_model=GetMemoryResponse)
 def get_memory_by_id(memory_id: str):
+    # Look up the memory's owning cube and verify access
+    authenticated = get_authenticated_user()
+    if authenticated and user_manager:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=[memory_id])
+        owner = owner_map.get(memory_id)
+        if owner and not user_manager.validate_user_cube_access(authenticated, owner):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied: user '{authenticated}' cannot read memory owned by '{owner}'",
+            )
     return handlers.memory_handler.handle_get_memory(
         memory_id=memory_id,
         naive_mem_cube=naive_mem_cube,
@@ -327,6 +383,19 @@ def get_memory_by_id(memory_id: str):
 
 @router.post("/get_memory_by_ids", summary="Get memory by ids", response_model=GetMemoryResponse)
 def get_memory_by_ids(memory_ids: list[str]):
+    # Filter out memories the caller cannot access
+    authenticated = get_authenticated_user()
+    if authenticated and user_manager and memory_ids:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=memory_ids)
+        forbidden = [
+            mid for mid, owner in owner_map.items()
+            if owner and not user_manager.validate_user_cube_access(authenticated, owner)
+        ]
+        if forbidden:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied: cannot read {len(forbidden)} memory ID(s) owned by other cubes",
+            )
     return handlers.memory_handler.handle_get_memory_by_ids(
         memory_ids=memory_ids,
         naive_mem_cube=naive_mem_cube,
@@ -337,6 +406,11 @@ def get_memory_by_ids(memory_ids: list[str]):
     "/delete_memory", summary="Delete memories for user", response_model=DeleteMemoryResponse
 )
 def delete_memories(memory_req: DeleteMemoryRequest):
+    authenticated = get_authenticated_user()
+    # Check cube access for each writable cube
+    cube_ids = memory_req.writable_cube_ids or ([memory_req.user_id] if memory_req.user_id else [])
+    for cube_id in cube_ids:
+        _enforce_cube_access(authenticated or cube_id, cube_id)
     return handlers.memory_handler.handle_delete_memories(
         delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
     )
@@ -354,6 +428,9 @@ def feedback_memories(feedback_req: APIFeedbackRequest):
 
     This endpoint uses the class-based FeedbackHandler for better code organization.
     """
+    cube_ids = feedback_req.writable_cube_ids or [feedback_req.user_id]
+    for cube_id in cube_ids:
+        _enforce_cube_access(feedback_req.user_id, cube_id)
     return feedback_handler.handle_feedback_memories(feedback_req)
 
 
@@ -369,7 +446,14 @@ def feedback_memories(feedback_req: APIFeedbackRequest):
 )
 def get_user_names_by_memory_ids(request: GetUserNamesByMemoryIdsRequest):
     """Get user names by memory ids. Now unified to query from graph_db only."""
+    authenticated = get_authenticated_user()
     result = graph_db.get_user_names_by_memory_ids(memory_ids=request.memory_ids)
+    # Filter results: only return mappings for cubes the caller can access
+    if authenticated and user_manager:
+        result = {
+            mid: uname for mid, uname in result.items()
+            if uname is None or user_manager.validate_user_cube_access(authenticated, uname)
+        }
 
     return GetUserNamesByMemoryIdsResponse(
         code=200,
@@ -384,11 +468,17 @@ def get_user_names_by_memory_ids(request: GetUserNamesByMemoryIdsRequest):
     response_model=ExistMemCubeIdResponse,
 )
 def exist_mem_cube_id(request: ExistMemCubeIdRequest):
-    """(inner) Check if mem cube id exists."""
+    """(inner) Check if mem cube id exists. Only returns True if caller has access."""
+    authenticated = get_authenticated_user()
+    exists = graph_db.exist_user_name(user_name=request.mem_cube_id)
+    # Only reveal existence if the caller has access to that cube
+    if exists and authenticated and user_manager:
+        if not user_manager.validate_user_cube_access(authenticated, request.mem_cube_id):
+            exists = False  # Hide existence from unauthorized callers
     return ExistMemCubeIdResponse(
         code=200,
         message="Successfully",
-        data=graph_db.exist_user_name(user_name=request.mem_cube_id),
+        data=exists,
     )
 
 
@@ -410,6 +500,8 @@ def chat_stream_business_user(chat_req: ChatBusinessRequest):
 )
 def delete_memory_by_record_id(memory_req: DeleteMemoryByRecordIdRequest):
     """(inner) Delete memory nodes by mem_cube_id (user_name) and delete_record_id. Record id is inner field, just for delete and recover memory, not for user to set."""
+    authenticated = get_authenticated_user()
+    _enforce_cube_access(authenticated or memory_req.mem_cube_id, memory_req.mem_cube_id)
     graph_db.delete_node_by_mem_cube_id(
         mem_cube_id=memory_req.mem_cube_id,
         delete_record_id=memory_req.record_id,
@@ -430,6 +522,8 @@ def delete_memory_by_record_id(memory_req: DeleteMemoryByRecordIdRequest):
 )
 def recover_memory_by_record_id(memory_req: RecoverMemoryByRecordIdRequest):
     """(inner) Recover memory nodes by mem_cube_id (user_name) and delete_record_id. Record id is inner field, just for delete and recover memory, not for user to set."""
+    authenticated = get_authenticated_user()
+    _enforce_cube_access(authenticated or memory_req.mem_cube_id, memory_req.mem_cube_id)
     graph_db.recover_memory_by_mem_cube_id(
         mem_cube_id=memory_req.mem_cube_id,
         delete_record_id=memory_req.delete_record_id,
@@ -446,6 +540,8 @@ def recover_memory_by_record_id(memory_req: RecoverMemoryByRecordIdRequest):
     "/get_memory_dashboard", summary="Get memories for dashboard", response_model=GetMemoryResponse
 )
 def get_memories_dashboard(memory_req: GetMemoryDashboardRequest):
+    if memory_req.mem_cube_id:
+        _enforce_cube_access(memory_req.user_id or memory_req.mem_cube_id, memory_req.mem_cube_id)
     return handlers.memory_handler.handle_get_memories_dashboard(
         get_mem_req=memory_req,
         naive_mem_cube=naive_mem_cube,

--- a/src/memos/api/routers/server_router.py
+++ b/src/memos/api/routers/server_router.py
@@ -16,6 +16,7 @@ import random as _random
 import socket
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from memos.api import handlers
 from memos.api.middleware.agent_auth import get_authenticated_user
@@ -402,18 +403,101 @@ def get_memory_by_ids(memory_ids: list[str]):
     )
 
 
-@router.post(
-    "/delete_memory", summary="Delete memories for user", response_model=DeleteMemoryResponse
+@router.api_route(
+    "/delete_memory",
+    methods=["POST", "DELETE"],
+    summary="Delete memories for user",
+    response_model=DeleteMemoryResponse,
 )
 def delete_memories(memory_req: DeleteMemoryRequest):
+    """Delete memories. Supports both singular (`mem_cube_id`, `memory_id`) and plural aliases.
+
+    Returns distinct status codes:
+    - 400: memory-id mode chosen but cube or memory id(s) missing.
+    - 403: caller lacks access to a requested cube (enforced by `_enforce_cube_access`).
+    - 404: memory-id mode where every id is missing from the targeted cube(s).
+    - 200: success — body carries `deleted`/`not_found` for partial results.
+    """
     authenticated = get_authenticated_user()
-    # Check cube access for each writable cube
-    cube_ids = memory_req.writable_cube_ids or ([memory_req.user_id] if memory_req.user_id else [])
+
+    cube_ids = memory_req.writable_cube_ids or []
+    mem_ids = memory_req.memory_ids or []
+
+    has_file_ids = bool(memory_req.file_ids)
+    # Memory-id mode wins when memory_ids is present; otherwise we fall back to file-id
+    # or filter/user_id/session_id mode. (user_id alone, without memory_ids, still means
+    # "delete everything for this user" — preserved for legacy callers.)
+    memory_id_mode = bool(mem_ids) or (
+        not has_file_ids
+        and not memory_req.filter
+        and not memory_req.user_id
+        and not memory_req.session_id
+    )
+
+    if memory_id_mode and (not cube_ids or not mem_ids):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Provide both a cube (mem_cube_id or writable_cube_ids) and "
+                "a memory id (memory_id or memory_ids), or use file_ids / filter mode."
+            ),
+        )
+
+    # 403 on any cube the caller cannot access.
     for cube_id in cube_ids:
         _enforce_cube_access(authenticated or cube_id, cube_id)
-    return handlers.memory_handler.handle_delete_memories(
-        delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
+
+    if not memory_id_mode:
+        return handlers.memory_handler.handle_delete_memories(
+            delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
+        )
+
+    # Memory-id mode: split existing vs missing before delegating to handler.
+    try:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=mem_ids)
+    except Exception:
+        logger.error("Failed to look up memory owners before delete", exc_info=True)
+        owner_map = {}
+
+    allowed_cubes = set(cube_ids)
+    deleted_ids: list[str] = []
+    not_found_ids: list[str] = []
+    for mid in mem_ids:
+        owner = owner_map.get(mid)
+        if owner and owner in allowed_cubes:
+            deleted_ids.append(mid)
+        else:
+            # Memory either does not exist at all, or belongs to a cube the
+            # caller did not target. From the caller's perspective it is not found.
+            not_found_ids.append(mid)
+
+    if not deleted_ids:
+        # Return envelope directly so {deleted, not_found} survives the global HTTP
+        # exception handler, which would otherwise stringify structured `detail`.
+        return JSONResponse(
+            status_code=404,
+            content={
+                "code": 404,
+                "message": "No matching memories found in the targeted cube(s).",
+                "data": {"deleted": [], "not_found": not_found_ids},
+            },
+        )
+
+    filtered_req = memory_req.model_copy(update={"memory_ids": deleted_ids})
+    resp = handlers.memory_handler.handle_delete_memories(
+        delete_mem_req=filtered_req, naive_mem_cube=naive_mem_cube
     )
+    data = dict(resp.data or {})
+    data["deleted"] = deleted_ids
+    data["not_found"] = not_found_ids
+    if not_found_ids and data.get("status") == "success":
+        data["status"] = "partial"
+    message = (
+        "Memories deleted successfully"
+        if not not_found_ids
+        else f"Deleted {len(deleted_ids)} memory(ies); {len(not_found_ids)} not found."
+    )
+    return DeleteMemoryResponse(code=200, message=message, data=data)
 
 
 # =============================================================================

--- a/src/memos/api/server_api.py
+++ b/src/memos/api/server_api.py
@@ -7,7 +7,10 @@ from fastapi.exceptions import RequestValidationError
 from starlette.staticfiles import StaticFiles
 
 from memos.api.exceptions import APIExceptionHandler
+from memos.api.middleware.agent_auth import AgentAuthMiddleware
+from memos.api.middleware.rate_limit import RateLimitMiddleware
 from memos.api.middleware.request_context import RequestContextMiddleware
+from memos.api.routers.admin_router import router as admin_router
 from memos.api.routers.server_router import router as server_router
 
 
@@ -25,9 +28,16 @@ app = FastAPI(
 
 app.mount("/download", StaticFiles(directory=os.getenv("FILE_LOCAL_PATH")), name="static_mapping")
 
+# Middleware execution order (outermost first):
+# 1. RateLimitMiddleware — reject excessive requests before any processing
+# 2. AgentAuthMiddleware — validate per-agent API keys, bind user_id to context
+# 3. RequestContextMiddleware — inject trace_id, log request metadata
+app.add_middleware(RateLimitMiddleware)
+app.add_middleware(AgentAuthMiddleware)
 app.add_middleware(RequestContextMiddleware, source="server_api")
 # Include routers
 app.include_router(server_router)
+app.include_router(admin_router)
 
 
 @app.get("/health")
@@ -59,4 +69,5 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8001)
     parser.add_argument("--workers", type=int, default=1)
     args = parser.parse_args()
-    uvicorn.run("memos.api.server_api:app", host="0.0.0.0", port=args.port, workers=args.workers)
+    bind_host = os.getenv("MEMOS_BIND_HOST", "127.0.0.1")
+    uvicorn.run("memos.api.server_api:app", host=bind_host, port=args.port, workers=args.workers)

--- a/src/memos/mem_user/user_manager.py
+++ b/src/memos/mem_user/user_manager.py
@@ -305,9 +305,12 @@ class UserManager:
     def validate_user_cube_access(self, user_id: str, cube_id: str) -> bool:
         """Validate if a user has access to a cube.
 
+        The cube_id parameter may be a cube_id, cube_name, or the owner's
+        user_id (MemOS agents address cubes by user_id, not cube_id).
+
         Args:
-            user_id (str): The user ID.
-            cube_id (str): The cube ID.
+            user_id (str): The user ID requesting access.
+            cube_id (str): The cube identifier (cube_id, cube_name, or owner user_id).
 
         Returns:
             bool: True if user has access to cube, False otherwise.
@@ -319,8 +322,13 @@ class UserManager:
             if not user:
                 return False
 
-            # Check if cube exists and is active
+            # Look up cube by cube_id first, then by cube_name, then by owner_id
             cube = session.query(Cube).filter(Cube.cube_id == cube_id, Cube.is_active).first()
+            if not cube:
+                cube = session.query(Cube).filter(Cube.cube_name == cube_id, Cube.is_active).first()
+            if not cube:
+                # MemOS agents use user_id as cube address — find the cube owned by that user
+                cube = session.query(Cube).filter(Cube.owner_id == cube_id, Cube.is_active).first()
             if not cube:
                 return False
 

--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import traceback
 
@@ -22,7 +23,7 @@ from memos.mem_scheduler.schemas.task_schemas import (
 )
 from memos.memories.textual.item import TextualMemoryItem
 from memos.multi_mem_cube.views import MemCubeView
-from memos.search import resolve_filter_for_cube, search_text_memories
+from memos.search import search_text_memories
 from memos.templates.mem_reader_prompts import PROMPT_MAPPING
 from memos.types.general_types import (
     FINE_STRATEGY,
@@ -91,13 +92,6 @@ class SingleCubeView(MemCubeView):
         Unified memory search handling (text + preference memories).
         Preference memories are now searched through the same _search_text flow.
         """
-        cube_filter = resolve_filter_for_cube(search_req.filter, self.cube_id)
-        if cube_filter is not search_req.filter:
-            import copy
-
-            search_req = copy.copy(search_req)
-            search_req.filter = cube_filter
-
         # Create UserContext object
         user_context = UserContext(
             user_id=search_req.user_id,
@@ -725,6 +719,43 @@ class SingleCubeView(MemCubeView):
         mem_group = [
             memory for memory in flattened_local if memory.metadata.memory_type != "RawFileMemory"
         ]
+
+        # ── Write-time dedup: skip memories that are near-duplicates of existing ones ──
+        DEDUP_SIMILARITY_THRESHOLD = float(os.getenv("MOS_DEDUP_THRESHOLD", "0.90"))
+        deduped_mem_group = []
+        graph_store = getattr(self.naive_mem_cube.text_mem, "graph_store", None)
+        logger.info(f"[DEDUP] Starting write-time dedup for {len(mem_group)} memories, graph_store={graph_store is not None}")
+        for memory in mem_group:
+            embedding = getattr(memory.metadata, "embedding", None)
+            if embedding and graph_store:
+                try:
+                    similar = graph_store.search_by_embedding(
+                        vector=embedding,
+                        top_k=1,
+                        status="activated",
+                        threshold=DEDUP_SIMILARITY_THRESHOLD,
+                        user_name=user_context.mem_cube_id,
+                    )
+                    if similar:
+                        best = similar[0]
+                        score = best.get('score', 0)
+                        logger.warning(
+                            f"[DEDUP] Skipping near-duplicate memory (score={score:.4f}): "
+                            f"'{memory.memory[:80]}...' matches existing id={best.get('id', '?')[:8]}"
+                        )
+                        continue
+                except Exception as e:
+                    logger.warning(f"[DEDUP] Vector search failed, keeping memory: {e}")
+            deduped_mem_group.append(memory)
+
+        if len(deduped_mem_group) < len(mem_group):
+            logger.warning(
+                f"[DEDUP] Filtered {len(mem_group) - len(deduped_mem_group)} duplicate(s) "
+                f"out of {len(mem_group)} candidate memories"
+            )
+        mem_group = deduped_mem_group
+        # ── End write-time dedup ──
+
         mem_ids_local: list[str] = self.naive_mem_cube.text_mem.add(
             mem_group,
             user_name=user_context.mem_cube_id,

--- a/src/memos/templates/mem_reader_prompts.py
+++ b/src/memos/templates/mem_reader_prompts.py
@@ -18,7 +18,12 @@ For example, write "The user felt exhausted..." instead of "I felt exhausted..."
    - Include all key experiences, thoughts, emotional responses, and plans — even if they seem minor.
    - Prioritize completeness and fidelity over conciseness.
    - Do not generalize or skip details that could be personally meaningful to user.
-5. Please avoid any content that violates national laws and regulations or involves politically sensitive information in the memories you extract.
+5. IMPORTANT — Granularity rule: Each distinct fact, finding, decision, plan, or topic MUST be its own separate memory item.
+   - NEVER merge multiple unrelated facts into a single memory item.
+   - If the conversation contains N distinct pieces of information, produce at least N memory items.
+   - For example, a research brief with 5 findings should produce at least 5 separate memory items (one per finding), plus any additional items for plans, decisions, or reactions.
+   - Each memory item should be atomic: it covers exactly one topic or fact and can be understood independently.
+6. Please avoid any content that violates national laws and regulations or involves politically sensitive information in the memories you extract.
 
 Return a single valid JSON object with the following structure:
 
@@ -36,7 +41,8 @@ Return a single valid JSON object with the following structure:
 }
 
 Language rules:
-- The `key`, `value`, `tags`, `summary` fields must match the mostly used language of the input conversation.  **如果输入是中文，请输出中文**
+- IMPORTANT: Always respond in the same language as the input conversation. If the input is in English, ALL memory keys, values, tags, and summary MUST be in English. If the input is in Chinese, respond in Chinese.
+- The `key`, `value`, `tags`, `summary` fields must match the mostly used language of the input conversation.
 - Keep `memory_type` in English.
 
 ${custom_tags_prompt}
@@ -89,21 +95,7 @@ Output:
 Note: When the dialogue contains only assistant messages, phrasing such as
 “assistant recommended” or “assistant suggested” should be used, rather than incorrectly attributing the content to the user’s statements or plans.
 
-Another Example in Chinese (注意: 当user的语言为中文时，你就需要也输出中文)：
-{
-  "memory list": [
-    {
-      "key": "项目会议",
-      "memory_type": "LongTermMemory",
-      "value": "在2025年6月25日下午3点，Tom与团队开会讨论了新项目，涉及时间表，并提出了对12月15日截止日期可行性的担忧。",
-      "tags": ["项目", "时间表", "会议", "截止日期"]
-    },
-    ...
-  ],
-  "summary": "Tom 目前专注于管理一个进度紧张的新项目..."
-}
-
-Always respond in the same language as the conversation.
+IMPORTANT REMINDER: Your output language MUST match the input conversation language. For English input, output everything in English.
 
 Conversation:
 ${conversation}
@@ -133,7 +125,13 @@ SIMPLE_STRUCT_MEM_READER_PROMPT_ZH = """您是记忆提取专家。
    - 优先考虑完整性和保真度，而非简洁性。
    - 不要泛化或跳过对用户具有个人意义的细节。
 
-5. 请避免在提取的记忆中包含违反国家法律法规或涉及政治敏感的信息。
+5. 重要——粒度规则：每个不同的事实、发现、决定、计划或主题必须作为单独的记忆项。
+   - 绝不将多个不相关的事实合并为一个记忆项。
+   - 如果对话包含N条不同的信息，至少生成N个记忆项。
+   - 例如，包含5项发现的研究报告应至少生成5个独立的记忆项（每项发现一个），再加上任何关于计划、决定或反应的额外项。
+   - 每个记忆项应是原子性的：只涵盖一个主题或事实，并且可以独立理解。
+
+6. 请避免在提取的记忆中包含违反国家法律法规或涉及政治敏感的信息。
 
 返回一个有效的JSON对象，结构如下：
 

--- a/src/memos/vec_dbs/qdrant.py
+++ b/src/memos/vec_dbs/qdrant.py
@@ -34,8 +34,6 @@ class QdrantVecDB(BaseVecDB):
         client_kwargs: dict[str, Any] = {}
         if self.config.url:
             client_kwargs["url"] = self.config.url
-            if self.config.api_key:
-                client_kwargs["api_key"] = self.config.api_key
         else:
             client_kwargs.update(
                 {
@@ -44,6 +42,12 @@ class QdrantVecDB(BaseVecDB):
                     "path": self.config.path,
                 }
             )
+        # Pass API key regardless of connection mode (url or host+port)
+        if self.config.api_key:
+            client_kwargs["api_key"] = self.config.api_key
+            # When using host+port (not url), force HTTP to avoid SSL errors on localhost
+            if "url" not in client_kwargs:
+                client_kwargs["https"] = False
 
             # If both host and port are None, we are running in local/embedded mode
             if self.config.host is None and self.config.port is None:

--- a/start-memos.sh
+++ b/start-memos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# start-memos.sh — Decrypt secrets, load env, start MemOS server
+# Usage: ./start-memos.sh [--port 8001]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AGE_KEY="${MEMOS_AGE_KEY:-$HOME/.memos/keys/memos.key}"
+SECRETS_ENC="${MEMOS_SECRETS:-$HOME/.memos/secrets.env.age}"
+AGE_BIN="${AGE_BIN:-$(command -v age || echo /home/linuxbrew/.linuxbrew/bin/age)}"
+PORT="${1:-8001}"
+
+# 1. Load base .env (non-secret config)
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+
+# 2. Decrypt and load secrets
+if [[ -f "$SECRETS_ENC" ]]; then
+    if [[ ! -f "$AGE_KEY" ]]; then
+        echo "ERROR: age key not found at $AGE_KEY" >&2
+        exit 1
+    fi
+    echo "Decrypting secrets from $SECRETS_ENC ..."
+    eval "$("$AGE_BIN" -d -i "$AGE_KEY" "$SECRETS_ENC" | grep -v '^#' | grep '=' | sed 's/^/export /')"
+    echo "Secrets loaded."
+else
+    echo "WARNING: No encrypted secrets file at $SECRETS_ENC — using env as-is" >&2
+fi
+
+# 3. Start server
+echo "Starting MemOS on port $PORT ..."
+exec python3.12 -m memos.api.server_api --port "$PORT"

--- a/tests/api/test_memory_handler_delete.py
+++ b/tests/api/test_memory_handler_delete.py
@@ -104,16 +104,28 @@ def test_delete_memories_filter_or_with_distribution():
     )
 
 
-def test_delete_memories_reject_multiple_modes():
+def test_delete_memories_memory_ids_wins_over_user_id_scope():
+    """memory_ids + user_id must use memory-id mode; user_id is identity context only."""
     naive_mem_cube = _build_naive_mem_cube()
     req = DeleteMemoryRequest(memory_ids=["m_1"], user_id="u_1")
 
     resp = handle_delete_memories(req, naive_mem_cube)
 
-    assert resp.data["status"] == "failure"
-    assert "Exactly one delete mode must be provided" in resp.message
+    assert resp.data["status"] == "success"
+    naive_mem_cube.text_mem.delete_by_memory_ids.assert_called_once_with(["m_1"])
     naive_mem_cube.text_mem.delete_by_filter.assert_not_called()
+
+
+def test_delete_memories_reject_memory_ids_and_file_ids_together():
+    naive_mem_cube = _build_naive_mem_cube()
+    req = DeleteMemoryRequest(memory_ids=["m_1"], file_ids=["f_1"])
+
+    resp = handle_delete_memories(req, naive_mem_cube)
+
+    assert resp.data["status"] == "failure"
+    assert "cannot be used together" in resp.message
     naive_mem_cube.text_mem.delete_by_memory_ids.assert_not_called()
+    naive_mem_cube.text_mem.delete_by_filter.assert_not_called()
 
 
 def test_delete_memories_reject_empty_filter():
@@ -140,3 +152,39 @@ def test_delete_memories_with_pref_mem_disabled():
         writable_cube_ids=None,
         filter={"and": [{"user_id": "u_1"}]},
     )
+
+
+# -----------------------------------------------------------------------------
+# Singular/plural normalization (fix/delete-api)
+# -----------------------------------------------------------------------------
+
+
+def test_singular_mem_cube_id_coerces_to_writable_cube_ids():
+    req = DeleteMemoryRequest(mem_cube_id="cube-a", memory_id="mem-1")
+
+    assert req.writable_cube_ids == ["cube-a"]
+    assert req.memory_ids == ["mem-1"]
+
+
+def test_plural_wins_when_both_cube_forms_given():
+    req = DeleteMemoryRequest(
+        writable_cube_ids=["cube-a", "cube-b"],
+        mem_cube_id="cube-ignored",
+        memory_ids=["m1", "m2"],
+        memory_id="m-ignored",
+    )
+
+    assert req.writable_cube_ids == ["cube-a", "cube-b"]
+    assert req.memory_ids == ["m1", "m2"]
+
+
+def test_delete_memories_routes_singular_memory_id_through_memory_ids_path():
+    """Coerced singular memory_id must drive the memory_ids delete branch, not filter mode."""
+    naive_mem_cube = _build_naive_mem_cube()
+    req = DeleteMemoryRequest(mem_cube_id="cube-a", memory_id="mem-1")
+
+    resp = handle_delete_memories(req, naive_mem_cube)
+
+    assert resp.data["status"] == "success"
+    naive_mem_cube.text_mem.delete_by_memory_ids.assert_called_once_with(["mem-1"])
+    naive_mem_cube.text_mem.delete_by_filter.assert_not_called()

--- a/tests/api/test_server_router.py
+++ b/tests/api/test_server_router.py
@@ -15,6 +15,7 @@ from memos.api.product_models import (
     APIADDRequest,
     APIChatCompleteRequest,
     APISearchRequest,
+    DeleteMemoryResponse,
     MemoryResponse,
     SearchResponse,
     SuggestionResponse,
@@ -415,3 +416,192 @@ class TestServerRouterGetAll:
         data = response.json()
         assert data["message"] == "Memories retrieved successfully"
         assert isinstance(data["data"], list)
+
+
+class TestServerRouterDeleteMemory:
+    """Tests for DELETE/POST /product/delete_memory status-code and param-alias behavior."""
+
+    @pytest.fixture
+    def delete_setup(self, mock_handlers):
+        """Patch graph_db + user_manager at the router module, re-enable the existing handler."""
+        delete_response = DeleteMemoryResponse(
+            message="Memories deleted successfully", data={"status": "success"}
+        )
+        mock_handlers["memory"].handle_delete_memories.return_value = delete_response
+
+        with (
+            patch("memos.api.routers.server_router.graph_db") as mock_graph_db,
+            patch("memos.api.routers.server_router.user_manager") as mock_user_manager,
+        ):
+            mock_user_manager.validate_user_cube_access.return_value = True
+            yield {
+                "graph_db": mock_graph_db,
+                "user_manager": mock_user_manager,
+                "memory": mock_handlers["memory"],
+            }
+
+    def test_legacy_plural_form_still_works(self, delete_setup, client):
+        """Existing callers using writable_cube_ids + memory_ids must keep working."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a"
+        }
+
+        response = client.request(
+            "POST",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "writable_cube_ids": ["cube-a"],
+                "memory_ids": ["mem-1"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"]["deleted"] == ["mem-1"]
+        assert body["data"]["not_found"] == []
+        delete_setup["memory"].handle_delete_memories.assert_called_once()
+
+    def test_singular_form_accepted_via_delete_method(self, delete_setup, client):
+        """New callers using singular mem_cube_id + memory_id over HTTP DELETE."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a"
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"]["deleted"] == ["mem-1"]
+
+    def test_nonexistent_memory_returns_404(self, delete_setup, client):
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "does-not-exist": None
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "does-not-exist",
+            },
+        )
+
+        assert response.status_code == 404
+        body = response.json()
+        assert body["data"]["not_found"] == ["does-not-exist"]
+        assert body["data"]["deleted"] == []
+        delete_setup["memory"].handle_delete_memories.assert_not_called()
+
+    def test_memory_in_different_cube_returns_404(self, delete_setup, client):
+        """Requesting cube A but memory lives in cube B (user-perspective 404, not 403)."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-b"
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 404
+
+    def test_forbidden_cube_returns_403(self, delete_setup, client):
+        """User targets a cube they have no access to → 403 (not 404)."""
+        delete_setup["user_manager"].validate_user_cube_access.return_value = False
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-not-mine",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 403
+        delete_setup["graph_db"].get_user_names_by_memory_ids.assert_not_called()
+
+    def test_partial_delete_returns_200_with_split(self, delete_setup, client):
+        """3 ids where 2 exist + 1 doesn't → 200 with deleted/not_found split."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a",
+            "mem-2": "cube-a",
+            "mem-missing": None,
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_ids": ["mem-1", "mem-2", "mem-missing"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert sorted(body["data"]["deleted"]) == ["mem-1", "mem-2"]
+        assert body["data"]["not_found"] == ["mem-missing"]
+        assert body["data"]["status"] == "partial"
+
+        # Handler should be called with filtered ids only.
+        call_kwargs = delete_setup["memory"].handle_delete_memories.call_args.kwargs
+        assert call_kwargs["delete_mem_req"].memory_ids == ["mem-1", "mem-2"]
+
+    def test_empty_body_returns_400(self, delete_setup, client):
+        """No cube, no memory, no filter/user_id/session_id → 400."""
+        response = client.request("DELETE", "/product/delete_memory", json={})
+
+        assert response.status_code == 400
+        delete_setup["memory"].handle_delete_memories.assert_not_called()
+
+    def test_memory_only_without_cube_returns_400(self, delete_setup, client):
+        """memory_id provided but no cube targeting info → 400."""
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={"memory_id": "mem-1"},
+        )
+
+        assert response.status_code == 400
+
+    def test_cube_only_without_memory_returns_400(self, delete_setup, client):
+        """mem_cube_id provided but no memory ids → 400 (prevents accidental bulk wipe)."""
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={"mem_cube_id": "cube-a"},
+        )
+
+        assert response.status_code == 400
+
+    def test_filter_mode_unchanged(self, delete_setup, client):
+        """Filter/user_id quick-delete mode bypasses the 400 cube+memory requirement."""
+        response = client.request(
+            "POST",
+            "/product/delete_memory",
+            json={"user_id": "user-a", "session_id": "s1"},
+        )
+
+        assert response.status_code == 200
+        delete_setup["memory"].handle_delete_memories.assert_called_once()
+        # Owner lookup must not happen in filter mode.
+        delete_setup["graph_db"].get_user_names_by_memory_ids.assert_not_called()


### PR DESCRIPTION
## Summary
- `DELETE /product/delete_memory` now accepts both singular (`mem_cube_id`, `memory_id`) and plural (`writable_cube_ids`, `memory_ids`) forms; plural wins when both are provided. Singular is coerced into the plural internally by the `DeleteMemoryRequest` validator.
- Endpoint responds on both `POST` and `DELETE` so existing callers keep working.
- Status codes are now distinct:
  - **400** — memory-id mode intended but cube or memory id(s) missing
  - **403** — caller cannot access a targeted cube (unchanged)
  - **404** — every requested memory id is missing from the targeted cube(s) (previously returned 403 when the cube was wrong)
  - **200** with `data.deleted` + `data.not_found` arrays on partial success (don't 404 the whole request when some ids exist)
- Handler's mode-precedence was relaxed: explicit `memory_ids`/`file_ids` now take priority over filter/user_id/session_id mode, so callers can pass `user_id` alongside `memory_ids` as identity context without hitting the old "multiple modes" rejection.

Fixes the confusing delete-endpoint behavior flagged in blind-audit-report.md § 12 + Bug 2.

## Test plan
Unit + FastAPI TestClient coverage:
- `tests/api/test_memory_handler_delete.py` (10 tests, was 7) — singular/plural coercion, `memory_ids + user_id` uses memory-id mode, `memory_ids + file_ids` still rejected.
- `tests/api/test_server_router.py::TestServerRouterDeleteMemory` (new, 9 tests) — legacy plural form over POST still works, singular form over DELETE works, 404 for missing memory, 404 for memory in a different cube (the Bug 2 repro), 403 for forbidden cube, 200 with split for partial delete, 400 for empty body / cube-only / memory-only, filter mode untouched.

Command: `PYTHONPATH=src python3.12 -m pytest tests/api/ -q`
Result: **41 passed** (was 32; new tests cover the behavior changes).

The full flow described in TASK.md's test plan (write → delete by plural → delete by singular → 404 on unknown id → 200 partial-delete) is covered by the router tests using a mocked `graph_db` and `user_manager`; live-curl verification requires a running MemOS + Neo4j stack which wasn't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)