### PR TITLE
fix(search): batch missing-embedding calls to avoid API batch-size limits

### DIFF
--- a/src/memos/api/handlers/search_handler.py
+++ b/src/memos/api/handlers/search_handler.py
@@ -10,6 +10,8 @@ import math
 
 from typing import Any
 
+_EMBED_BATCH_SIZE = 16  # max documents per embedder call to avoid API batch-size limits
+
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
 from memos.api.handlers.formatters_handler import rerank_knowledge_mem
 from memos.api.product_models import APISearchRequest, SearchResponse
@@ -446,7 +448,12 @@ class SearchHandler(BaseHandler):
             missing_documents.append(mem.get("memory", ""))
 
         if missing_indices:
-            computed = self.searcher.embedder.embed(missing_documents)
+            computed: list[list[float]] = []
+            for i in range(0, len(missing_documents), _EMBED_BATCH_SIZE):
+                batch = missing_documents[i : i + _EMBED_BATCH_SIZE]
+                batch_result = self.searcher.embedder.embed(batch)
+                if batch_result:
+                    computed.extend(batch_result)
             for idx, embedding in zip(missing_indices, computed, strict=False):
                 embeddings[idx] = embedding
                 memories[idx]["metadata"]["embedding"] = embedding


### PR DESCRIPTION
Fixes #1482

## Problem

`_extract_embeddings` in `search_handler.py` collects all documents that lack a cached embedding and calls `embedder.embed(all_missing)` in a single shot. Providers such as Dashscope `text-embedding-v4` reject or silently return `None` when the batch is too large (e.g. 25 documents), which then causes a `TypeError` when the code tries to iterate over the `None` result, or silently drops all missing embeddings.

The warning message before this:
```
[SearchHandler] MMR embedding metadata missing; will compute missing embeddings: missing_total=25
```
followed by a crash or silent failure in the MMR deduplication path.

## Solution

Split `missing_documents` into chunks of `_EMBED_BATCH_SIZE` (16) and call `embed()` for each chunk, extending a combined result list. Batches that return `None`/empty are skipped gracefully so remaining embeddings can still be used.

```python
_EMBED_BATCH_SIZE = 16

computed: list[list[float]] = []
for i in range(0, len(missing_documents), _EMBED_BATCH_SIZE):
    batch = missing_documents[i : i + _EMBED_BATCH_SIZE]
    batch_result = self.searcher.embedder.embed(batch)
    if batch_result:
        computed.extend(batch_result)
```

## Testing

- Verified with 25 missing documents: previously crashed with `TypeError`; now completes successfully using 2 batches of 16 and 9.
- Verified with <16 missing documents: behaviour unchanged (single call).