### PR TITLE
fix(memos-local-plugin): prevent orphan episode scan from closing active sessions; add episode delete API

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -142,7 +142,13 @@ class MemTensorProvider(MemoryProvider):
             logger.warning("MemOS: failed to start bridge — %s", err)
             return
         try:
-            self._bridge = MemosBridgeClient(tcp_host="127.0.0.1", tcp_port=18911)
+            # Try TCP mode first (connect to daemon bridge).
+            # Falls back to stdio (spawn subprocess) if daemon isn't running.
+            try:
+                self._bridge = MemosBridgeClient(tcp_host="127.0.0.1", tcp_port=18911)
+            except BridgeError:
+                logger.info("MemOS: TCP daemon not available, falling back to stdio bridge")
+                self._bridge = MemosBridgeClient()
             resp = self._bridge.request(
                 "session.open",
                 {
@@ -455,13 +461,14 @@ class MemTensorProvider(MemoryProvider):
         if pending:
             with contextlib.suppress(Exception):
                 self._turn_end(*pending)
-        # In TCP mode the daemon bridge owns the session — don't close it.
-        # The pipeline will finalize the episode naturally on the daemon side.
-        if not self._bridge._tcp_mode:
-            with contextlib.suppress(Exception):
-                self._bridge.request("episode.close", {"episodeId": self._episode_id})
-            with contextlib.suppress(Exception):
-                self._bridge.request("session.close", {"sessionId": self._session_id})
+        # Close the episode and session so the core stamps closure metadata
+        # (e.g. session.meta.closedAt). In TCP mode this ensures the daemon
+        # can distinguish "normal shutdown" from "abrupt disconnect" on
+        # restart, preventing orphan retention.
+        with contextlib.suppress(Exception):
+            self._bridge.request("episode.close", {"episodeId": self._episode_id})
+        with contextlib.suppress(Exception):
+            self._bridge.request("session.close", {"sessionId": self._session_id})
 
     def shutdown(self) -> None:  # type: ignore[override]
         if self._prefetch_thread and self._prefetch_thread.is_alive():

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -142,7 +142,7 @@ class MemTensorProvider(MemoryProvider):
             logger.warning("MemOS: failed to start bridge — %s", err)
             return
         try:
-            self._bridge = MemosBridgeClient()
+            self._bridge = MemosBridgeClient(tcp_host="127.0.0.1", tcp_port=18911)
             resp = self._bridge.request(
                 "session.open",
                 {
@@ -455,10 +455,13 @@ class MemTensorProvider(MemoryProvider):
         if pending:
             with contextlib.suppress(Exception):
                 self._turn_end(*pending)
-        with contextlib.suppress(Exception):
-            self._bridge.request("episode.close", {"episodeId": self._episode_id})
-        with contextlib.suppress(Exception):
-            self._bridge.request("session.close", {"sessionId": self._session_id})
+        # In TCP mode the daemon bridge owns the session — don't close it.
+        # The pipeline will finalize the episode naturally on the daemon side.
+        if not self._bridge._tcp_mode:
+            with contextlib.suppress(Exception):
+                self._bridge.request("episode.close", {"episodeId": self._episode_id})
+            with contextlib.suppress(Exception):
+                self._bridge.request("session.close", {"sessionId": self._session_id})
 
     def shutdown(self) -> None:  # type: ignore[override]
         if self._prefetch_thread and self._prefetch_thread.is_alive():

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -62,7 +62,7 @@ _PLUGIN_DIR = Path(__file__).resolve().parent
 if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
-from bridge_client import MemosBridgeClient  # noqa: E402
+from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
 from daemon_manager import ensure_bridge_running, shutdown_bridge  # noqa: E402
 
 

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -1,12 +1,12 @@
-"""JSON-RPC 2.0 over stdio client for the MemOS bridge.
+"""JSON-RPC 2.0 client for the MemOS bridge.
 
-Spawns ``node bridge.cts --agent=hermes`` as a subprocess and communicates
-via line-delimited JSON messages on its stdin/stdout. Responses are
-matched by ``id``. Notifications (events + logs) are forwarded to
-registered callbacks on a reader thread.
+Two transport modes:
+- **TCP** (recommended): connects to an existing daemon bridge via ``host:port``.
+  Hermes CLI exits without disrupting the daemon's session → episodes finalize properly.
+- **stdio** (fallback): spawns ``node bridge.cts --agent=hermes`` as a subprocess.
 
-The client is *blocking* by design — callers wanting async behaviour
-should wrap requests in a thread pool.
+Responses are matched by ``id``. Notifications (events + logs) are forwarded to
+registered callbacks on a reader thread. Thread-safe.
 """
 
 from __future__ import annotations
@@ -15,14 +15,16 @@ import contextlib
 import json
 import logging
 import os
+import socket as _socket
 import shutil
 import subprocess
 import threading
+import time
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-# Ensure at-most-one bridge instance via PID file.
+# Ensure at-most-one bridge instance via PID file (stdio mode only).
 from daemon_manager import kill_existing_bridge, register_bridge
 
 
@@ -31,6 +33,11 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_TCP_HOST = "127.0.0.1"
+DEFAULT_TCP_PORT = 18911
+_TCP_RECONNECT_DELAY = 1.0  # seconds between reconnection attempts
+_TCP_MAX_RECONNECT = 3
 
 
 class BridgeError(RuntimeError):
@@ -43,17 +50,52 @@ class BridgeError(RuntimeError):
         self.data = data
 
 
+class _SocketTransport:
+    """TCP socket wrapper with line-delimited JSON read/write."""
+
+    def __init__(self, host: str, port: int) -> None:
+        self._sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        self._sock.settimeout(15.0)
+        self._sock.connect((host, port))
+        self._sock.settimeout(None)  # blocking reads after connect
+        self._rfile = self._sock.makefile("r", buffering=1, encoding="utf-8")
+
+    def write_line(self, text: str) -> None:
+        self._sock.sendall((text + "\n").encode("utf-8"))
+
+    def read_line(self) -> str | None:
+        line = self._rfile.readline()
+        return line if line else None
+
+    def close(self) -> None:
+        try:
+            self._sock.shutdown(_socket.SHUT_RDWR)
+        except OSError:
+            pass
+        self._sock.close()
+
+
 class MemosBridgeClient:
-    """Client wrapping a line-delimited JSON-RPC 2.0 stdio bridge.
+    """Client wrapping a line-delimited JSON-RPC 2.0 bridge.
+
+    Two transport modes:
+
+    **TCP mode** (``tcp_host`` + ``tcp_port`` given):
+        Connects to an existing daemon bridge process.  The Hermes CLI can exit
+        without closing the daemon's session, so episodes get *finalized* by the
+        pipeline rather than *abandoned*.  On connection loss the client tries to
+        reconnect a few times.
+
+    **stdio mode** (default):
+        Spawns ``node bridge.cts --agent=hermes`` as a subprocess and communicates
+        over its stdin / stdout.  The Hermes CLI exiting causes the episode to be
+        abandoned.
 
     Usage:
         >>> client = MemosBridgeClient()
         >>> client.request("core.health", {})
         {'ok': True, 'version': '...'}
         >>> client.close()
-
-    Thread-safe: per-request locking ensures concurrent callers don't
-    interleave writes.
     """
 
     def __init__(
@@ -63,6 +105,8 @@ class MemosBridgeClient:
         node_binary: str | None = None,
         agent: str = "hermes",
         extra_env: dict[str, str] | None = None,
+        tcp_host: str | None = None,
+        tcp_port: int | None = None,
     ) -> None:
         self._lock = threading.Lock()
         self._next_id = 1
@@ -70,44 +114,91 @@ class MemosBridgeClient:
         self._events: list[Callable[[dict[str, Any]], None]] = []
         self._logs: list[Callable[[dict[str, Any]], None]] = []
         self._closed = False
+        self._tcp_mode = tcp_host is not None
 
-        node = node_binary or shutil.which("node") or "node"
-        script = bridge_path or str(
-            Path(__file__).resolve().parent.parent.parent.parent / "bridge.cts"
-        )
-        tsx_bin = str(
-            Path(__file__).resolve().parent.parent.parent.parent / "node_modules" / ".bin" / "tsx"
-        )
-        runtime = tsx_bin if Path(tsx_bin).exists() else node
-        runtime_args = [] if Path(tsx_bin).exists() else ["--experimental-strip-types"]
-        env = {**os.environ, **(extra_env or {})}
-        # Kill any previously-running bridge before spawning a new one.
-        kill_existing_bridge()
-        self._proc = subprocess.Popen(
-            [runtime, *runtime_args, script, f"--agent={agent}"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-            env=env,
-        )
-        # Register the new process so daemon_manager can track it.
-        register_bridge(self._proc)
-        self._reader = threading.Thread(
-            target=self._read_loop,
-            daemon=True,
-            name="memos-bridge-reader",
-        )
-        self._reader.start()
-        self._stderr_reader = threading.Thread(
-            target=self._stderr_loop,
-            daemon=True,
-            name="memos-bridge-stderr",
-        )
-        self._stderr_reader.start()
+        if self._tcp_mode:
+            self._tcp_host = tcp_host or DEFAULT_TCP_HOST
+            self._tcp_port = tcp_port or DEFAULT_TCP_PORT
+            self._transport: _SocketTransport | None = None
+            self._connect_tcp()
+        else:
+            # ── stdio mode (original behaviour, spawn subprocess) ──
+            node = node_binary or shutil.which("node") or "node"
+            script = bridge_path or str(
+                Path(__file__).resolve().parent.parent.parent.parent / "bridge.cts"
+            )
+            tsx_bin = str(
+                Path(__file__).resolve().parent.parent.parent.parent / "node_modules" / ".bin" / "tsx"
+            )
+            runtime = tsx_bin if Path(tsx_bin).exists() else node
+            runtime_args = [] if Path(tsx_bin).exists() else ["--experimental-strip-types"]
+            env = {**os.environ, **(extra_env or {})}
+            # Kill any previously-running bridge before spawning a new one.
+            kill_existing_bridge()
+            self._proc = subprocess.Popen(
+                [runtime, *runtime_args, script, f"--agent={agent}"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                env=env,
+            )
+            # Register the new process so daemon_manager can track it.
+            register_bridge(self._proc)
+            self._reader = threading.Thread(
+                target=self._read_loop_stdio,
+                daemon=True,
+                name="memos-bridge-reader",
+            )
+            self._reader.start()
+            self._stderr_reader = threading.Thread(
+                target=self._stderr_loop,
+                daemon=True,
+                name="memos-bridge-stderr",
+            )
+            self._stderr_reader.start()
 
-    # ─── Public API ──
+    # ── TCP connection helpers ──────────────────────────────────────
+
+    def _connect_tcp(self) -> None:
+        """Connect (or reconnect) to the daemon bridge TCP port."""
+        last_err = None
+        for attempt in range(_TCP_MAX_RECONNECT):
+            try:
+                self._transport = _SocketTransport(self._tcp_host, self._tcp_port)
+                # Start reader thread
+                self._reader = threading.Thread(
+                    target=self._read_loop_tcp,
+                    daemon=True,
+                    name="memos-bridge-tcp-reader",
+                )
+                self._reader.start()
+                logger.info(
+                    "bridge_client: connected to daemon at %s:%s",
+                    self._tcp_host, self._tcp_port,
+                )
+                return
+            except (ConnectionRefusedError, OSError) as e:
+                last_err = e
+                if attempt < _TCP_MAX_RECONNECT - 1:
+                    time.sleep(_TCP_RECONNECT_DELAY * (attempt + 1))
+        raise BridgeError(
+            "tcp_connect_failed",
+            f"Could not connect to daemon bridge at {self._tcp_host}:{self._tcp_port} "
+            f"after {_TCP_MAX_RECONNECT} attempts: {last_err}",
+        )
+
+    def _reconnect_tcp(self) -> None:
+        """Attempt transparent reconnection after transport loss."""
+        logger.warning("bridge_client: TCP transport lost, reconnecting…")
+        self._transport = None
+        self._connect_tcp()
+        # Re-send session greetings so the daemon knows this client is alive.
+        # The daemon treats a new TCP connection as a new client — no session
+        # creation needed on the daemon side (it already has its own session).
+
+    # ── Public API ──────────────────────────────────────────────────
 
     def request(
         self,
@@ -128,12 +219,7 @@ class MemosBridgeClient:
                 {"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params},
                 ensure_ascii=False,
             )
-            try:
-                self._proc.stdin.write(payload + "\n")
-                self._proc.stdin.flush()
-            except (BrokenPipeError, OSError) as err:
-                self._pending.pop(rpc_id, None)
-                raise BridgeError("transport_closed", str(err)) from err
+            self._write_or_raise(payload + "\n")
 
         if not waiter.wait(timeout=timeout):
             with self._lock:
@@ -154,9 +240,8 @@ class MemosBridgeClient:
         with self._lock:
             payload = json.dumps({"jsonrpc": "2.0", "method": method, "params": params})
             try:
-                self._proc.stdin.write(payload + "\n")
-                self._proc.stdin.flush()
-            except (BrokenPipeError, OSError):
+                self._write_text(payload + "\n")
+            except (BrokenPipeError, OSError, ConnectionError):
                 pass
 
     def on_event(self, cb: Callable[[dict[str, Any]], None]) -> None:
@@ -169,14 +254,10 @@ class MemosBridgeClient:
         if self._closed:
             return
         self._closed = True
-        with contextlib.suppress(Exception):
-            self._proc.stdin.close()
-        try:
-            self._proc.wait(timeout=5.0)
-        except subprocess.TimeoutExpired:
-            self._proc.kill()
-        # Clear PID file so a future incarnation starts fresh.
-        register_bridge(None)
+        if self._tcp_mode:
+            self._close_tcp()
+        else:
+            self._close_stdio()
         # unblock any pending waiters
         with self._lock:
             for entry in list(self._pending.values()):
@@ -188,36 +269,95 @@ class MemosBridgeClient:
                 entry["event"].set()
             self._pending.clear()
 
-    # ─── Internals ──
+    # ── Internals: write helpers ────────────────────────────────────
 
-    def _read_loop(self) -> None:
+    def _write_or_raise(self, text: str) -> None:
+        """Write *text* to the transport; raise on failure."""
+        if self._tcp_mode:
+            if self._transport is None:
+                raise BridgeError("transport_closed", "TCP transport disconnected")
+            try:
+                self._transport.write_line(text)
+            except (BrokenPipeError, OSError, ConnectionError) as err:
+                # Attempt transparent reconnect
+                try:
+                    self._reconnect_tcp()
+                    self._transport.write_line(text)
+                except Exception as reconnect_err:
+                    raise BridgeError("transport_closed", str(reconnect_err)) from err
+        else:
+            assert self._proc.stdin is not None
+            try:
+                self._proc.stdin.write(text)
+                self._proc.stdin.flush()
+            except (BrokenPipeError, OSError) as err:
+                raise BridgeError("transport_closed", str(err)) from err
+
+    def _write_text(self, text: str) -> None:
+        """Best-effort write, swallow errors."""
+        try:
+            if self._tcp_mode:
+                if self._transport is not None:
+                    self._transport.write_line(text)
+            else:
+                assert self._proc.stdin is not None
+                self._proc.stdin.write(text)
+                self._proc.stdin.flush()
+        except (BrokenPipeError, OSError, ConnectionError):
+            pass
+
+    # ── Internals: close ────────────────────────────────────────────
+
+    def _close_tcp(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+
+    def _close_stdio(self) -> None:
+        with contextlib.suppress(Exception):
+            self._proc.stdin.close()
+        try:
+            self._proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+        # Clear PID file so a future incarnation starts fresh.
+        register_bridge(None)
+
+    # ── Internals: read loops ───────────────────────────────────────
+
+    def _read_loop_tcp(self) -> None:
+        """Read line-delimited JSON from the TCP socket."""
+        transport = self._transport
+        if transport is None:
+            return
+        while not self._closed:
+            try:
+                line = transport.read_line()
+            except (OSError, ConnectionError):
+                if not self._closed:
+                    logger.error("bridge_client: TCP read error, reader exiting")
+                break
+            if line is None:
+                if not self._closed:
+                    logger.warning("bridge_client: TCP connection closed by peer")
+                break
+            line = line.strip()
+            if not line:
+                continue
+            self._dispatch(line)
+        # If the socket died but the client isn't closed, try a reconnect
+        # in the background.  The next request() call will also trigger
+        # reconnection via _write_or_raise.
+        if not self._closed and self._transport is not None:
+            logger.info("bridge_client: TCP reader lost; will reconnect on next request")
+
+    def _read_loop_stdio(self) -> None:
         assert self._proc.stdout is not None
         for line in self._proc.stdout:
             line = line.strip()
             if not line:
                 continue
-            try:
-                msg = json.loads(line)
-            except json.JSONDecodeError:
-                logger.debug("bridge: malformed line: %r", line[:120])
-                continue
-            if "id" in msg and msg["id"] is not None and ("result" in msg or "error" in msg):
-                self._resolve(msg)
-                continue
-            if msg.get("method") == "events.notify":
-                for cb in list(self._events):
-                    try:
-                        cb(msg.get("params") or {})
-                    except Exception:
-                        logger.debug("event listener threw", exc_info=True)
-                continue
-            if msg.get("method") == "logs.forward":
-                for cb in list(self._logs):
-                    try:
-                        cb(msg.get("params") or {})
-                    except Exception:
-                        logger.debug("log listener threw", exc_info=True)
-                continue
+            self._dispatch(line)
 
     def _stderr_loop(self) -> None:
         assert self._proc.stderr is not None
@@ -225,6 +365,33 @@ class MemosBridgeClient:
             line = line.rstrip()
             if line:
                 logger.debug("bridge.stderr: %s", line)
+
+    # ── Common dispatch ─────────────────────────────────────────────
+
+    def _dispatch(self, line: str) -> None:
+        """Parse a JSON-RPC line and route it to the right handler."""
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            logger.debug("bridge: malformed line: %r", line[:120])
+            return
+        if "id" in msg and msg["id"] is not None and ("result" in msg or "error" in msg):
+            self._resolve(msg)
+            return
+        if msg.get("method") == "events.notify":
+            for cb in list(self._events):
+                try:
+                    cb(msg.get("params") or {})
+                except Exception:
+                    logger.debug("event listener threw", exc_info=True)
+            return
+        if msg.get("method") == "logs.forward":
+            for cb in list(self._logs):
+                try:
+                    cb(msg.get("params") or {})
+                except Exception:
+                    logger.debug("log listener threw", exc_info=True)
+            return
 
     def _resolve(self, msg: dict[str, Any]) -> None:
         rpc_id = msg.get("id")

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -116,7 +116,7 @@ class MemosBridgeClient:
         self._events: list[Callable[[dict[str, Any]], None]] = []
         self._logs: list[Callable[[dict[str, Any]], None]] = []
         self._closed = False
-        self._tcp_mode = tcp_host is not None
+        self._tcp_mode = tcp_host is not None or tcp_port is not None
 
         if self._tcp_mode:
             self._tcp_host = tcp_host or DEFAULT_TCP_HOST

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -71,6 +71,10 @@ class _SocketTransport:
 
     def close(self) -> None:
         try:
+            self._rfile.close()
+        except Exception:
+            pass
+        try:
             self._sock.shutdown(_socket.SHUT_RDWR)
         except OSError:
             pass

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -61,7 +61,9 @@ class _SocketTransport:
         self._rfile = self._sock.makefile("r", buffering=1, encoding="utf-8")
 
     def write_line(self, text: str) -> None:
-        self._sock.sendall((text + "\n").encode("utf-8"))
+        # Avoid double newline: callers may or may not include \n.
+        payload = text if text.endswith("\n") else text + "\n"
+        self._sock.sendall(payload.encode("utf-8"))
 
     def read_line(self) -> str | None:
         line = self._rfile.readline()

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -194,7 +194,11 @@ class MemosBridgeClient:
     def _reconnect_tcp(self) -> None:
         """Attempt transparent reconnection after transport loss."""
         logger.warning("bridge_client: TCP transport lost, reconnecting…")
+        old = self._transport
         self._transport = None
+        if old is not None:
+            with contextlib.suppress(Exception):
+                old.close()
         self._connect_tcp()
         # Re-send session greetings so the daemon knows this client is alive.
         # The daemon treats a new TCP connection as a new client — no session

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -22,6 +22,9 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+# Ensure at-most-one bridge instance via PID file.
+from daemon_manager import kill_existing_bridge, register_bridge
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -72,9 +75,16 @@ class MemosBridgeClient:
         script = bridge_path or str(
             Path(__file__).resolve().parent.parent.parent.parent / "bridge.cts"
         )
+        tsx_bin = str(
+            Path(__file__).resolve().parent.parent.parent.parent / "node_modules" / ".bin" / "tsx"
+        )
+        runtime = tsx_bin if Path(tsx_bin).exists() else node
+        runtime_args = [] if Path(tsx_bin).exists() else ["--experimental-strip-types"]
         env = {**os.environ, **(extra_env or {})}
+        # Kill any previously-running bridge before spawning a new one.
+        kill_existing_bridge()
         self._proc = subprocess.Popen(
-            [node, "--experimental-strip-types", script, f"--agent={agent}"],
+            [runtime, *runtime_args, script, f"--agent={agent}"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -82,6 +92,8 @@ class MemosBridgeClient:
             bufsize=1,
             env=env,
         )
+        # Register the new process so daemon_manager can track it.
+        register_bridge(self._proc)
         self._reader = threading.Thread(
             target=self._read_loop,
             daemon=True,
@@ -163,6 +175,8 @@ class MemosBridgeClient:
             self._proc.wait(timeout=5.0)
         except subprocess.TimeoutExpired:
             self._proc.kill()
+        # Clear PID file so a future incarnation starts fresh.
+        register_bridge(None)
         # unblock any pending waiters
         with self._lock:
             for entry in list(self._pending.values()):

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -5,6 +5,8 @@ Responsibilities:
 - Probe Node.js availability so ``MemTensorProvider.is_available`` can
   answer cheaply at plugin-startup time.
 - Graceful shutdown helpers invoked from ``MemTensorProvider.shutdown``.
+- PID file management to prevent duplicate bridge processes across
+  Hermes session restarts.
 
 This file intentionally has **no runtime dependency** on the client; the
 provider instantiates its own client. Keeping these concerns split means
@@ -17,9 +19,12 @@ the dependency graph for the Hermes plugin stays acyclic:
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import signal
 import subprocess
 import threading
+import time
 
 from pathlib import Path
 
@@ -28,6 +33,41 @@ logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
 _bridge_ok: bool | None = None
+_ACTIVE_BRIDGE_PROC: subprocess.Popen | None = None
+
+
+# ─── PID file helpers ────────────────────────────────────────────────────
+
+
+def _pid_path() -> Path:
+    """Path to the singleton PID file under the plugin data directory."""
+    return Path(__file__).resolve().parent.parent.parent.parent / "data" / "bridge.pid"
+
+
+def _read_pid() -> int | None:
+    try:
+        return int(_pid_path().read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def _write_pid(pid: int) -> None:
+    _pid_path().write_text(str(pid))
+
+
+def _clean_pid() -> None:
+    _pid_path().unlink(missing_ok=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
+# ─── Bridge lifecycle ────────────────────────────────────────────────────
 
 
 def _bridge_script() -> Path:
@@ -69,8 +109,55 @@ def ensure_bridge_running(*, probe_only: bool = False) -> bool:
         return True
 
 
+def kill_existing_bridge() -> None:
+    """Kill any previously-running bridge process recorded in the PID file.
+
+    Called **before** spawning a new bridge to guarantee at-most-one
+    instance. Safe to call even when no stale PID exists.
+    """
+    pid = _read_pid()
+    if pid is not None and _pid_alive(pid):
+        logger.info("MemOS: killing stale bridge (pid=%d)", pid)
+        try:
+            os.kill(pid, signal.SIGTERM)
+            for _ in range(25):  # wait up to 2.5 s
+                if not _pid_alive(pid):
+                    break
+                time.sleep(0.1)
+            else:
+                os.kill(pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            pass
+    _clean_pid()
+
+
+def register_bridge(proc: subprocess.Popen | None) -> None:
+    """Record the current running bridge process.
+
+    Pass ``None`` (e.g. on close) to clear the registration and PID file.
+    """
+    global _ACTIVE_BRIDGE_PROC
+    _ACTIVE_BRIDGE_PROC = proc
+    if proc is not None:
+        _write_pid(proc.pid)
+    else:
+        _clean_pid()
+
+
 def shutdown_bridge() -> None:
-    """Best-effort cleanup; each client owns its own subprocess."""
-    global _bridge_ok
+    """Gracefully shut down the tracked bridge subprocess and clean PID file."""
+    global _bridge_ok, _ACTIVE_BRIDGE_PROC
     with _lock:
         _bridge_ok = None
+    if _ACTIVE_BRIDGE_PROC is not None:
+        try:
+            _ACTIVE_BRIDGE_PROC.terminate()
+            _ACTIVE_BRIDGE_PROC.wait(timeout=5.0)
+            logger.info("MemOS: bridge terminated (pid=%d)", _ACTIVE_BRIDGE_PROC.pid)
+        except subprocess.TimeoutExpired:
+            _ACTIVE_BRIDGE_PROC.kill()
+            logger.warning("MemOS: bridge killed after timeout (pid=%d)", _ACTIVE_BRIDGE_PROC.pid)
+        except Exception:
+            pass
+        _ACTIVE_BRIDGE_PROC = None
+    _clean_pid()

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -40,7 +40,15 @@ _ACTIVE_BRIDGE_PROC: subprocess.Popen | None = None
 
 
 def _pid_path() -> Path:
-    """Path to the singleton PID file under the plugin data directory."""
+    """Path to the singleton PID file under the runtime daemon directory.
+
+    Respects ``MEMOS_HOME`` when set (``~/.hermes/memos-plugin`` by
+    convention), falling back to the plugin source tree only when the env
+    var is absent for compatibility with development installs.
+    """
+    memos_home = os.environ.get("MEMOS_HOME")
+    if memos_home:
+        return Path(memos_home) / "daemon" / "bridge.pid"
     return Path(__file__).resolve().parent.parent.parent.parent / "data" / "bridge.pid"
 
 
@@ -111,25 +119,66 @@ def ensure_bridge_running(*, probe_only: bool = False) -> bool:
         return True
 
 
+def _is_bridge_process(pid: int) -> bool:
+    """Return True when *pid* looks like a bridge process.
+
+    Checks the process command line for ``bridge.cts`` to avoid killing an
+    unrelated process that happened to recycle a stale PID.
+    """
+    try:
+        if os.name == "nt":
+            import ctypes
+
+            import ctypes.wintypes
+
+            kernel32 = ctypes.windll.kernel32
+            handle = kernel32.OpenProcess(0x0400 | 0x0010, False, pid)
+            if not handle:
+                return False
+            try:
+                exe_path = (ctypes.c_wchar * 260)()
+                size = ctypes.wintypes.DWORD(260)
+                if kernel32.K32GetProcessImageFileNameW(handle, exe_path, size):
+                    return "bridge" in str(exe_path.value).lower()
+            finally:
+                kernel32.CloseHandle(handle)
+            return False
+        # Unix: read /proc/<pid>/cmdline
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
+        return b"bridge.cts" in cmdline
+    except Exception:
+        # If we can't validate, err on the side of safety — skip kill.
+        return False
+
+
 def kill_existing_bridge() -> None:
     """Kill any previously-running bridge process recorded in the PID file.
 
     Called **before** spawning a new bridge to guarantee at-most-one
-    instance. Safe to call even when no stale PID exists.
+    instance. Validates that the PID belongs to a bridge process before
+    sending any signal to avoid killing an unrelated process when the
+    PID file is stale.
     """
     pid = _read_pid()
     if pid is not None and _pid_alive(pid):
-        logger.info("MemOS: killing stale bridge (pid=%d)", pid)
-        try:
-            os.kill(pid, signal.SIGTERM)
-            for _ in range(25):  # wait up to 2.5 s
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.1)
-            else:
-                os.kill(pid, signal.SIGKILL)
-        except (OSError, ProcessLookupError):
-            pass
+        if not _is_bridge_process(pid):
+            logger.warning(
+                "MemOS: PID %d is alive but does not appear to be a bridge "
+                "process — refusing to kill. Removing stale PID file.",
+                pid,
+            )
+        else:
+            logger.info("MemOS: killing stale bridge (pid=%d)", pid)
+            try:
+                os.kill(pid, signal.SIGTERM)
+                for _ in range(25):  # wait up to 2.5 s
+                    if not _pid_alive(pid):
+                        break
+                    time.sleep(0.1)
+                else:
+                    os.kill(pid, signal.SIGKILL)
+            except (OSError, ProcessLookupError):
+                pass
     _clean_pid()
 
 

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -52,7 +52,9 @@ def _read_pid() -> int | None:
 
 
 def _write_pid(pid: int) -> None:
-    _pid_path().write_text(str(pid))
+    pid_path = _pid_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(pid))
 
 
 def _clean_pid() -> None:

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -91,8 +91,8 @@ export interface MemoryCore {
     userMessage?: string;
   }): Promise<EpisodeId>;
   closeEpisode(episodeId: EpisodeId): Promise<void>;
-  deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }>;
-  deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }>;
+  deleteEpisode?(episodeId: EpisodeId): Promise<{ deleted: boolean }>;
+  deleteEpisodes?(ids: readonly EpisodeId[]): Promise<{ deleted: number }>;
 
   // ── pipeline (per turn) ──
   /** Called *before* the agent acts. Returns the context to inject. */

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -91,8 +91,8 @@ export interface MemoryCore {
     userMessage?: string;
   }): Promise<EpisodeId>;
   closeEpisode(episodeId: EpisodeId): Promise<void>;
-  deleteEpisode?(episodeId: EpisodeId): Promise<{ deleted: boolean }>;
-  deleteEpisodes?(ids: readonly EpisodeId[]): Promise<{ deleted: number }>;
+  deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }>;
+  deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }>;
 
   // ── pipeline (per turn) ──
   /** Called *before* the agent acts. Returns the context to inject. */

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -91,6 +91,8 @@ export interface MemoryCore {
     userMessage?: string;
   }): Promise<EpisodeId>;
   closeEpisode(episodeId: EpisodeId): Promise<void>;
+  deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }>;
+  deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }>;
 
   // ── pipeline (per turn) ──
   /** Called *before* the agent acts. Returns the context to inject. */

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -61,8 +61,10 @@ async function main(): Promise<void> {
   });
   await core.init();
 
-  // Default transport: stdio. Start TCP only in daemon mode when a port was given.
-  const stdio = startStdioServer({ core });
+  // In daemon mode stdin is typically /dev/null — starting the stdio
+  // server would subscribe to events/logs and buffer writes to a pipe
+  // that nobody drains, wasting memory. Skip it.
+  const stdio = args.daemon ? null : startStdioServer({ core });
   let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
   if (args.tcpPort !== undefined && !args.daemon) {
     process.stderr.write(
@@ -143,7 +145,15 @@ async function main(): Promise<void> {
     } catch {
       /* best-effort */
     }
-    await waitForShutdown(core, stdio);
+    if (stdio) {
+      await waitForShutdown(core, stdio);
+    } else {
+      try {
+        await core.shutdown();
+      } catch {
+        /* swallow */
+      }
+    }
     process.exit(0);
   };
 
@@ -155,7 +165,7 @@ async function main(): Promise<void> {
   if (args.daemon && tcpServer) {
     await tcpServer.done;
     await shutdown("daemon_done");
-  } else {
+  } else if (stdio) {
     await stdio.done;
     try {
       if (viewer) await viewer.close();
@@ -164,6 +174,9 @@ async function main(): Promise<void> {
     }
     await core.shutdown();
     process.exit(0);
+  } else {
+    // Daemon mode without TCP — wait forever (kept alive by event loop).
+    await new Promise(() => {});
   }
 }
 

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -45,6 +45,9 @@ async function main(): Promise<void> {
   const { startStdioServer, waitForShutdown } = (await import(
     pathToEsmUrl(path.resolve(__dirname, "bridge/stdio.ts"))
   )) as typeof import("./bridge/stdio.js");
+  const { startTcpServer } = (await import(
+    pathToEsmUrl(path.resolve(__dirname, "bridge/tcp.ts"))
+  )) as typeof import("./bridge/tcp.js");
   const { startHttpServer } = (await import(
     pathToEsmUrl(path.resolve(__dirname, "server/index.ts"))
   )) as typeof import("./server/index.js");
@@ -58,8 +61,24 @@ async function main(): Promise<void> {
   });
   await core.init();
 
-  // Default transport: stdio. Daemon + TCP support arrives in V1.1.
+  // Default transport: stdio. In daemon mode, also start TCP if a port was given.
   const stdio = startStdioServer({ core });
+
+  let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
+  if (args.tcpPort !== undefined) {
+    try {
+      tcpServer = startTcpServer({
+        core,
+        host: "127.0.0.1",
+        port: args.tcpPort,
+      });
+      process.stderr.write(`bridge: tcp → ${tcpServer.url}\n`);
+    } catch (err) {
+      process.stderr.write(
+        `bridge: tcp server failed to start: ${(err as Error).message}\n`,
+      );
+    }
+  }
 
   // Boot a viewer too — hermes needs its own HTTP surface for the
   // Memory Viewer, and it discovers the openclaw hub (if any) so
@@ -98,6 +117,11 @@ async function main(): Promise<void> {
   const shutdown = async (sig: string) => {
     process.stderr.write(`bridge: received ${sig}, shutting down\n`);
     try {
+      if (tcpServer) await tcpServer.close();
+    } catch {
+      /* best-effort */
+    }
+    try {
       if (viewer) await viewer.close();
     } catch {
       /* best-effort */
@@ -109,10 +133,11 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => void shutdown("SIGINT"));
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
-  // In daemon mode, run indefinitely (stdin is /dev/null — EOF is normal).
+  // In daemon mode, keep alive until TCP server stops (stdin is /dev/null).
   // In stdio mode, run until the calling process closes stdin.
-  if (args.daemon) {
-    await new Promise(() => {});  // never resolve → process lives forever
+  if (args.daemon && tcpServer) {
+    await tcpServer.done;
+    await shutdown("daemon_done");
   } else {
     await stdio.done;
     try {

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -61,11 +61,14 @@ async function main(): Promise<void> {
   });
   await core.init();
 
-  // Default transport: stdio. In daemon mode, also start TCP if a port was given.
+  // Default transport: stdio. Start TCP only in daemon mode when a port was given.
   const stdio = startStdioServer({ core });
-
   let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
-  if (args.tcpPort !== undefined) {
+  if (args.tcpPort !== undefined && !args.daemon) {
+    process.stderr.write(
+      "bridge: ignoring --tcp because TCP mode requires --daemon\n",
+    );
+  } else if (args.tcpPort !== undefined) {
     if (!Number.isFinite(args.tcpPort) || args.tcpPort < 1 || args.tcpPort > 65535) {
       process.stderr.write(
         `bridge: invalid --tcp port value: ${String(args.tcpPort)} (must be 1–65535)\n`,
@@ -83,6 +86,10 @@ async function main(): Promise<void> {
         process.stderr.write(
           `bridge: tcp server failed to start: ${(err as Error).message}\n`,
         );
+        if (tcpServer) {
+          await tcpServer.close().catch(() => {});
+          tcpServer = null;
+        }
       }
     }
   }

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -77,6 +77,7 @@ async function main(): Promise<void> {
           host: "127.0.0.1",
           port: args.tcpPort,
         });
+        await tcpServer.ready;  // throws on EADDRINUSE etc.
         process.stderr.write(`bridge: tcp → ${tcpServer.url}\n`);
       } catch (err) {
         process.stderr.write(

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -120,8 +120,12 @@ async function main(): Promise<void> {
       `bridge: viewer failed to start: ${(err as Error).message}\n`,
     );
   }
+  let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
+  let shuttingDown = false;
 
   const shutdown = async (sig: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     process.stderr.write(`bridge: received ${sig}, shutting down\n`);
     try {
       if (tcpServer) await tcpServer.close();

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -15,6 +15,7 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require("node:path") as typeof import("node:path");
+const pkgVersion: string = (require(path.resolve(__dirname, "package.json")) as { version: string }).version;
 
 interface BridgeArgs {
   daemon: boolean;
@@ -53,7 +54,7 @@ async function main(): Promise<void> {
 
   const { core, config, home } = await bootstrapMemoryCoreFull({
     agent: args.agent,
-    pkgVersion: "2.0.0-alpha.1",
+    pkgVersion,
   });
   await core.init();
 
@@ -108,15 +109,20 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => void shutdown("SIGINT"));
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
-  // Keep the process alive until stdin ends.
-  await stdio.done;
-  try {
-    if (viewer) await viewer.close();
-  } catch {
-    /* best-effort */
+  // In daemon mode, run indefinitely (stdin is /dev/null — EOF is normal).
+  // In stdio mode, run until the calling process closes stdin.
+  if (args.daemon) {
+    await new Promise(() => {});  // never resolve → process lives forever
+  } else {
+    await stdio.done;
+    try {
+      if (viewer) await viewer.close();
+    } catch {
+      /* best-effort */
+    }
+    await core.shutdown();
+    process.exit(0);
   }
-  await core.shutdown();
-  process.exit(0);
 }
 
 async function tryHubRegister(opts: {
@@ -127,7 +133,7 @@ async function tryHubRegister(opts: {
   const body = JSON.stringify({
     agent: opts.selfAgent,
     port: opts.selfPort,
-    version: "2.0.0-alpha.1",
+    version: pkgVersion,
   });
   for (let i = 0; i < 6; i++) {
     try {

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -66,17 +66,23 @@ async function main(): Promise<void> {
 
   let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
   if (args.tcpPort !== undefined) {
-    try {
-      tcpServer = startTcpServer({
-        core,
-        host: "127.0.0.1",
-        port: args.tcpPort,
-      });
-      process.stderr.write(`bridge: tcp → ${tcpServer.url}\n`);
-    } catch (err) {
+    if (!Number.isFinite(args.tcpPort) || args.tcpPort < 1 || args.tcpPort > 65535) {
       process.stderr.write(
-        `bridge: tcp server failed to start: ${(err as Error).message}\n`,
+        `bridge: invalid --tcp port value: ${String(args.tcpPort)} (must be 1–65535)\n`,
       );
+    } else {
+      try {
+        tcpServer = startTcpServer({
+          core,
+          host: "127.0.0.1",
+          port: args.tcpPort,
+        });
+        process.stderr.write(`bridge: tcp → ${tcpServer.url}\n`);
+      } catch (err) {
+        process.stderr.write(
+          `bridge: tcp server failed to start: ${(err as Error).message}\n`,
+        );
+      }
     }
   }
 

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -120,7 +120,6 @@ async function main(): Promise<void> {
       `bridge: viewer failed to start: ${(err as Error).message}\n`,
     );
   }
-  let tcpServer: Awaited<ReturnType<typeof startTcpServer>> | null = null;
   let shuttingDown = false;
 
   const shutdown = async (sig: string) => {

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -41,6 +41,8 @@ export interface TcpServerOptions {
 
 export interface TcpServerHandle {
   readonly url: string;
+  /** Resolves once the server is actually listening, rejects on error. */
+  ready: Promise<void>;
   close: () => Promise<void>;
   done: Promise<void>;
 }
@@ -172,18 +174,26 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
     });
   });
 
-  server.on("error", (err) => {
-    process.stderr.write(`bridge.tcp: server error: ${err.message}\n`);
+  // Wrap listen in a promise so callers can catch EADDRINUSE etc.
+  const listenPromise = new Promise<void>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(port, host, () => {
+      process.stderr.write(`bridge.tcp: listening on ${host}:${port}\n`);
+      resolve();
+    });
   });
-
-  server.listen(port, host, () => {
-    process.stderr.write(`bridge.tcp: listening on ${host}:${port}\n`);
-  });
+  // Once listening, switch error handler to non-fatal logging.
+  listenPromise.then(
+    () => server.removeAllListeners("error"),
+    () => {}, // rejection handled by caller
+  );
 
   return {
     get url() {
       return `tcp://${host}:${port}`;
     },
+    /** Resolves once the server is actually listening. */
+    ready: listenPromise,
     async close() {
       if (closed) return;
       closed = true;

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -171,7 +171,9 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
     sock.on("error", (err) => {
       process.stderr.write(`bridge.tcp: socket error: ${err.message}\n`);
       clients.delete(sock);
-      sock.destroy();
+      if (!sock.destroyed) {
+        sock.destroy();
+      }
     });
   });
 

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -117,7 +117,7 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
       return;
     }
 
-    if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0" || !msg.method) {
+    if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0" || typeof msg.method !== "string") {
       writeLine(sock, errorResponse(msg?.id ?? null, JSONRPC_INVALID_REQUEST, "not JSON-RPC 2.0"));
       return;
     }
@@ -171,6 +171,7 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
     sock.on("error", (err) => {
       process.stderr.write(`bridge.tcp: socket error: ${err.message}\n`);
       clients.delete(sock);
+      sock.destroy();
     });
   });
 

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -178,18 +178,21 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
   });
 
   // Wrap listen in a promise so callers can catch EADDRINUSE etc.
+  let isListening = false;
   const listenPromise = new Promise<void>((resolve, reject) => {
-    server.on("error", reject);
+    server.on("error", (err) => {
+      if (!isListening) {
+        reject(err);
+        return;
+      }
+      process.stderr.write(`bridge.tcp: server error: ${err.message}\n`);
+    });
     server.listen(port, host, () => {
+      isListening = true;
       process.stderr.write(`bridge.tcp: listening on ${host}:${port}\n`);
       resolve();
     });
   });
-  // Once listening, switch error handler to non-fatal logging.
-  listenPromise.then(
-    () => server.removeAllListeners("error"),
-    () => {}, // rejection handled by caller
-  );
 
   return {
     get url() {

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -194,7 +194,12 @@ export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
         sock.destroy();
       }
       clients.clear();
-      server.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
       doneResolve();
     },
     done: donePromise,

--- a/apps/memos-local-plugin/bridge/tcp.ts
+++ b/apps/memos-local-plugin/bridge/tcp.ts
@@ -1,0 +1,202 @@
+/**
+ * Line-delimited JSON-RPC over TCP.
+ *
+ * A TCP server that accepts connections from remote clients (e.g. the
+ * Hermes Python provider) and dispatches JSON-RPC 2.0 messages through
+ * the same `Dispatcher` used by the stdio server.
+ *
+ * Each connected client gets its own read/write loop.  Notifications
+ * (events + logs) are broadcast to all connected clients.
+ *
+ * The transport:
+ *   - Listens on the port given via `--tcp=<port>`.
+ *   - Reads each connection as UTF-8 text, splits by `\n`.
+ *   - Parses each line as JSON, dispatches via `Dispatcher`.
+ *   - Writes responses as JSON followed by `\n` to the originating socket.
+ *   - Broadcasts `LogRecord` and `CoreEvent` as JSON-RPC notifications
+ *     (method = `logs.forward` / `events.notify`) to all connected clients.
+ */
+
+import { createServer, type Socket } from "node:net";
+import {
+  JSONRPC_PARSE_ERROR,
+  JSONRPC_INVALID_REQUEST,
+  RPC_METHODS,
+  rpcCodeForError,
+  type JsonRpcFailure,
+  type JsonRpcRequest,
+  type JsonRpcSuccess,
+} from "../agent-contract/jsonrpc.js";
+import type { MemoryCore } from "../agent-contract/memory-core.js";
+import { MemosError } from "../agent-contract/errors.js";
+import { errorCodeOf, makeDispatcher } from "./methods.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface TcpServerOptions {
+  core: MemoryCore;
+  host: string;
+  port: number;
+}
+
+export interface TcpServerHandle {
+  readonly url: string;
+  close: () => Promise<void>;
+  done: Promise<void>;
+}
+
+// ─── Server ─────────────────────────────────────────────────────────────────
+
+export function startTcpServer(options: TcpServerOptions): TcpServerHandle {
+  const { core, host, port } = options;
+  const dispatch = makeDispatcher(core);
+
+  const clients = new Set<Socket>();
+  let closed = false;
+  let doneResolve: () => void;
+  const donePromise = new Promise<void>((resolve) => {
+    doneResolve = resolve;
+  });
+
+  // Subscribe to events + logs and broadcast to all connected clients.
+  const eventsUnsub = core.subscribeEvents((e) => {
+    broadcast({ jsonrpc: "2.0", method: RPC_METHODS.EVENTS_NOTIFY, params: e });
+  });
+  const logsUnsub = core.subscribeLogs((r) => {
+    broadcast({ jsonrpc: "2.0", method: RPC_METHODS.LOGS_FORWARD, params: r });
+  });
+
+  function broadcast(obj: unknown): void {
+    const payload = JSON.stringify(obj) + "\n";
+    for (const sock of clients) {
+      try {
+        sock.write(payload);
+      } catch {
+        /* best-effort per client */
+      }
+    }
+  }
+
+  function errorResponse(
+    id: JsonRpcRequest["id"] | null,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): JsonRpcFailure {
+    return {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error: { code, message, data: data as any },
+    };
+  }
+
+  function writeLine(sock: Socket, obj: unknown): void {
+    try {
+      sock.write(JSON.stringify(obj) + "\n");
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function handleLine(sock: Socket, line: string): Promise<void> {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return;
+
+    let msg: JsonRpcRequest | null = null;
+    try {
+      msg = JSON.parse(trimmed) as JsonRpcRequest;
+    } catch (err) {
+      writeLine(
+        sock,
+        errorResponse(null, JSONRPC_PARSE_ERROR, "invalid JSON", {
+          text: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return;
+    }
+
+    if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0" || !msg.method) {
+      writeLine(sock, errorResponse(msg?.id ?? null, JSONRPC_INVALID_REQUEST, "not JSON-RPC 2.0"));
+      return;
+    }
+
+    try {
+      const result = await dispatch(msg.method, msg.params);
+      if (msg.id !== undefined && msg.id !== null) {
+        const ok: JsonRpcSuccess = { jsonrpc: "2.0", id: msg.id, result };
+        writeLine(sock, ok);
+      }
+    } catch (err) {
+      const code = rpcCodeForError(errorCodeOf(err));
+      const mErr =
+        err instanceof MemosError
+          ? err
+          : new MemosError("internal", err instanceof Error ? err.message : String(err));
+      writeLine(sock, errorResponse(msg.id ?? null, code, mErr.message, mErr.toJSON()));
+      process.stderr.write(`bridge.tcp.dispatch.err ${msg.method}: ${mErr.message}\n`);
+    }
+  }
+
+  // ─── Server ───────────────────────────────────────────────────────────────
+
+  const server = createServer((sock: Socket) => {
+    clients.add(sock);
+    process.stderr.write(
+      `bridge.tcp: client connected (${sock.remoteAddress ?? "unknown"}:${sock.remotePort ?? "?"})\n`,
+    );
+
+    let buffer = "";
+    sock.setEncoding("utf8");
+
+    sock.on("data", (chunk: string) => {
+      buffer += chunk;
+      let nl = buffer.indexOf("\n");
+      while (nl >= 0) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        void handleLine(sock, line);
+        nl = buffer.indexOf("\n");
+      }
+    });
+
+    sock.on("close", () => {
+      clients.delete(sock);
+      process.stderr.write(
+        `bridge.tcp: client disconnected (${sock.remoteAddress ?? "unknown"}:${sock.remotePort ?? "?"})\n`,
+      );
+    });
+
+    sock.on("error", (err) => {
+      process.stderr.write(`bridge.tcp: socket error: ${err.message}\n`);
+      clients.delete(sock);
+    });
+  });
+
+  server.on("error", (err) => {
+    process.stderr.write(`bridge.tcp: server error: ${err.message}\n`);
+  });
+
+  server.listen(port, host, () => {
+    process.stderr.write(`bridge.tcp: listening on ${host}:${port}\n`);
+  });
+
+  return {
+    get url() {
+      return `tcp://${host}:${port}`;
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      eventsUnsub();
+      logsUnsub();
+      for (const sock of clients) {
+        sock.end();
+        sock.destroy();
+      }
+      clients.clear();
+      server.close();
+      doneResolve();
+    },
+    done: donePromise,
+  };
+}

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -642,13 +642,27 @@ export function createMemoryCore(
     handle.sessionManager.finalizeEpisode(episodeId);
   }
 
+  function assertEpisodeDeletable(episodeId: EpisodeId): void {
+    const snap = handle.sessionManager.getEpisode(episodeId);
+    if (snap?.status === "open") {
+      throw new MemosError(
+        "conflict",
+        `cannot delete open episode: ${episodeId}`,
+      );
+    }
+  }
+
   async function deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }> {
     ensureLive();
+    assertEpisodeDeletable(episodeId);
     return { deleted: handle.repos.episodes.deleteById(episodeId) };
   }
 
   async function deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }> {
     ensureLive();
+    for (const id of ids) {
+      assertEpisodeDeletable(id);
+    }
     let deleted = 0;
     for (const id of ids) {
       if (handle.repos.episodes.deleteById(id)) deleted++;

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -332,9 +332,19 @@ export function createMemoryCore(
     // to `closed` + sets `closeReason: "abandoned"` without touching
     // trace_ids_json.
     try {
-      const orphans = handle.repos.episodes.list({ status: "open", limit: 500 });
+      const openEpisodes = handle.repos.episodes.list({ status: "open", limit: 500 });
+      // Only treat an open episode as an orphan if its session has been
+      // explicitly closed (meta.closedAt is set) or no longer exists.
+      // Otherwise the session might reconnect — leave it alone.
+      const orphans = openEpisodes.filter((ep) => {
+        const session = handle.repos.sessions.getById(ep.sessionId);
+        if (!session) return true; // session row gone — orphan
+        if (session.meta?.closedAt != null) return true; // explicitly closed — orphan
+        return false; // session exists and not closed — skip, might reconnect
+      });
       if (orphans.length > 0) {
-        log.info("init.orphan_episodes.close", { count: orphans.length });
+        const skipped = openEpisodes.length - orphans.length;
+        log.info("init.orphan_episodes.close", { count: orphans.length, skipped });
         const endedAt = Date.now();
         for (const ep of orphans) {
           try {
@@ -630,6 +640,20 @@ export function createMemoryCore(
     }
     if (snap.status === "closed") return;
     handle.sessionManager.finalizeEpisode(episodeId);
+  }
+
+  async function deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }> {
+    ensureLive();
+    return { deleted: handle.repos.episodes.deleteById(episodeId) };
+  }
+
+  async function deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }> {
+    ensureLive();
+    let deleted = 0;
+    for (const id of ids) {
+      if (handle.repos.episodes.deleteById(id)) deleted++;
+    }
+    return { deleted };
   }
 
   // ─── Pipeline (per turn) ──
@@ -1947,6 +1971,8 @@ export function createMemoryCore(
     closeSession,
     openEpisode,
     closeEpisode,
+    deleteEpisode,
+    deleteEpisodes,
     onTurnStart,
     onTurnEnd,
     submitFeedback,

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -333,11 +333,17 @@ export function createMemoryCore(
     // trace_ids_json.
     try {
       const openEpisodes = handle.repos.episodes.list({ status: "open", limit: 500 });
+      // Batch-fetch sessions to avoid N+1 lookups per episode.
+      const sessionIds = new Set(openEpisodes.map((ep) => ep.sessionId));
+      const sessionById = new Map<string, ReturnType<typeof handle.repos.sessions.getById>>();
+      for (const sid of sessionIds) {
+        sessionById.set(sid, handle.repos.sessions.getById(sid));
+      }
       // Only treat an open episode as an orphan if its session has been
       // explicitly closed (meta.closedAt is set) or no longer exists.
       // Otherwise the session might reconnect — leave it alone.
       const orphans = openEpisodes.filter((ep) => {
-        const session = handle.repos.sessions.getById(ep.sessionId);
+        const session = sessionById.get(ep.sessionId);
         if (!session) return true; // session row gone — orphan
         if (session.meta?.closedAt != null) return true; // explicitly closed — orphan
         return false; // session exists and not closed — skip, might reconnect
@@ -648,6 +654,14 @@ export function createMemoryCore(
       throw new MemosError(
         "conflict",
         `cannot delete open episode: ${episodeId}`,
+      );
+    }
+    // After restart the in-memory manager may not have this episode,
+    // but it might still be open in SQLite — double-check the DB.
+    if (!snap && handle.repos.episodes.getById(episodeId)?.status === "open") {
+      throw new MemosError(
+        "conflict",
+        `cannot delete open episode: ${episodeId} (open in DB)`,
       );
     }
   }

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -666,20 +666,31 @@ export function createMemoryCore(
     }
   }
 
+  function deleteClosedEpisode(episodeId: EpisodeId): boolean {
+    const existing = handle.repos.episodes.getById(episodeId);
+    assertEpisodeDeletable(episodeId);
+    const deleted = handle.repos.episodes.deleteById(episodeId);
+    // Guard against regressions where deletion silently becomes a no-op
+    // for an existing closed episode. Missing episodes return `false`.
+    if (existing && !deleted) {
+      throw new MemosError(
+        "internal",
+        `failed to delete closed episode: ${episodeId}`,
+      );
+    }
+    return deleted;
+  }
+
   async function deleteEpisode(episodeId: EpisodeId): Promise<{ deleted: boolean }> {
     ensureLive();
-    assertEpisodeDeletable(episodeId);
-    return { deleted: handle.repos.episodes.deleteById(episodeId) };
+    return { deleted: deleteClosedEpisode(episodeId) };
   }
 
   async function deleteEpisodes(ids: readonly EpisodeId[]): Promise<{ deleted: number }> {
     ensureLive();
-    for (const id of ids) {
-      assertEpisodeDeletable(id);
-    }
     let deleted = 0;
     for (const id of ids) {
-      if (handle.repos.episodes.deleteById(id)) deleted++;
+      if (deleteClosedEpisode(id)) deleted++;
     }
     return { deleted };
   }

--- a/apps/memos-local-plugin/core/session/manager.ts
+++ b/apps/memos-local-plugin/core/session/manager.ts
@@ -143,6 +143,14 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     for (const ep of epm.listForSession(id)) {
       if (ep.status === "open") epm.abandon(ep.id, `session_closed:${reason}`);
     }
+    // Stamp the session row with closedAt so future bridge init()
+    // can distinguish "explicitly closed" from "might reconnect".
+    try {
+      const row = deps.sessionsRepo.getById(id);
+      if (row) {
+        deps.sessionsRepo.touchLastSeen(id, Date.now(), { closedAt: Date.now() });
+      }
+    } catch { /* best-effort */ }
     live.delete(id);
     log.info("session.closed", { sessionId: id, reason });
     bus.emit({ kind: "session.closed", sessionId: id, reason });

--- a/apps/memos-local-plugin/core/session/manager.ts
+++ b/apps/memos-local-plugin/core/session/manager.ts
@@ -148,7 +148,8 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     try {
       const row = deps.sessionsRepo.getById(id);
       if (row) {
-        deps.sessionsRepo.touchLastSeen(id, Date.now(), { closedAt: Date.now() });
+        const ts = now();
+        deps.sessionsRepo.touchLastSeen(id, ts, { closedAt: ts });
       }
     } catch { /* best-effort */ }
     live.delete(id);

--- a/apps/memos-local-plugin/core/storage/repos/episodes.ts
+++ b/apps/memos-local-plugin/core/storage/repos/episodes.ts
@@ -90,6 +90,13 @@ export function makeEpisodesRepo(db: StorageDb) {
       ).run({ id });
     },
 
+    deleteById(id: EpisodeId): boolean {
+      const r = db.prepare<{ id: string }>(
+        `DELETE FROM episodes WHERE id=@id`,
+      ).run({ id });
+      return r.changes > 0;
+    },
+
     setRTask(id: EpisodeId, rTask: number): void {
       db.prepare<{ id: string; r: number }>(
         `UPDATE episodes SET r_task=@r WHERE id=@id`,

--- a/apps/memos-local-plugin/package-lock.json
+++ b/apps/memos-local-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memtensor/memos-local-plugin",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -906,9 +906,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -924,9 +921,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -944,9 +938,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -962,9 +953,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -982,9 +970,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1000,9 +985,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1020,9 +1002,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1039,9 +1018,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1057,9 +1033,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1083,9 +1056,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1107,9 +1077,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1133,9 +1100,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1157,9 +1121,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1183,9 +1144,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1208,9 +1166,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1232,9 +1187,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1700,9 +1652,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1717,9 +1666,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1734,9 +1680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1751,9 +1694,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1768,9 +1708,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1785,9 +1722,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1802,9 +1736,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1819,9 +1750,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1836,9 +1764,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,9 +1778,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1792,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,9 +1806,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/apps/memos-local-plugin/server/routes/session.ts
+++ b/apps/memos-local-plugin/server/routes/session.ts
@@ -51,8 +51,20 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "episodeId is required");
       return;
     }
-    await deps.core.closeEpisode(id as EpisodeId);
-    return { ok: true };
+    const result = await deps.core.deleteEpisode(id as EpisodeId);
+    return result;
+  });
+
+  routes.set("POST /api/v1/episodes/delete", async (ctx) => {
+    const body = parseJson<{ ids?: unknown }>(ctx);
+    const ids = Array.isArray(body.ids)
+      ? body.ids.filter((v): v is string => typeof v === "string" && v.length > 0)
+      : [];
+    if (ids.length === 0) {
+      writeError(ctx, 400, "invalid_argument", "ids[] is required");
+      return;
+    }
+    return await deps.core.deleteEpisodes(ids as EpisodeId[]);
   });
 
   routes.set("GET /api/v1/episodes", async (ctx) => {
@@ -61,10 +73,6 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
     const rawOffset = numberOrUndefined(ctx.url.searchParams.get("offset"));
     const limit = rawLimit && rawLimit > 0 ? rawLimit : 50;
     const offset = rawOffset && rawOffset >= 0 ? rawOffset : 0;
-    // Return the rich row shape — the viewer's task list needs
-    // session id / status / turn count / preview. The old `ids`-only
-    // variant is still available under the `episode.list` JSON-RPC
-    // method and via `?shape=ids`.
     if (ctx.url.searchParams.get("shape") === "ids") {
       const episodeIds = await deps.core.listEpisodes({ sessionId, limit, offset });
       return {
@@ -83,9 +91,6 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
     };
   });
 
-  // Backward-compat: legacy `/api/v1/episodes/timeline?episodeId=…`
-  // still works; the preferred path `/api/v1/episodes/:id/timeline`
-  // is registered in `trace.ts`.
   routes.set("GET /api/v1/episodes/timeline", async (ctx) => {
     const episodeId = ctx.url.searchParams.get("episodeId");
     if (!episodeId) {

--- a/apps/memos-local-plugin/server/routes/session.ts
+++ b/apps/memos-local-plugin/server/routes/session.ts
@@ -52,7 +52,7 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const result = await deps.core.deleteEpisode(id as EpisodeId);
-    return result;
+    return { ok: true, deleted: result.deleted };
   });
 
   routes.set("POST /api/v1/episodes/delete", async (ctx) => {
@@ -64,7 +64,8 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "ids[] is required");
       return;
     }
-    return await deps.core.deleteEpisodes(ids as EpisodeId[]);
+    const result = await deps.core.deleteEpisodes(ids as EpisodeId[]);
+    return { ok: true, deleted: result.deleted };
   });
 
   routes.set("GET /api/v1/episodes", async (ctx) => {

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -188,7 +188,180 @@ describe("MemoryCore façade", () => {
   });
 });
 
-describe("bootstrapMemoryCore", () => {
+describe("init() orphan episode handling", () => {
+    it("preserves open episodes for sessions that were not explicitly closed", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      // Simulate a session still active on disk — no meta.closedAt.
+      db!.repos.sessions.upsert({
+        id: "s-orphan-keep",
+        agent: "openclaw",
+        startedAt: 1_700_000_000_000,
+        lastSeenAt: 1_700_000_100_000,
+        meta: {},
+      });
+      db!.repos.episodes.insert({
+        id: "ep-orphan-keep",
+        sessionId: "s-orphan-keep",
+        startedAt: 1_700_000_000_000,
+        endedAt: null,
+        traceIds: [],
+        rTask: null,
+        status: "open",
+        meta: {},
+      });
+
+      await core.init();
+
+      const ep = db!.repos.episodes.getById("ep-orphan-keep");
+      expect(ep).not.toBeNull();
+      expect(ep!.status).toBe("open");
+    });
+
+    it("closes open episodes for sessions that were explicitly closed", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      db!.repos.sessions.upsert({
+        id: "s-orphan-close",
+        agent: "openclaw",
+        startedAt: 1_700_000_000_000,
+        lastSeenAt: 1_700_000_200_000,
+        meta: { closedAt: 1_700_000_200_000 },
+      });
+      db!.repos.episodes.insert({
+        id: "ep-orphan-close",
+        sessionId: "s-orphan-close",
+        startedAt: 1_700_000_000_000,
+        endedAt: null,
+        traceIds: [],
+        rTask: null,
+        status: "open",
+        meta: {},
+      });
+
+      await core.init();
+
+      const ep = db!.repos.episodes.getById("ep-orphan-close");
+      expect(ep).not.toBeNull();
+      expect(ep!.status).toBe("closed");
+    });
+
+    it("closes open episodes for sessions that no longer exist", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      // FK requires the session to exist first; we then delete it via
+      // raw SQL to simulate a session row that was removed (e.g. manual
+      // DB cleanup), leaving an orphan episode behind.
+      db!.repos.sessions.upsert({
+        id: "s-gone",
+        agent: "openclaw",
+        startedAt: 1_700_000_000_000,
+        lastSeenAt: 1_700_000_000_000,
+        meta: {},
+      });
+      db!.repos.episodes.insert({
+        id: "ep-no-session",
+        sessionId: "s-gone",
+        startedAt: 1_700_000_000_000,
+        endedAt: null,
+        traceIds: [],
+        rTask: null,
+        status: "open",
+        meta: {},
+      });
+      // Temporarily disable FK checks so we can delete the session
+      // while keeping the orphan episode for the test.
+      db!.db.exec("PRAGMA foreign_keys = OFF; DELETE FROM sessions WHERE id='s-gone'; PRAGMA foreign_keys = ON;");
+
+      await core.init();
+
+      const ep = db!.repos.episodes.getById("ep-no-session");
+      expect(ep).not.toBeNull();
+      expect(ep!.status).toBe("closed");
+    });
+  });
+
+  describe("deleteEpisode / deleteEpisodes", () => {
+    it("deletes a closed episode and returns deleted: true", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      await core.init();
+      const sid = await core.openSession({ agent: "openclaw" });
+      const eid = await core.openEpisode({ sessionId: sid });
+      await core.closeEpisode(eid);
+
+      const result = await core.deleteEpisode(eid);
+      expect(result.deleted).toBe(true);
+      expect(db!.repos.episodes.getById(eid)).toBeNull();
+    });
+
+    it("returns deleted: false for a missing episode", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      await core.init();
+
+      const result = await core.deleteEpisode("ep-does-not-exist");
+      expect(result.deleted).toBe(false);
+    });
+
+    it("throws conflict when deleting an open episode", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      await core.init();
+      const sid = await core.openSession({ agent: "openclaw" });
+      const eid = await core.openEpisode({ sessionId: sid });
+
+      await expect(core.deleteEpisode(eid)).rejects.toMatchObject({
+        code: "conflict",
+      });
+    });
+
+    it("deleteEpisodes bulk-deletes multiple closed episodes", async () => {
+      pipeline = createPipeline(buildDeps(db!));
+      core = createMemoryCore(
+        pipeline,
+        resolveHome("openclaw", "/tmp/memos-mc-test"),
+        "test",
+      );
+      await core.init();
+      const sid = await core.openSession({ agent: "openclaw" });
+      const e1 = await core.openEpisode({ sessionId: sid });
+      const e2 = await core.openEpisode({ sessionId: sid });
+      await core.closeEpisode(e1);
+      await core.closeEpisode(e2);
+
+      const result = await core.deleteEpisodes([e1, e2]);
+      expect(result.deleted).toBe(2);
+      expect(db!.repos.episodes.getById(e1)).toBeNull();
+      expect(db!.repos.episodes.getById(e2)).toBeNull();
+    });
+  });
+
+  describe("bootstrapMemoryCore", () => {
   let home: TmpHomeContext | null = null;
 
   afterEach(async () => {


### PR DESCRIPTION
## Description

This PR introduces three related changes for the `memos-local-plugin` (Hermes adapter):

### 1. Orphan Episode Protection (Reliability Fix)
**Problem:** Previously, the bridge `init()` treated all `status='open'` episodes as orphans upon startup, auto-closing them with the reason "插件上次未正常退出". This caused episodes from active sessions to be prematurely abandoned during bridge restarts, gateway loops, or session switches.

**Fix:**
- Updated `init()` to check `session.meta.closedAt` before closing open episodes. Episodes belonging to sessions that haven't been explicitly closed are now preserved.
- Updated `closeSession()` in the session manager to stamp `closedAt` via `touchLastSeen()`, enabling the system to distinguish between a "properly closed session" and a "bridge crash/reconnect" scenario.
- Batch-fetches session rows for distinct `sessionId`s to avoid N+1 queries during the orphan scan.

### 2. WebUI Tasks Page Deletion Fix & Bulk Delete
**Problem:** The "Delete selected" button on the Tasks page was calling `closeEpisode()`, which is a no-op for already-closed episodes.

**Fix:**
- **Repository Level:** Added `deleteById()` to the episodes SQLite repo (supports cascading trace deletion via Foreign Keys).
- **Core Level:** Added `deleteEpisode` and `deleteEpisodes` methods to the `MemoryCore` interface and implementation. Open episodes are rejected with a 409/conflict error.
- **API Level:** Changed `DELETE /api/v1/episodes` to use `deleteEpisode` instead of `closeEpisode`, and added `POST /api/v1/episodes/delete` for bulk deletion.

### 3. TCP Transport Layer for Daemon Bridge
**Problem:** The bridge previously only supported stdio JSON-RPC, requiring the Hermes Python provider to spawn a child process. This was fragile across restarts and didn't support daemon mode.

**Fix:**
- Added `bridge/tcp.ts` — a TCP JSON-RPC server with line-delimited framing, method whitelist validation, and graceful shutdown.
- Updated `bridge.cts` to start the TCP server in daemon mode (via `--daemon --tcp=<port>`), with stdio fallback.
- Updated the Hermes Python provider (`bridge_client.py`, `daemon_manager.py`, `__init__.py`) to connect via TCP when available, falling back to stdio. Includes PID-file singleton management to prevent duplicate daemon processes, reconnect with FD leak fixes, and socket cleanup on close.

---

## Files Changed

| File | Change |
|------|--------|
| `agent-contract/memory-core.ts` | Added `deleteEpisode` / `deleteEpisodes` to interface |
| `core/pipeline/memory-core.ts` | Orphan filter with `closedAt` check; delete implementation with open-episode guard |
| `core/session/manager.ts` | Stamp `closedAt` on `closeSession()` |
| `core/storage/repos/episodes.ts` | Added `deleteById()` |
| `server/routes/session.ts` | Fixed delete route + bulk delete endpoint |
| `bridge.cts` | Daemon mode, `--tcp` flag, version from package.json |
| `bridge/tcp.ts` | **New.** TCP JSON-RPC server with framing, method validation, shutdown |
| `adapters/hermes/memos_provider/__init__.py` | TCP mode with stdio fallback |
| `adapters/hermes/memos_provider/bridge_client.py` | TCP transport, reconnect, PID-file management |
| `adapters/hermes/memos_provider/daemon_manager.py` | **New.** PID-file singleton bridge lifecycle |
| `tests/unit/pipeline/memory-core.test.ts` | Unit tests for orphan init behavior and delete APIs |

## How Has This Been Tested?

- **Orphan Fix:** Created episodes in an active session → killed bridge → restarted. All 20+ open episodes survived the `init()` scan.
- **Delete Fix:** Deletion on closed episodes physically removed rows from SQLite (previously no-op).
- **TCP Transport:** Daemon mode with `--tcp=18911` running continuously. Hermes Python provider successfully connects via TCP, survives reconnect cycles.
- **Unit Tests:** Added 7 new tests covering orphan init filtering and deleteEpisode/deleteEpisodes (see updated `memory-core.test.ts`).

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in complex logic areas.
- [x] I have added tests that prove my fix is effective.
- [ ] I have created related documentation in MemOS-Docs.