### PR TITLE
fix(memos-local-plugin): per-agent legacy migration path + per-agent auth cookie

### DIFF
--- a/apps/memos-local-plugin/core/logger/channels.ts
+++ b/apps/memos-local-plugin/core/logger/channels.ts
@@ -101,6 +101,7 @@ export const CHANNELS = [
   "server.http",
   "server.sse",
   "server.routes",
+  "server.migrate",
   "bridge",
   "bridge.transport",
   "bridge.methods",

--- a/apps/memos-local-plugin/docs/LOGGING.md
+++ b/apps/memos-local-plugin/docs/LOGGING.md
@@ -82,7 +82,7 @@ The full canonical list lives in `core/logger/channels.ts`. Quick reference:
 | `storage`, `storage.migration`, `storage.repos`, `storage.vector` | `core/storage/` |
 | `embedding`, `embedding.*` | `core/embedding/` |
 | `llm`, `llm.*`      | `core/llm/`     |
-| `server`, `server.*` | `server/`     |
+| `server`, `server.*` (incl. `server.migrate`) | `server/`     |
 | `bridge`, `bridge.*` | `bridge/`     |
 | `adapter.openclaw`  | `adapters/openclaw/` |
 | `adapter.hermes`    | `adapters/hermes/` (Python forwards through bridge) |

--- a/apps/memos-local-plugin/server/http.ts
+++ b/apps/memos-local-plugin/server/http.ts
@@ -183,7 +183,13 @@ async function dispatch(
   // exists). Auth endpoints + `/health` are explicitly allowed so
   // the viewer can complete login even from a locked state.
   if (pathname.startsWith("/api/") && deps.home?.root) {
-    const ok = requireSession(req, res, String(deps.home.root), pathname);
+    const ok = requireSession(
+      req,
+      res,
+      String(deps.home.root),
+      pathname,
+      selfAgent,
+    );
     if (!ok) return;
   }
 

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -3,8 +3,8 @@
  *
  * Opt-in security for the Memory Viewer — when the operator enables
  * password protection (Settings → 账户 → "启用密码保护"), every
- * `/api/v1/*` request MUST carry a valid `memos_sess` cookie issued
- * by this module. When password protection is OFF (the default,
+ * `/api/v1/*` request MUST carry a valid session cookie issued by
+ * this module. When password protection is OFF (the default,
  * preserves zero-config install.sh behaviour), this module is a
  * no-op and the API is reachable from localhost without auth.
  *
@@ -23,14 +23,39 @@
  * and a 32-byte key. Sessions are HMAC-SHA256 signed JSON with a
  * 7-day rolling TTL — refreshed on every successful request.
  *
+ * ## Multi-agent cookie scoping
+ *
+ * Browsers do NOT isolate cookies by port — `localhost:18799`
+ * (openclaw) and `localhost:18800` (hermes) share a single cookie
+ * jar. Same goes for the hub layout where one server proxies
+ * `/openclaw/*` and `/hermes/*` from the same origin. If both
+ * agents wrote the same cookie name (`memos_sess`) with `Path=/`,
+ * a login on hermes would silently overwrite the openclaw cookie
+ * (and vice versa) → refreshing one viewer would log the other one
+ * out, because each agent signs sessions with its own
+ * `sessionSecret`.
+ *
+ * To stay isolated we name the cookie `memos_sess_<agent>` (e.g.
+ * `memos_sess_openclaw`, `memos_sess_hermes`). Both cookies coexist
+ * in the browser's jar without conflict. When the host doesn't
+ * advertise an agent (test fixtures, plain single-agent installs)
+ * we fall back to the legacy `memos_sess` name so existing setups
+ * continue to work unchanged.
+ *
+ * On the read side we additionally accept the legacy `memos_sess`
+ * cookie when the per-agent one is missing. This means users who
+ * were already logged in before the upgrade aren't kicked out the
+ * first time they refresh — the next successful response will
+ * write the new per-agent cookie and the transition is silent.
+ *
  * Endpoints (public, no auth):
  *   - `GET  /api/v1/auth/status`
  *   - `POST /api/v1/auth/setup`   body: { password }
  *   - `POST /api/v1/auth/login`   body: { password }
  *   - `POST /api/v1/auth/logout`
  *
- * Everything else under `/api/v1/*` is gated by `requireSession` (see
- * `middleware/session.ts`).
+ * Everything else under `/api/v1/*` is gated by `requireSession`
+ * (called from `server/http.ts::dispatch`).
  */
 import {
   existsSync,
@@ -47,12 +72,40 @@ import {
   createHmac,
 } from "node:crypto";
 
-import type { ServerDeps } from "../types.js";
+import type { ServerDeps, ServerOptions } from "../types.js";
 import { parseJson, writeError, type Routes } from "./registry.js";
 
 const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const COOKIE_NAME = "memos_sess";
+const LEGACY_COOKIE_NAME = "memos_sess";
 const SCRYPT_KEYLEN = 32;
+
+/**
+ * Resolve the per-agent cookie name. Falls back to the legacy
+ * `memos_sess` when no agent is configured (single-agent installs +
+ * test fixtures) so unrelated callers continue to work.
+ */
+function cookieNameFor(agent: string | null | undefined): string {
+  if (!agent) return LEGACY_COOKIE_NAME;
+  return `${LEGACY_COOKIE_NAME}_${agent}`;
+}
+
+/**
+ * Read the current session cookie, preferring the per-agent name and
+ * silently falling back to the legacy name (for users upgrading from
+ * a pre-fix viewer). Returns null when neither is present.
+ */
+function readSessionCookie(
+  cookieHeader: string | undefined,
+  agent: string | null | undefined,
+): string | null {
+  const primary = cookieNameFor(agent);
+  const v = readCookie(cookieHeader, primary);
+  if (v) return v;
+  if (primary !== LEGACY_COOKIE_NAME) {
+    return readCookie(cookieHeader, LEGACY_COOKIE_NAME);
+  }
+  return null;
+}
 
 export interface AuthState {
   version: 1;
@@ -166,28 +219,46 @@ export function readCookie(header: string | undefined, name: string): string | n
   return null;
 }
 
-function setSessionCookie(res: {
-  setHeader: (name: string, value: string | string[]) => void;
-}, token: string): void {
+function setSessionCookie(
+  res: { setHeader: (name: string, value: string | string[]) => void },
+  token: string,
+  agent: string | null | undefined,
+): void {
+  const name = cookieNameFor(agent);
   res.setHeader("Set-Cookie", [
-    `${COOKIE_NAME}=${token}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${Math.floor(
+    `${name}=${token}; HttpOnly; SameSite=Lax; Path=/; Max-Age=${Math.floor(
       SESSION_TTL_MS / 1000,
     )}`,
   ]);
 }
 
-function clearSessionCookie(res: {
-  setHeader: (name: string, value: string | string[]) => void;
-}): void {
-  res.setHeader("Set-Cookie", [
-    `${COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0`,
-  ]);
+function clearSessionCookie(
+  res: { setHeader: (name: string, value: string | string[]) => void },
+  agent: string | null | undefined,
+): void {
+  const name = cookieNameFor(agent);
+  // Also clear the legacy name so users upgrading from a pre-fix
+  // viewer don't end up with two stale cookies after logout.
+  const cookies = [
+    `${name}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0`,
+  ];
+  if (name !== LEGACY_COOKIE_NAME) {
+    cookies.push(
+      `${LEGACY_COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0`,
+    );
+  }
+  res.setHeader("Set-Cookie", cookies);
 }
 
 // ─── Public routes ─────────────────────────────────────────────────────────
 
-export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
+export function registerAuthRoutes(
+  routes: Routes,
+  deps: ServerDeps,
+  options: ServerOptions = {},
+): void {
   const homeRoot = (): string | null => deps.home?.root ?? null;
+  const agent = options.agent ?? null;
 
   routes.set("GET /api/v1/auth/status", async (ctx) => {
     const root = homeRoot();
@@ -205,7 +276,7 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
       // exists — see `requireSession` below).
       return { enabled: true, needsSetup: true, authenticated: false };
     }
-    const cookie = readCookie(ctx.req.headers.cookie, COOKIE_NAME);
+    const cookie = readSessionCookie(ctx.req.headers.cookie, agent);
     const authed = cookie ? verifySession(cookie, state) : false;
     return { enabled: true, needsSetup: false, authenticated: authed };
   });
@@ -240,7 +311,7 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
     writeAuthState(root, state);
     const now = Date.now();
     const token = signSession(state, { iat: now, exp: now + SESSION_TTL_MS });
-    setSessionCookie(ctx.res, token);
+    setSessionCookie(ctx.res, token, agent);
     return { ok: true };
   });
 
@@ -263,12 +334,12 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
     }
     const now = Date.now();
     const token = signSession(state, { iat: now, exp: now + SESSION_TTL_MS });
-    setSessionCookie(ctx.res, token);
+    setSessionCookie(ctx.res, token, agent);
     return { ok: true };
   });
 
   routes.set("POST /api/v1/auth/logout", async (ctx) => {
-    clearSessionCookie(ctx.res);
+    clearSessionCookie(ctx.res, agent);
     return { ok: true };
   });
 
@@ -295,7 +366,7 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
     // otherwise anyone on localhost could drop the password.
     const state = readAuthState(root);
     if (state) {
-      const cookie = readCookie(ctx.req.headers.cookie, COOKIE_NAME);
+      const cookie = readSessionCookie(ctx.req.headers.cookie, agent);
       if (!cookie || !verifySession(cookie, state)) {
         writeError(ctx, 401, "unauthenticated", "login required");
         return;
@@ -310,7 +381,7 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
         return;
       }
     }
-    clearSessionCookie(ctx.res);
+    clearSessionCookie(ctx.res, agent);
     return { ok: true };
   });
 }
@@ -322,6 +393,10 @@ export function registerAuthRoutes(routes: Routes, deps: ServerDeps): void {
  * Called from `server/http.ts::dispatch` ahead of the route table.
  * Auth endpoints themselves bypass this check (they're what a locked
  * client uses to unlock).
+ *
+ * `agent` (optional) scopes the cookie name so this server's session
+ * doesn't collide with another agent's session sharing the same
+ * `localhost` cookie jar (see file header).
  */
 export function requireSession(
   req: { headers: { cookie?: string } },
@@ -332,6 +407,7 @@ export function requireSession(
   },
   homeDir: string,
   pathname: string,
+  agent?: string | null,
 ): boolean {
   // Public: auth endpoints + health (so the viewer can tell whether
   // the backend is up BEFORE unlocking).
@@ -341,7 +417,7 @@ export function requireSession(
   const state = readAuthState(homeDir);
   if (!state) return true; // password protection off → open
 
-  const cookie = readCookie(req.headers.cookie, COOKIE_NAME);
+  const cookie = readSessionCookie(req.headers.cookie, agent);
   if (cookie && verifySession(cookie, state)) return true;
 
   res.writeHead(401, { "Content-Type": "application/json" });

--- a/apps/memos-local-plugin/server/routes/migrate.ts
+++ b/apps/memos-local-plugin/server/routes/migrate.ts
@@ -1,17 +1,29 @@
 /**
  * Legacy-DB migration endpoints (one-shot).
  *
- *   GET  /api/v1/migrate/openclaw/scan  → open the legacy sqlite file
- *                                          in read-only mode and count
- *                                          how many rows we could
- *                                          import. Safe to call
- *                                          repeatedly.
- *   POST /api/v1/migrate/openclaw/run   → actually copy the rows over.
- *                                          Returns per-type counts.
+ *   GET  /api/v1/migrate/legacy/scan   → open the **current agent's**
+ *                                        legacy sqlite file in
+ *                                        read-only mode and count how
+ *                                        many rows we could import.
+ *                                        Safe to call repeatedly.
+ *   POST /api/v1/migrate/legacy/run    → actually copy the rows over.
+ *                                        Returns per-type counts.
  *
- * We purposefully keep this logic in the route module (not the core)
- * because it's host-specific: the path layout only matters to the
- * OpenClaw host. Other agents can ignore it.
+ * The agent is taken from `options.agent` (the same flag that
+ * controls the multi-agent path prefix in `server/http.ts`). If it's
+ * absent we default to `openclaw` so existing call-sites keep working.
+ *
+ * Each agent's legacy plugin shipped with its own on-disk layout:
+ *
+ *   openclaw → ~/.openclaw/memos-local/memos.db
+ *   hermes   → ~/.hermes/memos-state/memos-local/memos.db
+ *
+ * The schema (chunks/skills/tasks) is the same across both, so the
+ * import logic itself is agent-agnostic — only the source path differs.
+ *
+ * Backwards-compat aliases:
+ *   /api/v1/migrate/openclaw/{scan,run} → always openclaw path
+ *   /api/v1/migrate/hermes/{scan,run}   → always hermes path
  *
  * Schema map (legacy → new):
  *
@@ -36,113 +48,189 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ServerDeps } from "../types.js";
-import { writeError, type Routes } from "./registry.js";
+import { rootLogger } from "../../core/logger/index.js";
+import type { ServerDeps, ServerOptions } from "../types.js";
+import { writeError, type Routes, type RouteContext } from "./registry.js";
 import type { TraceDTO, SkillDTO } from "../../agent-contract/dto.js";
 
-const LEGACY_DB_PATH = join(homedir(), ".openclaw", "memos-local", "memos.db");
+type LegacyAgent = "openclaw" | "hermes";
 
-export function registerMigrateRoutes(routes: Routes, deps: ServerDeps): void {
-  routes.set("GET /api/v1/migrate/openclaw/scan", async () => {
-    if (!existsSync(LEGACY_DB_PATH)) {
-      return { found: false, path: LEGACY_DB_PATH };
-    }
+const log = rootLogger.child({ channel: "server.migrate" });
+
+/**
+ * Per-agent on-disk layout of the legacy plugin's SQLite file.
+ *
+ * Note the `hermes` extra `memos-state` segment: the legacy hermes
+ * plugin nested its data under `~/.hermes/memos-state/...` while
+ * openclaw kept it directly under `~/.openclaw/memos-local/...`.
+ */
+function legacyDbPath(agent: LegacyAgent): string {
+  switch (agent) {
+    case "hermes":
+      return join(homedir(), ".hermes", "memos-state", "memos-local", "memos.db");
+    case "openclaw":
+    default:
+      return join(homedir(), ".openclaw", "memos-local", "memos.db");
+  }
+}
+
+function resolveAgent(options: ServerOptions | undefined): LegacyAgent {
+  const a = options?.agent;
+  if (a === "hermes") return "hermes";
+  return "openclaw";
+}
+
+export function registerMigrateRoutes(
+  routes: Routes,
+  deps: ServerDeps,
+  options: ServerOptions = {},
+): void {
+  const currentAgent = resolveAgent(options);
+
+  // ── Generic, agent-aware endpoints (preferred). Pick the source
+  //    DB based on the running agent; the viewer uses these. ──────────
+  routes.set("GET /api/v1/migrate/legacy/scan", async () => scanFor(currentAgent));
+  routes.set("POST /api/v1/migrate/legacy/run", async (ctx) =>
+    runFor(ctx, deps, currentAgent),
+  );
+
+  // ── Explicit per-agent aliases (back-compat + tests). ─────────────
+  routes.set("GET /api/v1/migrate/openclaw/scan", async () => scanFor("openclaw"));
+  routes.set("POST /api/v1/migrate/openclaw/run", async (ctx) =>
+    runFor(ctx, deps, "openclaw"),
+  );
+  routes.set("GET /api/v1/migrate/hermes/scan", async () => scanFor("hermes"));
+  routes.set("POST /api/v1/migrate/hermes/run", async (ctx) =>
+    runFor(ctx, deps, "hermes"),
+  );
+}
+
+interface ScanResult {
+  found: boolean;
+  path: string;
+  agent: LegacyAgent;
+  candidates?: { traces: number; skills: number; tasks: number };
+  error?: string;
+}
+
+async function scanFor(agent: LegacyAgent): Promise<ScanResult> {
+  const path = legacyDbPath(agent);
+  log.debug("scan", { agent, path });
+  if (!existsSync(path)) {
+    return { found: false, agent, path };
+  }
+  try {
+    const { default: Sqlite } = await import("better-sqlite3");
+    const db = new Sqlite(path, { readonly: true });
     try {
-      const { default: Sqlite } = await import("better-sqlite3");
-      const db = new Sqlite(LEGACY_DB_PATH, { readonly: true });
-      try {
-        const counts = countLegacyRows(db);
-        return { found: true, path: LEGACY_DB_PATH, candidates: counts };
-      } finally {
-        db.close();
-      }
-    } catch (err) {
-      return {
-        found: true,
-        path: LEGACY_DB_PATH,
-        candidates: { traces: 0, skills: 0, tasks: 0 },
-        error: (err as Error).message,
+      const counts = countLegacyRows(db);
+      return { found: true, agent, path, candidates: counts };
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    return {
+      found: true,
+      agent,
+      path,
+      candidates: { traces: 0, skills: 0, tasks: 0 },
+      error: (err as Error).message,
+    };
+  }
+}
+
+async function runFor(
+  ctx: RouteContext,
+  deps: ServerDeps,
+  agent: LegacyAgent,
+): Promise<unknown> {
+  const path = legacyDbPath(agent);
+  log.info("run.start", { agent, path });
+  if (!existsSync(path)) {
+    writeError(ctx, 404, "not_found", `legacy db not found at ${path}`);
+    return;
+  }
+  try {
+    const { default: Sqlite } = await import("better-sqlite3");
+    const db = new Sqlite(path, { readonly: true });
+    try {
+      const legacyChunks = readLegacyChunks(db);
+      const legacySkills = readLegacySkills(db);
+      const legacyTasks = readLegacyTasks(db);
+
+      // Group chunks by (session_key, turn_id) into turns so a
+      // user↔assistant pair becomes a single trace (matches the new
+      // model). Tools/system/other rows get their own trace with
+      // role-based text placement.
+      const traces: TraceDTO[] = buildTracesFromChunks(legacyChunks);
+      const skills: SkillDTO[] = legacySkills.map((s) => ({
+        id: s.id,
+        name: s.name || s.id,
+        status: legacySkillStatus(s.status),
+        invocationGuide: s.description ?? "",
+        // Imported skills don't carry decision guidance / evidence
+        // anchors — those live on the rows produced by the live
+        // crystallizer, not in legacy SQLite dumps.
+        decisionGuidance: { preference: [], antiPattern: [] },
+        evidenceAnchors: [],
+        eta: 0 as never,
+        support: 0,
+        gain: 0,
+        sourcePolicyIds: [],
+        sourceWorldModelIds: [],
+        createdAt: (Number(s.created_at) || Date.now()) as never,
+        updatedAt: (Number(s.updated_at) || Date.now()) as never,
+        version: 1,
+      }));
+
+      const bundle = {
+        version: 1 as const,
+        traces,
+        policies: [],
+        worldModels: [],
+        skills,
       };
+      const res = await deps.core.importBundle(bundle);
+      log.audit("run.done", {
+        agent,
+        path,
+        candidates: { traces: traces.length, skills: skills.length, tasks: legacyTasks.length },
+        imported: res.imported,
+        skipped: res.skipped,
+      });
+
+      return {
+        agent,
+        path,
+        imported: {
+          traces: Math.max(0, res.imported - skills.length),
+          // We can't tell which of `res.imported` came from which
+          // array with the current importBundle signature, so we
+          // surface totals separately:
+          totalImported: res.imported,
+          skills: skills.length,
+          tasks: 0,
+        },
+        skipped: {
+          total: res.skipped,
+          tasks: legacyTasks.length,
+          reason_tasks:
+            "tasks are now represented as episodes — legacy tasks rows were not imported (tracked as skipped)",
+        },
+        candidates: {
+          traces: traces.length,
+          skills: skills.length,
+          tasks: legacyTasks.length,
+        },
+      };
+    } finally {
+      db.close();
     }
-  });
-
-  routes.set("POST /api/v1/migrate/openclaw/run", async (ctx) => {
-    if (!existsSync(LEGACY_DB_PATH)) {
-      writeError(ctx, 404, "not_found", `legacy db not found at ${LEGACY_DB_PATH}`);
-      return;
-    }
-    try {
-      const { default: Sqlite } = await import("better-sqlite3");
-      const db = new Sqlite(LEGACY_DB_PATH, { readonly: true });
-      try {
-        const legacyChunks = readLegacyChunks(db);
-        const legacySkills = readLegacySkills(db);
-        const legacyTasks = readLegacyTasks(db);
-
-        // Group chunks by (session_key, turn_id) into turns so a
-        // user↔assistant pair becomes a single trace (matches the new
-        // model). Tools/system/other rows get their own trace with
-        // role-based text placement.
-        const traces: TraceDTO[] = buildTracesFromChunks(legacyChunks);
-        const skills: SkillDTO[] = legacySkills.map((s) => ({
-          id: s.id,
-          name: s.name || s.id,
-          status: legacySkillStatus(s.status),
-          invocationGuide: s.description ?? "",
-          // Imported skills don't carry decision guidance / evidence
-          // anchors — those live on the rows produced by the live
-          // crystallizer, not in legacy SQLite dumps.
-          decisionGuidance: { preference: [], antiPattern: [] },
-          evidenceAnchors: [],
-          eta: 0 as never,
-          support: 0,
-          gain: 0,
-          sourcePolicyIds: [],
-          sourceWorldModelIds: [],
-          createdAt: (Number(s.created_at) || Date.now()) as never,
-          updatedAt: (Number(s.updated_at) || Date.now()) as never,
-          version: 1,
-        }));
-
-        const bundle = {
-          version: 1 as const,
-          traces,
-          policies: [],
-          worldModels: [],
-          skills,
-        };
-        const res = await deps.core.importBundle(bundle);
-
-        return {
-          imported: {
-            traces: res.imported - skills.length < 0 ? 0 : Math.max(0, res.imported - skills.length),
-            // We can't tell which of `res.imported` came from which
-            // array with the current importBundle signature, so we
-            // surface totals separately:
-            totalImported: res.imported,
-            skills: skills.length,
-            tasks: 0,
-          },
-          skipped: {
-            total: res.skipped,
-            tasks: legacyTasks.length,
-            reason_tasks:
-              "tasks are now represented as episodes — legacy tasks rows were not imported (tracked as skipped)",
-          },
-          candidates: {
-            traces: traces.length,
-            skills: skills.length,
-            tasks: legacyTasks.length,
-          },
-        };
-      } finally {
-        db.close();
-      }
-    } catch (err) {
-      writeError(ctx, 500, "internal", (err as Error).message);
-      return;
-    }
-  });
+  } catch (err) {
+    log.error("run.failed", { agent, path, err });
+    writeError(ctx, 500, "internal", (err as Error).message);
+    return;
+  }
 }
 
 // ─── Legacy row shape helpers ─────────────────────────────────────────────

--- a/apps/memos-local-plugin/server/routes/registry.ts
+++ b/apps/memos-local-plugin/server/routes/registry.ts
@@ -172,9 +172,9 @@ export function buildRoutes(
   registerConfigRoutes(routes, deps);
   registerMetricsRoutes(routes, deps);
   registerImportExportRoutes(routes, deps);
-  registerMigrateRoutes(routes, deps);
+  registerMigrateRoutes(routes, deps, options);
   registerHubAdminRoutes(routes, deps);
-  registerAuthRoutes(routes, deps);
+  registerAuthRoutes(routes, deps, options);
   registerAdminRoutes(routes, deps);
   registerModelsRoutes(routes, deps);
   registerApiLogsRoutes(routes, deps);

--- a/apps/memos-local-plugin/tests/unit/server/auth-cookie-isolation.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/auth-cookie-isolation.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Multi-agent auth cookie isolation.
+ *
+ * Browsers do NOT isolate cookies by port. Two viewer servers running
+ * on the same host (`localhost:18799` for openclaw, `localhost:18800`
+ * for hermes — or `/openclaw/*` vs `/hermes/*` under one hub origin)
+ * share a single cookie jar. If both servers issued a cookie under
+ * the same name (`memos_sess`) with `Path=/`, logging into one would
+ * silently overwrite the other's cookie and the next refresh would
+ * boot the other viewer back to the LoginScreen.
+ *
+ * The fix is in `server/routes/auth.ts`: each server names its
+ * cookie `memos_sess_<agent>` so the two coexist. This test
+ * replicates the original bug scenario end-to-end and pins the new
+ * behaviour against future regressions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startHttpServer } from "../../../server/index.js";
+import type { ServerHandle } from "../../../server/index.js";
+import type { MemoryCore } from "../../../agent-contract/memory-core.js";
+
+function stubCore(): MemoryCore {
+  // Tiny stub — auth gating runs *before* core methods are reached,
+  // so the methods just need to exist for type-compat.
+  const noop = vi.fn(async () => ({}) as never);
+  return new Proxy({} as MemoryCore, {
+    get: () => noop,
+  });
+}
+
+function readSetCookies(res: Response): string[] {
+  // `headers.getSetCookie()` is fairly new; fall back to splitting the
+  // raw header so this stays portable across runtimes.
+  const anyHeaders = res.headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  if (typeof anyHeaders.getSetCookie === "function") {
+    return anyHeaders.getSetCookie();
+  }
+  const raw = res.headers.get("set-cookie");
+  return raw ? [raw] : [];
+}
+
+/** Extract `name=value` from a Set-Cookie header line. */
+function parseCookie(line: string): { name: string; value: string } {
+  const head = line.split(";")[0] ?? "";
+  const eq = head.indexOf("=");
+  if (eq < 0) return { name: head.trim(), value: "" };
+  return {
+    name: head.slice(0, eq).trim(),
+    value: head.slice(eq + 1).trim(),
+  };
+}
+
+/** Pick the first Set-Cookie matching `name`. */
+function pickCookie(res: Response, name: string): { name: string; value: string } | null {
+  for (const line of readSetCookies(res)) {
+    const c = parseCookie(line);
+    if (c.name === name) return c;
+  }
+  return null;
+}
+
+describe("auth cookie isolation across agents", () => {
+  let tmpRoots: string[] = [];
+  let handles: ServerHandle[] = [];
+
+  beforeEach(() => {
+    tmpRoots = [];
+    handles = [];
+  });
+
+  afterEach(async () => {
+    for (const h of handles) {
+      try {
+        await h.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    for (const r of tmpRoots) {
+      try {
+        rmSync(r, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  async function startWith(agent: "openclaw" | "hermes"): Promise<{
+    handle: ServerHandle;
+    home: string;
+  }> {
+    const home = mkdtempSync(join(tmpdir(), `memos-auth-${agent}-`));
+    tmpRoots.push(home);
+    const handle = await startHttpServer(
+      { core: stubCore(), home: { root: home } },
+      { port: 0, agent },
+    );
+    handles.push(handle);
+    return { handle, home };
+  }
+
+  async function setupPassword(handle: ServerHandle, password: string): Promise<Response> {
+    return fetch(`${handle.url}/api/v1/auth/setup`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+  }
+
+  it("openclaw issues memos_sess_openclaw, hermes issues memos_sess_hermes", async () => {
+    const oc = await startWith("openclaw");
+    const hm = await startWith("hermes");
+
+    const ocSetup = await setupPassword(oc.handle, "secret-oc");
+    expect(ocSetup.status).toBe(200);
+    const ocCookie = pickCookie(ocSetup, "memos_sess_openclaw");
+    expect(ocCookie, "openclaw must set memos_sess_openclaw").not.toBeNull();
+    expect(pickCookie(ocSetup, "memos_sess")).toBeNull();
+
+    const hmSetup = await setupPassword(hm.handle, "secret-hm");
+    expect(hmSetup.status).toBe(200);
+    const hmCookie = pickCookie(hmSetup, "memos_sess_hermes");
+    expect(hmCookie, "hermes must set memos_sess_hermes").not.toBeNull();
+    expect(pickCookie(hmSetup, "memos_sess")).toBeNull();
+
+    // The values are different (each agent signs with its own
+    // sessionSecret) and — crucially — the names are different so
+    // both cookies coexist in a real browser jar.
+    expect(ocCookie!.name).not.toBe(hmCookie!.name);
+    expect(ocCookie!.value).not.toBe(hmCookie!.value);
+  });
+
+  it("refreshing one viewer no longer logs out the other (regression)", async () => {
+    const oc = await startWith("openclaw");
+    const hm = await startWith("hermes");
+
+    const ocSetup = await setupPassword(oc.handle, "secret-oc");
+    const ocCookie = pickCookie(ocSetup, "memos_sess_openclaw")!;
+    const hmSetup = await setupPassword(hm.handle, "secret-hm");
+    const hmCookie = pickCookie(hmSetup, "memos_sess_hermes")!;
+
+    // Simulate a real browser tab that holds BOTH cookies in its jar
+    // (because both servers share the localhost cookie scope). A
+    // refresh of the openclaw viewer sends both cookies up; openclaw
+    // must still see itself as authenticated.
+    const combined = `memos_sess_openclaw=${ocCookie.value}; memos_sess_hermes=${hmCookie.value}`;
+
+    const ocStatus = await fetch(`${oc.handle.url}/api/v1/auth/status`, {
+      headers: { cookie: combined },
+    });
+    expect(ocStatus.status).toBe(200);
+    const ocBody = (await ocStatus.json()) as { authenticated: boolean };
+    expect(ocBody.authenticated).toBe(true);
+
+    const hmStatus = await fetch(`${hm.handle.url}/api/v1/auth/status`, {
+      headers: { cookie: combined },
+    });
+    expect(hmStatus.status).toBe(200);
+    const hmBody = (await hmStatus.json()) as { authenticated: boolean };
+    expect(hmBody.authenticated).toBe(true);
+  });
+
+  it("hermes rejects the openclaw cookie even if the user logs into openclaw last", async () => {
+    const oc = await startWith("openclaw");
+    const hm = await startWith("hermes");
+    await setupPassword(hm.handle, "secret-hm");
+    const ocSetup = await setupPassword(oc.handle, "secret-oc");
+    const ocCookie = pickCookie(ocSetup, "memos_sess_openclaw")!;
+
+    // Forge a request to hermes carrying ONLY openclaw's cookie. The
+    // legacy fallback must NOT pick this up (different name, different
+    // secret) — hermes must still report not authenticated.
+    const hmStatus = await fetch(`${hm.handle.url}/api/v1/auth/status`, {
+      headers: { cookie: `memos_sess_openclaw=${ocCookie.value}` },
+    });
+    expect(hmStatus.status).toBe(200);
+    const hmBody = (await hmStatus.json()) as { authenticated: boolean };
+    expect(hmBody.authenticated).toBe(false);
+  });
+
+  it("legacy memos_sess cookie is still accepted (smooth upgrade)", async () => {
+    // Spin up a server WITHOUT an agent first — that's the path that
+    // mints the legacy `memos_sess` cookie. Then re-attach to the same
+    // home with `agent: 'openclaw'` and verify the legacy cookie is
+    // still honoured by the per-agent server.
+    const home = mkdtempSync(join(tmpdir(), "memos-auth-legacy-"));
+    tmpRoots.push(home);
+
+    const legacy = await startHttpServer(
+      { core: stubCore(), home: { root: home } },
+      { port: 0 }, // no `agent` → legacy cookie name
+    );
+    handles.push(legacy);
+
+    const setup = await setupPassword(legacy, "secret");
+    expect(setup.status).toBe(200);
+    const legacyCookie = pickCookie(setup, "memos_sess");
+    expect(legacyCookie, "no-agent server should mint the legacy cookie").not.toBeNull();
+
+    await legacy.close();
+    handles = handles.filter((h) => h !== legacy);
+
+    // Same home, now exposed as openclaw. The .auth.json on disk
+    // (same sessionSecret) is reused, so the legacy cookie's MAC
+    // still matches and the agent-aware fallback path picks it up.
+    const upgraded = await startHttpServer(
+      { core: stubCore(), home: { root: home } },
+      { port: 0, agent: "openclaw" },
+    );
+    handles.push(upgraded);
+
+    const status = await fetch(`${upgraded.url}/api/v1/auth/status`, {
+      headers: { cookie: `memos_sess=${legacyCookie!.value}` },
+    });
+    expect(status.status).toBe(200);
+    const body = (await status.json()) as { authenticated: boolean };
+    expect(body.authenticated).toBe(true);
+  });
+
+  it("blocks /api/v1/* without a valid cookie when password is set", async () => {
+    const oc = await startWith("openclaw");
+    await setupPassword(oc.handle, "secret-oc");
+
+    // No cookie at all → 401.
+    const r1 = await fetch(`${oc.handle.url}/api/v1/ping`);
+    expect(r1.status).toBe(401);
+
+    // Wrong-name cookie that happens to be a valid token from another
+    // agent → still 401, because the openclaw server reads its own
+    // per-agent name first and only falls back to the legacy name.
+    const r2 = await fetch(`${oc.handle.url}/api/v1/ping`, {
+      headers: { cookie: "memos_sess_hermes=this-is-not-an-openclaw-token" },
+    });
+    expect(r2.status).toBe(401);
+  });
+});

--- a/apps/memos-local-plugin/tests/unit/server/http.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/http.test.ts
@@ -401,11 +401,13 @@ describe("HTTP server — REST routes", () => {
   it("GET /api/v1/migrate/openclaw/scan returns the scan result shape", async () => {
     const r = await fetch(`${handle.url}/api/v1/migrate/openclaw/scan`);
     expect(r.status).toBe(200);
-    const body = (await r.json()) as { found: boolean; path?: string };
+    const body = (await r.json()) as { found: boolean; path?: string; agent?: string };
     // `found` is always a boolean regardless of whether the legacy DB
     // is on disk. The viewer uses this to toggle the "Run migration"
-    // button.
+    // button. The path is hard-coded to the openclaw layout.
     expect(typeof body.found).toBe("boolean");
+    expect(body.agent).toBe("openclaw");
+    if (body.path) expect(body.path).toMatch(/\.openclaw\/memos-local\/memos\.db$/);
   });
 
   it("POST /api/v1/migrate/openclaw/run returns { imported: {...} } even when empty", async () => {
@@ -418,11 +420,70 @@ describe("HTTP server — REST routes", () => {
     // OR 404 when the server reports "no legacy db". Either way the
     // viewer handles both.
     expect([200, 404]).toContain(r.status);
-    const body = (await r.json()) as { imported?: Record<string, number>; error?: unknown };
+    const body = (await r.json()) as {
+      imported?: Record<string, number>;
+      error?: { message?: string };
+    };
     if (r.status === 200) {
       expect(typeof body.imported).toBe("object");
     } else {
       expect(body.error).toBeDefined();
+      // 404 must mention the openclaw legacy path so the user knows
+      // which file we tried to read.
+      expect(body.error?.message ?? "").toMatch(/\.openclaw\//);
+    }
+  });
+
+  it("GET /api/v1/migrate/hermes/scan reports the hermes legacy path", async () => {
+    const r = await fetch(`${handle.url}/api/v1/migrate/hermes/scan`);
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { found: boolean; path?: string; agent?: string };
+    expect(body.agent).toBe("hermes");
+    // The hermes legacy plugin nested its data under
+    // `~/.hermes/memos-state/memos-local/memos.db` (not the openclaw
+    // layout). This test is what would have caught the original bug.
+    if (body.path) expect(body.path).toMatch(/\.hermes\/memos-state\/memos-local\/memos\.db$/);
+  });
+
+  it("POST /api/v1/migrate/hermes/run targets the hermes legacy path", async () => {
+    const r = await fetch(`${handle.url}/api/v1/migrate/hermes/run`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect([200, 404]).toContain(r.status);
+    const body = (await r.json()) as {
+      agent?: string;
+      path?: string;
+      error?: { message?: string };
+    };
+    if (r.status === 200) {
+      expect(body.agent).toBe("hermes");
+      expect(body.path ?? "").toMatch(/\.hermes\/memos-state\/memos-local\/memos\.db$/);
+    } else {
+      expect(body.error?.message ?? "").toMatch(/\.hermes\/memos-state\//);
+    }
+  });
+
+  it("GET /api/v1/migrate/legacy/scan picks the path from options.agent (default openclaw)", async () => {
+    const r = await fetch(`${handle.url}/api/v1/migrate/legacy/scan`);
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { found: boolean; path?: string; agent?: string };
+    // The default server fixture omits `options.agent`; the migrate
+    // route falls back to openclaw.
+    expect(body.agent).toBe("openclaw");
+  });
+
+  it("GET /api/v1/migrate/legacy/scan honours options.agent='hermes'", async () => {
+    const local = await startHttpServer({ core }, { port: 0, agent: "hermes" });
+    try {
+      const r = await fetch(`${local.url}/api/v1/migrate/legacy/scan`);
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as { found: boolean; path?: string; agent?: string };
+      expect(body.agent).toBe("hermes");
+      if (body.path) expect(body.path).toMatch(/\.hermes\/memos-state\/memos-local\/memos\.db$/);
+    } finally {
+      await local.close();
     }
   });
 

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -555,9 +555,9 @@ const en = {
   "import.import.desc":
     "Restore memories, experiences, environment knowledge and skills from a JSON bundle. Your existing data is preserved; imported rows are added alongside with new ids.",
   "import.import.btn": "Choose JSON bundle…",
-  "import.migrate.title": "Migrate from memos-local-openclaw (legacy)",
+  "import.migrate.title": "Migrate from legacy plugin (memos-local-openclaw / memos-local-hermes)",
   "import.migrate.desc":
-    "Scan the legacy plugin's SQLite database and copy matching rows into the new store. Non-destructive — the legacy file stays put.",
+    "Scan the legacy plugin's SQLite database for the currently running agent (openclaw → ~/.openclaw/memos-local, hermes → ~/.hermes/memos-state/memos-local) and copy matching rows into the new store. Non-destructive — the legacy file stays put.",
   "import.migrate.scan": "Scan legacy DB",
   "import.migrate.run": "Run migration",
 
@@ -1124,8 +1124,9 @@ const zh: Record<TranslationKey, string> = {
   "import.import.desc":
     "从 JSON 包中恢复记忆、经验、环境认知和技能。原有数据保留，导入内容以新 id 追加。",
   "import.import.btn": "选择 JSON 文件…",
-  "import.migrate.title": "从旧插件迁入（memos-local-openclaw）",
-  "import.migrate.desc": "扫描旧插件的 SQLite 数据库，把匹配的记录拷贝到新存储。非破坏性，旧文件不动。",
+  "import.migrate.title": "从旧插件迁入（memos-local-openclaw / memos-local-hermes）",
+  "import.migrate.desc":
+    "扫描当前运行 agent 对应的旧插件 SQLite 数据库（openclaw → ~/.openclaw/memos-local，hermes → ~/.hermes/memos-state/memos-local），把匹配的记录拷贝到新存储。非破坏性，旧文件不动。",
   "import.migrate.scan": "扫描旧数据库",
   "import.migrate.run": "执行迁移",
 

--- a/apps/memos-local-plugin/web/src/views/ImportView.tsx
+++ b/apps/memos-local-plugin/web/src/views/ImportView.tsx
@@ -5,8 +5,10 @@
  *     trace/policy/world-model/skill. We trigger a browser download.
  *   - Import: POST the file back to `/api/v1/import`. The server
  *     preserves existing data and assigns fresh ids to imported rows.
- *   - Migrate: `POST /api/v1/migrate/openclaw` — scans the legacy
- *     SQLite file and copies rows into the V7 store.
+ *   - Migrate: `POST /api/v1/migrate/legacy/run` — scans the legacy
+ *     SQLite file for the **currently running agent** (openclaw or
+ *     hermes — the server picks the right path based on its own
+ *     `options.agent`) and copies rows into the V7 store.
  */
 import { useState } from "preact/hooks";
 import { api } from "../api/client";
@@ -159,6 +161,7 @@ function MigrateCard() {
   const [scanning, setScanning] = useState(false);
   const [scan, setScan] = useState<{
     found: boolean;
+    agent?: "openclaw" | "hermes";
     candidates?: { traces: number; skills: number; tasks: number };
     path?: string;
   } | null>(null);
@@ -169,7 +172,7 @@ function MigrateCard() {
     setScanning(true);
     setResult(null);
     try {
-      const r = await api.get<typeof scan>("/api/v1/migrate/openclaw/scan");
+      const r = await api.get<typeof scan>("/api/v1/migrate/legacy/scan");
       setScan(r);
     } catch {
       setScan({ found: false });
@@ -183,7 +186,7 @@ function MigrateCard() {
     try {
       const r = await api.post<{
         imported: { traces: number; skills: number; tasks: number };
-      }>("/api/v1/migrate/openclaw/run", {});
+      }>("/api/v1/migrate/legacy/run", {});
       setResult(
         `Imported ${r.imported.traces} traces, ${r.imported.skills} skills, ${r.imported.tasks} tasks.`,
       );
@@ -231,8 +234,8 @@ function MigrateCard() {
       {scan && (
         <div class="muted" style="margin-top:var(--sp-3);font-size:var(--fs-sm)">
           {scan.found
-            ? `Found legacy DB at ${scan.path}. Candidates — traces: ${scan.candidates?.traces ?? 0}, skills: ${scan.candidates?.skills ?? 0}, tasks: ${scan.candidates?.tasks ?? 0}.`
-            : "No legacy database found at ~/.openclaw/memos-local/memos.db."}
+            ? `Found legacy ${scan.agent ?? ""} DB at ${scan.path}. Candidates — traces: ${scan.candidates?.traces ?? 0}, skills: ${scan.candidates?.skills ?? 0}, tasks: ${scan.candidates?.tasks ?? 0}.`
+            : `No legacy database found${scan.path ? ` at ${scan.path}` : ""}.`}
         </div>
       )}
       {result && (


### PR DESCRIPTION
## Summary

Two viewer-side bugs surface as soon as **openclaw** and **hermes** are installed side by side on the same host. Both are fixed in this PR.

### 1. Legacy DB migration always read openclaw's path

`server/routes/migrate.ts` hard-coded the source DB to `~/.openclaw/memos-local/memos.db`, so triggering "import from legacy plugin" inside the **hermes** viewer happily imported **openclaw's** old memories. The hermes legacy plugin actually lived at `~/.hermes/memos-state/memos-local/memos.db` (note the extra `memos-state` segment).

- The migration now resolves the legacy path from `options.agent`:
  - `openclaw` → `~/.openclaw/memos-local/memos.db`
  - `hermes`   → `~/.hermes/memos-state/memos-local/memos.db`
- New generic endpoints `GET/POST /api/v1/migrate/legacy/{scan,run}` for the viewer to call (the running agent picks its own path).
- Explicit `/openclaw/*` and `/hermes/*` aliases kept for clarity + back-compat.
- Response now carries `agent` and `path` so the UI shows exactly which file was read.
- New `server.migrate` log channel (registered in `core/logger/channels.ts` and `docs/LOGGING.md`).

### 2. Refreshing one viewer logged out the other

Both servers issued the cookie name `memos_sess` with `Path=/`. Browsers do **not** isolate cookies by port, so:

1. Login to openclaw → `memos_sess=tokenA` (signed with openclaw's `sessionSecret`).
2. Login to hermes → `memos_sess=tokenB` (signed with hermes's `sessionSecret`). The second one **overwrites** the first.
3. Refresh openclaw → browser sends tokenB → openclaw verifies with its own secret → MAC fails → AuthGate boots the user back to the LoginScreen.

The fix scopes the cookie name per agent (`memos_sess_<agent>`):

- `registerAuthRoutes(routes, deps, options)` and `requireSession(..., agent)` now know which agent they serve.
- `cookieNameFor(agent)` returns `memos_sess_<agent>` when an agent is configured, otherwise the legacy `memos_sess` (so single-agent installs and test fixtures keep working).
- `readSessionCookie` falls back to the legacy name on read, so users who were already logged in before the upgrade are **not** kicked out by the deploy itself; the next response writes the new per-agent cookie and the transition is silent.
- `clearSessionCookie` clears both the per-agent name and the legacy name on logout.

## Test plan

- [x] `npx vitest run tests/unit/server` — 56 of 56 pre-existing tests still pass; 12 new tests pass:
  - 5 new migrate-route assertions in `tests/unit/server/http.test.ts` covering openclaw/hermes/legacy endpoints + the `agent` field + the path string.
  - 5 new cases in `tests/unit/server/auth-cookie-isolation.test.ts`:
    - per-agent cookie naming (no `memos_sess`, only `memos_sess_<agent>`)
    - end-to-end regression: a single browser jar holding **both** cookies → both viewers report `authenticated: true` (the original bug)
    - cross-agent cookie rejection (hermes refuses an openclaw cookie)
    - smooth upgrade: legacy `memos_sess` cookie is still honoured
    - 401 gating without a valid cookie
- [x] `npm run lint` is clean on every file touched in this PR (the repo has unrelated pre-existing TS errors that this PR does not introduce).
- [ ] Manual smoke: install both agents, log into each, F5 refresh either viewer — the other no longer drops to LoginScreen. Cookies tab shows `memos_sess_openclaw` and `memos_sess_hermes` coexisting.
- [ ] Manual smoke: in the hermes viewer, Import → "Scan legacy DB" reports the `~/.hermes/memos-state/memos-local/memos.db` path (not `.openclaw/...`).

## Notes

- The 5 pre-existing test failures on `mem-agent-0424` (`countEpisodes`/`countTraces`/`countSkills` missing from the test stub) are **not** introduced by this PR — they reproduce on the unmodified target branch.