### PR TITLE
fix(utils): re-raise in timed_with_status when no fallback configured

### DIFF
--- a/src/memos/utils.py
+++ b/src/memos/utils.py
@@ -53,6 +53,11 @@ def timed_with_status(
                 if fallback is not None and callable(fallback):
                     result = fallback(e, *args, **kwargs)
                     return result
+                # No fallback configured -> re-raise so callers see the failure
+                # instead of receiving an implicit None. Otherwise downstream
+                # parsers (e.g. clean_json_response) crash with confusing
+                # AttributeErrors that hide the real LLM/HTTP error.
+                raise
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000.0
 


### PR DESCRIPTION
Fixes #1523.

## Problem

`timed_with_status` caught every exception, ran the optional `fallback`, but when no fallback was configured the wrapper fell through to an implicit `return None`. Decorated functions returned `None` on any failure instead of raising.

Concrete consequence: `OpenAILLM.generate` (decorated with this) returned `None` on a MiniMax 400 (`chat content is empty (2013)` for system-only messages), and the suggestion handler then died in `clean_json_response` with `AttributeError: 'NoneType' object has no attribute 'replace'`. The real 400 was hidden.

## Change

Add a single `raise` after the fallback branch:

```python
                if fallback is not None and callable(fallback):
                    result = fallback(e, *args, **kwargs)
                    return result
                # No fallback configured -> re-raise so callers see the failure
                # instead of receiving an implicit None. ...
                raise
            finally:
                ...
```

`finally` still runs, so the timing/status log line is unchanged.

## Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Tested

- Reproduced locally with `MOS_CHAT_MODEL=MiniMax-M2.7`, `OPENAI_API_BASE=https://api.minimax.io/v1`, system-only suggestion prompt.
  - **Before:** HTTP 500 `'NoneType' object has no attribute 'replace'`
  - **After:** HTTP 500 surfaces the real `openai.BadRequestError: 400 ... invalid params, chat content is empty (2013)` to the caller, exactly as `[TIMER_WITH_STATUS]` already logged.
- Existing fallback path (`fallback=` arg supplied) is exercised by other handlers; behaviour unchanged because `raise` is reached only when no fallback returns.

## Checklist

- [x] Self-review done
- [x] Comment added explaining the fix
- [ ] Unit test added (existing test suite did not cover this branch; happy to add a small one if maintainers want it)
- [x] Linked to issue