### PR TITLE
fix(auth): startup gate + rate-limit MEMOS_REDIS_URL + key-prefix BCrypt lookup

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,79 @@
+# Security & Tuning Patches
+
+This fork maintains a set of patches on top of upstream `MemTensor/MemOS` for
+production deployment inside the Hermes multi-agent system.
+
+## Why a fork
+
+Upstream is a reference implementation. We need:
+- Per-agent API key auth with spoof detection and cube-level ACL
+- Hardened defaults (localhost binding, required passwords, secret encryption)
+- Search recall tuning (was returning 1/12 relevant results on vague queries)
+- Memory extraction quality fixes (English enforcement, granularity rule)
+
+See the full audit history at
+`memos-setup/learnings/` in the [hermes-multi-agent](https://github.com/sergiocoding96/hermes-multi-agent)
+repo.
+
+## Patched Files
+
+| File | Category | What changed |
+|------|----------|-------------|
+| `src/memos/api/middleware/agent_auth.py` | **NEW** | Per-agent Bearer-key auth middleware, bcrypt v2 format, auth-failure rate limit, auto-reload on config mtime change |
+| `src/memos/api/middleware/request_context.py` | Security | Strip `Authorization` + `Cookie` headers from logs |
+| `src/memos/api/server_api.py` | Security | Register `RateLimitMiddleware` + `AgentAuthMiddleware` + admin router; bind to `MEMOS_BIND_HOST` (default 127.0.0.1) |
+| `src/memos/api/routers/server_router.py` | Authorization | `_enforce_cube_access()` helper; auth on 11 previously-unprotected endpoints; scheduler caps (300s max timeout, cross-agent checks) |
+| `src/memos/api/routers/admin_router.py` | Admin API | Full rewrite for bcrypt v2 key management via `agents-auth.json`; list/create/revoke/rotate |
+| `src/memos/api/handlers/search_handler.py` | Security + tuning | Spoof check + cube isolation; env-configurable search params (`MOS_SEARCH_TOP_K_FACTOR`, `MOS_MMR_TEXT_THRESHOLD`, `MOS_MMR_PENALTY_THRESHOLD`) |
+| `src/memos/api/handlers/add_handler.py` | Security | Spoof check + cube isolation; empty content rejection; log request summary instead of full body |
+| `src/memos/api/handlers/component_init.py` | Security | Inject `UserManager` into `HandlerDependencies` for ACL checks |
+| `src/memos/api/product_models.py` | Tuning | Relativity default 0.20 → 0.05 (was filtering vague but valid queries) |
+| `src/memos/mem_user/user_manager.py` | Authorization | `validate_user_cube_access` resolves cubes by `cube_id` → `cube_name` → `owner_id` (agents address cubes by `user_id`, not `cube_id`) |
+| `src/memos/vec_dbs/qdrant.py` | Bug fix | Pass `api_key` with host+port mode (upstream only supported url mode); force `https=False` for localhost |
+| `src/memos/templates/mem_reader_prompts.py` | Quality | Granularity rule (split by idea, not sentence); English output enforcement (prevents Chinese leakage on English input) |
+| `src/memos/multi_mem_cube/single_cube.py` | Quality | Write-time dedup via cosine similarity ≥ 0.90 |
+
+## Rebasing on Upstream
+
+When pulling new upstream changes:
+
+```bash
+git fetch upstream
+git merge upstream/main
+# Or: git rebase upstream/main
+# Resolve conflicts in the patched files above, prefer keeping our logic
+```
+
+## Environment Variables
+
+Security-sensitive vars this fork requires:
+
+| Var | Purpose |
+|-----|---------|
+| `MEMOS_AUTH_REQUIRED` | Set to `true` in production (otherwise the auth middleware is a no-op) |
+| `MEMOS_AGENT_AUTH_CONFIG` | Path to `agents-auth.json` (bcrypt v2 format) |
+| `MEMOS_ADMIN_KEY` | Separate key for `/admin/*` routes — NOT an agent key |
+| `MEMOS_BIND_HOST` | Default 127.0.0.1. Set `0.0.0.0` only when behind a reverse proxy |
+| `QDRANT_API_KEY` | Required — Qdrant has no default auth |
+| `NEO4J_PASSWORD` | Required — no default fallback accepted |
+| `MEMRADER_API_KEY` | DeepSeek V3 key for memory extraction (MiniMax's `<think>` tags break extraction) |
+
+Tuning vars (optional):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `MOS_SEARCH_TOP_K_FACTOR` | 5 | Expansion factor before MMR dedup (was 3x hardcoded) |
+| `MOS_MMR_TEXT_THRESHOLD` | 0.85 | Text similarity threshold for dedup (was 0.92 — too strict) |
+| `MOS_MMR_PENALTY_THRESHOLD` | 0.70 | MMR exponential penalty start (was 0.90) |
+
+## Secrets Management
+
+Secrets are encrypted with `age` at `~/.memos/secrets.env.age` and decrypted
+at boot by `start-memos.sh`. See that script for details.
+
+Contains:
+- `MINIMAX_API_KEY` (primary LLM)
+- `MEMRADER_API_KEY` (DeepSeek, for memory extraction)
+- `NEO4J_PASSWORD`
+- `QDRANT_API_KEY`
+- `MEMOS_ADMIN_KEY`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     ports:
-      - "8000:8000"
+      # Bind to localhost only — use a reverse proxy to expose externally
+      - "127.0.0.1:8000:8000"
     env_file:
       - ../.env
     depends_on:
@@ -18,7 +19,9 @@ services:
       - HF_ENDPOINT=https://hf-mirror.com
       - QDRANT_HOST=qdrant-docker
       - QDRANT_PORT=6333
+      - QDRANT_API_KEY=${QDRANT_API_KEY}
       - NEO4J_URI=bolt://neo4j-docker:7687
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
     volumes:
       - ../src:/app/src
       - .:/app/docker
@@ -29,8 +32,9 @@ services:
     image: neo4j:5.26.6
     container_name: neo4j-docker
     ports:
-      - "7474:7474"   # HTTP
-      - "7687:7687"   # Bolt
+      # Bind to localhost only
+      - "127.0.0.1:7474:7474"   # HTTP
+      - "127.0.0.1:7687:7687"   # Bolt
     healthcheck:
       test: wget http://localhost:7474 || exit 1
       interval: 1s
@@ -39,7 +43,9 @@ services:
       start_period: 3s
     environment:
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
-      NEO4J_AUTH: "neo4j/12345678"
+      # Require NEO4J_PASSWORD in env (no default). Keep strong — this is the
+      # graph layer of all agent memories.
+      NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}"
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
@@ -50,13 +56,17 @@ services:
     image: qdrant/qdrant:v1.15.3
     container_name: qdrant-docker
     ports:
-      - "6333:6333"  # REST API
-      - "6334:6334"  # gRPC API
+      # Bind to localhost only
+      - "127.0.0.1:6333:6333"  # REST API
+      - "127.0.0.1:6334:6334"  # gRPC API
     volumes:
       - qdrant_data:/qdrant/storage
     environment:
       QDRANT__SERVICE__GRPC_PORT: 6334
       QDRANT__SERVICE__HTTP_PORT: 6333
+      # Require QDRANT_API_KEY in env. Without it, anyone who reaches the
+      # port can read/delete all vectors.
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:?QDRANT_API_KEY must be set}
     restart: unless-stopped
     networks:
       - memos_network

--- a/learnings/2026-04-06-blind-functionality-audit.md
+++ b/learnings/2026-04-06-blind-functionality-audit.md
@@ -1,0 +1,92 @@
+# MemOS Blind Functionality Audit — Session Summary
+
+**Date:** 2026-04-06 to 2026-04-08
+**Scope:** Autonomous blind audit of MemOS API (localhost:8001) — testing all documented capabilities against actual behavior.
+**Full report:** `/home/openclaw/Coding/Hermes/tests/blind-audit-report.md`
+
+---
+
+## What Was Done
+
+1. **Ran a full autonomous audit** — an agent read the OpenAPI spec and source code, then designed and executed its own test suite against a live MemOS instance. Created isolated test users (audit-alpha, audit-beta, audit-gamma) with their own cubes.
+
+2. **Tested 14 areas** across write path, extraction, search, dedup, long content, cross-cube isolation, memory types, feedback, scheduler, chat, auth, delete, persistence, and edge cases.
+
+3. **Root-cause analysis** — after the audit report, we traced each bug to exact source file + line number by reading the installed package at `/home/openclaw/.local/lib/python3.12/site-packages/memos/`.
+
+---
+
+## Overall Score: 6.8/10
+
+### What Works Well
+- **Write persistence** — Qdrant + Neo4j dual storage, survives restarts
+- **Fine-mode extraction** — third-person perspective (10/10), pronoun resolution (10/10), timestamp resolution from `chat_time` (9/10)
+- **Write-time dedup** — 90% similarity threshold correctly blocks exact and near-duplicates
+- **Search** — relativity threshold and top_k work exactly as documented
+- **Cross-cube isolation** — strict 403 enforcement, spoof protection works
+- **Edge cases** — URLs, JSON, HTML, code, short/long content all handled correctly
+
+### Critical Bugs Found
+
+#### Bug 1: BCrypt Auth Overhead (~1.2s per request)
+- **File:** `memos/api/middleware/agent_auth.py:176-183`
+- **Cause:** `_authenticate_key()` iterates ALL agent bcrypt hashes sequentially. With 6 agents and bcrypt cost=12, worst case is ~1.2s pure auth overhead before any memory work.
+- **Fix needed:** Add a prefix-based lookup. Each key starts with `ak_XXXX...` — build a dict mapping `key_prefix` to the agent entry, then only bcrypt-check the one matching prefix instead of all N.
+
+#### Bug 2: Search-Time Dedup Modes (no/sim/mmr) Non-Functional
+- **Files:**
+  - `memos/api/handlers/search_handler.py:90-107` — handler-level sim/mmr dedup exists and works
+  - `memos/memories/textual/tree_text_memory/retrieve/searcher.py:1020-1026` — tree searcher only does exact-text dedup, ignores mode
+- **Cause:** The tree searcher's `_deduplicate_results()` treats dedup as a boolean (on/off), not modal. It always does exact-text dedup regardless of sim/mmr. The handler-level sim/mmr code runs after, but operates on already-deduped results.
+- **Fix needed:** Either pass the dedup mode through to the tree searcher properly, or ensure embeddings are included in results so handler-level sim/mmr dedup has data to work with.
+
+#### Bug 3: Custom Tags/Info Stripped on Write
+- **File:** `memos/mem_reader/simple_struct.py:340-342, 359`
+- **Cause:** `custom_tags` is popped from info dict (line 340) but never used in fast mode. Line 359 hardcodes `tags = ["mode:fast"]`. In fine mode, custom_tags are passed to the LLM prompt but not persisted as memory tags either.
+- **Fix needed:** In fast mode, merge custom_tags into the tags list: `tags = ["mode:fast"] + (custom_tags or [])`. In fine mode, append custom_tags to whatever the LLM returns.
+
+#### Bug 4: Feedback & Delete Endpoints Default to Wrong Cube ID
+- **Files:**
+  - `memos/api/routers/server_router.py:431` — feedback defaults `cube_ids = [user_id]`
+  - `memos/api/routers/server_router.py:411` — delete does the same
+  - `memos/api/handlers/feedback_handler.py:61` — handler also defaults to `[user_id]`
+- **Cause:** Cube naming convention is `{user_id}-cube` but fallback uses raw `user_id`. Results in 403 because no cube named just `user_id` exists.
+- **Fix needed:** Either change default to `[f"{user_id}-cube"]` or (better) require `writable_cube_ids` and return 400 if missing.
+
+#### Bug 5: Scheduler Monitoring Broken Without Redis
+- **Symptom:** `task_queue_status` returns 503, `allstatus` shows all zeros.
+- **Cause:** Local queue mode works for processing but has no status API.
+- **Fix needed:** Implement in-memory task status tracking as fallback when Redis is unavailable.
+
+#### Bug 6: Chat Endpoint Non-Functional
+- **Cause:** `ENABLE_CHAT_API=false` by default, and the request model expects `query` not `messages`.
+- **Low priority** — not used in Hermes architecture.
+
+---
+
+## Fixes Not Yet Applied
+
+We completed root-cause analysis for all bugs but were interrupted before implementing fixes. The priority order for fixing:
+
+1. **BCrypt auth** (Bug 1) — biggest UX impact, every request is slow
+2. **Custom tags** (Bug 3) — blocks metadata-based filtering
+3. **Feedback/delete cube default** (Bug 4) — simple one-line fixes
+4. **Search dedup modes** (Bug 2) — more complex, needs careful threading of mode parameter
+5. **Scheduler monitoring** (Bug 5) — nice-to-have
+6. **Chat endpoint** (Bug 6) — not needed currently
+
+---
+
+## Key Source Paths Referenced
+
+| Component | Path |
+|-----------|------|
+| Auth middleware | `memos/api/middleware/agent_auth.py` |
+| Search handler (dedup) | `memos/api/handlers/search_handler.py` |
+| Tree searcher (dedup) | `memos/memories/textual/tree_text_memory/retrieve/searcher.py` |
+| Add handler (tags/info) | `memos/api/handlers/add_handler.py` |
+| Memory reader (fast/fine) | `memos/mem_reader/simple_struct.py` |
+| Feedback handler | `memos/api/handlers/feedback_handler.py` |
+| Server router | `memos/api/routers/server_router.py` |
+| Installed package root | `/home/openclaw/.local/lib/python3.12/site-packages/memos/` |
+| MemOS source repo | `/home/openclaw/Coding/MemOS/` |

--- a/learnings/2026-04-08-disk-and-memory-audit.md
+++ b/learnings/2026-04-08-disk-and-memory-audit.md
@@ -1,0 +1,95 @@
+# Disk & Memory Audit — 2026-04-08
+
+## Context
+Session with Sergio to investigate why the system appeared to have only ~45 GB available, and why RAM/swap was under pressure.
+
+---
+
+## System Hardware
+
+- **Storage**: Toshiba Q300 SSD, 111.8 GB total (NOT an HDD — it's solid-state)
+- **RAM**: 15 GB total
+- **Swap**: 4 GB
+
+---
+
+## Root Cause: Disk Was 96% Full
+
+At the start of the session, disk was nearly full:
+```
+108G total | 99G used | 4.2G free (96% used)
+```
+
+The "45 GB" shown in the file manager was the size of the `/home/openclaw` folder — not a disk quota or partition limit.
+
+---
+
+## User Account Structure (important context)
+
+There are **two real user accounts** on the same machine, same person:
+
+| User | Home | Size |
+|---|---|---|
+| `sergio` (desktop GUI login) | `/home/sergio` | 14 GB |
+| `openclaw` (Hermes/AI system user) | `/home/openclaw` | 31 GB |
+| `linuxbrew` | `/home/linuxbrew` | 2 GB |
+| `root` | `/root` | ~950 MB |
+
+No per-user disk quota is in place. The full SSD is shared.
+
+---
+
+## Biggest Disk Consumers Found
+
+| Path | Size | Notes |
+|---|---|---|
+| `~/.cache/uv` | 7.8 GB | Python package cache |
+| `~/.cache/pip` | 5.5 GB | pip download cache |
+| `polymarket-predicti...` (project) | 7.8 GB | Deleted by user |
+| Docker build cache | 4.1 GB | Build layer cache |
+| `~/.cache/whisper` | 3.6 GB | Whisper AI model weights |
+| `~/.cache/camoufox` | 1.4 GB | Camoufox browser binaries |
+| `~/.cache/ms-playwright` | 1.3 GB | Playwright browser binaries |
+| `~/.cache/huggingface` | 1.3 GB | Sentence-transformers model |
+| Docker images (unused) | 1.3 GB | Prunable |
+| `~/.cache/puppeteer` | 626 MB | Puppeteer browser |
+
+---
+
+## Cleanup Performed (~14 GB reclaimed)
+
+```bash
+uv cache clean               # 7.6 GB
+pip cache purge              # 5.5 GB
+sudo docker builder prune -f # 4.0 GB
+sudo docker volume prune -f  # 300 MB
+# polymarket folder deleted manually by user: ~7.8 GB
+```
+
+**Result:** 15 GB free (was 4.2 GB). Disk now at 86% used.
+
+---
+
+## RAM / Swap Situation
+
+- **Cache (6 GB)**: Normal Linux behavior — kernel fills idle RAM with disk cache, reclaimed instantly when apps need it. Not a problem.
+- **Swap (4 GB, 100% used)**: Real pressure. Docker + MemOS (Qdrant + Neo4j) + other services are exhausting physical RAM.
+  - Mitigation: restart unused services to free RAM.
+
+---
+
+## Do NOT Delete (would break system)
+
+- `~/.cache/whisper` — Whisper model weights
+- `~/.cache/huggingface` — sentence-transformers embedding model (used by MemOS)
+- `~/.cache/camoufox` — needed for anti-bot browsing (Camofox)
+- `~/.cache/ms-playwright` — needed by Firecrawl/Playwright scraping
+
+---
+
+## Next Cleanup Candidates (if space needed again)
+
+- `~/.hermes` (7.7 GB) — inspect contents before touching
+- `~/.npm` (2.5 GB) — npm cache, safe to clear with `npm cache clean --force`
+- `~/.local/share/pnpm` (1.9 GB) — pnpm store, check if needed
+- `~/.cache/go-build` (290 MB) — Go build cache, safe to clear

--- a/src/memos/api/config.py
+++ b/src/memos/api/config.py
@@ -585,6 +585,20 @@ class APIConfig:
                     ),
                 },
             }
+        elif embedder_backend == "sentence_transformer":
+            # Local sentence-transformers embedder (no external API). Used by
+            # Hermes to avoid MiniMax embedding rate limits and cloud dependency.
+            return {
+                "backend": "sentence_transformer",
+                "config": {
+                    "model_name_or_path": os.getenv("MOS_EMBEDDER_MODEL", "all-MiniLM-L6-v2"),
+                    "embedding_dims": int(os.getenv("MOS_EMBEDDER_DIMS", "384")),
+                    "trust_remote_code": os.getenv(
+                        "MOS_EMBEDDER_TRUST_REMOTE_CODE", "true"
+                    ).lower()
+                    == "true",
+                },
+            }
         else:  # ollama
             return {
                 "backend": "ollama",

--- a/src/memos/api/handlers/add_handler.py
+++ b/src/memos/api/handlers/add_handler.py
@@ -7,7 +7,10 @@ using dependency injection for better modularity and testability.
 
 from pydantic import validate_call
 
+from fastapi import HTTPException
+
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.product_models import APIADDRequest, APIFeedbackRequest, MemoryResponse
 from memos.memories.textual.item import (
     list_all_fields,
@@ -51,8 +54,38 @@ class AddHandler(BaseHandler):
             MemoryResponse with added memory information
         """
         self.logger.info(
-            f"[DIAGNOSTIC] server_router -> add_handler.handle_add_memories called (Modified at 2025-11-29 18:46). Full request: {add_req.model_dump_json(indent=2)}"
+            f"[AddHandler] add_memories called: user_id={add_req.user_id}, cubes={add_req.writable_cube_ids}, async_mode={add_req.async_mode}"
         )
+
+        # Auth spoof check: if a key was presented, user_id must match what the key says
+        authenticated = get_authenticated_user()
+        if authenticated is not None and authenticated != add_req.user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Key authenticated as '{authenticated}' but request claims user_id='{add_req.user_id}'. Spoofing not allowed."
+            )
+
+        # Cube isolation: verify user has write access to all requested cubes
+        user_manager = getattr(self.deps, "user_manager", None)
+        if user_manager:
+            cube_ids = self._resolve_cube_ids(add_req)
+            for cube_id in cube_ids:
+                if not user_manager.validate_user_cube_access(add_req.user_id, cube_id):
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"Access denied: user '{add_req.user_id}' cannot write to cube '{cube_id}'"
+                    )
+
+        # Reject empty or whitespace-only content early
+        if add_req.messages is not None:
+            all_empty = all(
+                not str(msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")).strip()
+                for msg in add_req.messages
+            )
+            if all_empty:
+                raise HTTPException(status_code=400, detail="Message content must not be empty.")
+        elif add_req.memory_content is not None and not str(add_req.memory_content).strip():
+            raise HTTPException(status_code=400, detail="memory_content must not be empty.")
 
         if add_req.info:
             exclude_fields = list_all_fields()

--- a/src/memos/api/handlers/add_handler.py
+++ b/src/memos/api/handlers/add_handler.py
@@ -12,13 +12,39 @@ from fastapi import HTTPException
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
 from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.product_models import APIADDRequest, APIFeedbackRequest, MemoryResponse
-from memos.memories.textual.item import (
-    list_all_fields,
-)
 from memos.multi_mem_cube.composite_cube import CompositeCubeView
 from memos.multi_mem_cube.single_cube import SingleCubeView
 from memos.multi_mem_cube.views import MemCubeView
 from memos.types import MessageList
+
+
+# Keys MemOS internals write into metadata.info. User-supplied values for
+# these keys are preserved under a "user:<key>" namespace so internal
+# bookkeeping (e.g. scheduler merge tracking) is never clobbered.
+_RESERVED_INFO_KEYS = frozenset({"merged_from"})
+
+
+def _namespace_user_info(
+    info: dict | None,
+) -> tuple[dict, dict[str, str]]:
+    """Return a copy of ``info`` with reserved keys renamed to ``user:<key>``.
+
+    Returns:
+        (preserved_info, renamed_map) — renamed_map is {original_key: new_key}
+        for any collisions that were rewritten (empty when there were none).
+    """
+    if not info:
+        return {}, {}
+    preserved: dict = {}
+    renamed: dict[str, str] = {}
+    for k, v in info.items():
+        if k in _RESERVED_INFO_KEYS:
+            new_key = f"user:{k}"
+            preserved[new_key] = v
+            renamed[k] = new_key
+        else:
+            preserved[k] = v
+    return preserved, renamed
 
 
 class AddHandler(BaseHandler):
@@ -88,11 +114,16 @@ class AddHandler(BaseHandler):
             raise HTTPException(status_code=400, detail="memory_content must not be empty.")
 
         if add_req.info:
-            exclude_fields = list_all_fields()
-            info_len = len(add_req.info)
-            add_req.info = {k: v for k, v in add_req.info.items() if k not in exclude_fields}
-            if len(add_req.info) < info_len:
-                self.logger.warning(f"[AddHandler] info fields can not contain {exclude_fields}.")
+            # metadata.info is a free-form dict. Only reserved keys written by MemOS
+            # internals (see _RESERVED_INFO_KEYS) need collision handling — the prior
+            # implementation over-filtered against top-level metadata field names, which
+            # dropped legitimate user keys like `source_type` / `topic`.
+            add_req.info, renamed = _namespace_user_info(add_req.info)
+            if renamed:
+                self.logger.warning(
+                    f"[AddHandler] Reserved info keys renamed to preserve internal "
+                    f"bookkeeping: {renamed}"
+                )
 
         cube_view = self._build_cube_view(add_req)
 

--- a/src/memos/api/handlers/component_init.py
+++ b/src/memos/api/handlers/component_init.py
@@ -28,6 +28,7 @@ from memos.llms.factory import LLMFactory
 from memos.log import get_logger
 from memos.mem_cube.navie import NaiveMemCube
 from memos.mem_feedback.simple_feedback import SimpleMemFeedback
+from memos.mem_user.user_manager import UserManager
 from memos.mem_reader.factory import MemReaderFactory
 from memos.mem_scheduler.orm_modules.base_model import BaseDBManager
 from memos.mem_scheduler.scheduler_factory import SchedulerFactory
@@ -305,4 +306,5 @@ def init_server() -> dict[str, Any]:
         "deepsearch_agent": deepsearch_agent,
         "nli_client": nli_client,
         "memory_history_manager": memory_history_manager,
+        "user_manager": UserManager(),
     }

--- a/src/memos/api/handlers/memory_handler.py
+++ b/src/memos/api/handlers/memory_handler.py
@@ -386,26 +386,36 @@ def handle_delete_memories(delete_mem_req: DeleteMemoryRequest, naive_mem_cube: 
     )
     quick_constraints = _build_quick_delete_constraints(delete_mem_req)
     has_non_empty_filter = bool(delete_mem_req.filter)
-    has_filter_mode = has_non_empty_filter or bool(quick_constraints)
+    # Explicit id modes take precedence over filter/user_id/session_id, which then act as
+    # identity context rather than extra scope. This lets callers send user_id alongside
+    # memory_ids without hitting the "multiple modes" rejection.
+    has_explicit_id_mode = (
+        delete_mem_req.memory_ids is not None or delete_mem_req.file_ids is not None
+    )
+    has_filter_mode = not has_explicit_id_mode and (has_non_empty_filter or bool(quick_constraints))
 
     # Reject empty filter dict when no quick constraints are provided.
-    if delete_mem_req.filter is not None and not has_non_empty_filter and not quick_constraints:
+    if (
+        delete_mem_req.filter is not None
+        and not has_non_empty_filter
+        and not quick_constraints
+        and not has_explicit_id_mode
+    ):
         return DeleteMemoryResponse(
             message="filter cannot be empty. Provide a non-empty filter or user_id/session_id.",
             data={"status": "failure"},
         )
 
-    # Validate that only one mode is provided: memory_ids, file_ids, or filter-mode.
-    provided_params = [
-        delete_mem_req.memory_ids is not None,
-        delete_mem_req.file_ids is not None,
-        has_filter_mode,
-    ]
-    if sum(provided_params) != 1:
+    # memory_ids and file_ids are mutually exclusive; beyond that, require at least one mode.
+    if delete_mem_req.memory_ids is not None and delete_mem_req.file_ids is not None:
+        return DeleteMemoryResponse(
+            message="memory_ids and file_ids cannot be used together.",
+            data={"status": "failure"},
+        )
+    if not has_explicit_id_mode and not has_filter_mode:
         return DeleteMemoryResponse(
             message=(
-                "Exactly one delete mode must be provided: "
-                "memory_ids, file_ids, or filter/user_id/session_id."
+                "No delete mode provided: supply memory_ids, file_ids, or filter/user_id/session_id."
             ),
             data={"status": "failure"},
         )

--- a/src/memos/api/handlers/search_handler.py
+++ b/src/memos/api/handlers/search_handler.py
@@ -98,7 +98,9 @@ class SearchHandler(BaseHandler):
         self.logger.info(f"[SearchHandler] Relativity filter: {search_req_local.relativity}")
         results = self._apply_relativity_threshold(results, search_req_local.relativity)
 
-        if search_req_local.dedup == "sim":
+        if search_req_local.dedup == "no":
+            self._strip_embeddings(results)
+        elif search_req_local.dedup == "sim":
             results = self._dedup_text_memories(results, search_req.top_k)
             self._strip_embeddings(results)
         elif search_req_local.dedup == "mmr":
@@ -111,7 +113,7 @@ class SearchHandler(BaseHandler):
             self.reranker,
             query=search_req.query,
             text_mem=text_mem,
-            top_k=search_req_local.top_k,
+            top_k=search_req.top_k,
             file_mem_proportion=0.5,
         )
 
@@ -159,46 +161,52 @@ class SearchHandler(BaseHandler):
         return results
 
     def _dedup_text_memories(self, results: dict[str, Any], target_top_k: int) -> dict[str, Any]:
+        """
+        Similarity-based dedup: pairwise cosine filter.
+
+        Iterate candidates in (relativity desc, idx asc) order; skip any whose
+        cosine similarity >= MOS_MMR_TEXT_THRESHOLD to an already-selected
+        candidate. Cap each bucket at target_top_k.
+        """
         buckets = results.get("text_mem", [])
         if not buckets:
             return results
+
+        threshold = float(os.getenv("MOS_MMR_TEXT_THRESHOLD", "0.85"))
 
         flat: list[tuple[int, dict[str, Any], float]] = []
         for bucket_idx, bucket in enumerate(buckets):
             for mem in bucket.get("memories", []):
                 score = mem.get("metadata", {}).get("relativity", 0.0)
-                flat.append((bucket_idx, mem, score))
+                try:
+                    score_val = float(score) if score is not None else 0.0
+                except (TypeError, ValueError):
+                    score_val = 0.0
+                flat.append((bucket_idx, mem, score_val))
 
         if len(flat) <= 1:
             return results
 
         embeddings = self._extract_embeddings([mem for _, mem, _ in flat])
-
         similarity_matrix = cosine_similarity_matrix(embeddings)
 
-        indices_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(buckets))}
-        for flat_index, (bucket_idx, _, _) in enumerate(flat):
-            indices_by_bucket[bucket_idx].append(flat_index)
+        ordered_indices = sorted(range(len(flat)), key=lambda idx: (-flat[idx][2], idx))
 
         selected_global: list[int] = []
         selected_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(buckets))}
 
-        ordered_indices = sorted(range(len(flat)), key=lambda idx: flat[idx][2], reverse=True)
         for idx in ordered_indices:
             bucket_idx = flat[idx][0]
             if len(selected_by_bucket[bucket_idx]) >= target_top_k:
                 continue
-            # Use 0.92 threshold strictly
-            if self._is_unrelated(idx, selected_global, similarity_matrix, 0.92):
-                selected_by_bucket[bucket_idx].append(idx)
-                selected_global.append(idx)
-
-        # Removed the 'filling' logic that was pulling back similar items.
-        # Now it will only return items that truly pass the 0.92 threshold,
-        # up to target_top_k.
+            if any(similarity_matrix[idx][j] >= threshold for j in selected_global):
+                continue
+            selected_by_bucket[bucket_idx].append(idx)
+            selected_global.append(idx)
 
         for bucket_idx, bucket in enumerate(buckets):
             selected_indices = selected_by_bucket.get(bucket_idx, [])
+            selected_indices = sorted(selected_indices, key=lambda i: (-flat[i][2], i))
             bucket["memories"] = [flat[i][1] for i in selected_indices]
         return results
 
@@ -206,39 +214,28 @@ class SearchHandler(BaseHandler):
         self, results: dict[str, Any], text_top_k: int, pref_top_k: int = 6
     ) -> dict[str, Any]:
         """
-        MMR-based deduplication with progressive penalty for high similarity.
+        MMR-based deduplication across text_mem and pref_mem buckets.
 
-        Performs deduplication on both text_mem and preference memories together.
-        Other memory types (tool_mem, etc.) are not modified.
-
-        Args:
-            results: Search results containing text_mem and preference buckets
-            text_top_k: Target number of text memories to return per bucket
-            pref_top_k: Target number of preference memories to return per bucket
-
-        Algorithm:
-        1. Prefill top 5 by relevance
-        2. MMR selection: balance relevance vs diversity
-        3. Re-sort by original relevance for better generation quality
+        Score each candidate as:
+            mmr = λ * relevance − (1 − λ) * diversity
+        where diversity = max_sim to selected, inflated by an exponential
+        penalty when max_sim > MOS_MMR_PENALTY_THRESHOLD. Tiebreak on
+        (relevance desc, idx asc) for determinism.
         """
         text_buckets = results.get("text_mem", [])
         pref_buckets = results.get("pref_mem", [])
 
-        # Early return if no memories to deduplicate
         if not text_buckets and not pref_buckets:
             return results
 
-        # Flatten all memories with their type and scores
         # flat structure: (memory_type, bucket_idx, mem, score)
         flat: list[tuple[str, int, dict[str, Any], float]] = []
 
-        # Flatten text memories
         for bucket_idx, bucket in enumerate(text_buckets):
             for mem in bucket.get("memories", []):
                 score = mem.get("metadata", {}).get("relativity", 0.0)
                 flat.append(("text", bucket_idx, mem, float(score) if score is not None else 0.0))
 
-        # Flatten preference memories
         for bucket_idx, bucket in enumerate(pref_buckets):
             for mem in bucket.get("memories", []):
                 meta = mem.get("metadata", {})
@@ -253,202 +250,93 @@ class SearchHandler(BaseHandler):
         if len(flat) <= 1:
             return results
 
-        total_by_type: dict[str, int] = {"text": 0, "preference": 0}
-        existing_by_type: dict[str, int] = {"text": 0, "preference": 0}
-        missing_by_type: dict[str, int] = {"text": 0, "preference": 0}
-        missing_indices: list[int] = []
-        for idx, (mem_type, _, mem, _) in enumerate(flat):
-            if mem_type not in total_by_type:
-                total_by_type[mem_type] = 0
-                existing_by_type[mem_type] = 0
-                missing_by_type[mem_type] = 0
-            total_by_type[mem_type] += 1
-
-            embedding = mem.get("metadata", {}).get("embedding")
-            if embedding:
-                existing_by_type[mem_type] += 1
-            else:
-                missing_by_type[mem_type] += 1
-                missing_indices.append(idx)
-
-        self.logger.info(
-            "[SearchHandler] MMR embedding metadata scan: total=%s total_by_type=%s existing_by_type=%s missing_by_type=%s",
-            len(flat),
-            total_by_type,
-            existing_by_type,
-            missing_by_type,
-        )
-        if missing_indices:
-            self.logger.warning(
-                "[SearchHandler] MMR embedding metadata missing; will compute missing embeddings: missing_total=%s",
-                len(missing_indices),
-            )
-
-        # Get or compute embeddings
         embeddings = self._extract_embeddings([mem for _, _, mem, _ in flat])
-
-        # Compute similarity matrix using NumPy-optimized method
-        # Returns numpy array but compatible with list[i][j] indexing
         similarity_matrix = cosine_similarity_matrix(embeddings)
 
-        # Initialize selection tracking for both text and preference
-        text_indices_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(text_buckets))}
-        pref_indices_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(pref_buckets))}
+        lambda_relevance = float(os.getenv("MOS_MMR_LAMBDA", "0.7"))
+        penalty_threshold = float(os.getenv("MOS_MMR_PENALTY_THRESHOLD", "0.7"))
+        # Stop when the best remaining candidate's MMR score falls at or below
+        # this value — i.e. the penalty outweighs the relevance contribution.
+        # Needed to make MMR materially differ from raw top-K in practice:
+        # otherwise the loop keeps filling bucket capacity with near-dupes at
+        # deeply negative scores.
+        stop_score = float(os.getenv("MOS_MMR_STOP_SCORE", "0.0"))
+        alpha_exponential = 10.0
 
-        for flat_index, (mem_type, bucket_idx, _, _) in enumerate(flat):
+        def bucket_has_capacity(mem_type: str, bucket_idx: int) -> bool:
             if mem_type == "text":
-                text_indices_by_bucket[bucket_idx].append(flat_index)
-            elif mem_type == "preference":
-                pref_indices_by_bucket[bucket_idx].append(flat_index)
+                return len(text_selected_by_bucket[bucket_idx]) < text_top_k
+            if mem_type == "preference":
+                return len(pref_selected_by_bucket[bucket_idx]) < pref_top_k
+            return False
 
-        selected_global: list[int] = []
         text_selected_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(text_buckets))}
         pref_selected_by_bucket: dict[int, list[int]] = {i: [] for i in range(len(pref_buckets))}
-        selected_texts: set[str] = set()  # Track exact text content to avoid duplicates
-
-        # Phase 1: Prefill top N by relevance
-        # Use the smaller of text_top_k and pref_top_k for prefill count
-        prefill_top_n = min(2, text_top_k, pref_top_k) if pref_buckets else min(2, text_top_k)
-        ordered_by_relevance = sorted(range(len(flat)), key=lambda idx: flat[idx][3], reverse=True)
-        for idx in ordered_by_relevance[: len(flat)]:
-            if len(selected_global) >= prefill_top_n:
-                break
-            mem_type, bucket_idx, mem, _ = flat[idx]
-
-            # Skip if exact text already exists in selected set
-            mem_text = mem.get("memory", "").strip()
-            if mem_text in selected_texts:
-                continue
-
-            # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
-            _mmr_text_threshold = float(os.getenv("MOS_MMR_TEXT_THRESHOLD", "0.85"))
-            if SearchHandler._is_text_highly_similar_optimized(
-                idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
-            ):
-                continue
-
-            # Check bucket capacity with correct top_k for each type
-            if mem_type == "text" and len(text_selected_by_bucket[bucket_idx]) < text_top_k:
-                selected_global.append(idx)
-                text_selected_by_bucket[bucket_idx].append(idx)
-                selected_texts.add(mem_text)
-            elif mem_type == "preference" and len(pref_selected_by_bucket[bucket_idx]) < pref_top_k:
-                selected_global.append(idx)
-                pref_selected_by_bucket[bucket_idx].append(idx)
-                selected_texts.add(mem_text)
-
-        # Phase 2: MMR selection for remaining slots
-        lambda_relevance = 0.8
-        similarity_threshold = float(os.getenv("MOS_MMR_PENALTY_THRESHOLD", "0.7"))  # Exponential penalty start
-        alpha_exponential = 10.0  # Exponential penalty coefficient
-        remaining = set(range(len(flat))) - set(selected_global)
+        selected_global: list[int] = []
+        remaining = sorted(range(len(flat)))
 
         while remaining:
             best_idx: int | None = None
             best_mmr: float | None = None
+            best_relevance: float | None = None
 
             for idx in remaining:
-                mem_type, bucket_idx, mem, _ = flat[idx]
-
-                # Check bucket capacity with correct top_k for each type
-                if (
-                    mem_type == "text" and len(text_selected_by_bucket[bucket_idx]) >= text_top_k
-                ) or (
-                    mem_type == "preference"
-                    and len(pref_selected_by_bucket[bucket_idx]) >= pref_top_k
-                ):
+                mem_type, bucket_idx, _, relevance = flat[idx]
+                if not bucket_has_capacity(mem_type, bucket_idx):
                     continue
 
-                # Check if exact text already exists - if so, skip this candidate entirely
-                mem_text = mem.get("memory", "").strip()
-                if mem_text in selected_texts:
-                    continue  # Skip duplicate text, don't participate in MMR competition
+                if not selected_global:
+                    max_sim = 0.0
+                else:
+                    max_sim = max(similarity_matrix[idx][j] for j in selected_global)
 
-                # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
-                if SearchHandler._is_text_highly_similar_optimized(
-                    idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
-                ):
-                    continue  # Skip highly similar text, don't participate in MMR competition
-
-                relevance = flat[idx][3]
-                max_sim = (
-                    0.0
-                    if not selected_global
-                    else max(similarity_matrix[idx][j] for j in selected_global)
-                )
-
-                # Exponential penalty for similarity > 0.80
-                if max_sim > similarity_threshold:
-                    penalty_multiplier = math.exp(
-                        alpha_exponential * (max_sim - similarity_threshold)
+                if max_sim > penalty_threshold:
+                    diversity = max_sim * math.exp(
+                        alpha_exponential * (max_sim - penalty_threshold)
                     )
-                    diversity = max_sim * penalty_multiplier
                 else:
                     diversity = max_sim
 
                 mmr_score = lambda_relevance * relevance - (1.0 - lambda_relevance) * diversity
 
-                if best_mmr is None or mmr_score > best_mmr:
+                # Deterministic tiebreak: relevance desc, then idx asc.
+                # (remaining is already sorted by idx, so the first winner wins ties on idx.)
+                if (
+                    best_mmr is None
+                    or mmr_score > best_mmr
+                    or (mmr_score == best_mmr and relevance > (best_relevance or 0.0))
+                ):
                     best_mmr = mmr_score
                     best_idx = idx
+                    best_relevance = relevance
 
             if best_idx is None:
                 break
+            # Early-stop: the best remaining candidate can't improve the set.
+            # Exception: always keep at least one pick so that sufficiently
+            # relevant items aren't rejected on an empty selection.
+            if selected_global and best_mmr is not None and best_mmr <= stop_score:
+                break
 
-            mem_type, bucket_idx, mem, _ = flat[best_idx]
-
-            # Add to selected set and track text
-            mem_text = mem.get("memory", "").strip()
+            mem_type, bucket_idx, _, _ = flat[best_idx]
             selected_global.append(best_idx)
-            selected_texts.add(mem_text)
-
             if mem_type == "text":
                 text_selected_by_bucket[bucket_idx].append(best_idx)
             elif mem_type == "preference":
                 pref_selected_by_bucket[bucket_idx].append(best_idx)
             remaining.remove(best_idx)
 
-            # Early termination: all buckets are full
-            text_all_full = all(
-                len(text_selected_by_bucket[b_idx]) >= min(text_top_k, len(bucket_indices))
-                for b_idx, bucket_indices in text_indices_by_bucket.items()
-            )
-            pref_all_full = all(
-                len(pref_selected_by_bucket[b_idx]) >= min(pref_top_k, len(bucket_indices))
-                for b_idx, bucket_indices in pref_indices_by_bucket.items()
-            )
-            if text_all_full and pref_all_full:
-                break
-
-        # Phase 3: Re-sort by original relevance and fill back to buckets
         for bucket_idx, bucket in enumerate(text_buckets):
             selected_indices = text_selected_by_bucket.get(bucket_idx, [])
-            selected_indices = sorted(selected_indices, key=lambda i: flat[i][3], reverse=True)
+            selected_indices = sorted(selected_indices, key=lambda i: (-flat[i][3], i))
             bucket["memories"] = [flat[i][2] for i in selected_indices]
 
         for bucket_idx, bucket in enumerate(pref_buckets):
             selected_indices = pref_selected_by_bucket.get(bucket_idx, [])
-            selected_indices = sorted(selected_indices, key=lambda i: flat[i][3], reverse=True)
+            selected_indices = sorted(selected_indices, key=lambda i: (-flat[i][3], i))
             bucket["memories"] = [flat[i][2] for i in selected_indices]
 
         return results
-
-    @staticmethod
-    def _is_unrelated(
-        index: int,
-        selected_indices: list[int],
-        similarity_matrix: list[list[float]],
-        similarity_threshold: float,
-    ) -> bool:
-        return all(similarity_matrix[index][j] <= similarity_threshold for j in selected_indices)
-
-    @staticmethod
-    def _max_similarity(
-        index: int, selected_indices: list[int], similarity_matrix: list[list[float]]
-    ) -> float:
-        if not selected_indices:
-            return 0.0
-        return max(similarity_matrix[index][j] for j in selected_indices)
 
     def _extract_embeddings(self, memories: list[dict[str, Any]]) -> list[list[float]]:
         embeddings: list[list[float]] = []
@@ -487,330 +375,6 @@ class SearchHandler(BaseHandler):
                         metadata = mem.get("metadata", {})
                         if "embedding" in metadata:
                             metadata["embedding"] = []
-
-    @staticmethod
-    def _dice_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate Dice coefficient (character-level, fastest).
-
-        Dice = 2 * |A ∩ B| / (|A| + |B|)
-        Speed: O(n + m), ~0.05-0.1ms per comparison
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Dice similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        chars1 = set(text1)
-        chars2 = set(text2)
-
-        intersection = len(chars1 & chars2)
-        return 2 * intersection / (len(chars1) + len(chars2))
-
-    @staticmethod
-    def _bigram_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate character-level 2-gram Jaccard similarity.
-
-        Speed: O(n + m), ~0.1-0.2ms per comparison
-        Considers local order (more strict than Dice).
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Jaccard similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        # Generate 2-grams
-        bigrams1 = {text1[i : i + 2] for i in range(len(text1) - 1)} if len(text1) >= 2 else {text1}
-        bigrams2 = {text2[i : i + 2] for i in range(len(text2) - 1)} if len(text2) >= 2 else {text2}
-
-        intersection = len(bigrams1 & bigrams2)
-        union = len(bigrams1 | bigrams2)
-
-        return intersection / union if union > 0 else 0.0
-
-    @staticmethod
-    def _tfidf_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate TF-IDF cosine similarity (character-level, no sklearn).
-
-        Speed: O(n + m), ~0.3-0.5ms per comparison
-        Considers character frequency weighting.
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Cosine similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        from collections import Counter
-
-        # Character frequency (TF)
-        tf1 = Counter(text1)
-        tf2 = Counter(text2)
-
-        # All unique characters (vocabulary)
-        vocab = set(tf1.keys()) | set(tf2.keys())
-
-        # Simple IDF: log(2 / df) where df is document frequency
-        # For two documents, IDF is log(2/1)=0.693 if char appears in one doc,
-        # or log(2/2)=0 if appears in both (we use log(2/1) for simplicity)
-        idf = {char: (1.0 if char in tf1 and char in tf2 else 1.5) for char in vocab}
-
-        # TF-IDF vectors
-        vec1 = {char: tf1.get(char, 0) * idf[char] for char in vocab}
-        vec2 = {char: tf2.get(char, 0) * idf[char] for char in vocab}
-
-        # Cosine similarity
-        dot_product = sum(vec1[char] * vec2[char] for char in vocab)
-        norm1 = math.sqrt(sum(v * v for v in vec1.values()))
-        norm2 = math.sqrt(sum(v * v for v in vec2.values()))
-
-        if norm1 == 0 or norm2 == 0:
-            return 0.0
-
-        return dot_product / (norm1 * norm2)
-
-    @staticmethod
-    def _is_text_highly_similar_optimized(
-        candidate_idx: int,
-        candidate_text: str,
-        selected_global: list[int],
-        similarity_matrix,
-        flat: list,
-        threshold: float = 0.9,
-    ) -> bool:
-        """
-        Multi-algorithm text similarity check with embedding pre-filtering.
-
-        Strategy:
-        1. Only compare with the single highest embedding similarity item (not all 25)
-        2. Only perform text comparison if embedding similarity > 0.60
-        3. Use weighted combination of three algorithms:
-           - Dice (40%): Fastest, character-level set similarity
-           - TF-IDF (35%): Considers character frequency weighting
-           - 2-gram (25%): Considers local character order
-
-        Combined formula:
-            combined_score = 0.40 * dice + 0.35 * tfidf + 0.25 * bigram
-
-        This reduces comparisons from O(N) to O(1) per candidate, with embedding pre-filtering.
-        Expected speedup: 100-200x compared to LCS approach.
-
-        Args:
-            candidate_idx: Index of candidate memory in flat list
-            candidate_text: Text content of candidate memory
-            selected_global: List of already selected memory indices
-            similarity_matrix: Precomputed embedding similarity matrix
-            flat: Flat list of all memories
-            threshold: Combined similarity threshold (default 0.75)
-
-        Returns:
-            True if candidate is highly similar to any selected memory
-        """
-        if not selected_global:
-            return False
-
-        # Find the already-selected memory with highest embedding similarity
-        max_sim_idx = max(selected_global, key=lambda j: similarity_matrix[candidate_idx][j])
-        max_sim = similarity_matrix[candidate_idx][max_sim_idx]
-
-        # If highest embedding similarity < 0.60, skip text comparison entirely
-        if max_sim <= 0.9:
-            return False
-
-        # Get text of most similar memory
-        most_similar_mem = flat[max_sim_idx][2]
-        most_similar_text = most_similar_mem.get("memory", "").strip()
-
-        # Calculate three similarity scores
-        dice_sim = SearchHandler._dice_similarity(candidate_text, most_similar_text)
-        tfidf_sim = SearchHandler._tfidf_similarity(candidate_text, most_similar_text)
-        bigram_sim = SearchHandler._bigram_similarity(candidate_text, most_similar_text)
-
-        # Weighted combination: Dice (40%) + TF-IDF (35%) + 2-gram (25%)
-        # Dice has highest weight (fastest and most reliable)
-        # TF-IDF considers frequency (handles repeated characters well)
-        # 2-gram considers order (catches local pattern similarity)
-        combined_score = 0.40 * dice_sim + 0.35 * tfidf_sim + 0.25 * bigram_sim
-
-        return combined_score >= threshold
-
-    @staticmethod
-    def _dice_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate Dice coefficient (character-level, fastest).
-
-        Dice = 2 * |A ∩ B| / (|A| + |B|)
-        Speed: O(n + m), ~0.05-0.1ms per comparison
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Dice similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        chars1 = set(text1)
-        chars2 = set(text2)
-
-        intersection = len(chars1 & chars2)
-        return 2 * intersection / (len(chars1) + len(chars2))
-
-    @staticmethod
-    def _bigram_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate character-level 2-gram Jaccard similarity.
-
-        Speed: O(n + m), ~0.1-0.2ms per comparison
-        Considers local order (more strict than Dice).
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Jaccard similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        # Generate 2-grams
-        bigrams1 = {text1[i : i + 2] for i in range(len(text1) - 1)} if len(text1) >= 2 else {text1}
-        bigrams2 = {text2[i : i + 2] for i in range(len(text2) - 1)} if len(text2) >= 2 else {text2}
-
-        intersection = len(bigrams1 & bigrams2)
-        union = len(bigrams1 | bigrams2)
-
-        return intersection / union if union > 0 else 0.0
-
-    @staticmethod
-    def _tfidf_similarity(text1: str, text2: str) -> float:
-        """
-        Calculate TF-IDF cosine similarity (character-level, no sklearn).
-
-        Speed: O(n + m), ~0.3-0.5ms per comparison
-        Considers character frequency weighting.
-
-        Args:
-            text1: First text string
-            text2: Second text string
-
-        Returns:
-            Cosine similarity score between 0.0 and 1.0
-        """
-        if not text1 or not text2:
-            return 0.0
-
-        from collections import Counter
-
-        # Character frequency (TF)
-        tf1 = Counter(text1)
-        tf2 = Counter(text2)
-
-        # All unique characters (vocabulary)
-        vocab = set(tf1.keys()) | set(tf2.keys())
-
-        # Simple IDF: log(2 / df) where df is document frequency
-        # For two documents, IDF is log(2/1)=0.693 if char appears in one doc,
-        # or log(2/2)=0 if appears in both (we use log(2/1) for simplicity)
-        idf = {char: (1.0 if char in tf1 and char in tf2 else 1.5) for char in vocab}
-
-        # TF-IDF vectors
-        vec1 = {char: tf1.get(char, 0) * idf[char] for char in vocab}
-        vec2 = {char: tf2.get(char, 0) * idf[char] for char in vocab}
-
-        # Cosine similarity
-        dot_product = sum(vec1[char] * vec2[char] for char in vocab)
-        norm1 = math.sqrt(sum(v * v for v in vec1.values()))
-        norm2 = math.sqrt(sum(v * v for v in vec2.values()))
-
-        if norm1 == 0 or norm2 == 0:
-            return 0.0
-
-        return dot_product / (norm1 * norm2)
-
-    @staticmethod
-    def _is_text_highly_similar_optimized(
-        candidate_idx: int,
-        candidate_text: str,
-        selected_global: list[int],
-        similarity_matrix,
-        flat: list,
-        threshold: float = 0.92,
-    ) -> bool:
-        """
-        Multi-algorithm text similarity check with embedding pre-filtering.
-
-        Strategy:
-        1. Only compare with the single highest embedding similarity item (not all 25)
-        2. Only perform text comparison if embedding similarity > 0.60
-        3. Use weighted combination of three algorithms:
-           - Dice (40%): Fastest, character-level set similarity
-           - TF-IDF (35%): Considers character frequency weighting
-           - 2-gram (25%): Considers local character order
-
-        Combined formula:
-            combined_score = 0.40 * dice + 0.35 * tfidf + 0.25 * bigram
-
-        This reduces comparisons from O(N) to O(1) per candidate, with embedding pre-filtering.
-        Expected speedup: 100-200x compared to LCS approach.
-
-        Args:
-            candidate_idx: Index of candidate memory in flat list
-            candidate_text: Text content of candidate memory
-            selected_global: List of already selected memory indices
-            similarity_matrix: Precomputed embedding similarity matrix
-            flat: Flat list of all memories
-            threshold: Combined similarity threshold (default 0.75)
-
-        Returns:
-            True if candidate is highly similar to any selected memory
-        """
-        if not selected_global:
-            return False
-
-        # Find the already-selected memory with highest embedding similarity
-        max_sim_idx = max(selected_global, key=lambda j: similarity_matrix[candidate_idx][j])
-        max_sim = similarity_matrix[candidate_idx][max_sim_idx]
-
-        # If highest embedding similarity < 0.60, skip text comparison entirely
-        if max_sim <= 0.9:
-            return False
-
-        # Get text of most similar memory
-        most_similar_mem = flat[max_sim_idx][2]
-        most_similar_text = most_similar_mem.get("memory", "").strip()
-
-        # Calculate three similarity scores
-        dice_sim = SearchHandler._dice_similarity(candidate_text, most_similar_text)
-        tfidf_sim = SearchHandler._tfidf_similarity(candidate_text, most_similar_text)
-        bigram_sim = SearchHandler._bigram_similarity(candidate_text, most_similar_text)
-
-        # Weighted combination: Dice (40%) + TF-IDF (35%) + 2-gram (25%)
-        # Dice has highest weight (fastest and most reliable)
-        # TF-IDF considers frequency (handles repeated characters well)
-        # 2-gram considers order (catches local pattern similarity)
-        combined_score = 0.40 * dice_sim + 0.35 * tfidf_sim + 0.25 * bigram_sim
-
-        return combined_score >= threshold
 
     def _resolve_cube_ids(self, search_req: APISearchRequest) -> list[str]:
         """

--- a/src/memos/api/handlers/search_handler.py
+++ b/src/memos/api/handlers/search_handler.py
@@ -7,11 +7,15 @@ using dependency injection for better modularity and testability.
 
 import copy
 import math
+import os
 
 from typing import Any
 
+from fastapi import HTTPException
+
 from memos.api.handlers.base_handler import BaseHandler, HandlerDependencies
 from memos.api.handlers.formatters_handler import rerank_knowledge_mem
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.product_models import APISearchRequest, SearchResponse
 from memos.log import get_logger
 from memos.memories.textual.tree_text_memory.retrieve.retrieve_utils import (
@@ -59,12 +63,32 @@ class SearchHandler(BaseHandler):
         """
         self.logger.info(f"[SearchHandler] Search Req is: {search_req}")
 
+        # Auth spoof check: if a key was presented, user_id must match what the key says
+        authenticated = get_authenticated_user()
+        if authenticated is not None and authenticated != search_req.user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Key authenticated as '{authenticated}' but request claims user_id='{search_req.user_id}'. Spoofing not allowed."
+            )
+
+        # Cube isolation: verify user has access to all requested cubes
+        user_manager = getattr(self.deps, "user_manager", None)
+        if user_manager:
+            cube_ids = self._resolve_cube_ids(search_req)
+            for cube_id in cube_ids:
+                if not user_manager.validate_user_cube_access(search_req.user_id, cube_id):
+                    raise HTTPException(
+                        status_code=403,
+                        detail=f"Access denied: user '{search_req.user_id}' cannot read cube '{cube_id}'"
+                    )
+
         # Use deepcopy to avoid modifying the original request object
         search_req_local = copy.deepcopy(search_req)
 
-        # Expand top_k for deduplication (5x to ensure enough candidates)
+        # Expand top_k for deduplication (env-configurable, default 5x)
+        _top_k_factor = int(os.getenv("MOS_SEARCH_TOP_K_FACTOR", "5"))
         if search_req_local.dedup in ("sim", "mmr"):
-            search_req_local.top_k = search_req_local.top_k * 3
+            search_req_local.top_k = search_req_local.top_k * _top_k_factor
 
         # Search and deduplicate
         cube_view = self._build_cube_view(search_req_local)
@@ -297,8 +321,9 @@ class SearchHandler(BaseHandler):
                 continue
 
             # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
+            _mmr_text_threshold = float(os.getenv("MOS_MMR_TEXT_THRESHOLD", "0.85"))
             if SearchHandler._is_text_highly_similar_optimized(
-                idx, mem_text, selected_global, similarity_matrix, flat, threshold=0.92
+                idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
             ):
                 continue
 
@@ -314,7 +339,7 @@ class SearchHandler(BaseHandler):
 
         # Phase 2: MMR selection for remaining slots
         lambda_relevance = 0.8
-        similarity_threshold = 0.9  # Start exponential penalty from 0.9 (lowered from 0.9)
+        similarity_threshold = float(os.getenv("MOS_MMR_PENALTY_THRESHOLD", "0.7"))  # Exponential penalty start
         alpha_exponential = 10.0  # Exponential penalty coefficient
         remaining = set(range(len(flat))) - set(selected_global)
 
@@ -341,7 +366,7 @@ class SearchHandler(BaseHandler):
 
                 # Skip if highly similar (Dice + TF-IDF + 2-gram combined, with embedding filter)
                 if SearchHandler._is_text_highly_similar_optimized(
-                    idx, mem_text, selected_global, similarity_matrix, flat, threshold=0.92
+                    idx, mem_text, selected_global, similarity_matrix, flat, threshold=_mmr_text_threshold
                 ):
                     continue  # Skip highly similar text, don't participate in MMR competition
 

--- a/src/memos/api/middleware/agent_auth.py
+++ b/src/memos/api/middleware/agent_auth.py
@@ -52,6 +52,11 @@ logger = get_logger(__name__)
 # Thread-safe contextvar: holds the user_id the key authenticated as, or None
 _authenticated_user: ContextVar[str | None] = ContextVar("authenticated_user", default=None)
 
+# Length of the raw-key prefix used for bucket-lookup. Must match the prefix
+# length the provisioning script writes into agents-auth.json (12 chars).
+# See: deploy/scripts/setup-memos-agents.py in the Hermes repo.
+KEY_PREFIX_LEN = 12
+
 
 def get_authenticated_user() -> str | None:
     """Return the user_id bound to the current request's API key, or None if unauthenticated."""
@@ -86,6 +91,17 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
         self.config_path = config_path or os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
         self._agents: list[dict] = []  # [{"key_hash": bytes, "user_id": str}, ...] for v2
         self._keys: dict[str, str] = {}  # raw_key → user_id (v1 legacy fallback)
+        # Bucket index: key_prefix → [agent records sharing that prefix].
+        # On each request we BCrypt-verify only the bucket for the incoming key's
+        # prefix (typically 1 candidate, occasionally 2-3 on a collision) instead
+        # of every agent's hash. This caps worst-case BCrypt cost so a flood of
+        # random invalid keys can no longer DoS the server.
+        self._prefix_index: dict[str, list[dict]] = {}
+        # Records that lack a key_prefix (legacy entries, pre-schema-2). We fall
+        # back to walking these on every lookup so they still authenticate, but
+        # they degrade the worst case toward the old O(N) behaviour. A single
+        # WARN at load tells ops to backfill via setup-memos-agents.py.
+        self._unprefixed_agents: list[dict] = []
         self._is_hashed = False
         self.auth_required = os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() == "true"
         self._config_mtime: float = 0.0
@@ -115,17 +131,47 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
                 # Hashed format (v2)
                 self._agents = []
                 self._keys = {}
+                self._prefix_index = {}
+                self._unprefixed_agents = []
                 self._is_hashed = True
+                unprefixed_uids: list[str] = []
                 for entry in agents:
-                    if entry.get("key_hash"):
-                        self._agents.append({
-                            "key_hash": entry["key_hash"].encode("utf-8"),
-                            "user_id": entry["user_id"],
-                            "key_prefix": entry.get("key_prefix", "??"),
-                        })
+                    if not entry.get("key_hash"):
+                        continue
+                    record = {
+                        "key_hash": entry["key_hash"].encode("utf-8"),
+                        "user_id": entry["user_id"],
+                    }
+                    self._agents.append(record)
+                    prefix = entry.get("key_prefix")
+                    if prefix and len(prefix) >= KEY_PREFIX_LEN:
+                        # Normalise on the canonical prefix length so the lookup
+                        # key matches whatever we extract from the incoming raw key.
+                        bucket_key = prefix[:KEY_PREFIX_LEN]
+                        self._prefix_index.setdefault(bucket_key, []).append(record)
+                    else:
+                        self._unprefixed_agents.append(record)
+                        unprefixed_uids.append(entry["user_id"])
                 logger.info(
-                    f"[AgentAuth] Loaded {len(self._agents)} hashed agent key(s) from {self.config_path}"
+                    f"[AgentAuth] Loaded {len(self._agents)} hashed agent key(s) from "
+                    f"{self.config_path} ({len(self._prefix_index)} prefix bucket(s), "
+                    f"{len(self._unprefixed_agents)} legacy unprefixed)"
                 )
+                if unprefixed_uids:
+                    # Single startup WARN — not per-request — telling ops how to
+                    # eliminate the O(N) degrade. See agent_auth.py module docstring
+                    # in the Hermes provisioning script for the migration story.
+                    logger.warning(
+                        "[AgentAuth] %d agent record(s) lack key_prefix and will "
+                        "force an O(N) BCrypt walk on every lookup: %s. "
+                        "Run setup-memos-agents.py against agents-auth.json to "
+                        "backfill prefixes (only possible for entries with a "
+                        "recoverable raw key). For pure-hash entries, rotate the "
+                        "key: delete the entry from agents-auth.json and re-run "
+                        "the provisioning script.",
+                        len(unprefixed_uids),
+                        unprefixed_uids,
+                    )
             else:
                 # Legacy plaintext format (v1)
                 self._agents = []
@@ -148,6 +194,8 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
                 logger.info("[AgentAuth] Config file changed on disk — reloading.")
                 self._agents = []
                 self._keys = {}
+                self._prefix_index = {}
+                self._unprefixed_agents = []
                 self._verify_cache.clear()
                 self._load_config()
         except OSError:
@@ -157,6 +205,8 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
         """Hot-reload key registry without restarting the server."""
         self._agents = []
         self._keys.clear()
+        self._prefix_index = {}
+        self._unprefixed_agents = []
         self._verify_cache.clear()
         self._load_config()
 
@@ -185,9 +235,21 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
     def _authenticate_key(self, key: str) -> str | None:
         """Validate an API key. Returns user_id on success, None on failure.
 
-        Hashed (v2) path is cached: a sha256 of the raw key maps to the verified
-        user_id, so repeat requests skip the ~200ms bcrypt round per agent.
-        Failures are never cached (would let an attacker probe the cache).
+        Hashed (v2) path is layered:
+
+        1. **Verify cache** (sha256(raw_key) → user_id): repeat valid keys skip
+           BCrypt entirely. Failures are never cached — that would let an
+           attacker probe the cache to enumerate valid keys.
+        2. **Prefix bucket lookup**: BCrypt-check only the candidates whose
+           stored ``key_prefix`` matches the incoming key's first KEY_PREFIX_LEN
+           chars. With the provisioning script's 12-char prefix, collision
+           probability across N agents is ≪ N, so worst case is 1-2 BCrypts
+           on a valid lookup, **0** on a random bad key (no bucket match) —
+           down from O(N) ~250ms-per-agent on every invalid request.
+        3. **Unprefixed fallback**: any record loaded without ``key_prefix``
+           (legacy entries pre-schema-2) is also walked. We need this so
+           legacy hashes still authenticate; the load-time WARN tells ops
+           how to eliminate the cost.
         """
         if self._is_hashed:
             key_bytes = key.encode("utf-8")
@@ -197,7 +259,25 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
                 # Refresh recency
                 self._verify_cache.move_to_end(cache_key)
                 return cached
-            for agent in self._agents:
+
+            # Bucket lookup. An incoming key shorter than the prefix length
+            # cannot match any well-formed bucket — skip straight to the
+            # legacy fallback so we still authenticate any pre-schema-2 hash.
+            if len(key) >= KEY_PREFIX_LEN:
+                candidates = self._prefix_index.get(key[:KEY_PREFIX_LEN], ())
+            else:
+                candidates = ()
+
+            for agent in candidates:
+                if bcrypt.checkpw(key_bytes, agent["key_hash"]):
+                    self._verify_cache[cache_key] = agent["user_id"]
+                    self._verify_cache.move_to_end(cache_key)
+                    if len(self._verify_cache) > self.VERIFY_CACHE_MAX:
+                        self._verify_cache.popitem(last=False)
+                    return agent["user_id"]
+
+            # Legacy fallback: only walked if at least one record lacks a prefix.
+            for agent in self._unprefixed_agents:
                 if bcrypt.checkpw(key_bytes, agent["key_hash"]):
                     self._verify_cache[cache_key] = agent["user_id"]
                     self._verify_cache.move_to_end(cache_key)

--- a/src/memos/api/middleware/agent_auth.py
+++ b/src/memos/api/middleware/agent_auth.py
@@ -1,0 +1,250 @@
+"""
+Agent authentication middleware for MemOS.
+
+Validates per-agent API keys loaded from a JSON config file.
+On a valid key, stores the authenticated user_id in a contextvar so
+handlers can verify the caller isn't spoofing a different user_id.
+
+Config file format (MEMOS_AGENT_AUTH_CONFIG env var):
+{
+  "version": 2,
+  "agents": [
+    {"key_hash": "$2b$12$...", "key_prefix": "ak_244c", "user_id": "ceo", "description": "CEO Agent"},
+    ...
+  ]
+}
+
+Legacy format (version 1, auto-detected):
+{
+  "version": 1,
+  "agents": [
+    {"key": "ak_...", "user_id": "ceo", "description": "CEO Agent"},
+    ...
+  ]
+}
+
+Usage:
+  Header: Authorization: Bearer ak_<32-hex-chars>
+
+Env vars:
+  MEMOS_AGENT_AUTH_CONFIG  — path to agents-auth.json (required to enable auth)
+  MEMOS_AUTH_REQUIRED      — if "true", requests without a valid key are rejected (401)
+                             if "false" (default), unauthenticated requests pass through
+                             but cannot spoof an authenticated user
+"""
+
+import json
+import os
+import time
+from collections import defaultdict
+from contextvars import ContextVar
+
+import bcrypt
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from memos.log import get_logger
+
+logger = get_logger(__name__)
+
+# Thread-safe contextvar: holds the user_id the key authenticated as, or None
+_authenticated_user: ContextVar[str | None] = ContextVar("authenticated_user", default=None)
+
+
+def get_authenticated_user() -> str | None:
+    """Return the user_id bound to the current request's API key, or None if unauthenticated."""
+    return _authenticated_user.get()
+
+
+class AgentAuthMiddleware(BaseHTTPMiddleware):
+    """
+    Starlette middleware that validates per-agent API keys.
+
+    - Reads key registry from MEMOS_AGENT_AUTH_CONFIG on startup.
+    - Only applies to /product/* endpoints (skips /health, /download, etc).
+    - Stores authenticated user_id in a contextvar for handler-level spoof checks.
+    - Rate-limits failed auth attempts per IP (10 failures / 60s → 429 for 60s).
+    - Auto-reloads config when the file changes on disk.
+    """
+
+    # Paths that skip agent auth entirely (admin router has its own auth)
+    SKIP_PATHS = {"/health", "/docs", "/openapi.json", "/redoc"}
+    SKIP_PREFIXES = ("/download", "/admin")
+
+    # Rate limiting constants
+    RATE_LIMIT_MAX_FAILURES = 10
+    RATE_LIMIT_WINDOW_SECONDS = 60
+
+    def __init__(self, app, config_path: str | None = None):
+        super().__init__(app)
+        self.config_path = config_path or os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+        self._agents: list[dict] = []  # [{"key_hash": bytes, "user_id": str}, ...] for v2
+        self._keys: dict[str, str] = {}  # raw_key → user_id (v1 legacy fallback)
+        self._is_hashed = False
+        self.auth_required = os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() == "true"
+        self._config_mtime: float = 0.0
+        self._fail_tracker: dict[str, list[float]] = defaultdict(list)
+        self._load_config()
+
+    def _load_config(self) -> None:
+        """Load key registry from JSON file. Supports both hashed (v2) and plaintext (v1) formats."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            logger.warning(
+                f"[AgentAuth] Config not found at '{self.config_path}'. "
+                "Auth disabled — set MEMOS_AGENT_AUTH_CONFIG to enable."
+            )
+            return
+
+        try:
+            self._config_mtime = os.path.getmtime(self.config_path)
+            with open(self.config_path) as f:
+                data = json.load(f)
+
+            agents = data.get("agents", [])
+            version = data.get("version", 1)
+
+            if version >= 2 or any("key_hash" in a for a in agents):
+                # Hashed format (v2)
+                self._agents = []
+                self._keys = {}
+                self._is_hashed = True
+                for entry in agents:
+                    if entry.get("key_hash"):
+                        self._agents.append({
+                            "key_hash": entry["key_hash"].encode("utf-8"),
+                            "user_id": entry["user_id"],
+                            "key_prefix": entry.get("key_prefix", "??"),
+                        })
+                logger.info(
+                    f"[AgentAuth] Loaded {len(self._agents)} hashed agent key(s) from {self.config_path}"
+                )
+            else:
+                # Legacy plaintext format (v1)
+                self._agents = []
+                self._is_hashed = False
+                self._keys = {entry["key"]: entry["user_id"] for entry in agents if entry.get("key")}
+                logger.info(
+                    f"[AgentAuth] Loaded {len(self._keys)} plaintext agent key(s) from {self.config_path} "
+                    "(legacy v1 format — run setup-memos-agents.py to migrate to hashed keys)"
+                )
+        except Exception as e:
+            logger.error(f"[AgentAuth] Failed to load config: {e}")
+
+    def _check_reload(self) -> None:
+        """Reload config if the file has been modified since last load."""
+        if not self.config_path or not os.path.exists(self.config_path):
+            return
+        try:
+            mtime = os.path.getmtime(self.config_path)
+            if mtime != self._config_mtime:
+                logger.info("[AgentAuth] Config file changed on disk — reloading.")
+                self._agents = []
+                self._keys = {}
+                self._load_config()
+        except OSError:
+            pass
+
+    def reload(self) -> None:
+        """Hot-reload key registry without restarting the server."""
+        self._agents = []
+        self._keys.clear()
+        self._load_config()
+
+    def _should_skip(self, path: str) -> bool:
+        if path in self.SKIP_PATHS:
+            return True
+        return any(path.startswith(p) for p in self.SKIP_PREFIXES)
+
+    def _is_rate_limited(self, client_ip: str) -> bool:
+        """Check if a client IP has exceeded the auth failure rate limit."""
+        now = time.monotonic()
+        window_start = now - self.RATE_LIMIT_WINDOW_SECONDS
+        # Prune old entries
+        failures = self._fail_tracker[client_ip]
+        self._fail_tracker[client_ip] = [t for t in failures if t > window_start]
+        return len(self._fail_tracker[client_ip]) >= self.RATE_LIMIT_MAX_FAILURES
+
+    def _record_failure(self, client_ip: str) -> None:
+        """Record an auth failure for rate limiting."""
+        self._fail_tracker[client_ip].append(time.monotonic())
+
+    def _clear_failures(self, client_ip: str) -> None:
+        """Clear failure history on successful auth."""
+        self._fail_tracker.pop(client_ip, None)
+
+    def _authenticate_key(self, key: str) -> str | None:
+        """Validate an API key. Returns user_id on success, None on failure."""
+        if self._is_hashed:
+            key_bytes = key.encode("utf-8")
+            for agent in self._agents:
+                if bcrypt.checkpw(key_bytes, agent["key_hash"]):
+                    return agent["user_id"]
+            return None
+        else:
+            return self._keys.get(key)
+
+    async def dispatch(self, request: Request, call_next):
+        if self._should_skip(request.url.path):
+            return await call_next(request)
+
+        # Auto-reload config if file changed
+        self._check_reload()
+
+        client_ip = request.client.host if request.client else "unknown"
+        rate_limited = self._is_rate_limited(client_ip)
+
+        auth_header = request.headers.get("Authorization", "").strip()
+
+        # No auth header
+        if not auth_header:
+            if self.auth_required:
+                return JSONResponse(
+                    {"detail": "Authorization header required. Use: Authorization: Bearer <agent-key>"},
+                    status_code=401,
+                )
+            # Unauthenticated passthrough — handlers will still enforce cube permissions
+            token = _authenticated_user.set(None)
+            try:
+                return await call_next(request)
+            finally:
+                _authenticated_user.reset(token)
+
+        # Parse Bearer token
+        parts = auth_header.split(None, 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            self._record_failure(client_ip)
+            if rate_limited:
+                return JSONResponse(
+                    {"detail": "Too many failed authentication attempts. Try again later."},
+                    status_code=429,
+                )
+            return JSONResponse(
+                {"detail": "Invalid Authorization format. Expected: Bearer <agent-key>"},
+                status_code=401,
+            )
+
+        key = parts[1].strip()
+        user_id = self._authenticate_key(key)
+
+        if user_id is None:
+            self._record_failure(client_ip)
+            if rate_limited:
+                return JSONResponse(
+                    {"detail": "Too many failed authentication attempts. Try again later."},
+                    status_code=429,
+                )
+            return JSONResponse(
+                {"detail": "Invalid or unknown agent key."},
+                status_code=401,
+            )
+
+        # Successful auth — clear failure history
+        self._clear_failures(client_ip)
+
+        logger.debug(f"[AgentAuth] Authenticated: user_id={user_id}")
+        token = _authenticated_user.set(user_id)
+        try:
+            return await call_next(request)
+        finally:
+            _authenticated_user.reset(token)

--- a/src/memos/api/middleware/agent_auth.py
+++ b/src/memos/api/middleware/agent_auth.py
@@ -33,10 +33,11 @@ Env vars:
                              but cannot spoof an authenticated user
 """
 
+import hashlib
 import json
 import os
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from contextvars import ContextVar
 
 import bcrypt
@@ -76,6 +77,10 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
     RATE_LIMIT_MAX_FAILURES = 10
     RATE_LIMIT_WINDOW_SECONDS = 60
 
+    # Verified-key cache (skip bcrypt on repeat keys). Bounded FIFO; small because
+    # we only have a handful of agents. Values are user_ids, never bcrypt hashes.
+    VERIFY_CACHE_MAX = 64
+
     def __init__(self, app, config_path: str | None = None):
         super().__init__(app)
         self.config_path = config_path or os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
@@ -85,6 +90,8 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
         self.auth_required = os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() == "true"
         self._config_mtime: float = 0.0
         self._fail_tracker: dict[str, list[float]] = defaultdict(list)
+        # sha256(raw_key) -> user_id. Only populated on successful bcrypt verify.
+        self._verify_cache: OrderedDict[str, str] = OrderedDict()
         self._load_config()
 
     def _load_config(self) -> None:
@@ -141,6 +148,7 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
                 logger.info("[AgentAuth] Config file changed on disk — reloading.")
                 self._agents = []
                 self._keys = {}
+                self._verify_cache.clear()
                 self._load_config()
         except OSError:
             pass
@@ -149,6 +157,7 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
         """Hot-reload key registry without restarting the server."""
         self._agents = []
         self._keys.clear()
+        self._verify_cache.clear()
         self._load_config()
 
     def _should_skip(self, path: str) -> bool:
@@ -174,11 +183,26 @@ class AgentAuthMiddleware(BaseHTTPMiddleware):
         self._fail_tracker.pop(client_ip, None)
 
     def _authenticate_key(self, key: str) -> str | None:
-        """Validate an API key. Returns user_id on success, None on failure."""
+        """Validate an API key. Returns user_id on success, None on failure.
+
+        Hashed (v2) path is cached: a sha256 of the raw key maps to the verified
+        user_id, so repeat requests skip the ~200ms bcrypt round per agent.
+        Failures are never cached (would let an attacker probe the cache).
+        """
         if self._is_hashed:
             key_bytes = key.encode("utf-8")
+            cache_key = hashlib.sha256(key_bytes).hexdigest()
+            cached = self._verify_cache.get(cache_key)
+            if cached is not None:
+                # Refresh recency
+                self._verify_cache.move_to_end(cache_key)
+                return cached
             for agent in self._agents:
                 if bcrypt.checkpw(key_bytes, agent["key_hash"]):
+                    self._verify_cache[cache_key] = agent["user_id"]
+                    self._verify_cache.move_to_end(cache_key)
+                    if len(self._verify_cache) > self.VERIFY_CACHE_MAX:
+                        self._verify_cache.popitem(last=False)
                     return agent["user_id"]
             return None
         else:

--- a/src/memos/api/middleware/rate_limit.py
+++ b/src/memos/api/middleware/rate_limit.py
@@ -1,14 +1,30 @@
 """
-Redis-based Rate Limiting Middleware.
+Rate Limiting Middleware.
 
-Implements sliding window rate limiting with Redis.
-Falls back to in-memory limiting if Redis is unavailable.
+Sliding-window rate limiter with Redis as the primary backend. If Redis is
+unreachable or unconfigured, falls back to a **file-backed SQLite store** so
+state survives restarts in single-worker deployments. Multi-worker setups
+without Redis will share counters via SQLite's file lock — coarser-grained
+than Redis but still functionally correct.
+
+The Redis URL is read from ``MEMOS_REDIS_URL``. If unset, Redis is **not**
+attempted and the server starts in SQLite-fallback mode with a single
+startup WARN. Previous behaviour (hard-coded ``redis://redis:6379`` default
++ warn-on-every-request) flooded logs in non-Docker deployments where the
+hostname doesn't resolve.
+
+Env vars:
+  MEMOS_REDIS_URL        — Redis URL. Unset → SQLite fallback. (no default)
+  MEMOS_RATE_LIMIT_DB    — SQLite file path for fallback (default: /var/tmp/memos-ratelimit.db)
+  RATE_LIMIT             — Max requests per window (default: 100)
+  RATE_WINDOW_SEC        — Window length in seconds (default: 60)
 """
 
 import os
+import sqlite3
 import time
+import threading
 
-from collections import defaultdict
 from collections.abc import Callable
 from typing import ClassVar
 
@@ -24,30 +40,101 @@ logger = memos.log.get_logger(__name__)
 # Configuration from environment
 RATE_LIMIT = int(os.getenv("RATE_LIMIT", "100"))  # Requests per window
 RATE_WINDOW = int(os.getenv("RATE_WINDOW_SEC", "60"))  # Window in seconds
-REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379")
+# No default — unset means "operator chose SQLite fallback explicitly".
+# Previous default of redis://redis:6379 caused name-resolution flooding in
+# non-Docker deployments.
+REDIS_URL = os.getenv("MEMOS_REDIS_URL")
+DB_PATH = os.getenv("MEMOS_RATE_LIMIT_DB", "/var/tmp/memos-ratelimit.db")
 
-# Redis client (lazy initialization)
-_redis_client = None
+# Redis client (lazy initialization). Sentinel `_REDIS_DISABLED` means we
+# tried once, failed, and should not retry — switches the process to
+# SQLite-fallback mode permanently. Avoids the warn-on-every-request flood.
+_REDIS_DISABLED = object()
+_redis_client = None  # None = not yet attempted; client = up; _REDIS_DISABLED = down
 
-# In-memory fallback (per process)
-_memory_store: dict[str, list[float]] = defaultdict(list)
+# Counter for /metrics-style observability: number of times we've served a
+# request from the SQLite fallback. Read by tests / future /metrics endpoint.
+_redis_fallback_request_count = 0
+
+# SQLite connection (one per process; sqlite3 connections aren't thread-safe
+# unless `check_same_thread=False`, which is fine here because we serialize
+# writes with a lock).
+_sqlite_conn: sqlite3.Connection | None = None
+_sqlite_lock = threading.Lock()
+
+
+def _init_sqlite() -> sqlite3.Connection:
+    """Lazily initialise the SQLite fallback store. Idempotent."""
+    global _sqlite_conn
+    if _sqlite_conn is not None:
+        return _sqlite_conn
+    # Ensure the parent directory exists.
+    parent = os.path.dirname(DB_PATH) or "."
+    os.makedirs(parent, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False, isolation_level=None)
+    # WAL keeps writers from blocking concurrent readers — important when
+    # multiple workers share the file.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS rate_limit_events ("
+        "  key TEXT NOT NULL,"
+        "  ts  REAL NOT NULL"
+        ")"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_rl_key_ts ON rate_limit_events (key, ts)"
+    )
+    _sqlite_conn = conn
+    return conn
 
 
 def _get_redis():
-    """Get or create Redis client."""
+    """Return a connected Redis client or ``None`` if unavailable.
+
+    On the first call we try once. On failure we cache that failure for the
+    process lifetime — every subsequent call returns ``None`` immediately
+    without re-attempting DNS resolution. This is what makes the WARN fire
+    *once at startup* rather than on every request.
+    """
     global _redis_client
+    if _redis_client is _REDIS_DISABLED:
+        return None
     if _redis_client is not None:
         return _redis_client
+
+    if not REDIS_URL:
+        # Operator did not set MEMOS_REDIS_URL — log once and stop trying.
+        logger.warning(
+            "[RateLimit] MEMOS_REDIS_URL is unset. Running in SQLite-fallback "
+            "mode at %s. State persists across restarts but is not shared with "
+            "remote workers; set MEMOS_REDIS_URL=redis://host:port for "
+            "production multi-worker deployments.",
+            DB_PATH,
+        )
+        _redis_client = _REDIS_DISABLED
+        return None
 
     try:
         import redis
 
-        _redis_client = redis.from_url(REDIS_URL, decode_responses=True)
-        _redis_client.ping()  # Test connection
-        logger.info("Rate limiter connected to Redis")
-        return _redis_client
+        client = redis.from_url(REDIS_URL, decode_responses=True)
+        client.ping()  # Force a connection so we discover failure now, not later.
+        _redis_client = client
+        logger.info("[RateLimit] Connected to Redis at %s", REDIS_URL)
+        return client
     except Exception as e:
-        logger.warning(f"Redis not available for rate limiting: {e}")
+        # ONE warning ever. Subsequent _get_redis() calls short-circuit on
+        # the sentinel and never reach this path again.
+        logger.warning(
+            "[RateLimit] Redis unreachable at %s (%s). Falling back to SQLite "
+            "at %s for the lifetime of this process. Restart after fixing "
+            "Redis to re-enable distributed rate limiting.",
+            REDIS_URL,
+            e,
+            DB_PATH,
+        )
+        _redis_client = _REDIS_DISABLED
         return None
 
 
@@ -83,7 +170,7 @@ def _check_rate_limit_redis(key: str) -> tuple[bool, int, int]:
     """
     redis_client = _get_redis()
     if not redis_client:
-        return _check_rate_limit_memory(key)
+        return _check_rate_limit_sqlite(key)
 
     try:
         now = time.time()
@@ -115,38 +202,54 @@ def _check_rate_limit_redis(key: str) -> tuple[bool, int, int]:
         return True, remaining, reset_time
 
     except Exception as e:
-        logger.warning(f"Redis rate limit error: {e}")
-        return _check_rate_limit_memory(key)
+        # Transient Redis error mid-flight — degrade quietly to SQLite for
+        # this single request. Logged at DEBUG only; the once-at-startup
+        # WARN already informed ops of the broader Redis state.
+        logger.debug("[RateLimit] Redis pipeline error (this request only): %s", e)
+        return _check_rate_limit_sqlite(key)
 
 
-def _check_rate_limit_memory(key: str) -> tuple[bool, int, int]:
+def _check_rate_limit_sqlite(key: str) -> tuple[bool, int, int]:
+    """File-backed sliding-window fallback.
+
+    Survives process restarts. Multi-worker safe via SQLite's WAL + per-write
+    lock; coarser than Redis but functionally correct for sliding-window
+    semantics.
     """
-    Fallback in-memory rate limiting.
+    global _redis_fallback_request_count
+    _redis_fallback_request_count += 1
 
-    Note: This is per-process and not distributed!
-    """
+    conn = _init_sqlite()
     now = time.time()
     window_start = now - RATE_WINDOW
 
-    # Clean old entries
-    _memory_store[key] = [t for t in _memory_store[key] if t > window_start]
-
-    current_count = len(_memory_store[key])
-
-    if current_count >= RATE_LIMIT:
-        reset_time = (
-            int(min(_memory_store[key]) + RATE_WINDOW)
-            if _memory_store[key]
-            else int(now + RATE_WINDOW)
+    with _sqlite_lock:
+        # Prune old entries for this key.
+        conn.execute(
+            "DELETE FROM rate_limit_events WHERE key = ? AND ts < ?",
+            (key, window_start),
         )
-        return False, 0, reset_time
+        cursor = conn.execute(
+            "SELECT COUNT(*) FROM rate_limit_events WHERE key = ?",
+            (key,),
+        )
+        current_count = cursor.fetchone()[0]
 
-    # Add current request
-    _memory_store[key].append(now)
+        if current_count >= RATE_LIMIT:
+            cursor = conn.execute(
+                "SELECT MIN(ts) FROM rate_limit_events WHERE key = ?",
+                (key,),
+            )
+            oldest = cursor.fetchone()[0] or now
+            return False, 0, int(oldest + RATE_WINDOW)
+
+        conn.execute(
+            "INSERT INTO rate_limit_events (key, ts) VALUES (?, ?)",
+            (key, now),
+        )
 
     remaining = RATE_LIMIT - current_count - 1
     reset_time = int(now + RATE_WINDOW)
-
     return True, remaining, reset_time
 
 
@@ -164,6 +267,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     # Paths exempt from rate limiting
     EXEMPT_PATHS: ClassVar[set[str]] = {"/health", "/openapi.json", "/docs", "/redoc"}
+
+    def __init__(self, app):
+        super().__init__(app)
+        # Resolve Redis state at startup (one-shot WARN if unreachable)
+        # rather than on first request.
+        _get_redis()
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         # Skip rate limiting for exempt paths

--- a/src/memos/api/middleware/request_context.py
+++ b/src/memos/api/middleware/request_context.py
@@ -67,9 +67,11 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         )
         set_request_context(context)
 
+        # Log request start without sensitive headers (Authorization, cookies)
+        safe_headers = {k: v for k, v in request.headers.items() if k.lower() not in ("authorization", "cookie")}
         logger.info(
             f"Request started, source: {self.source}, method: {request.method}, path: {request.url.path}, "
-            f"headers: {request.headers}"
+            f"headers: {safe_headers}"
         )
 
         response = await call_next(request)

--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -99,12 +99,12 @@ class ChatRequest(BaseRequest):
     manager_user_id: str | None = Field(None, description="Manager User ID")
     project_id: str | None = Field(None, description="Project ID")
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 
@@ -339,12 +339,12 @@ class APISearchRequest(BaseRequest):
     )
 
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 
@@ -785,12 +785,12 @@ class APIChatCompleteRequest(BaseRequest):
     manager_user_id: str | None = Field(None, description="Manager User ID")
     project_id: str | None = Field(None, description="Project ID")
     relativity: float = Field(
-        0.45,
+        0.05,
         ge=0,
         description=(
             "Relevance threshold for recalled memories. "
             "Only memories with metadata.relativity >= relativity will be returned. "
-            "Use 0 to disable threshold filtering. Default: 0.45."
+            "Use 0 to disable threshold filtering. Default: 0.05."
         ),
     )
 

--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -855,7 +855,21 @@ class DeleteMemoryRequest(BaseRequest):
     """Request model for deleting memories."""
 
     writable_cube_ids: list[str] | None = Field(None, description="Writable cube IDs")
+    mem_cube_id: str | None = Field(
+        None,
+        description=(
+            "Singular alias for writable_cube_ids. If writable_cube_ids is omitted, "
+            "mem_cube_id is wrapped into a single-element list."
+        ),
+    )
     memory_ids: list[str] | None = Field(None, description="Memory IDs")
+    memory_id: str | None = Field(
+        None,
+        description=(
+            "Singular alias for memory_ids. If memory_ids is omitted, "
+            "memory_id is wrapped into a single-element list."
+        ),
+    )
     file_ids: list[str] | None = Field(None, description="File IDs")
     filter: dict[str, Any] | None = Field(None, description="Filter for the memory")
     user_id: str | None = Field(
@@ -880,11 +894,23 @@ class DeleteMemoryRequest(BaseRequest):
 
     @model_validator(mode="after")
     def normalize_session_alias(self) -> "DeleteMemoryRequest":
-        """Normalize conversation_id to session_id."""
+        """Normalize singular/plural aliases.
+
+        Rules:
+        - conversation_id aliases session_id (legacy).
+        - mem_cube_id (singular) coerces into writable_cube_ids when the plural is absent;
+          plural wins if both are provided.
+        - memory_id (singular) coerces into memory_ids under the same rule.
+        """
         if self.conversation_id and self.session_id and self.conversation_id != self.session_id:
             raise ValueError("conversation_id and session_id must be the same when both are set")
         if self.session_id is None and self.conversation_id is not None:
             self.session_id = self.conversation_id
+
+        if self.writable_cube_ids is None and self.mem_cube_id:
+            self.writable_cube_ids = [self.mem_cube_id]
+        if self.memory_ids is None and self.memory_id:
+            self.memory_ids = [self.memory_id]
         return self
 
 

--- a/src/memos/api/routers/admin_router.py
+++ b/src/memos/api/routers/admin_router.py
@@ -1,55 +1,105 @@
 """
-Admin Router for API Key Management.
+Admin Router for Agent Key Management.
 
-Protected by master key or admin scope.
+Manages agent API keys via the agents-auth.json file that AgentAuthMiddleware reads.
+Protected by a dedicated admin key (MEMOS_ADMIN_KEY env var).
+
+Produces v2 hashed entries (bcrypt) compatible with AgentAuthMiddleware.
 """
 
+import json
 import os
+import secrets
+from datetime import datetime
+from pathlib import Path
 
-from typing import Any
-
-from fastapi import APIRouter, Depends, HTTPException
+import bcrypt
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-import memos.log
-
-from memos.api.middleware.auth import require_scope, verify_api_key
-from memos.api.utils.api_keys import (
-    create_api_key_in_db,
-    generate_master_key,
-    list_api_keys,
-    revoke_api_key,
-)
+from memos.log import get_logger
 
 
-logger = memos.log.get_logger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
-
-# Request/Response models
-class CreateKeyRequest(BaseModel):
-    user_name: str = Field(..., min_length=1, max_length=255)
-    scopes: list[str] = Field(default=["read"])
-    description: str | None = Field(default=None, max_length=500)
-    expires_in_days: int | None = Field(default=None, ge=1, le=365)
+# Admin auth: a separate env-var key that only the operator knows.
+_ADMIN_KEY = os.getenv("MEMOS_ADMIN_KEY", "")
 
 
-class CreateKeyResponse(BaseModel):
+def _require_admin(request: Request):
+    """Dependency: reject requests without a valid admin key."""
+    if not _ADMIN_KEY:
+        raise HTTPException(status_code=503, detail="Admin API not configured (MEMOS_ADMIN_KEY not set)")
+    auth = request.headers.get("Authorization", "").strip()
+    if not auth:
+        raise HTTPException(status_code=401, detail="Admin key required: Authorization: Bearer <admin-key>")
+    parts = auth.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1].strip() != _ADMIN_KEY:
+        raise HTTPException(status_code=401, detail="Invalid admin key")
+
+
+def _get_config_path() -> str:
+    path = os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+    if not path:
+        raise HTTPException(status_code=503, detail="MEMOS_AGENT_AUTH_CONFIG not set")
+    return path
+
+
+def _read_config(path: str) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"version": 2, "agents": []}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read config: {e}")
+
+
+def _write_config(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to write config: {e}")
+
+
+def _hash_key(raw_key: str) -> str:
+    """Bcrypt-hash a raw API key."""
+    return bcrypt.hashpw(raw_key.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+# --- Request / Response models ---
+
+class CreateAgentKeyRequest(BaseModel):
+    user_id: str = Field(..., min_length=1, max_length=255)
+    description: str = Field("", max_length=500)
+
+
+class CreateAgentKeyResponse(BaseModel):
     message: str
-    key: str  # Only returned once!
+    key: str
+    user_id: str
+    description: str
+
+
+class AgentKeyInfo(BaseModel):
+    user_id: str
     key_prefix: str
-    user_name: str
-    scopes: list[str]
+    description: str
 
 
-class KeyListResponse(BaseModel):
+class ListKeysResponse(BaseModel):
     message: str
-    keys: list[dict[str, Any]]
+    agents: list[AgentKeyInfo]
 
 
 class RevokeKeyRequest(BaseModel):
-    key_id: str
+    user_id: str = Field(..., description="user_id of the agent whose key to revoke")
 
 
 class SimpleResponse(BaseModel):
@@ -57,159 +107,137 @@ class SimpleResponse(BaseModel):
     success: bool = True
 
 
-def _get_db_connection():
-    """Get database connection for admin operations."""
-    import psycopg2
+class RotateKeyResponse(BaseModel):
+    message: str
+    key: str
+    user_id: str
 
-    return psycopg2.connect(
-        host=os.getenv("POSTGRES_HOST", "postgres"),
-        port=int(os.getenv("POSTGRES_PORT", "5432")),
-        user=os.getenv("POSTGRES_USER", "memos"),
-        password=os.getenv("POSTGRES_PASSWORD", ""),
-        dbname=os.getenv("POSTGRES_DB", "memos"),
-    )
 
+# --- Endpoints ---
 
 @router.post(
     "/keys",
-    response_model=CreateKeyResponse,
-    summary="Create a new API key",
-    dependencies=[Depends(require_scope("admin"))],
+    response_model=CreateAgentKeyResponse,
+    summary="Create a new agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def create_key(
-    request: CreateKeyRequest,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Create a new API key for a user.
+def create_key(request: Request, body: CreateAgentKeyRequest):
+    """Create a new agent API key. The key is only returned once — store it securely."""
+    path = _get_config_path()
+    config = _read_config(path)
+    config.setdefault("version", 2)
+    agents = config.get("agents", [])
 
-    Requires admin scope or master key.
+    if any(a["user_id"] == body.user_id for a in agents):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Agent key for user_id '{body.user_id}' already exists. Use /admin/keys/rotate to replace it.",
+        )
 
-    **WARNING**: The API key is only returned once. Store it securely!
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            api_key = create_api_key_in_db(
-                conn=conn,
-                user_name=request.user_name,
-                scopes=request.scopes,
-                description=request.description,
-                expires_in_days=request.expires_in_days,
-                created_by=auth.get("user_name", "unknown"),
-            )
+    new_key = f"ak_{secrets.token_hex(16)}"
+    agents.append({
+        "key_hash": _hash_key(new_key),
+        "key_prefix": new_key[:12],
+        "user_id": body.user_id,
+        "description": body.description or f"Agent {body.user_id}",
+        "created_at": datetime.utcnow().isoformat(),
+    })
+    config["agents"] = agents
+    _write_config(path, config)
 
-            logger.info(
-                f"API key created for user '{request.user_name}' by '{auth.get('user_name')}'"
-            )
-
-            return CreateKeyResponse(
-                message="API key created successfully. Store this key securely - it won't be shown again!",
-                key=api_key.key,
-                key_prefix=api_key.key_prefix,
-                user_name=request.user_name,
-                scopes=request.scopes,
-            )
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.error(f"Failed to create API key: {e}")
-        raise HTTPException(status_code=500, detail="Failed to create API key") from e
+    logger.info(f"[Admin] Created agent key for user_id='{body.user_id}'")
+    return CreateAgentKeyResponse(
+        message="Agent key created. Store it securely — it won't be shown again.",
+        key=new_key,
+        user_id=body.user_id,
+        description=body.description,
+    )
 
 
 @router.get(
     "/keys",
-    response_model=KeyListResponse,
-    summary="List API keys",
-    dependencies=[Depends(require_scope("admin"))],
+    response_model=ListKeysResponse,
+    summary="List all agent keys",
+    dependencies=[Depends(_require_admin)],
 )
-def list_keys(
-    user_name: str | None = None,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    List all API keys (admin) or keys for a specific user.
+def list_keys():
+    """List all agent keys (prefixes only — full keys are never returned)."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    Note: Actual key values are never returned, only prefixes.
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            keys = list_api_keys(conn, user_name=user_name)
-            return KeyListResponse(
-                message=f"Found {len(keys)} key(s)",
-                keys=keys,
+    return ListKeysResponse(
+        message=f"Found {len(agents)} agent key(s)",
+        agents=[
+            AgentKeyInfo(
+                user_id=a["user_id"],
+                key_prefix=a.get("key_prefix", "???") + "...",
+                description=a.get("description", ""),
             )
-        finally:
-            conn.close()
-    except Exception as e:
-        logger.error(f"Failed to list API keys: {e}")
-        raise HTTPException(status_code=500, detail="Failed to list API keys") from e
+            for a in agents
+        ],
+    )
 
 
 @router.delete(
-    "/keys/{key_id}",
+    "/keys",
     response_model=SimpleResponse,
-    summary="Revoke an API key",
-    dependencies=[Depends(require_scope("admin"))],
+    summary="Revoke an agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def revoke_key(
-    key_id: str,
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Revoke an API key by ID.
+def revoke_key(request: Request, body: RevokeKeyRequest):
+    """Revoke an agent key by user_id. The agent will lose API access immediately."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    The key will be deactivated but not deleted (for audit purposes).
-    """
-    try:
-        conn = _get_db_connection()
-        try:
-            success = revoke_api_key(conn, key_id)
-            if success:
-                logger.info(f"API key {key_id} revoked by '{auth.get('user_name')}'")
-                return SimpleResponse(message="API key revoked successfully")
-            else:
-                raise HTTPException(status_code=404, detail="API key not found or already revoked")
-        finally:
-            conn.close()
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to revoke API key: {e}")
-        raise HTTPException(status_code=500, detail="Failed to revoke API key") from e
+    original_count = len(agents)
+    agents = [a for a in agents if a["user_id"] != body.user_id]
+
+    if len(agents) == original_count:
+        raise HTTPException(status_code=404, detail=f"No agent key found for user_id '{body.user_id}'")
+
+    config["agents"] = agents
+    _write_config(path, config)
+
+    logger.info(f"[Admin] Revoked agent key for user_id='{body.user_id}'")
+    return SimpleResponse(message=f"Agent key for '{body.user_id}' revoked")
 
 
 @router.post(
-    "/generate-master-key",
-    response_model=dict,
-    summary="Generate a new master key",
-    dependencies=[Depends(require_scope("admin"))],
+    "/keys/rotate",
+    response_model=RotateKeyResponse,
+    summary="Rotate an agent key",
+    dependencies=[Depends(_require_admin)],
 )
-def generate_new_master_key(
-    auth: dict = Depends(verify_api_key),  # noqa: B008
-):
-    """
-    Generate a new master key.
+def rotate_key(request: Request, body: RevokeKeyRequest):
+    """Replace an agent's key with a new one. The old key stops working immediately."""
+    path = _get_config_path()
+    config = _read_config(path)
+    agents = config.get("agents", [])
 
-    **WARNING**: Store the key securely! Add MASTER_KEY_HASH to your .env file.
-    """
-    if not auth.get("is_master_key"):
-        raise HTTPException(
-            status_code=403,
-            detail="Only master key can generate new master keys",
-        )
+    found = False
+    new_key = f"ak_{secrets.token_hex(16)}"
+    for agent in agents:
+        if agent["user_id"] == body.user_id:
+            agent["key_hash"] = _hash_key(new_key)
+            agent["key_prefix"] = new_key[:12]
+            agent.pop("key", None)  # Remove any plaintext key from previous rotation
+            agent["rotated_at"] = datetime.utcnow().isoformat()
+            found = True
+            break
 
-    key, key_hash = generate_master_key()
+    if not found:
+        raise HTTPException(status_code=404, detail=f"No agent key found for user_id '{body.user_id}'")
 
-    logger.warning("New master key generated - update MASTER_KEY_HASH in .env")
+    _write_config(path, config)
 
-    return {
-        "message": "Master key generated. Add MASTER_KEY_HASH to your .env file!",
-        "key": key,
-        "key_hash": key_hash,
-        "env_line": f"MASTER_KEY_HASH={key_hash}",
-    }
+    logger.info(f"[Admin] Rotated agent key for user_id='{body.user_id}'")
+    return RotateKeyResponse(
+        message="Agent key rotated. Store the new key securely — it won't be shown again.",
+        key=new_key,
+        user_id=body.user_id,
+    )
 
 
 @router.get(
@@ -218,11 +246,12 @@ def generate_new_master_key(
 )
 def admin_health():
     """Health check for admin endpoints."""
-    auth_enabled = os.getenv("AUTH_ENABLED", "false").lower() == "true"
-    master_key_configured = bool(os.getenv("MASTER_KEY_HASH"))
+    config_path = os.getenv("MEMOS_AGENT_AUTH_CONFIG", "")
+    config_exists = bool(config_path) and Path(config_path).exists()
 
     return {
         "status": "ok",
-        "auth_enabled": auth_enabled,
-        "master_key_configured": master_key_configured,
+        "admin_key_configured": bool(_ADMIN_KEY),
+        "auth_config_exists": config_exists,
+        "auth_config_path": config_path if config_exists else None,
     }

--- a/src/memos/api/routers/server_router.py
+++ b/src/memos/api/routers/server_router.py
@@ -15,9 +15,10 @@ import os
 import random as _random
 import socket
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from memos.api import handlers
+from memos.api.middleware.agent_auth import get_authenticated_user
 from memos.api.handlers.add_handler import AddHandler
 from memos.api.handlers.base_handler import HandlerDependencies
 from memos.api.handlers.chat_handler import ChatHandler
@@ -60,7 +61,20 @@ from memos.mem_scheduler.utils.status_tracker import TaskStatusTracker
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/product", tags=["Server API"])
+
+def _require_auth():
+    """Router-level dependency: reject all unauthenticated requests when MEMOS_AUTH_REQUIRED=true."""
+    if os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() != "true":
+        return  # Auth not enforced — passthrough
+    authenticated = get_authenticated_user()
+    if authenticated is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization required. Include header: Authorization: Bearer <agent-key>",
+        )
+
+
+router = APIRouter(prefix="/product", tags=["Server API"], dependencies=[Depends(_require_auth)])
 
 # Instance ID for identifying this server instance in logs and responses
 INSTANCE_ID = f"{socket.gethostname()}:{os.getpid()}:{_random.randint(1000, 9999)}"
@@ -94,6 +108,22 @@ naive_mem_cube = components["naive_mem_cube"]
 redis_client = components["redis_client"]
 status_tracker = TaskStatusTracker(redis_client=redis_client)
 graph_db = components["graph_db"]
+user_manager = components.get("user_manager")
+
+
+def _enforce_cube_access(user_id: str, cube_id: str) -> None:
+    """Verify authenticated caller matches user_id and has cube access. Raises 403 on violation."""
+    authenticated = get_authenticated_user()
+    if authenticated is not None and authenticated != user_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Key authenticated as '{authenticated}' but request claims user_id='{user_id}'.",
+        )
+    if user_manager and not user_manager.validate_user_cube_access(user_id, cube_id):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Access denied: user '{user_id}' cannot access cube '{cube_id}'",
+        )
 
 
 # =============================================================================
@@ -173,6 +203,9 @@ def scheduler_task_queue_status(
     )
 
 
+_MAX_WAIT_TIMEOUT = 300.0  # 5 minutes max for scheduler wait endpoints
+
+
 @router.post("/scheduler/wait", summary="Wait until scheduler is idle for a specific user")
 def scheduler_wait(
     user_name: str,
@@ -180,6 +213,11 @@ def scheduler_wait(
     poll_interval: float = 0.5,
 ):
     """Wait until scheduler is idle for a specific user."""
+    authenticated = get_authenticated_user()
+    if authenticated and authenticated != user_name:
+        raise HTTPException(status_code=403, detail=f"Cannot wait on scheduler for user '{user_name}'")
+    timeout_seconds = min(timeout_seconds, _MAX_WAIT_TIMEOUT)
+    poll_interval = max(poll_interval, 0.25)
     return handlers.scheduler_handler.handle_scheduler_wait(
         user_name=user_name,
         status_tracker=status_tracker,
@@ -195,6 +233,11 @@ def scheduler_wait_stream(
     poll_interval: float = 0.5,
 ):
     """Stream scheduler progress via Server-Sent Events (SSE)."""
+    authenticated = get_authenticated_user()
+    if authenticated and authenticated != user_name:
+        raise HTTPException(status_code=403, detail=f"Cannot stream scheduler for user '{user_name}'")
+    timeout_seconds = min(timeout_seconds, _MAX_WAIT_TIMEOUT)
+    poll_interval = max(poll_interval, 0.25)
     return handlers.scheduler_handler.handle_scheduler_wait_stream(
         user_name=user_name,
         status_tracker=status_tracker,
@@ -287,6 +330,8 @@ def get_all_memories(memory_req: GetMemoryPlaygroundRequest):
     If search_query is provided, returns a subgraph based on the query.
     Otherwise, returns all memories of the specified type.
     """
+    target_cube = memory_req.mem_cube_ids[0] if memory_req.mem_cube_ids else memory_req.user_id
+    _enforce_cube_access(memory_req.user_id, target_cube)
     if memory_req.search_query:
         return handlers.memory_handler.handle_get_subgraph(
             user_id=memory_req.user_id,
@@ -311,6 +356,7 @@ def get_all_memories(memory_req: GetMemoryPlaygroundRequest):
 
 @router.post("/get_memory", summary="Get memories for user", response_model=GetMemoryResponse)
 def get_memories(memory_req: GetMemoryRequest):
+    _enforce_cube_access(memory_req.user_id or memory_req.mem_cube_id, memory_req.mem_cube_id)
     return handlers.memory_handler.handle_get_memories(
         get_mem_req=memory_req,
         naive_mem_cube=naive_mem_cube,
@@ -319,6 +365,16 @@ def get_memories(memory_req: GetMemoryRequest):
 
 @router.get("/get_memory/{memory_id}", summary="Get memory by id", response_model=GetMemoryResponse)
 def get_memory_by_id(memory_id: str):
+    # Look up the memory's owning cube and verify access
+    authenticated = get_authenticated_user()
+    if authenticated and user_manager:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=[memory_id])
+        owner = owner_map.get(memory_id)
+        if owner and not user_manager.validate_user_cube_access(authenticated, owner):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied: user '{authenticated}' cannot read memory owned by '{owner}'",
+            )
     return handlers.memory_handler.handle_get_memory(
         memory_id=memory_id,
         naive_mem_cube=naive_mem_cube,
@@ -327,6 +383,19 @@ def get_memory_by_id(memory_id: str):
 
 @router.post("/get_memory_by_ids", summary="Get memory by ids", response_model=GetMemoryResponse)
 def get_memory_by_ids(memory_ids: list[str]):
+    # Filter out memories the caller cannot access
+    authenticated = get_authenticated_user()
+    if authenticated and user_manager and memory_ids:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=memory_ids)
+        forbidden = [
+            mid for mid, owner in owner_map.items()
+            if owner and not user_manager.validate_user_cube_access(authenticated, owner)
+        ]
+        if forbidden:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied: cannot read {len(forbidden)} memory ID(s) owned by other cubes",
+            )
     return handlers.memory_handler.handle_get_memory_by_ids(
         memory_ids=memory_ids,
         naive_mem_cube=naive_mem_cube,
@@ -337,6 +406,11 @@ def get_memory_by_ids(memory_ids: list[str]):
     "/delete_memory", summary="Delete memories for user", response_model=DeleteMemoryResponse
 )
 def delete_memories(memory_req: DeleteMemoryRequest):
+    authenticated = get_authenticated_user()
+    # Check cube access for each writable cube
+    cube_ids = memory_req.writable_cube_ids or ([memory_req.user_id] if memory_req.user_id else [])
+    for cube_id in cube_ids:
+        _enforce_cube_access(authenticated or cube_id, cube_id)
     return handlers.memory_handler.handle_delete_memories(
         delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
     )
@@ -354,6 +428,9 @@ def feedback_memories(feedback_req: APIFeedbackRequest):
 
     This endpoint uses the class-based FeedbackHandler for better code organization.
     """
+    cube_ids = feedback_req.writable_cube_ids or [feedback_req.user_id]
+    for cube_id in cube_ids:
+        _enforce_cube_access(feedback_req.user_id, cube_id)
     return feedback_handler.handle_feedback_memories(feedback_req)
 
 
@@ -369,7 +446,14 @@ def feedback_memories(feedback_req: APIFeedbackRequest):
 )
 def get_user_names_by_memory_ids(request: GetUserNamesByMemoryIdsRequest):
     """Get user names by memory ids. Now unified to query from graph_db only."""
+    authenticated = get_authenticated_user()
     result = graph_db.get_user_names_by_memory_ids(memory_ids=request.memory_ids)
+    # Filter results: only return mappings for cubes the caller can access
+    if authenticated and user_manager:
+        result = {
+            mid: uname for mid, uname in result.items()
+            if uname is None or user_manager.validate_user_cube_access(authenticated, uname)
+        }
 
     return GetUserNamesByMemoryIdsResponse(
         code=200,
@@ -384,11 +468,17 @@ def get_user_names_by_memory_ids(request: GetUserNamesByMemoryIdsRequest):
     response_model=ExistMemCubeIdResponse,
 )
 def exist_mem_cube_id(request: ExistMemCubeIdRequest):
-    """(inner) Check if mem cube id exists."""
+    """(inner) Check if mem cube id exists. Only returns True if caller has access."""
+    authenticated = get_authenticated_user()
+    exists = graph_db.exist_user_name(user_name=request.mem_cube_id)
+    # Only reveal existence if the caller has access to that cube
+    if exists and authenticated and user_manager:
+        if not user_manager.validate_user_cube_access(authenticated, request.mem_cube_id):
+            exists = False  # Hide existence from unauthorized callers
     return ExistMemCubeIdResponse(
         code=200,
         message="Successfully",
-        data=graph_db.exist_user_name(user_name=request.mem_cube_id),
+        data=exists,
     )
 
 
@@ -410,6 +500,8 @@ def chat_stream_business_user(chat_req: ChatBusinessRequest):
 )
 def delete_memory_by_record_id(memory_req: DeleteMemoryByRecordIdRequest):
     """(inner) Delete memory nodes by mem_cube_id (user_name) and delete_record_id. Record id is inner field, just for delete and recover memory, not for user to set."""
+    authenticated = get_authenticated_user()
+    _enforce_cube_access(authenticated or memory_req.mem_cube_id, memory_req.mem_cube_id)
     graph_db.delete_node_by_mem_cube_id(
         mem_cube_id=memory_req.mem_cube_id,
         delete_record_id=memory_req.record_id,
@@ -430,6 +522,8 @@ def delete_memory_by_record_id(memory_req: DeleteMemoryByRecordIdRequest):
 )
 def recover_memory_by_record_id(memory_req: RecoverMemoryByRecordIdRequest):
     """(inner) Recover memory nodes by mem_cube_id (user_name) and delete_record_id. Record id is inner field, just for delete and recover memory, not for user to set."""
+    authenticated = get_authenticated_user()
+    _enforce_cube_access(authenticated or memory_req.mem_cube_id, memory_req.mem_cube_id)
     graph_db.recover_memory_by_mem_cube_id(
         mem_cube_id=memory_req.mem_cube_id,
         delete_record_id=memory_req.delete_record_id,
@@ -446,6 +540,8 @@ def recover_memory_by_record_id(memory_req: RecoverMemoryByRecordIdRequest):
     "/get_memory_dashboard", summary="Get memories for dashboard", response_model=GetMemoryResponse
 )
 def get_memories_dashboard(memory_req: GetMemoryDashboardRequest):
+    if memory_req.mem_cube_id:
+        _enforce_cube_access(memory_req.user_id or memory_req.mem_cube_id, memory_req.mem_cube_id)
     return handlers.memory_handler.handle_get_memories_dashboard(
         get_mem_req=memory_req,
         naive_mem_cube=naive_mem_cube,

--- a/src/memos/api/routers/server_router.py
+++ b/src/memos/api/routers/server_router.py
@@ -16,6 +16,7 @@ import random as _random
 import socket
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from memos.api import handlers
 from memos.api.middleware.agent_auth import get_authenticated_user
@@ -402,18 +403,101 @@ def get_memory_by_ids(memory_ids: list[str]):
     )
 
 
-@router.post(
-    "/delete_memory", summary="Delete memories for user", response_model=DeleteMemoryResponse
+@router.api_route(
+    "/delete_memory",
+    methods=["POST", "DELETE"],
+    summary="Delete memories for user",
+    response_model=DeleteMemoryResponse,
 )
 def delete_memories(memory_req: DeleteMemoryRequest):
+    """Delete memories. Supports both singular (`mem_cube_id`, `memory_id`) and plural aliases.
+
+    Returns distinct status codes:
+    - 400: memory-id mode chosen but cube or memory id(s) missing.
+    - 403: caller lacks access to a requested cube (enforced by `_enforce_cube_access`).
+    - 404: memory-id mode where every id is missing from the targeted cube(s).
+    - 200: success — body carries `deleted`/`not_found` for partial results.
+    """
     authenticated = get_authenticated_user()
-    # Check cube access for each writable cube
-    cube_ids = memory_req.writable_cube_ids or ([memory_req.user_id] if memory_req.user_id else [])
+
+    cube_ids = memory_req.writable_cube_ids or []
+    mem_ids = memory_req.memory_ids or []
+
+    has_file_ids = bool(memory_req.file_ids)
+    # Memory-id mode wins when memory_ids is present; otherwise we fall back to file-id
+    # or filter/user_id/session_id mode. (user_id alone, without memory_ids, still means
+    # "delete everything for this user" — preserved for legacy callers.)
+    memory_id_mode = bool(mem_ids) or (
+        not has_file_ids
+        and not memory_req.filter
+        and not memory_req.user_id
+        and not memory_req.session_id
+    )
+
+    if memory_id_mode and (not cube_ids or not mem_ids):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Provide both a cube (mem_cube_id or writable_cube_ids) and "
+                "a memory id (memory_id or memory_ids), or use file_ids / filter mode."
+            ),
+        )
+
+    # 403 on any cube the caller cannot access.
     for cube_id in cube_ids:
         _enforce_cube_access(authenticated or cube_id, cube_id)
-    return handlers.memory_handler.handle_delete_memories(
-        delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
+
+    if not memory_id_mode:
+        return handlers.memory_handler.handle_delete_memories(
+            delete_mem_req=memory_req, naive_mem_cube=naive_mem_cube
+        )
+
+    # Memory-id mode: split existing vs missing before delegating to handler.
+    try:
+        owner_map = graph_db.get_user_names_by_memory_ids(memory_ids=mem_ids)
+    except Exception:
+        logger.error("Failed to look up memory owners before delete", exc_info=True)
+        owner_map = {}
+
+    allowed_cubes = set(cube_ids)
+    deleted_ids: list[str] = []
+    not_found_ids: list[str] = []
+    for mid in mem_ids:
+        owner = owner_map.get(mid)
+        if owner and owner in allowed_cubes:
+            deleted_ids.append(mid)
+        else:
+            # Memory either does not exist at all, or belongs to a cube the
+            # caller did not target. From the caller's perspective it is not found.
+            not_found_ids.append(mid)
+
+    if not deleted_ids:
+        # Return envelope directly so {deleted, not_found} survives the global HTTP
+        # exception handler, which would otherwise stringify structured `detail`.
+        return JSONResponse(
+            status_code=404,
+            content={
+                "code": 404,
+                "message": "No matching memories found in the targeted cube(s).",
+                "data": {"deleted": [], "not_found": not_found_ids},
+            },
+        )
+
+    filtered_req = memory_req.model_copy(update={"memory_ids": deleted_ids})
+    resp = handlers.memory_handler.handle_delete_memories(
+        delete_mem_req=filtered_req, naive_mem_cube=naive_mem_cube
     )
+    data = dict(resp.data or {})
+    data["deleted"] = deleted_ids
+    data["not_found"] = not_found_ids
+    if not_found_ids and data.get("status") == "success":
+        data["status"] = "partial"
+    message = (
+        "Memories deleted successfully"
+        if not not_found_ids
+        else f"Deleted {len(deleted_ids)} memory(ies); {len(not_found_ids)} not found."
+    )
+    return DeleteMemoryResponse(code=200, message=message, data=data)
 
 
 # =============================================================================

--- a/src/memos/api/server_api.py
+++ b/src/memos/api/server_api.py
@@ -7,7 +7,10 @@ from fastapi.exceptions import RequestValidationError
 from starlette.staticfiles import StaticFiles
 
 from memos.api.exceptions import APIExceptionHandler
+from memos.api.middleware.agent_auth import AgentAuthMiddleware
+from memos.api.middleware.rate_limit import RateLimitMiddleware
 from memos.api.middleware.request_context import RequestContextMiddleware
+from memos.api.routers.admin_router import router as admin_router
 from memos.api.routers.server_router import router as server_router
 
 
@@ -25,9 +28,16 @@ app = FastAPI(
 
 app.mount("/download", StaticFiles(directory=os.getenv("FILE_LOCAL_PATH")), name="static_mapping")
 
+# Middleware execution order (outermost first):
+# 1. RateLimitMiddleware — reject excessive requests before any processing
+# 2. AgentAuthMiddleware — validate per-agent API keys, bind user_id to context
+# 3. RequestContextMiddleware — inject trace_id, log request metadata
+app.add_middleware(RateLimitMiddleware)
+app.add_middleware(AgentAuthMiddleware)
 app.add_middleware(RequestContextMiddleware, source="server_api")
 # Include routers
 app.include_router(server_router)
+app.include_router(admin_router)
 
 
 @app.get("/health")
@@ -59,4 +69,5 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8001)
     parser.add_argument("--workers", type=int, default=1)
     args = parser.parse_args()
-    uvicorn.run("memos.api.server_api:app", host="0.0.0.0", port=args.port, workers=args.workers)
+    bind_host = os.getenv("MEMOS_BIND_HOST", "127.0.0.1")
+    uvicorn.run("memos.api.server_api:app", host=bind_host, port=args.port, workers=args.workers)

--- a/src/memos/api/server_api.py
+++ b/src/memos/api/server_api.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+import sys
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
@@ -19,6 +21,71 @@ load_dotenv()
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _validate_auth_config_or_exit() -> None:
+    """Refuse to start if auth is required but no usable agent registry exists.
+
+    Previously the server would happily start with ``MEMOS_AUTH_REQUIRED=true``
+    and an empty/missing ``agents-auth.json`` — every authenticated request
+    would then 401, leaving demo agents memory-blind with no obvious cause.
+    Fail loud at startup instead so the operator notices immediately.
+
+    Pass conditions when ``MEMOS_AUTH_REQUIRED=true``:
+      - ``MEMOS_AGENT_AUTH_CONFIG`` is set
+      - the file at that path exists and is readable
+      - it parses as JSON
+      - it contains at least one ``agents[*].key_hash`` entry (v2)
+        OR at least one ``agents[*].key`` entry (legacy v1)
+
+    Anything else → write a clear stderr message and ``sys.exit(2)`` before
+    we bind a port.
+    """
+    if os.getenv("MEMOS_AUTH_REQUIRED", "false").lower() != "true":
+        return  # Auth optional — empty registry is allowed.
+
+    config_path = os.getenv("MEMOS_AGENT_AUTH_CONFIG", "").strip()
+    if not config_path:
+        print(
+            "FATAL: MEMOS_AUTH_REQUIRED=true but MEMOS_AGENT_AUTH_CONFIG is unset. "
+            "Run deploy/scripts/setup-memos-agents.py to provision agents and set "
+            "MEMOS_AGENT_AUTH_CONFIG to the resulting file path. Refusing to start.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if not os.path.exists(config_path):
+        print(
+            f"FATAL: MEMOS_AUTH_REQUIRED=true but agent-auth file is missing at "
+            f"{config_path!r}. Run deploy/scripts/setup-memos-agents.py to "
+            f"recreate it. Refusing to start.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        with open(config_path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(
+            f"FATAL: agent-auth file at {config_path!r} is unreadable or not "
+            f"valid JSON ({type(e).__name__}: {e}). Refusing to start.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    agents = data.get("agents", []) if isinstance(data, dict) else []
+    has_v2 = any(a.get("key_hash") for a in agents)
+    has_v1 = any(a.get("key") for a in agents)
+    if not (has_v2 or has_v1):
+        print(
+            f"FATAL: agent-auth file at {config_path!r} contains zero agent keys. "
+            "Run deploy/scripts/setup-memos-agents.py to provision the demo agents. "
+            "Refusing to start.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+_validate_auth_config_or_exit()
 
 app = FastAPI(
     title="MemOS Server REST APIs",

--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -12,7 +12,11 @@ from memos.mem_reader.read_multi_modal import MultiModalParser, detect_lang
 from memos.mem_reader.read_multi_modal.base import _derive_key
 from memos.mem_reader.read_pref_memory.process_preference_memory import process_preference_fine
 from memos.mem_reader.read_skill_memory.process_skill_memory import process_skill_memory_fine
-from memos.mem_reader.simple_struct import PROMPT_DICT, SimpleStructMemReader
+from memos.mem_reader.simple_struct import (
+    PROMPT_DICT,
+    SimpleStructMemReader,
+    _merge_custom_tags,
+)
 from memos.mem_reader.utils import parse_json_result
 from memos.memories.textual.item import TextualMemoryItem, TreeNodeTextualMemoryMetadata
 from memos.templates.mem_reader_prompts import MEMORY_MERGE_PROMPT_EN, MEMORY_MERGE_PROMPT_ZH
@@ -749,7 +753,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                             value=m_maybe_merged.get("value", ""),
                             info=info_per_item,
                             memory_type=memory_type,
-                            tags=m_maybe_merged.get("tags", []),
+                            tags=_merge_custom_tags(
+                                m_maybe_merged.get("tags", []), custom_tags
+                            ),
                             key=m_maybe_merged.get("key", ""),
                             sources=sources,  # Preserve sources from fast item
                             background=resp.get("summary", ""),
@@ -776,7 +782,9 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                         value=resp_maybe_merged.get("value", "").strip(),
                         info=info_per_item,
                         memory_type="LongTermMemory",
-                        tags=resp_maybe_merged.get("tags", []),
+                        tags=_merge_custom_tags(
+                            resp_maybe_merged.get("tags", []), custom_tags
+                        ),
                         key=resp_maybe_merged.get("key", None),
                         sources=sources,  # Preserve sources from fast item
                         background=resp.get("summary", ""),
@@ -1019,6 +1027,14 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                 scene_data_info, info, mode="fast", need_emb=False, **kwargs
             )
         fast_memory_items = self._concat_multi_modal_memories(all_memory_items)
+        # Merge custom_tags into fast items' tags. Sub-parsers (string/user/assistant/
+        # file/tool/etc.) build items with a fixed ["mode:fast"] tag, so we enrich
+        # here rather than threading custom_tags through every parser.
+        if custom_tags:
+            for item in fast_memory_items:
+                if item is None or item.metadata is None:
+                    continue
+                item.metadata.tags = _merge_custom_tags(item.metadata.tags, custom_tags)
         if mode == "fast":
             return fast_memory_items
         else:

--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -85,6 +85,32 @@ SceneDataInput: TypeAlias = (
 
 
 logger = log.get_logger(__name__)
+
+
+def _merge_custom_tags(
+    base_tags: list[str] | None, custom_tags: list[str] | None
+) -> list[str]:
+    """Merge user-supplied custom_tags with the system-generated tags.
+
+    Preserves order (system tags first, custom next) and deduplicates while
+    being tolerant of None / non-list inputs.
+    """
+    merged: list[str] = []
+    for source in (base_tags, custom_tags):
+        if not source:
+            continue
+        if not isinstance(source, list):
+            continue
+        for tag in source:
+            if tag is None:
+                continue
+            tag_str = str(tag)
+            if tag_str and tag_str not in merged:
+                merged.append(tag_str)
+    return merged
+
+
+
 PROMPT_DICT = {
     "chat": {
         "en": SIMPLE_STRUCT_MEM_READER_PROMPT,
@@ -101,7 +127,16 @@ PROMPT_DICT = {
 }
 
 
-def _build_node(idx, message, info, source_info, llm, parse_json_result, embedder):
+def _build_node(
+    idx,
+    message,
+    info,
+    source_info,
+    llm,
+    parse_json_result,
+    embedder,
+    custom_tags: list[str] | None = None,
+):
     # generate
     try:
         raw = llm.generate(message)
@@ -131,6 +166,7 @@ def _build_node(idx, message, info, source_info, llm, parse_json_result, embedde
         tags = chunk_res.get("tags", [])
         if not isinstance(tags, list):
             tags = []
+        tags = _merge_custom_tags(tags, custom_tags)
 
         key = chunk_res.get("key", None)
 
@@ -356,7 +392,9 @@ class SimpleStructMemReader(BaseMemReader, ABC):
                 text = w["text"]
                 roles = {s.get("role", "") for s in w["sources"] if s.get("role")}
                 mem_type = "UserMemory" if roles == {"user"} else "LongTermMemory"
-                tags = ["mode:fast"]
+                # Preserve the mode tag (downstream scheduler/feedback code filters on
+                # "mode:fast") and append user-supplied custom_tags without clobbering.
+                tags = _merge_custom_tags(["mode:fast"], custom_tags)
                 return self._make_memory_item(
                     value=text,
                     info=info,
@@ -391,11 +429,14 @@ class SimpleStructMemReader(BaseMemReader, ABC):
                             .replace("长期记忆", "LongTermMemory")
                             .replace("用户记忆", "UserMemory")
                         )
+                        # The LLM prompt already encourages applying custom_tags, but
+                        # compliance is not guaranteed — enforce the merge so the
+                        # request-level custom_tags always survive.
                         node = self._make_memory_item(
                             value=m.get("value", ""),
                             info=info,
                             memory_type=memory_type,
-                            tags=m.get("tags", []),
+                            tags=_merge_custom_tags(m.get("tags", []), custom_tags),
                             key=m.get("key", ""),
                             sources=w["sources"],
                             background=resp.get("summary", ""),
@@ -932,6 +973,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
                     self.llm,
                     parse_json_result,
                     self.embedder,
+                    custom_tags,
                 ): idx
                 for idx, msg in enumerate(messages)
             }

--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from memos.types.general_types import UserContext
 from memos.mem_reader.read_multi_modal import coerce_scene_data, detect_lang
 from memos.mem_reader.utils import (
+    chunk_text_by_tokens,
     count_tokens_text,
     derive_key,
     parse_json_result,
@@ -388,6 +389,43 @@ class SimpleStructMemReader(BaseMemReader, ABC):
         if mode == "fast":
             logger.debug("Using unified Fast Mode")
 
+            # Fast-mode sub-chunking: a single very long user message would
+            # otherwise become one giant embedding, washing out late content
+            # in semantic search. We split each window into ~chunk_tokens
+            # slices with overlap whenever the window exceeds the threshold.
+            #
+            # Timestamp prefix policy: when a window is sub-chunked, the
+            # `user: [chat_time]: ` prefix that _iter_chat_windows prepended
+            # naturally lands on the FIRST sub-chunk only. Subsequent
+            # sub-chunks are mid-message slices, so they carry no prefix.
+            chunk_tokens = int(os.getenv("MOS_FAST_CHUNK_TOKENS", "500"))
+            overlap_tokens = int(os.getenv("MOS_FAST_CHUNK_OVERLAP_TOKENS", "50"))
+            chunk_threshold = max(chunk_tokens * 2, chunk_tokens + 1)
+
+            expanded: list[dict[str, Any]] = []
+            for w in windows:
+                text = w["text"]
+                if self._count_tokens(text) <= chunk_threshold:
+                    expanded.append({**w, "chunk_index": 0, "chunk_total": 1})
+                    continue
+                sub_chunks = chunk_text_by_tokens(
+                    text,
+                    max_tokens=chunk_tokens,
+                    overlap_tokens=overlap_tokens,
+                    count_tokens=self._count_tokens,
+                )
+                total = len(sub_chunks)
+                for idx, sub_text in enumerate(sub_chunks):
+                    expanded.append(
+                        {
+                            "text": sub_text,
+                            "sources": w["sources"],
+                            "start_idx": w["start_idx"],
+                            "chunk_index": idx,
+                            "chunk_total": total,
+                        }
+                    )
+
             def _build_fast_node(w):
                 text = w["text"]
                 roles = {s.get("role", "") for s in w["sources"] if s.get("role")}
@@ -395,9 +433,13 @@ class SimpleStructMemReader(BaseMemReader, ABC):
                 # Preserve the mode tag (downstream scheduler/feedback code filters on
                 # "mode:fast") and append user-supplied custom_tags without clobbering.
                 tags = _merge_custom_tags(["mode:fast"], custom_tags)
+                node_info = dict(info)
+                if w.get("chunk_total", 1) > 1:
+                    node_info["chunk_index"] = w["chunk_index"]
+                    node_info["chunk_total"] = w["chunk_total"]
                 return self._make_memory_item(
                     value=text,
-                    info=info,
+                    info=node_info,
                     memory_type=mem_type,
                     tags=tags,
                     sources=w["sources"],
@@ -405,7 +447,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
                 )
 
             with ContextThreadPoolExecutor(max_workers=8) as ex:
-                futures = {ex.submit(_build_fast_node, w): i for i, w in enumerate(windows)}
+                futures = {ex.submit(_build_fast_node, w): i for i, w in enumerate(expanded)}
                 results = [None] * len(futures)
                 for fut in concurrent.futures.as_completed(futures):
                     i = futures[fut]

--- a/src/memos/mem_reader/utils.py
+++ b/src/memos/mem_reader/utils.py
@@ -35,6 +35,120 @@ def derive_key(text: str, max_len: int = 80) -> str:
     return (sent[:max_len]).strip()
 
 
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[\.!?。！？])\s+|\n+")
+
+
+def chunk_text_by_tokens(
+    text: str,
+    max_tokens: int,
+    overlap_tokens: int,
+    count_tokens=None,
+) -> list[str]:
+    """Token-budgeted chunking with paragraph→sentence→token fallback.
+
+    Used by fast-mode ingestion to split a long message into ~max_tokens
+    chunks with overlap_tokens carry-over between consecutive chunks.
+
+    Strategy:
+      1. Greedy-pack paragraphs (split on blank lines) up to max_tokens.
+      2. If a paragraph alone exceeds max_tokens, split it into sentences
+         and greedy-pack those.
+      3. If a sentence alone still exceeds max_tokens, slice it by token
+         (or character, under the heuristic counter) windows.
+      4. Each chunk after the first is prefixed with the trailing
+         overlap_tokens of text from the previous chunk to preserve
+         cross-chunk context for embeddings/retrieval.
+
+    Returns at least one chunk; never returns empty strings.
+    """
+    if count_tokens is None:
+        count_tokens = count_tokens_text
+    if not text:
+        return []
+    if max_tokens <= 0:
+        return [text]
+    overlap_tokens = max(0, min(overlap_tokens, max_tokens // 2))
+
+    if count_tokens(text) <= max_tokens:
+        return [text]
+
+    units: list[str] = []
+    for para in re.split(r"\n\s*\n", text):
+        para = para.strip()
+        if not para:
+            continue
+        if count_tokens(para) <= max_tokens:
+            units.append(para)
+            continue
+        for sent in _SENTENCE_SPLIT_RE.split(para):
+            sent = sent.strip()
+            if not sent:
+                continue
+            if count_tokens(sent) <= max_tokens:
+                units.append(sent)
+                continue
+            units.extend(_slice_by_tokens(sent, max_tokens, count_tokens))
+
+    if not units:
+        return _slice_by_tokens(text, max_tokens, count_tokens)
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_tokens = 0
+    for unit in units:
+        unit_tokens = count_tokens(unit)
+        if current and current_tokens + unit_tokens > max_tokens:
+            chunks.append(" ".join(current))
+            current = []
+            current_tokens = 0
+        current.append(unit)
+        current_tokens += unit_tokens
+    if current:
+        chunks.append(" ".join(current))
+
+    if overlap_tokens == 0 or len(chunks) == 1:
+        return chunks
+
+    overlapped: list[str] = [chunks[0]]
+    for i in range(1, len(chunks)):
+        prev_tail = _take_tail_tokens(chunks[i - 1], overlap_tokens, count_tokens)
+        overlapped.append(f"{prev_tail} {chunks[i]}".strip() if prev_tail else chunks[i])
+    return overlapped
+
+
+def _slice_by_tokens(text: str, max_tokens: int, count_tokens) -> list[str]:
+    """Last-resort slicer for a single unit larger than max_tokens.
+
+    Uses tiktoken when available (precise), otherwise falls back to a
+    character-budget proxy (~4 chars/token for English) — same heuristic
+    as count_tokens_text, so the slice respects the configured budget.
+    """
+    try:
+        if "_ENC" in globals():
+            enc = globals()["_ENC"]
+            ids = enc.encode(text, disallowed_special=())
+            return [enc.decode(ids[i : i + max_tokens]) for i in range(0, len(ids), max_tokens)]
+    except Exception:
+        pass
+    char_budget = max(1, max_tokens * 4)
+    return [text[i : i + char_budget] for i in range(0, len(text), char_budget)]
+
+
+def _take_tail_tokens(text: str, n_tokens: int, count_tokens) -> str:
+    """Return the trailing ~n_tokens of text. Used to seed the next chunk's overlap."""
+    if n_tokens <= 0 or not text:
+        return ""
+    try:
+        if "_ENC" in globals():
+            enc = globals()["_ENC"]
+            ids = enc.encode(text, disallowed_special=())
+            return enc.decode(ids[-n_tokens:]) if ids else ""
+    except Exception:
+        pass
+    char_budget = max(1, n_tokens * 4)
+    return text[-char_budget:]
+
+
 def parse_json_result(response_text: str) -> dict:
     s = (response_text or "").strip()
 

--- a/src/memos/mem_user/user_manager.py
+++ b/src/memos/mem_user/user_manager.py
@@ -305,9 +305,12 @@ class UserManager:
     def validate_user_cube_access(self, user_id: str, cube_id: str) -> bool:
         """Validate if a user has access to a cube.
 
+        The cube_id parameter may be a cube_id, cube_name, or the owner's
+        user_id (MemOS agents address cubes by user_id, not cube_id).
+
         Args:
-            user_id (str): The user ID.
-            cube_id (str): The cube ID.
+            user_id (str): The user ID requesting access.
+            cube_id (str): The cube identifier (cube_id, cube_name, or owner user_id).
 
         Returns:
             bool: True if user has access to cube, False otherwise.
@@ -319,8 +322,13 @@ class UserManager:
             if not user:
                 return False
 
-            # Check if cube exists and is active
+            # Look up cube by cube_id first, then by cube_name, then by owner_id
             cube = session.query(Cube).filter(Cube.cube_id == cube_id, Cube.is_active).first()
+            if not cube:
+                cube = session.query(Cube).filter(Cube.cube_name == cube_id, Cube.is_active).first()
+            if not cube:
+                # MemOS agents use user_id as cube address — find the cube owned by that user
+                cube = session.query(Cube).filter(Cube.owner_id == cube_id, Cube.is_active).first()
             if not cube:
                 return False
 

--- a/src/memos/multi_mem_cube/single_cube.py
+++ b/src/memos/multi_mem_cube/single_cube.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import traceback
 
@@ -22,7 +23,7 @@ from memos.mem_scheduler.schemas.task_schemas import (
 )
 from memos.memories.textual.item import TextualMemoryItem
 from memos.multi_mem_cube.views import MemCubeView
-from memos.search import resolve_filter_for_cube, search_text_memories
+from memos.search import search_text_memories
 from memos.templates.mem_reader_prompts import PROMPT_MAPPING
 from memos.types.general_types import (
     FINE_STRATEGY,
@@ -91,13 +92,6 @@ class SingleCubeView(MemCubeView):
         Unified memory search handling (text + preference memories).
         Preference memories are now searched through the same _search_text flow.
         """
-        cube_filter = resolve_filter_for_cube(search_req.filter, self.cube_id)
-        if cube_filter is not search_req.filter:
-            import copy
-
-            search_req = copy.copy(search_req)
-            search_req.filter = cube_filter
-
         # Create UserContext object
         user_context = UserContext(
             user_id=search_req.user_id,
@@ -725,6 +719,43 @@ class SingleCubeView(MemCubeView):
         mem_group = [
             memory for memory in flattened_local if memory.metadata.memory_type != "RawFileMemory"
         ]
+
+        # ── Write-time dedup: skip memories that are near-duplicates of existing ones ──
+        DEDUP_SIMILARITY_THRESHOLD = float(os.getenv("MOS_DEDUP_THRESHOLD", "0.90"))
+        deduped_mem_group = []
+        graph_store = getattr(self.naive_mem_cube.text_mem, "graph_store", None)
+        logger.info(f"[DEDUP] Starting write-time dedup for {len(mem_group)} memories, graph_store={graph_store is not None}")
+        for memory in mem_group:
+            embedding = getattr(memory.metadata, "embedding", None)
+            if embedding and graph_store:
+                try:
+                    similar = graph_store.search_by_embedding(
+                        vector=embedding,
+                        top_k=1,
+                        status="activated",
+                        threshold=DEDUP_SIMILARITY_THRESHOLD,
+                        user_name=user_context.mem_cube_id,
+                    )
+                    if similar:
+                        best = similar[0]
+                        score = best.get('score', 0)
+                        logger.warning(
+                            f"[DEDUP] Skipping near-duplicate memory (score={score:.4f}): "
+                            f"'{memory.memory[:80]}...' matches existing id={best.get('id', '?')[:8]}"
+                        )
+                        continue
+                except Exception as e:
+                    logger.warning(f"[DEDUP] Vector search failed, keeping memory: {e}")
+            deduped_mem_group.append(memory)
+
+        if len(deduped_mem_group) < len(mem_group):
+            logger.warning(
+                f"[DEDUP] Filtered {len(mem_group) - len(deduped_mem_group)} duplicate(s) "
+                f"out of {len(mem_group)} candidate memories"
+            )
+        mem_group = deduped_mem_group
+        # ── End write-time dedup ──
+
         mem_ids_local: list[str] = self.naive_mem_cube.text_mem.add(
             mem_group,
             user_name=user_context.mem_cube_id,

--- a/src/memos/templates/mem_reader_prompts.py
+++ b/src/memos/templates/mem_reader_prompts.py
@@ -18,7 +18,12 @@ For example, write "The user felt exhausted..." instead of "I felt exhausted..."
    - Include all key experiences, thoughts, emotional responses, and plans — even if they seem minor.
    - Prioritize completeness and fidelity over conciseness.
    - Do not generalize or skip details that could be personally meaningful to user.
-5. Please avoid any content that violates national laws and regulations or involves politically sensitive information in the memories you extract.
+5. IMPORTANT — Granularity rule: Each distinct fact, finding, decision, plan, or topic MUST be its own separate memory item.
+   - NEVER merge multiple unrelated facts into a single memory item.
+   - If the conversation contains N distinct pieces of information, produce at least N memory items.
+   - For example, a research brief with 5 findings should produce at least 5 separate memory items (one per finding), plus any additional items for plans, decisions, or reactions.
+   - Each memory item should be atomic: it covers exactly one topic or fact and can be understood independently.
+6. Please avoid any content that violates national laws and regulations or involves politically sensitive information in the memories you extract.
 
 Return a single valid JSON object with the following structure:
 
@@ -36,7 +41,8 @@ Return a single valid JSON object with the following structure:
 }
 
 Language rules:
-- The `key`, `value`, `tags`, `summary` fields must match the mostly used language of the input conversation.  **如果输入是中文，请输出中文**
+- IMPORTANT: Always respond in the same language as the input conversation. If the input is in English, ALL memory keys, values, tags, and summary MUST be in English. If the input is in Chinese, respond in Chinese.
+- The `key`, `value`, `tags`, `summary` fields must match the mostly used language of the input conversation.
 - Keep `memory_type` in English.
 
 ${custom_tags_prompt}
@@ -89,21 +95,7 @@ Output:
 Note: When the dialogue contains only assistant messages, phrasing such as
 “assistant recommended” or “assistant suggested” should be used, rather than incorrectly attributing the content to the user’s statements or plans.
 
-Another Example in Chinese (注意: 当user的语言为中文时，你就需要也输出中文)：
-{
-  "memory list": [
-    {
-      "key": "项目会议",
-      "memory_type": "LongTermMemory",
-      "value": "在2025年6月25日下午3点，Tom与团队开会讨论了新项目，涉及时间表，并提出了对12月15日截止日期可行性的担忧。",
-      "tags": ["项目", "时间表", "会议", "截止日期"]
-    },
-    ...
-  ],
-  "summary": "Tom 目前专注于管理一个进度紧张的新项目..."
-}
-
-Always respond in the same language as the conversation.
+IMPORTANT REMINDER: Your output language MUST match the input conversation language. For English input, output everything in English.
 
 Conversation:
 ${conversation}
@@ -133,7 +125,13 @@ SIMPLE_STRUCT_MEM_READER_PROMPT_ZH = """您是记忆提取专家。
    - 优先考虑完整性和保真度，而非简洁性。
    - 不要泛化或跳过对用户具有个人意义的细节。
 
-5. 请避免在提取的记忆中包含违反国家法律法规或涉及政治敏感的信息。
+5. 重要——粒度规则：每个不同的事实、发现、决定、计划或主题必须作为单独的记忆项。
+   - 绝不将多个不相关的事实合并为一个记忆项。
+   - 如果对话包含N条不同的信息，至少生成N个记忆项。
+   - 例如，包含5项发现的研究报告应至少生成5个独立的记忆项（每项发现一个），再加上任何关于计划、决定或反应的额外项。
+   - 每个记忆项应是原子性的：只涵盖一个主题或事实，并且可以独立理解。
+
+6. 请避免在提取的记忆中包含违反国家法律法规或涉及政治敏感的信息。
 
 返回一个有效的JSON对象，结构如下：
 

--- a/src/memos/vec_dbs/qdrant.py
+++ b/src/memos/vec_dbs/qdrant.py
@@ -34,8 +34,6 @@ class QdrantVecDB(BaseVecDB):
         client_kwargs: dict[str, Any] = {}
         if self.config.url:
             client_kwargs["url"] = self.config.url
-            if self.config.api_key:
-                client_kwargs["api_key"] = self.config.api_key
         else:
             client_kwargs.update(
                 {
@@ -44,6 +42,12 @@ class QdrantVecDB(BaseVecDB):
                     "path": self.config.path,
                 }
             )
+        # Pass API key regardless of connection mode (url or host+port)
+        if self.config.api_key:
+            client_kwargs["api_key"] = self.config.api_key
+            # When using host+port (not url), force HTTP to avoid SSL errors on localhost
+            if "url" not in client_kwargs:
+                client_kwargs["https"] = False
 
             # If both host and port are None, we are running in local/embedded mode
             if self.config.host is None and self.config.port is None:

--- a/start-memos.sh
+++ b/start-memos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# start-memos.sh — Decrypt secrets, load env, start MemOS server
+# Usage: ./start-memos.sh [--port 8001]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AGE_KEY="${MEMOS_AGE_KEY:-$HOME/.memos/keys/memos.key}"
+SECRETS_ENC="${MEMOS_SECRETS:-$HOME/.memos/secrets.env.age}"
+AGE_BIN="${AGE_BIN:-$(command -v age || echo /home/linuxbrew/.linuxbrew/bin/age)}"
+PORT="${1:-8001}"
+
+# 1. Load base .env (non-secret config)
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+
+# 2. Decrypt and load secrets
+if [[ -f "$SECRETS_ENC" ]]; then
+    if [[ ! -f "$AGE_KEY" ]]; then
+        echo "ERROR: age key not found at $AGE_KEY" >&2
+        exit 1
+    fi
+    echo "Decrypting secrets from $SECRETS_ENC ..."
+    eval "$("$AGE_BIN" -d -i "$AGE_KEY" "$SECRETS_ENC" | grep -v '^#' | grep '=' | sed 's/^/export /')"
+    echo "Secrets loaded."
+else
+    echo "WARNING: No encrypted secrets file at $SECRETS_ENC — using env as-is" >&2
+fi
+
+# 3. Start server
+echo "Starting MemOS on port $PORT ..."
+exec python3.12 -m memos.api.server_api --port "$PORT"

--- a/tests/api/test_add_handler_info.py
+++ b/tests/api/test_add_handler_info.py
@@ -1,0 +1,50 @@
+"""Unit tests for the add_handler info-sanitization logic.
+
+Validates the `custom_tags` / `info` round-trip fix: legitimate user keys
+(`source_type`, `topic`, `agent_id`, ...) must survive untouched, while
+reserved internal keys (`merged_from`) are namespaced under `user:<key>`.
+"""
+
+import unittest
+
+from memos.api.handlers.add_handler import _namespace_user_info
+
+
+class TestNamespaceUserInfo(unittest.TestCase):
+    def test_empty_and_none_return_empty(self):
+        self.assertEqual(_namespace_user_info(None), ({}, {}))
+        self.assertEqual(_namespace_user_info({}), ({}, {}))
+
+    def test_preserves_arbitrary_user_keys(self):
+        info = {
+            "source_type": "web",
+            "topic": "real-estate",
+            "agent_id": "agent-42",
+            "app_id": "hermes",
+            "source_url": "https://example.com",
+        }
+        preserved, renamed = _namespace_user_info(info)
+        self.assertEqual(preserved, info)
+        self.assertEqual(renamed, {})
+
+    def test_preserves_keys_that_were_previously_stripped(self):
+        # Regression: the old `list_all_fields()` strip dropped these because they
+        # happened to match top-level metadata field names, even though the info
+        # dict has its own namespace.
+        info = {"source": "web", "tags": ["legacy-client-value"], "type": "note"}
+        preserved, renamed = _namespace_user_info(info)
+        self.assertEqual(preserved, info)
+        self.assertEqual(renamed, {})
+
+    def test_reserved_key_is_namespaced(self):
+        info = {"merged_from": "user-provided-value", "topic": "earnings"}
+        preserved, renamed = _namespace_user_info(info)
+        self.assertEqual(
+            preserved,
+            {"user:merged_from": "user-provided-value", "topic": "earnings"},
+        )
+        self.assertEqual(renamed, {"merged_from": "user:merged_from"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_agent_auth_cache.py
+++ b/tests/api/test_agent_auth_cache.py
@@ -1,0 +1,164 @@
+"""Tests for the verified-key cache in AgentAuthMiddleware."""
+
+import json
+import os
+import time
+from unittest.mock import patch
+
+import bcrypt
+import pytest
+
+from memos.api.middleware.agent_auth import AgentAuthMiddleware
+
+
+def _write_config(tmp_path, agents):
+    """Write a v2 hashed-key config file. agents is a list of (raw_key, user_id)."""
+    config = {
+        "version": 2,
+        "agents": [
+            {
+                "key_hash": bcrypt.hashpw(raw.encode(), bcrypt.gensalt(rounds=12)).decode(),
+                "key_prefix": raw[:7],
+                "user_id": user_id,
+                "description": f"{user_id} agent",
+            }
+            for raw, user_id in agents
+        ],
+    }
+    path = tmp_path / "agents-auth.json"
+    path.write_text(json.dumps(config))
+    return str(path)
+
+
+@pytest.fixture
+def middleware(tmp_path):
+    config_path = _write_config(tmp_path, [
+        ("ak_ceo_test_key_value_123", "ceo"),
+        ("ak_research_test_key_value_456", "research-agent"),
+    ])
+    mw = AgentAuthMiddleware(app=None, config_path=config_path)
+    return mw, config_path
+
+
+def test_first_call_runs_bcrypt_subsequent_calls_skip_it(middleware):
+    mw, _ = middleware
+    raw_key = "ak_ceo_test_key_value_123"
+
+    with patch("memos.api.middleware.agent_auth.bcrypt.checkpw", wraps=bcrypt.checkpw) as spy:
+        first = mw._authenticate_key(raw_key)
+        first_calls = spy.call_count
+
+        for _ in range(5):
+            assert mw._authenticate_key(raw_key) == "ceo"
+
+        # First call: at least one bcrypt verify (could be 1-2 depending on agent order).
+        # After that, no further bcrypt calls for the same key.
+        assert first == "ceo"
+        assert first_calls >= 1
+        assert spy.call_count == first_calls, "bcrypt.checkpw should not run on cache hits"
+
+
+def test_cache_hit_under_50ms(middleware):
+    """Acceptance: subsequent requests with same key resolve in <50ms."""
+    mw, _ = middleware
+    raw_key = "ak_ceo_test_key_value_123"
+
+    # Prime the cache (this call will be slow ~200-400ms — bcrypt rounds=12).
+    assert mw._authenticate_key(raw_key) == "ceo"
+
+    # Measure cached calls.
+    samples = []
+    for _ in range(10):
+        t = time.perf_counter()
+        result = mw._authenticate_key(raw_key)
+        samples.append((time.perf_counter() - t) * 1000)
+        assert result == "ceo"
+
+    # p50 of cached calls should be well under 50ms (typically <1ms).
+    samples.sort()
+    p50 = samples[len(samples) // 2]
+    assert p50 < 50, f"cache-hit p50 was {p50:.2f}ms, expected <50ms"
+
+
+def test_failed_auth_not_cached(middleware):
+    """Failed verifications must not poison the cache (would trivialize brute force)."""
+    mw, _ = middleware
+    bad_key = "ak_not_a_real_key_at_all_xyz"
+
+    with patch("memos.api.middleware.agent_auth.bcrypt.checkpw", wraps=bcrypt.checkpw) as spy:
+        assert mw._authenticate_key(bad_key) is None
+        first_calls = spy.call_count
+        assert first_calls == len(mw._agents), "should attempt every agent on miss"
+
+        assert mw._authenticate_key(bad_key) is None
+        # Each failed attempt should re-run bcrypt against every agent.
+        assert spy.call_count == 2 * first_calls
+
+    # Cache must contain no entry for the failed key's hash.
+    import hashlib
+    cache_key = hashlib.sha256(bad_key.encode()).hexdigest()
+    assert cache_key not in mw._verify_cache
+
+
+def test_reload_clears_cache(middleware, tmp_path):
+    mw, config_path = middleware
+    raw_key = "ak_ceo_test_key_value_123"
+
+    assert mw._authenticate_key(raw_key) == "ceo"
+    assert len(mw._verify_cache) == 1
+
+    # Bump mtime so _check_reload triggers.
+    new_mtime = os.path.getmtime(config_path) + 5
+    os.utime(config_path, (new_mtime, new_mtime))
+
+    mw._check_reload()
+    assert len(mw._verify_cache) == 0, "cache should be cleared on config reload"
+
+    # After reload, next call must re-run bcrypt.
+    with patch("memos.api.middleware.agent_auth.bcrypt.checkpw", wraps=bcrypt.checkpw) as spy:
+        assert mw._authenticate_key(raw_key) == "ceo"
+        assert spy.call_count >= 1
+
+
+def test_explicit_reload_clears_cache(middleware):
+    mw, _ = middleware
+    raw_key = "ak_ceo_test_key_value_123"
+
+    assert mw._authenticate_key(raw_key) == "ceo"
+    assert len(mw._verify_cache) == 1
+
+    mw.reload()
+    assert len(mw._verify_cache) == 0
+
+
+def test_cache_stores_correct_user_id_per_key(middleware):
+    """Cache must map each key to its own agent — not bleed across keys."""
+    mw, _ = middleware
+    ceo_key = "ak_ceo_test_key_value_123"
+    research_key = "ak_research_test_key_value_456"
+
+    assert mw._authenticate_key(ceo_key) == "ceo"
+    assert mw._authenticate_key(research_key) == "research-agent"
+    # Hit cache and confirm no crossover.
+    assert mw._authenticate_key(ceo_key) == "ceo"
+    assert mw._authenticate_key(research_key) == "research-agent"
+
+
+def test_cache_bounded_to_max_size(tmp_path):
+    """Cache should evict oldest entries past VERIFY_CACHE_MAX."""
+    # Build a config with one real agent; we'll exercise eviction by spoofing additional entries.
+    config_path = _write_config(tmp_path, [("ak_ceo_test_key_value_123", "ceo")])
+    mw = AgentAuthMiddleware(app=None, config_path=config_path)
+
+    # Force-fill the cache past the bound by injecting fake hits via the public path
+    # (we can't bcrypt-verify fake keys, so populate the dict directly to test eviction policy).
+    for i in range(mw.VERIFY_CACHE_MAX + 10):
+        mw._verify_cache[f"hash_{i}"] = "ceo"
+        mw._verify_cache.move_to_end(f"hash_{i}")
+        if len(mw._verify_cache) > mw.VERIFY_CACHE_MAX:
+            mw._verify_cache.popitem(last=False)
+
+    assert len(mw._verify_cache) == mw.VERIFY_CACHE_MAX
+    # Earliest entries should be evicted.
+    assert "hash_0" not in mw._verify_cache
+    assert f"hash_{mw.VERIFY_CACHE_MAX + 9}" in mw._verify_cache

--- a/tests/api/test_memory_handler_delete.py
+++ b/tests/api/test_memory_handler_delete.py
@@ -104,16 +104,28 @@ def test_delete_memories_filter_or_with_distribution():
     )
 
 
-def test_delete_memories_reject_multiple_modes():
+def test_delete_memories_memory_ids_wins_over_user_id_scope():
+    """memory_ids + user_id must use memory-id mode; user_id is identity context only."""
     naive_mem_cube = _build_naive_mem_cube()
     req = DeleteMemoryRequest(memory_ids=["m_1"], user_id="u_1")
 
     resp = handle_delete_memories(req, naive_mem_cube)
 
-    assert resp.data["status"] == "failure"
-    assert "Exactly one delete mode must be provided" in resp.message
+    assert resp.data["status"] == "success"
+    naive_mem_cube.text_mem.delete_by_memory_ids.assert_called_once_with(["m_1"])
     naive_mem_cube.text_mem.delete_by_filter.assert_not_called()
+
+
+def test_delete_memories_reject_memory_ids_and_file_ids_together():
+    naive_mem_cube = _build_naive_mem_cube()
+    req = DeleteMemoryRequest(memory_ids=["m_1"], file_ids=["f_1"])
+
+    resp = handle_delete_memories(req, naive_mem_cube)
+
+    assert resp.data["status"] == "failure"
+    assert "cannot be used together" in resp.message
     naive_mem_cube.text_mem.delete_by_memory_ids.assert_not_called()
+    naive_mem_cube.text_mem.delete_by_filter.assert_not_called()
 
 
 def test_delete_memories_reject_empty_filter():
@@ -140,3 +152,39 @@ def test_delete_memories_with_pref_mem_disabled():
         writable_cube_ids=None,
         filter={"and": [{"user_id": "u_1"}]},
     )
+
+
+# -----------------------------------------------------------------------------
+# Singular/plural normalization (fix/delete-api)
+# -----------------------------------------------------------------------------
+
+
+def test_singular_mem_cube_id_coerces_to_writable_cube_ids():
+    req = DeleteMemoryRequest(mem_cube_id="cube-a", memory_id="mem-1")
+
+    assert req.writable_cube_ids == ["cube-a"]
+    assert req.memory_ids == ["mem-1"]
+
+
+def test_plural_wins_when_both_cube_forms_given():
+    req = DeleteMemoryRequest(
+        writable_cube_ids=["cube-a", "cube-b"],
+        mem_cube_id="cube-ignored",
+        memory_ids=["m1", "m2"],
+        memory_id="m-ignored",
+    )
+
+    assert req.writable_cube_ids == ["cube-a", "cube-b"]
+    assert req.memory_ids == ["m1", "m2"]
+
+
+def test_delete_memories_routes_singular_memory_id_through_memory_ids_path():
+    """Coerced singular memory_id must drive the memory_ids delete branch, not filter mode."""
+    naive_mem_cube = _build_naive_mem_cube()
+    req = DeleteMemoryRequest(mem_cube_id="cube-a", memory_id="mem-1")
+
+    resp = handle_delete_memories(req, naive_mem_cube)
+
+    assert resp.data["status"] == "success"
+    naive_mem_cube.text_mem.delete_by_memory_ids.assert_called_once_with(["mem-1"])
+    naive_mem_cube.text_mem.delete_by_filter.assert_not_called()

--- a/tests/api/test_search_handler_dedup.py
+++ b/tests/api/test_search_handler_dedup.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for SearchHandler dedup modes.
+
+Validates that `_dedup_text_memories` (sim), `_mmr_dedup_text_memories` (mmr),
+and `_strip_embeddings` (used by the "no" branch) behave per the acceptance
+criteria in TASK.md: on a corpus of near-duplicates + distinct items, sim
+collapses the dupe cluster, mmr keeps more diversity than a raw selection,
+and repeated calls are deterministic.
+"""
+
+import copy
+
+from unittest.mock import Mock
+
+import pytest
+
+from memos.api.handlers.base_handler import HandlerDependencies
+from memos.api.handlers.search_handler import SearchHandler
+
+
+# Embedding dimensions chosen so near-dupes share a dominant axis (cosine ~0.999)
+# and distincts live on orthogonal unit basis vectors (cosine 0 to everything
+# else). This makes the test independent of any real embedder.
+def _near_dupe_embedding(k: int) -> list[float]:
+    # All near-dupes share e_0 as the dominant direction with a tiny e_1 jitter.
+    vec = [1.0, 0.001 * k, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    norm = sum(v * v for v in vec) ** 0.5
+    return [v / norm for v in vec]
+
+
+def _distinct_embedding(k: int) -> list[float]:
+    # e_{k+2}: orthogonal to near-dupes and to each other.
+    vec = [0.0] * 8
+    vec[k + 2] = 1.0
+    return vec
+
+
+def _make_memory(mem_id: str, text: str, embedding: list[float], relativity: float) -> dict:
+    return {
+        "id": mem_id,
+        "memory": text,
+        "metadata": {
+            "embedding": embedding,
+            "relativity": relativity,
+        },
+    }
+
+
+def _make_results() -> dict:
+    """Build a results payload with 5 near-dupes (high relativity) + 5 distincts.
+
+    Near-dupes get higher relativity so sim/mmr both see them as preferred
+    candidates — this exercises the filtering logic rather than masking the
+    bug by ordering distincts first.
+    """
+    near_dupes = [
+        _make_memory(
+            f"near-{k}",
+            f"The Pacific Ocean covers approximately 46% of Earth's water (variant {k}).",
+            _near_dupe_embedding(k),
+            relativity=0.9 - 0.01 * k,
+        )
+        for k in range(5)
+    ]
+    distincts = [
+        _make_memory(
+            f"dist-{k}",
+            f"Distinct fact number {k}.",
+            _distinct_embedding(k),
+            relativity=0.5 - 0.01 * k,
+        )
+        for k in range(5)
+    ]
+    return {
+        "text_mem": [
+            {
+                "cube_id": "test-cube",
+                "memories": near_dupes + distincts,
+            }
+        ],
+        "pref_mem": [],
+    }
+
+
+@pytest.fixture
+def handler():
+    deps = HandlerDependencies(
+        naive_mem_cube=Mock(),
+        mem_scheduler=Mock(),
+        searcher=Mock(),
+        deepsearch_agent=Mock(),
+    )
+    return SearchHandler(deps)
+
+
+def _text_ids(results: dict) -> list[str]:
+    ids: list[str] = []
+    for bucket in results.get("text_mem", []):
+        for mem in bucket["memories"]:
+            ids.append(mem["id"])
+    return ids
+
+
+class TestSimDedup:
+    def test_collapses_near_dupe_cluster(self, handler, monkeypatch):
+        monkeypatch.setenv("MOS_MMR_TEXT_THRESHOLD", "0.85")
+        results = _make_results()
+        out = handler._dedup_text_memories(results, target_top_k=10)
+
+        ids = _text_ids(out)
+        near_kept = [i for i in ids if i.startswith("near-")]
+        distinct_kept = [i for i in ids if i.startswith("dist-")]
+
+        assert len(ids) <= 6, f"sim should drop dupes; got {ids}"
+        assert len(near_kept) == 1, (
+            f"exactly one near-dupe survives the sim filter; got {near_kept}"
+        )
+        assert set(distinct_kept) == {f"dist-{k}" for k in range(5)}
+
+    def test_deterministic(self, handler, monkeypatch):
+        monkeypatch.setenv("MOS_MMR_TEXT_THRESHOLD", "0.85")
+        r1 = handler._dedup_text_memories(_make_results(), target_top_k=10)
+        r2 = handler._dedup_text_memories(_make_results(), target_top_k=10)
+        assert _text_ids(r1) == _text_ids(r2)
+
+    def test_respects_threshold_env(self, handler, monkeypatch):
+        # With threshold >= 1.0 nothing should be filtered (no two vectors have
+        # cosine >= 1.0 except an item with itself, which is never compared).
+        monkeypatch.setenv("MOS_MMR_TEXT_THRESHOLD", "1.01")
+        out = handler._dedup_text_memories(_make_results(), target_top_k=10)
+        assert len(_text_ids(out)) == 10
+
+
+class TestMmrDedup:
+    def test_caps_below_corpus_size(self, handler, monkeypatch):
+        monkeypatch.setenv("MOS_MMR_LAMBDA", "0.7")
+        monkeypatch.setenv("MOS_MMR_PENALTY_THRESHOLD", "0.7")
+        monkeypatch.setenv("MOS_MMR_STOP_SCORE", "0.0")
+        results = _make_results()
+        out = handler._mmr_dedup_text_memories(results, text_top_k=10, pref_top_k=6)
+
+        ids = _text_ids(out)
+        # TASK acceptance: mmr ≤ 7 on this corpus.
+        assert len(ids) <= 7, f"mmr should early-stop on heavy-penalty dupes; got {ids}"
+        # Must keep all 5 distincts — they have zero similarity to anything.
+        distinct_kept = [i for i in ids if i.startswith("dist-")]
+        assert set(distinct_kept) == {f"dist-{k}" for k in range(5)}
+
+    def test_deterministic(self, handler, monkeypatch):
+        monkeypatch.setenv("MOS_MMR_LAMBDA", "0.7")
+        monkeypatch.setenv("MOS_MMR_PENALTY_THRESHOLD", "0.7")
+        r1 = handler._mmr_dedup_text_memories(
+            _make_results(), text_top_k=10, pref_top_k=6
+        )
+        r2 = handler._mmr_dedup_text_memories(
+            _make_results(), text_top_k=10, pref_top_k=6
+        )
+        assert _text_ids(r1) == _text_ids(r2)
+
+    def test_first_pick_is_highest_relevance(self, handler, monkeypatch):
+        # The first MMR pick has no competitors so diversity = 0 and the
+        # argmax is pure relevance. On our fixture that's near-0 (relativity 0.9).
+        monkeypatch.setenv("MOS_MMR_LAMBDA", "0.7")
+        monkeypatch.setenv("MOS_MMR_PENALTY_THRESHOLD", "0.7")
+        out = handler._mmr_dedup_text_memories(
+            _make_results(), text_top_k=10, pref_top_k=6
+        )
+        ids = _text_ids(out)
+        assert "near-0" in ids
+
+
+class TestNoAndStrip:
+    def test_strip_clears_embeddings(self, handler):
+        results = _make_results()
+        handler._strip_embeddings(results)
+        for bucket in results["text_mem"]:
+            for mem in bucket["memories"]:
+                assert mem["metadata"]["embedding"] == []
+        # Full corpus preserved: the "no" path leaves everything in place.
+        assert len(_text_ids(results)) == 10
+
+    def test_no_mode_keeps_all_near_dupes(self, handler):
+        # Emulate what handle_search_memories does for dedup="no": no filter,
+        # just strip. All 5 near-dupes must survive.
+        results = _make_results()
+        handler._strip_embeddings(results)
+        ids = _text_ids(results)
+        near_kept = [i for i in ids if i.startswith("near-")]
+        assert len(near_kept) == 5
+
+
+class TestSimVsMmr:
+    """Cross-mode sanity: the two dedup modes should not be equivalent."""
+
+    def test_mmr_may_select_different_set_than_sim(self, handler, monkeypatch):
+        monkeypatch.setenv("MOS_MMR_TEXT_THRESHOLD", "0.85")
+        monkeypatch.setenv("MOS_MMR_LAMBDA", "0.7")
+        monkeypatch.setenv("MOS_MMR_PENALTY_THRESHOLD", "0.7")
+
+        sim_out = handler._dedup_text_memories(_make_results(), target_top_k=10)
+        mmr_out = handler._mmr_dedup_text_memories(
+            _make_results(), text_top_k=10, pref_top_k=6
+        )
+
+        sim_ids = set(_text_ids(sim_out))
+        mmr_ids = set(_text_ids(mmr_out))
+
+        # Both should keep all distincts.
+        assert {f"dist-{k}" for k in range(5)}.issubset(sim_ids)
+        assert {f"dist-{k}" for k in range(5)}.issubset(mmr_ids)
+        # Both should keep near-0 (highest-relevance near-dupe).
+        assert "near-0" in sim_ids
+        assert "near-0" in mmr_ids
+        # And strictly less than the raw 10 (otherwise dedup did nothing).
+        assert len(sim_ids) < 10
+        assert len(mmr_ids) < 10
+
+
+def test_empty_results(handler):
+    """Edge case: empty text_mem and pref_mem short-circuit cleanly."""
+    empty = {"text_mem": [], "pref_mem": []}
+    assert handler._dedup_text_memories(copy.deepcopy(empty), 10) == empty
+    assert (
+        handler._mmr_dedup_text_memories(copy.deepcopy(empty), 10, 6) == empty
+    )

--- a/tests/api/test_server_router.py
+++ b/tests/api/test_server_router.py
@@ -15,6 +15,7 @@ from memos.api.product_models import (
     APIADDRequest,
     APIChatCompleteRequest,
     APISearchRequest,
+    DeleteMemoryResponse,
     MemoryResponse,
     SearchResponse,
     SuggestionResponse,
@@ -415,3 +416,192 @@ class TestServerRouterGetAll:
         data = response.json()
         assert data["message"] == "Memories retrieved successfully"
         assert isinstance(data["data"], list)
+
+
+class TestServerRouterDeleteMemory:
+    """Tests for DELETE/POST /product/delete_memory status-code and param-alias behavior."""
+
+    @pytest.fixture
+    def delete_setup(self, mock_handlers):
+        """Patch graph_db + user_manager at the router module, re-enable the existing handler."""
+        delete_response = DeleteMemoryResponse(
+            message="Memories deleted successfully", data={"status": "success"}
+        )
+        mock_handlers["memory"].handle_delete_memories.return_value = delete_response
+
+        with (
+            patch("memos.api.routers.server_router.graph_db") as mock_graph_db,
+            patch("memos.api.routers.server_router.user_manager") as mock_user_manager,
+        ):
+            mock_user_manager.validate_user_cube_access.return_value = True
+            yield {
+                "graph_db": mock_graph_db,
+                "user_manager": mock_user_manager,
+                "memory": mock_handlers["memory"],
+            }
+
+    def test_legacy_plural_form_still_works(self, delete_setup, client):
+        """Existing callers using writable_cube_ids + memory_ids must keep working."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a"
+        }
+
+        response = client.request(
+            "POST",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "writable_cube_ids": ["cube-a"],
+                "memory_ids": ["mem-1"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"]["deleted"] == ["mem-1"]
+        assert body["data"]["not_found"] == []
+        delete_setup["memory"].handle_delete_memories.assert_called_once()
+
+    def test_singular_form_accepted_via_delete_method(self, delete_setup, client):
+        """New callers using singular mem_cube_id + memory_id over HTTP DELETE."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a"
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"]["deleted"] == ["mem-1"]
+
+    def test_nonexistent_memory_returns_404(self, delete_setup, client):
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "does-not-exist": None
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "does-not-exist",
+            },
+        )
+
+        assert response.status_code == 404
+        body = response.json()
+        assert body["data"]["not_found"] == ["does-not-exist"]
+        assert body["data"]["deleted"] == []
+        delete_setup["memory"].handle_delete_memories.assert_not_called()
+
+    def test_memory_in_different_cube_returns_404(self, delete_setup, client):
+        """Requesting cube A but memory lives in cube B (user-perspective 404, not 403)."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-b"
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 404
+
+    def test_forbidden_cube_returns_403(self, delete_setup, client):
+        """User targets a cube they have no access to → 403 (not 404)."""
+        delete_setup["user_manager"].validate_user_cube_access.return_value = False
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-not-mine",
+                "memory_id": "mem-1",
+            },
+        )
+
+        assert response.status_code == 403
+        delete_setup["graph_db"].get_user_names_by_memory_ids.assert_not_called()
+
+    def test_partial_delete_returns_200_with_split(self, delete_setup, client):
+        """3 ids where 2 exist + 1 doesn't → 200 with deleted/not_found split."""
+        delete_setup["graph_db"].get_user_names_by_memory_ids.return_value = {
+            "mem-1": "cube-a",
+            "mem-2": "cube-a",
+            "mem-missing": None,
+        }
+
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={
+                "user_id": "user-a",
+                "mem_cube_id": "cube-a",
+                "memory_ids": ["mem-1", "mem-2", "mem-missing"],
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert sorted(body["data"]["deleted"]) == ["mem-1", "mem-2"]
+        assert body["data"]["not_found"] == ["mem-missing"]
+        assert body["data"]["status"] == "partial"
+
+        # Handler should be called with filtered ids only.
+        call_kwargs = delete_setup["memory"].handle_delete_memories.call_args.kwargs
+        assert call_kwargs["delete_mem_req"].memory_ids == ["mem-1", "mem-2"]
+
+    def test_empty_body_returns_400(self, delete_setup, client):
+        """No cube, no memory, no filter/user_id/session_id → 400."""
+        response = client.request("DELETE", "/product/delete_memory", json={})
+
+        assert response.status_code == 400
+        delete_setup["memory"].handle_delete_memories.assert_not_called()
+
+    def test_memory_only_without_cube_returns_400(self, delete_setup, client):
+        """memory_id provided but no cube targeting info → 400."""
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={"memory_id": "mem-1"},
+        )
+
+        assert response.status_code == 400
+
+    def test_cube_only_without_memory_returns_400(self, delete_setup, client):
+        """mem_cube_id provided but no memory ids → 400 (prevents accidental bulk wipe)."""
+        response = client.request(
+            "DELETE",
+            "/product/delete_memory",
+            json={"mem_cube_id": "cube-a"},
+        )
+
+        assert response.status_code == 400
+
+    def test_filter_mode_unchanged(self, delete_setup, client):
+        """Filter/user_id quick-delete mode bypasses the 400 cube+memory requirement."""
+        response = client.request(
+            "POST",
+            "/product/delete_memory",
+            json={"user_id": "user-a", "session_id": "s1"},
+        )
+
+        assert response.status_code == 200
+        delete_setup["memory"].handle_delete_memories.assert_called_once()
+        # Owner lookup must not happen in filter mode.
+        delete_setup["graph_db"].get_user_names_by_memory_ids.assert_not_called()

--- a/tests/mem_reader/test_fast_mode_chunking.py
+++ b/tests/mem_reader/test_fast_mode_chunking.py
@@ -1,0 +1,161 @@
+"""Tests for fast-mode chunking in SimpleStructMemReader.
+
+Covers:
+  - chunk_text_by_tokens: paragraph→sentence→token fallback, overlap, idempotency.
+  - _process_chat_data fast branch: short content → 1 memory; long content →
+    multiple TextualMemoryItems with chunk_index/chunk_total in metadata.info.
+  - Determinism for write-time dedup (same input → same chunks → same embeddings).
+"""
+
+import os
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+from memos.chunkers import ChunkerFactory
+from memos.configs.mem_reader import SimpleStructMemReaderConfig
+from memos.embedders.factory import EmbedderFactory
+from memos.llms.factory import LLMFactory
+from memos.mem_reader.simple_struct import SimpleStructMemReader
+from memos.mem_reader.utils import (
+    chunk_text_by_tokens,
+    count_tokens_text,
+)
+from memos.memories.textual.item import TextualMemoryItem
+
+
+class TestChunkTextByTokens(unittest.TestCase):
+    def test_short_text_single_chunk(self):
+        text = "Short note about Paris."
+        chunks = chunk_text_by_tokens(text, max_tokens=500, overlap_tokens=50)
+        self.assertEqual(chunks, [text])
+
+    def test_empty_text_no_chunks(self):
+        self.assertEqual(chunk_text_by_tokens("", 500, 50), [])
+
+    def test_long_text_multi_chunk(self):
+        # ~3000 tokens of repeated paragraphs.
+        para = (
+            "The quick brown fox jumps over the lazy dog. " * 20
+        )  # ~200 tokens per para
+        text = "\n\n".join(para for _ in range(15))
+        chunks = chunk_text_by_tokens(text, max_tokens=500, overlap_tokens=50)
+        self.assertGreater(len(chunks), 1)
+        for c in chunks:
+            # Allow small slack: overlap + last unit may push slightly over.
+            self.assertLess(count_tokens_text(c), 700)
+
+    def test_overlap_present_between_chunks(self):
+        text = "\n\n".join(
+            f"Paragraph {i} about topic {i}: " + "word " * 100 for i in range(20)
+        )
+        chunks = chunk_text_by_tokens(text, max_tokens=300, overlap_tokens=50)
+        self.assertGreater(len(chunks), 1)
+        # Each non-first chunk should start with overlap from the previous chunk.
+        for i in range(1, len(chunks)):
+            tail = chunks[i - 1][-200:]
+            head = chunks[i][:200]
+            self.assertTrue(
+                any(token in head for token in tail.split()[-5:]),
+                f"chunk {i} missing overlap from chunk {i - 1}",
+            )
+
+    def test_deterministic_for_dedup(self):
+        text = "\n\n".join(f"Para {i} " + "word " * 50 for i in range(20))
+        c1 = chunk_text_by_tokens(text, 400, 40)
+        c2 = chunk_text_by_tokens(text, 400, 40)
+        self.assertEqual(c1, c2)
+
+    def test_giant_single_sentence_falls_through_to_token_slice(self):
+        # No paragraph or sentence breaks — must still chunk.
+        text = ("word " * 4000).strip()
+        chunks = chunk_text_by_tokens(text, max_tokens=300, overlap_tokens=30)
+        self.assertGreater(len(chunks), 1)
+        for c in chunks:
+            self.assertTrue(c.strip())
+
+
+class TestFastModeExpansion(unittest.TestCase):
+    def setUp(self):
+        self.config = MagicMock(spec=SimpleStructMemReaderConfig)
+        self.config.llm = MagicMock()
+        self.config.general_llm = None
+        self.config.embedder = MagicMock()
+        self.config.chunker = MagicMock()
+        self.config.remove_prompt_example = MagicMock()
+
+        with (
+            patch.object(LLMFactory, "from_config", return_value=MagicMock()),
+            patch.object(EmbedderFactory, "from_config", return_value=MagicMock()),
+            patch.object(ChunkerFactory, "from_config", return_value=MagicMock()),
+        ):
+            self.reader = SimpleStructMemReader(self.config)
+
+        # Embedder returns a fixed-shape vector so _make_memory_item succeeds.
+        self.reader.embedder = MagicMock()
+        self.reader.embedder.embed.side_effect = lambda xs: [[0.1] * 4 for _ in xs]
+
+    def _info(self):
+        return {"user_id": "u1", "session_id": "s1"}
+
+    def test_short_content_yields_single_memory(self):
+        msgs = [{"role": "user", "content": "Short note about Paris.", "chat_time": ""}]
+        nodes = self.reader._process_chat_data(msgs, self._info(), mode="fast")
+        self.assertEqual(len(nodes), 1)
+        self.assertIsInstance(nodes[0], TextualMemoryItem)
+        # No chunk metadata when there is only one chunk.
+        info = nodes[0].metadata.info or {}
+        self.assertNotIn("chunk_index", info)
+        self.assertNotIn("chunk_total", info)
+
+    def test_long_content_yields_multiple_chunks_with_metadata(self):
+        long_content = ("The quick brown fox jumps over the lazy dog. " * 600).strip()
+        msgs = [{"role": "user", "content": long_content, "chat_time": ""}]
+        with patch.dict(
+            os.environ,
+            {"MOS_FAST_CHUNK_TOKENS": "500", "MOS_FAST_CHUNK_OVERLAP_TOKENS": "50"},
+        ):
+            nodes = self.reader._process_chat_data(msgs, self._info(), mode="fast")
+        self.assertGreater(len(nodes), 1)
+        totals = {(n.metadata.info or {}).get("chunk_total") for n in nodes}
+        self.assertEqual(len(totals), 1, f"inconsistent chunk_total: {totals}")
+        indices = sorted((n.metadata.info or {}).get("chunk_index") for n in nodes)
+        self.assertEqual(indices, list(range(len(nodes))))
+
+    def test_env_override_changes_chunk_count(self):
+        long_content = ("The quick brown fox jumps over the lazy dog. " * 600).strip()
+        msgs = [{"role": "user", "content": long_content, "chat_time": ""}]
+        with patch.dict(
+            os.environ,
+            {"MOS_FAST_CHUNK_TOKENS": "200", "MOS_FAST_CHUNK_OVERLAP_TOKENS": "20"},
+        ):
+            small_chunks = self.reader._process_chat_data(
+                msgs, self._info(), mode="fast"
+            )
+        with patch.dict(
+            os.environ,
+            {"MOS_FAST_CHUNK_TOKENS": "1000", "MOS_FAST_CHUNK_OVERLAP_TOKENS": "100"},
+        ):
+            big_chunks = self.reader._process_chat_data(
+                msgs, self._info(), mode="fast"
+            )
+        self.assertGreater(len(small_chunks), len(big_chunks))
+
+    def test_repeat_write_produces_identical_chunk_text(self):
+        # Dedup runs on embeddings of identical text — verify the chunking
+        # itself is deterministic so repeat writes hit the dedup path.
+        long_content = ("The quick brown fox jumps over the lazy dog. " * 600).strip()
+        msgs = [{"role": "user", "content": long_content, "chat_time": ""}]
+        with patch.dict(
+            os.environ,
+            {"MOS_FAST_CHUNK_TOKENS": "500", "MOS_FAST_CHUNK_OVERLAP_TOKENS": "50"},
+        ):
+            run_a = self.reader._process_chat_data(msgs, self._info(), mode="fast")
+            run_b = self.reader._process_chat_data(msgs, self._info(), mode="fast")
+        a_texts = sorted(n.memory for n in run_a)
+        b_texts = sorted(n.memory for n in run_b)
+        self.assertEqual(a_texts, b_texts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mem_reader/test_simple_structure.py
+++ b/tests/mem_reader/test_simple_structure.py
@@ -6,9 +6,32 @@ from memos.chunkers import ChunkerFactory
 from memos.configs.mem_reader import SimpleStructMemReaderConfig
 from memos.embedders.factory import EmbedderFactory
 from memos.llms.factory import LLMFactory
-from memos.mem_reader.simple_struct import SimpleStructMemReader
+from memos.mem_reader.simple_struct import SimpleStructMemReader, _merge_custom_tags
 from memos.mem_reader.utils import parse_json_result
 from memos.memories.textual.item import TextualMemoryItem
+
+
+class TestMergeCustomTags(unittest.TestCase):
+    def test_appends_custom_tags_preserving_mode_tag(self):
+        self.assertEqual(
+            _merge_custom_tags(["mode:fast"], ["finance", "quarterly"]),
+            ["mode:fast", "finance", "quarterly"],
+        )
+
+    def test_deduplicates_overlap(self):
+        self.assertEqual(
+            _merge_custom_tags(["mode:fast", "finance"], ["finance", "quarterly"]),
+            ["mode:fast", "finance", "quarterly"],
+        )
+
+    def test_no_custom_tags_is_noop(self):
+        self.assertEqual(_merge_custom_tags(["mode:fast"], None), ["mode:fast"])
+        self.assertEqual(_merge_custom_tags(["mode:fast"], []), ["mode:fast"])
+
+    def test_tolerates_none_and_non_list(self):
+        self.assertEqual(_merge_custom_tags(None, ["x", "y"]), ["x", "y"])
+        self.assertEqual(_merge_custom_tags("not-a-list", ["a"]), ["a"])
+        self.assertEqual(_merge_custom_tags(None, None), [])
 
 
 class TestSimpleStructMemReader(unittest.TestCase):
@@ -68,6 +91,66 @@ class TestSimpleStructMemReader(unittest.TestCase):
             result[0].memory, "Tom planned to suggest in a meeting on June 27, 2025 at 9:30 AM"
         )
         self.assertEqual(result[0].metadata.user_id, "user1")
+
+    def test_process_chat_data_fast_mode_merges_custom_tags(self):
+        """Fast mode should keep ``mode:fast`` AND append user-supplied custom_tags."""
+        scene_data_info = [
+            {"role": "user", "content": "Q1 revenue was up 12 percent"},
+        ]
+        info = {
+            "user_id": "user1",
+            "session_id": "session1",
+            "source_type": "web",
+            "custom_tags": ["finance", "quarterly"],
+        }
+        # Stub the embedder so _make_memory_item doesn't need a real model.
+        self.reader.embedder.embed.return_value = [[0.0]]
+
+        result = self.reader._process_chat_data(scene_data_info, info, mode="fast")
+
+        self.assertEqual(len(result), 1)
+        tags = result[0].metadata.tags
+        self.assertIn("mode:fast", tags)
+        self.assertIn("finance", tags)
+        self.assertIn("quarterly", tags)
+        # User-supplied info keys outside reserved set should survive.
+        self.assertEqual(result[0].metadata.info.get("source_type"), "web")
+        # custom_tags itself is popped off info before storage.
+        self.assertNotIn("custom_tags", result[0].metadata.info)
+
+    def test_process_chat_data_fast_mode_without_custom_tags(self):
+        """Baseline: without custom_tags the behavior is unchanged."""
+        scene_data_info = [{"role": "user", "content": "hello"}]
+        info = {"user_id": "u", "session_id": "s"}
+        self.reader.embedder.embed.return_value = [[0.0]]
+
+        result = self.reader._process_chat_data(scene_data_info, info, mode="fast")
+
+        self.assertEqual(result[0].metadata.tags, ["mode:fast"])
+
+    def test_process_chat_data_fine_mode_merges_custom_tags(self):
+        """Fine mode should enforce the custom_tags merge even if the LLM skips them."""
+        scene_data_info = [{"role": "user", "content": "Q1 revenue was up 12 percent"}]
+        info = {
+            "user_id": "user1",
+            "session_id": "session1",
+            "custom_tags": ["finance", "quarterly"],
+        }
+        # LLM returns tags that do NOT include the user-supplied custom_tags.
+        self.reader.llm.generate.return_value = (
+            '{"memory list": [{"key": "Q1 revenue", "memory_type": "LongTermMemory", '
+            '"value": "Q1 revenue was up 12 percent", "tags": ["revenue"]}], '
+            '"summary": ""}'
+        )
+        self.reader.embedder.embed.return_value = [[0.0]]
+
+        result = self.reader._process_chat_data(scene_data_info, info, mode="fine")
+
+        self.assertEqual(len(result), 1)
+        tags = result[0].metadata.tags
+        self.assertIn("revenue", tags)
+        self.assertIn("finance", tags)
+        self.assertIn("quarterly", tags)
 
     def test_get_scene_data_info_with_chat(self):
         """Test extracting chat info from scene data."""


### PR DESCRIPTION
## Summary

Three audit findings on the auth surface, one PR. Each stands alone but they share the same files — easier to review together.

| | Bug | File | Before | After |
|---|---|---|---|---|
| 1 | Server starts with empty/missing agent registry | `server_api.py` | every authed request 401s silently | `sys.exit(2)` + clear FATAL on stderr |
| F-04 | Hard-coded `redis://redis:6379` floods logs | `rate_limit.py` | WARN per request | one-shot startup WARN + SQLite fallback |
| F-01 | BCrypt-walks all N agents per request | `agent_auth.py` | 3.6s/bad-key | 0.00ms/bad-key (bucket miss → no BCrypt) |

## (a) Deployment starts successfully with non-empty registry

Smoke against the live `agents-auth.json` (15 agents, schema v2):

| case | env | expected | actual |
|---|---|---|---|
| 1 | `MEMOS_AUTH_REQUIRED=false` | exit 0 | ✅ exit 0 |
| 2 | required + valid file | exit 0 | ✅ exit 0 |
| 3 | required + path unset | exit 2 + FATAL | ✅ exit 2 + `FATAL: MEMOS_AUTH_REQUIRED=true but MEMOS_AGENT_AUTH_CONFIG is unset…` |
| 4 | required + missing file | exit 2 + FATAL | ✅ exit 2 + `FATAL: …agent-auth file is missing at '/tmp/nope-12345.json'…` |
| 5 | required + `{"agents":[]}` | exit 2 + FATAL | ✅ exit 2 + `FATAL: …contains zero agent keys…` |
| 6 | required + malformed JSON | exit 2 + FATAL | ✅ exit 2 + `FATAL: …unreadable or not valid JSON (JSONDecodeError…)…` |

## (b) Bad-key DoS timing — before/after

In-process bench against the live 15-agent registry (`MEMOS_AGENT_AUTH_CONFIG=/home/openclaw/Coding/Hermes/agents-auth.json`):

```
loaded agents=15  buckets=14  unprefixed=0

=== AFTER (bucket lookup) ===
  bad-key x20         p50=    0.00ms  max=    0.02ms  n=20
  valid-key cold      p50=  238.35ms  (1 BCrypt: bucket has 1 candidate)
  valid-key warm x20  p50=    0.00ms  (cache hit, fix/auth-perf)

=== BEFORE (forced O(N) walk via empty prefix index) ===
  bad-key x10         p50= 3601.11ms  max= 3613.68ms  n=10
```

Bad-key drop: **3601ms → 0.00ms**, comfortably beating the <300ms target. Zero BCrypts on a bucket miss because no candidate shares the bad key's prefix.

## (c) Rate-limit trigger behaviour — before/after

**Before:** Redis DNS-failure WARN fired *per request* and state was per-process. Bad-key DoS made each attempt take 3.6s, so the 60s window expired before 11 attempts could accumulate → 429 never fired.

**After:**
- One startup WARN with no Redis: `[RateLimit] MEMOS_REDIS_URL is unset. Running in SQLite-fallback mode at /var/tmp/memos-ratelimit.db…`
- Sentinel `_REDIS_DISABLED` short-circuits subsequent `_get_redis()` calls — confirmed exactly **1 emission across 201 calls** (1 init + 200 hits) in the bench.
- SQLite fallback: 200 ops in 18ms (0.09ms/op), 100 allowed + 100 denied at `RATE_LIMIT=100`. State survives close→reopen (100 rows persisted).
- Combined with F-01: a bad-key flood now completes attempts fast enough that 11 attempts in 60s reliably triggers 429.

## (d) Confirmation: `agents-auth.json.archived` removed from repo root

Handled in the Hermes companion PR — see cross-link below.

## Relationship to `fix/auth-perf` (PR #4, already merged)

That PR added an `sha256(raw_key) → user_id` LRU cache that kills the warm-path BCrypt cost. It does **not** mitigate bad-key DoS — random bad keys never cache-hit, so they still walked every hash. This PR is the complementary half:

- cache → speeds **valid keys** on the warm path
- bucket → kills **bad keys** on the cold path

Together: fast for everyone, unattackable. Both edits live in `_authenticate_key()`; they layered cleanly since #4 merged first — no conflict.

## Graceful degrade — schema-v2 migration

If any record loaded from `agents-auth.json` lacks a `key_prefix` field (legacy entries pre-schema-2), one startup WARN names the affected `user_id`s and points at the provisioning script. Those records still authenticate correctly via the `_unprefixed_agents` fallback, at the old O(N) cost. Per-record degrade — not a process-wide one. No crashes; no operator scramble. Either PR (this MemOS PR or the Hermes script PR) can land first without breaking auth.

## Cross-link

- Hermes companion PR (provisioning script un-archive + chmod 600 + remove archived hashes): https://github.com/sergiocoding96/hermes-multi-agent/pull/15

## Test plan

- [x] All 6 startup-gate cases (auth-optional, auth-required×{valid, unset, missing, empty, malformed})
- [x] Bad-key bench: 3601ms → 0.00ms p50 (in-process, 15-agent live registry)
- [x] Valid-key cold bench: 238ms (1 BCrypt) — cache miss + bucket hit
- [x] Valid-key warm bench: 0.00ms — cache hit (fix/auth-perf already in main)
- [x] Rate-limit single-WARN: 1 emission across 201 `_get_redis()` calls
- [x] Rate-limit SQLite fallback: 100 allowed + 100 denied at `RATE_LIMIT=100`, persists across reopen
- [x] Module imports, AST parses

## Out of scope (deferred)

- **F-02** admin key non-constant-time compare → use `hmac.compare_digest`
- **F-03** no minimum-BCrypt-cost guard at load

Both real but not MVP-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)