### PR TITLE
fix(suggestion_handler): split system+user so non-OpenAI LLMs accept the request

### DIFF
--- a/src/memos/api/handlers/suggestion_handler.py
+++ b/src/memos/api/handlers/suggestion_handler.py
@@ -110,8 +110,21 @@ def handle_get_suggestion_queries(
         if text_mem_results:
             memories = "\n".join([m.memory[:200] for m in text_mem_results])
 
-        # Generate suggestions using LLM
-        message_list = [{"role": "system", "content": suggestion_prompt.format(memories=memories)}]
+        # Generate suggestions using LLM.
+        # The prompt is split into system+user roles so the request stays
+        # valid for backends that reject system-only payloads (e.g. MiniMax
+        # `chat content is empty (2013)`, Anthropic `messages must not be empty`).
+        # OpenAI accepts either shape, so this is a safe widening.
+        message_list = [
+            {
+                "role": "system",
+                "content": "You generate suggestion queries based on the user's recent memories.",
+            },
+            {
+                "role": "user",
+                "content": suggestion_prompt.format(memories=memories),
+            },
+        ]
         response = llm.generate(message_list)
         clean_response = clean_json_response(response)
         response_json = json.loads(clean_response)


### PR DESCRIPTION
Fixes #1527.

## Problem

`handle_get_suggestion_queries` builds a single system message:

```python
message_list = [{"role": "system", "content": suggestion_prompt.format(memories=memories)}]
```

OpenAI accepts this. MiniMax (both Text API and Anthropic-compatible API) and Anthropic itself reject it with HTTP 400 (`chat content is empty (2013)` / `messages must not be empty (2013)`). Per MiniMax's own minimal example in the docs, every request must contain at least one user turn.

## Change

Split into a short system persona + user message:

```python
message_list = [
    {"role": "system",
     "content": "You generate suggestion queries based on the user's recent memories."},
    {"role": "user",
     "content": suggestion_prompt.format(memories=memories)},
]
```

This is a strict widening:
- OpenAI: still accepted
- MiniMax (Text + Anthropic-compat): now accepted
- Anthropic native: now accepted

No behaviour change for existing OpenAI deployments.

## Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Tested

- `POST /product/suggestions` with `MOS_CHAT_MODEL=MiniMax-M2.7`, `OPENAI_API_BASE=https://api.minimax.io/v1`:
  - **Before:** 500 (or 'NoneType has no attribute replace' if running without #1524).
  - **After:** 200 with `{\"data\":{\"query\":[\"...\",\"...\",\"...\"]}}` populated by MiniMax-M2.7.
- Verified the same fix path works end-to-end (LLM call → JSON parse → SuggestionResponse).

## Checklist

- [x] Self-review
- [x] Comment added at the message-list construction explaining why both roles are needed
- [ ] Unit test (would need an LLM mock; happy to add if maintainers want one)
- [x] Linked to issue
- [ ] Docs update — should we mention this in any provider-compatibility table? Could open a follow-up doc PR.