### PR TITLE
fix(install.sh): comprehensive UX polish for installer output

### DIFF
--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -34,24 +34,48 @@ set -euo pipefail
 # ─── Colors ────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
 
-info()    { printf "${BLUE}%s${NC}\n" "$*"; }
-success() { printf "${GREEN}✓ %s${NC}\n" "$*"; }
-warn()    { printf "${YELLOW}⚠ %s${NC}\n" "$*" >&2; }
-error()   { printf "${RED}✗ %s${NC}\n" "$*" >&2; }
+info()    { printf "  ${BLUE}›${NC} %b\n" "$*"; }
+success() { printf "  ${GREEN}✔${NC} %b\n" "$*"; }
+warn()    { printf "  ${YELLOW}⚠${NC}  %b\n" "$*" >&2; }
+error()   { printf "  ${RED}✘${NC} %b\n" "$*" >&2; }
 die()     { error "$*"; exit 1; }
-header()  { printf "\n${BOLD}${BLUE}── %s ──${NC}\n\n" "$*"; }
+
+header() {
+  local text="$*"
+  local pad_total=$((46 - ${#text}))
+  (( pad_total < 0 )) && pad_total=0
+  local padding=""
+  local i; for ((i=0; i<pad_total; i++)); do padding+=" "; done
+  echo
+  printf "  ${BOLD}${BLUE}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}  ${BOLD}%s${NC}%s  ${BOLD}${BLUE}│${NC}\n" "${text}" "${padding}"
+  printf "  ${BOLD}${BLUE}└──────────────────────────────────────────────────┘${NC}\n"
+  echo
+}
+
+STEP_CURRENT=0
+step() {
+  STEP_CURRENT=$((STEP_CURRENT + 1))
+  printf "  ${BOLD}${CYAN}[%d]${NC} %s\n" "${STEP_CURRENT}" "$*"
+}
 
 banner() {
-  printf "\n${BOLD}${BLUE}╔════════════════════════════════════════════════════╗${NC}\n"
-  printf "${BOLD}${BLUE}║  🧠  MemOS Local — Reflect2Evolve V7 Installer    ║${NC}\n"
-  printf "${BOLD}${BLUE}╚════════════════════════════════════════════════════╝${NC}\n"
-  printf "${DIM}Layered L1/L2/L3 memory, skill crystallization, tier 1/2/3 retrieval.${NC}\n\n"
+  local ver="${VERSION_ARG:-latest}"
+  echo
+  printf "  ${BOLD}${BLUE}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}                                                  ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}   🧠  ${BOLD}MemOS Local Plugin Installer${NC}               ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}                                                  ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}└──────────────────────────────────────────────────┘${NC}\n"
+  printf "  ${DIM}Package: ${NPM_PACKAGE}  ·  Version: ${ver}${NC}\n"
+  echo
 }
 
 # ─── Constants ─────────────────────────────────────────────────────────────
@@ -164,11 +188,8 @@ ensure_node() {
   # Node 25+ has no better-sqlite3 prebuilts → must compile. Warn the
   # user (but don't block; the rebuild step below tries regardless).
   if (( current >= 25 )); then
-    warn "Node $(node -v) has no better-sqlite3 prebuild — will compile from source."
-    warn "Ensure C++ build tools are available:"
-    warn "  macOS:  xcode-select --install"
-    warn "  Linux:  sudo apt install build-essential python3"
-    warn "Or switch to Node LTS (22/24) for prebuilt binaries: nvm install 22"
+    warn "Node $(node -v) — no better-sqlite3 prebuild available, will compile from source."
+    printf "       ${DIM}Tip: switch to Node LTS for prebuilt binaries:  nvm install 22${NC}\n" >&2
   fi
   success "Node.js $(node -v)"
 }
@@ -189,21 +210,31 @@ find_openclaw_cli() {
 AGENT_SELECTION=""
 pick_agents_interactively() {
   echo
-  printf "${BOLD}Detected agents:${NC}\n"
-  [[ "${HAS_OPENCLAW}" == "true" ]] && success "  OpenClaw   (${HOME}/.openclaw)" || printf "${DIM}  OpenClaw   (not installed)${NC}\n"
-  [[ "${HAS_HERMES}"   == "true" ]] && success "  Hermes     (${HOME}/.hermes)"   || printf "${DIM}  Hermes     (not installed)${NC}\n"
+  printf "  ${BOLD}Detected agents:${NC}\n"
+  if [[ "${HAS_OPENCLAW}" == "true" ]]; then
+    printf "    ${GREEN}●${NC}  OpenClaw   ${DIM}~/.openclaw${NC}\n"
+  else
+    printf "    ${DIM}○  OpenClaw   (not installed)${NC}\n"
+  fi
+  if [[ "${HAS_HERMES}" == "true" ]]; then
+    printf "    ${GREEN}●${NC}  Hermes     ${DIM}~/.hermes${NC}\n"
+  else
+    printf "    ${DIM}○  Hermes     (not installed)${NC}\n"
+  fi
   echo
-  printf "${BOLD}Install into which agent?${NC}\n"
-  printf "  [Enter]  auto-detect\n"
-  printf "  1        OpenClaw only\n"
-  printf "  2        Hermes only\n"
-  printf "  3        Both\n"
-  printf "  q        Quit\n"
-  printf "Choice: "
   local choice
   if [[ ! -t 0 ]]; then
-    echo "(non-interactive — auto-detect)"; choice=""
+    info "Non-interactive mode — auto-detecting agents"
+    choice=""
   else
+    printf "  ${BOLD}Install into which agent?${NC}\n\n"
+    printf "    ${DIM}[Enter]${NC}  🔍  Auto-detect\n"
+    printf "        ${DIM}[1]${NC}  🦞  OpenClaw only\n"
+    printf "        ${DIM}[2]${NC}  👩  Hermes only\n"
+    printf "        ${DIM}[3]${NC}  📦  Both\n"
+    printf "        ${DIM}[q]${NC}  🚪  Quit\n"
+    echo
+    printf "  Choice: "
     read -r choice || choice=""
   fi
   case "${choice}" in
@@ -230,26 +261,26 @@ resolve_tarball() {
     BUILT_TARBALL="$(cd "$(dirname "${VERSION_ARG}")" && pwd)/$(basename "${VERSION_ARG}")"
     SOURCE_KIND="path"
     SOURCE_SPEC="${BUILT_TARBALL}"
-    info "Using local tarball: ${BUILT_TARBALL}"
+    success "Using local tarball: ${BUILT_TARBALL}"
     return 0
   fi
 
   local spec
   if [[ -z "${VERSION_ARG}" ]]; then
     spec="${NPM_PACKAGE}"
-    info "Fetching latest ${NPM_PACKAGE} from npm..."
+    info "Downloading latest ${NPM_PACKAGE} from npm …"
   else
     spec="${NPM_PACKAGE}@${VERSION_ARG}"
-    info "Fetching ${spec} from npm..."
+    info "Downloading ${spec} from npm …"
   fi
   SOURCE_KIND="npm"
   SOURCE_SPEC="${spec}"
 
-  (cd "${STAGE_DIR}" && npm pack "${spec}" --loglevel=error >/dev/null)
+  (cd "${STAGE_DIR}" && npm pack "${spec}" --loglevel=error >/dev/null 2>&1)
   BUILT_TARBALL="$(ls "${STAGE_DIR}"/*.tgz 2>/dev/null | head -1)"
   [[ -n "${BUILT_TARBALL}" && -f "${BUILT_TARBALL}" ]] \
     || die "npm pack failed for ${spec}. Check the npm registry or pass a local path via --version ./pkg.tgz"
-  success "Package downloaded: $(basename "${BUILT_TARBALL}")"
+  success "Package ready: $(basename "${BUILT_TARBALL}")"
 }
 
 # ─── Deploy tarball into a prefix + rebuild native deps ───────────────────
@@ -265,7 +296,7 @@ resolve_tarball() {
 # so npm install stays fast on re-install.
 deploy_tarball_to_prefix() {
   local prefix="$1"
-  info "Deploying to ${prefix}..."
+  step "Deploying to ${prefix}"
   local saved_dir=""
   local preserve=(node_modules data logs skills daemon config.yaml .auth.json)
   if [[ -d "${prefix}" ]]; then
@@ -273,9 +304,6 @@ deploy_tarball_to_prefix() {
     local item
     for item in "${preserve[@]}"; do
       if [[ -e "${prefix}/${item}" ]]; then
-        # Move preserves permissions, symlinks, and is instantaneous
-        # on same-volume rename. mkdir -p parent to handle nested
-        # items (none today, but future-proof).
         mkdir -p "$(dirname "${saved_dir}/${item}")"
         mv "${prefix}/${item}" "${saved_dir}/${item}"
       fi
@@ -285,8 +313,6 @@ deploy_tarball_to_prefix() {
     tar xzf "${BUILT_TARBALL}" -C "${prefix}" --strip-components=1
     for item in "${preserve[@]}"; do
       if [[ -e "${saved_dir}/${item}" ]]; then
-        # Overwrite any placeholder (e.g. empty templates/data/.gitkeep)
-        # the tarball may have just extracted.
         rm -rf "${prefix}/${item}"
         mv "${saved_dir}/${item}" "${prefix}/${item}"
       fi
@@ -297,26 +323,25 @@ deploy_tarball_to_prefix() {
     tar xzf "${BUILT_TARBALL}" -C "${prefix}" --strip-components=1
   fi
   [[ -f "${prefix}/package.json" ]] || die "Extraction failed: ${prefix}/package.json missing"
+  success "Package extracted"
 
-  info "Installing npm dependencies..."
-  ( cd "${prefix}" && MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error )
+  step "Installing npm dependencies"
+  ( cd "${prefix}" && MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error >/dev/null 2>&1 )
   [[ -d "${prefix}/node_modules" ]] || die "npm install failed in ${prefix}"
 
-  # Rebuild better-sqlite3 against the active Node ABI. Required on
-  # Node ≥ 25 (no prebuilds) and safe on Node 22/24 too.
   if [[ -d "${prefix}/node_modules/better-sqlite3" ]]; then
-    info "Rebuilding better-sqlite3 for Node $(node -v)..."
+    step "Rebuilding better-sqlite3 for Node $(node -v)"
     ( cd "${prefix}" && npm rebuild better-sqlite3 --loglevel=error >/dev/null 2>&1 ) \
       || ( cd "${prefix}" && npm rebuild better-sqlite3 --build-from-source --loglevel=error >/dev/null 2>&1 ) \
-      || warn "better-sqlite3 rebuild did not complete cleanly — see output above."
+      || warn "better-sqlite3 rebuild did not complete cleanly."
     if ( cd "${prefix}" && node -e "require('better-sqlite3')" >/dev/null 2>&1 ); then
-      success "better-sqlite3 loads"
+      success "better-sqlite3 native module OK"
     else
-      warn "better-sqlite3 native module not loadable — plugin will fail at startup."
-      warn "Fix: install build tools, then run: cd ${prefix} && npm rebuild better-sqlite3"
+      warn "better-sqlite3 not loadable — plugin will fail at startup."
+      printf "       ${DIM}Fix: cd ${prefix} && npm rebuild better-sqlite3${NC}\n" >&2
     fi
   fi
-  success "Dependencies installed"
+  success "Dependencies ready"
 }
 
 # ─── Generate runtime config.yaml ─────────────────────────────────────────
@@ -338,7 +363,7 @@ ensure_runtime_home() {
 
   local target="${home_dir}/config.yaml"
   if [[ -f "${target}" ]]; then
-    info "config.yaml at ${target} — left intact (delete it to regenerate)"
+    success "config.yaml exists — kept as-is"
   else
     cp "${template}" "${target}"
     chmod 600 "${target}"
@@ -346,52 +371,56 @@ ensure_runtime_home() {
   fi
 }
 
-# ─── Wait for viewer (adapted from legacy install.sh's spinner) ──────────
+# ─── Wait for viewer — spin until HTTP endpoint actually responds ─────────
 wait_for_viewer() {
   local port="$1"
   local url="http://127.0.0.1:${port}"
-  local deadline=$((SECONDS + 30))
+  local timeout="${2:-30}"
   local frames=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
   local idx=0
-  while (( SECONDS < deadline )); do
-    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 0.3 "${url}/" >/dev/null 2>&1; then
+  local elapsed=0
+  local spin_tick=0
+
+  while (( elapsed < timeout )); do
+    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 1 "${url}/" >/dev/null 2>&1; then
       printf "\r\033[K"
-      success "Memory Viewer ready: ${url}"
+      success "Memory Viewer is ready: ${CYAN}${url}${NC}"
       return 0
     fi
-    if command -v lsof >/dev/null 2>&1 && lsof -i ":${port}" -t >/dev/null 2>&1; then
-      printf "\r\033[K"
-      success "Memory Viewer listening on :${port} (may still be initialising)"
-      return 0
-    fi
-    printf "\r${BLUE}%s${NC} Waiting for Memory Viewer on :${port}... " "${frames[idx]}"
+    printf "\r  ${BLUE}%s${NC}  Starting Memory Viewer ${DIM}(%ds)${NC} …" "${frames[idx]}" "${elapsed}"
     idx=$(((idx + 1) % ${#frames[@]}))
-    sleep 0.2
+    sleep 0.12
+    spin_tick=$((spin_tick + 1))
+    if (( spin_tick % 8 == 0 )); then
+      elapsed=$((elapsed + 1))
+    fi
   done
   printf "\r\033[K"
+  warn "Memory Viewer not ready after ${timeout}s"
+  warn "Check: ${CYAN}${url}${NC}  Logs: ~/.openclaw/logs/ or ~/.hermes/memos-plugin/logs/"
   return 1
 }
 
 # ─── OpenClaw install ─────────────────────────────────────────────────────
 install_openclaw() {
-  header "OpenClaw install"
+  STEP_CURRENT=0
+  header "OpenClaw Install"
   local prefix="${HOME}/.openclaw/extensions/${PLUGIN_ID}"
   local home="${HOME}/.openclaw/memos-plugin"
   local config_path="${HOME}/.openclaw/openclaw.json"
   mkdir -p "${HOME}/.openclaw"
 
-  # 1. Stop gateway first — avoids SQLite + better-sqlite3 file locks.
   local oc_bin=""
   if oc_bin="$(find_openclaw_cli)"; then
-    info "Stopping OpenClaw gateway..."
+    step "Stopping OpenClaw gateway"
     "${oc_bin}" gateway stop >/dev/null 2>&1 || true
     sleep 1
+    success "Gateway stopped"
   fi
 
-  # 2. Deploy + rebuild native deps.
   deploy_tarball_to_prefix "${prefix}"
 
-  # 3. Runtime home + config.yaml.
+  step "Configuring runtime environment"
   ensure_runtime_home "openclaw" "${home}" "${prefix}"
 
   # 4. OpenClaw loads plugins via two artefacts:
@@ -422,8 +451,7 @@ install_openclaw() {
 }
 EOF
 
-  # 5. Patch ~/.openclaw/openclaw.json.
-  info "Patching ${config_path}..."
+  step "Patching ${config_path}"
   PLUGIN_ID="${PLUGIN_ID}" \
   INSTALL_PATH="${prefix}" \
   SOURCE_KIND="${SOURCE_KIND}" \
@@ -500,59 +528,86 @@ config.plugins.installs[pluginId] = installsEntry;
 
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
 NODE
-  success "openclaw.json patched (source: ${SOURCE_KIND}, slot: memory)"
+  success "openclaw.json patched"
 
-  # 6. Start gateway — surface failures instead of swallowing them.
   if [[ -z "${oc_bin}" ]]; then
     warn "openclaw CLI not on PATH — restart manually: openclaw gateway start"
     return 1
   fi
-  info "Starting OpenClaw gateway..."
+  step "Starting OpenClaw gateway"
   local start_out
   if ! start_out="$("${oc_bin}" gateway start 2>&1)"; then
-    error "openclaw gateway start failed:"
-    echo "${start_out}" | sed 's/^/  /' >&2
-    warn "Inspect ~/.openclaw/logs/gateway.err.log for the full reason."
-    return 1
+    # launchd KeepAlive may have already restarted the service after
+    # the stop above, making "gateway start" fail with a kickstart
+    # conflict. Check if the gateway is actually running before
+    # treating this as a real error.
+    if curl -fsS --max-time 2 "http://127.0.0.1:18789" >/dev/null 2>&1 \
+       || (command -v lsof >/dev/null 2>&1 && lsof -i ":18789" -t >/dev/null 2>&1); then
+      success "OpenClaw gateway already running"
+    else
+      error "openclaw gateway start failed:"
+      echo "${start_out}" | sed 's/^/       /' >&2
+      warn "Inspect ~/.openclaw/logs/gateway.err.log for the full reason."
+      return 1
+    fi
+  else
+    success "OpenClaw gateway started"
   fi
-  success "OpenClaw gateway started"
 
-  # 7. Wait for our viewer to answer.
+  step "Waiting for Memory Viewer"
   if wait_for_viewer "${OPENCLAW_PORT}"; then
+    echo
+    success "OpenClaw install complete"
+    printf "       ${DIM}Plugin:${NC}    %s\n" "${HOME}/.openclaw/extensions/${PLUGIN_ID}"
+    printf "       ${DIM}Viewer:${NC}    ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}/${NC}\n"
     return 0
   fi
   warn "Memory Viewer did not respond within 30s."
-  warn "Inspect ~/.openclaw/logs/gateway.err.log for plugin init errors."
+  printf "       ${DIM}Check: ~/.openclaw/logs/gateway.err.log${NC}\n" >&2
   return 1
 }
 
 # ─── Hermes install ───────────────────────────────────────────────────────
 install_hermes() {
-  header "Hermes install"
+  STEP_CURRENT=0
+  header "Hermes Install"
   local prefix="${HOME}/.hermes/memos-plugin"
   local home="${prefix}"
   local config_file="${HOME}/.hermes/config.yaml"
   local adapter_dir="${prefix}/adapters/hermes"
   mkdir -p "${HOME}/.hermes"
 
-  # Stop old bridge + hermes so new config applies.
   pkill -f "bridge.cts" >/dev/null 2>&1 || true
   local was_running="false"
   if pgrep -f "/bin/hermes" >/dev/null 2>&1; then
-    info "Stopping running hermes process..."
+    step "Stopping running Hermes process"
     pkill -f "/bin/hermes" >/dev/null 2>&1 || true
     sleep 2
     pgrep -f "/bin/hermes" >/dev/null 2>&1 && pkill -9 -f "/bin/hermes" >/dev/null 2>&1 || true
     was_running="true"
+    success "Hermes stopped"
+  fi
+
+  # Free Hermes' viewer port if something (e.g. a stale bridge from
+  # a prior install, or the OpenClaw gateway reload) left it occupied.
+  if command -v lsof >/dev/null 2>&1; then
+    local stale_pid
+    stale_pid="$(lsof -i ":${HERMES_PORT}" -t 2>/dev/null || true)"
+    if [[ -n "${stale_pid}" ]]; then
+      kill ${stale_pid} >/dev/null 2>&1 || true
+      sleep 1
+    fi
   fi
 
   deploy_tarball_to_prefix "${prefix}"
+
+  step "Configuring runtime environment"
   ensure_runtime_home "hermes" "${home}" "${prefix}"
 
   echo "${prefix}/bridge.cts" > "${adapter_dir}/bridge_path.txt"
-  success "Recorded bridge path"
+  success "Bridge path recorded"
 
-  # Locate Hermes Python venv.
+  step "Locating Hermes Python environment"
   local python_bin=""
   if command -v hermes >/dev/null 2>&1; then
     local shebang; shebang="$(head -1 "$(command -v hermes)" 2>/dev/null || true)"
@@ -564,9 +619,8 @@ install_hermes() {
   fi
   [[ -z "${python_bin}" || ! -x "${python_bin}" ]] && python_bin="$(command -v python3 || true)"
   [[ -n "${python_bin}" && -x "${python_bin}" ]] || die "Cannot locate Python for Hermes."
-  success "Hermes Python: ${python_bin}"
+  success "Python: ${python_bin}"
 
-  # plugins/memory discovery.
   local plugin_dir=""
   plugin_dir="$("${python_bin}" -c "
 from pathlib import Path
@@ -582,18 +636,18 @@ except Exception:
     done
   fi
   [[ -n "${plugin_dir}" && -d "${plugin_dir}" ]] || die "plugins/memory not found"
-  success "Hermes plugins/memory: ${plugin_dir}"
+  success "plugins/memory: ${plugin_dir}"
 
-  # Symlink memtensor provider.
+  step "Linking memtensor provider"
   local target="${plugin_dir}/memtensor"
   if [[ -L "${target}" ]]; then rm "${target}"
   elif [[ -e "${target}" ]]; then rm -rf "${target}"
   fi
   ln -s "${adapter_dir}/memos_provider" "${target}"
   cp "${adapter_dir}/plugin.yaml" "${adapter_dir}/memos_provider/plugin.yaml" 2>/dev/null || true
-  success "Symlinked memtensor provider → ${target}"
+  success "Symlinked → ${target}"
 
-  # Verify + patch config.yaml.
+  step "Verifying provider & patching config"
   local verify
   verify="$("${python_bin}" -c "
 from plugins.memory import load_memory_provider
@@ -628,16 +682,12 @@ CFGEOF
     success "Created ${config_file}"
   fi
 
-  # 8. Smoke test — boot the bridge briefly and confirm the viewer
-  #    actually answers on Hermes' fixed port. Catches TS loader /
-  #    native-module failures at install time rather than at first
-  #    `hermes chat`. Skipped only when something else already owns
-  #    :${HERMES_PORT} (rare — that port is reserved for hermes).
+  # Smoke test — boot the bridge briefly and confirm the viewer
+  # actually answers on Hermes' fixed port.
   if command -v lsof >/dev/null 2>&1 && lsof -i ":${HERMES_PORT}" -t >/dev/null 2>&1; then
-    warn "Port :${HERMES_PORT} is already in use — skipping smoke test."
-    warn "  Hermes' viewer needs this port. Free it (e.g. lsof -i :${HERMES_PORT}) and re-run."
+    warn "Port :${HERMES_PORT} already in use — skipping smoke test."
   else
-    info "Running bridge smoke test..."
+    step "Running bridge smoke test"
     local tsx_bin="${prefix}/node_modules/.bin/tsx"
     local bridge_cts="${prefix}/bridge.cts"
     if [[ -x "${tsx_bin}" && -f "${bridge_cts}" ]]; then
@@ -645,46 +695,41 @@ CFGEOF
       smoke_log="$(mktemp)"
       smoke_fifo="$(mktemp -u)"
       mkfifo "${smoke_fifo}"
-      # Keep stdin open via a FIFO backed by a long-running writer.
-      # Without this, the bridge detects end-of-stdin on launch and
-      # exits cleanly before the viewer can bind the port.
+      # Keep stdin open via a FIFO so the bridge doesn't exit on EOF.
       sleep 60 > "${smoke_fifo}" &
       sleeper_pid=$!
+      disown "${sleeper_pid}" 2>/dev/null || true
       ( cd "${prefix}" && "${tsx_bin}" "${bridge_cts}" --agent=hermes <"${smoke_fifo}" >"${smoke_log}" 2>&1 ) &
       smoke_pid=$!
+      disown "${smoke_pid}" 2>/dev/null || true
 
       if wait_for_viewer "${HERMES_PORT}"; then
         success "Bridge smoke test passed"
       else
         error "Memory Viewer did not respond within 30s."
-        warn "Smoke-test output (tail):"
-        tail -n 40 "${smoke_log}" 2>/dev/null | sed 's/^/  /' >&2 || true
-        warn "Re-install your plugin dependencies ( cd ${prefix} && npm install ) and re-run."
+        warn "Re-install dependencies and re-run: cd ${prefix} && npm install"
         kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-        sleep 1
         kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
         rm -f "${smoke_log}" "${smoke_fifo}"
         return 1
       fi
 
-      # Shut the probe down; hermes will spawn its own bridge on demand.
       kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-      sleep 1
       kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
       rm -f "${smoke_log}" "${smoke_fifo}"
     else
-      warn "tsx not found at ${tsx_bin}; skipping smoke test (dependencies may be incomplete)."
+      warn "tsx not found — skipping smoke test."
     fi
   fi
 
   echo
   success "Hermes install complete"
-  info "  Plugin:    ${prefix}"
-  info "  Viewer:    http://127.0.0.1:${HERMES_PORT}/ (starts on first \`hermes chat\`)"
+  printf "       ${DIM}Plugin:${NC}    %s\n" "${prefix}"
+  printf "       ${DIM}Viewer:${NC}    ${CYAN}http://127.0.0.1:${HERMES_PORT}/${NC}\n"
   if [[ "${was_running}" == "true" ]]; then
-    info "  Next step: ${BOLD}hermes chat${NC} ${DIM}(hermes was stopped — relaunch to apply)${NC}"
+    printf "       ${DIM}Next:${NC}      ${BOLD}hermes chat${NC}  ${DIM}(was stopped — relaunch to apply)${NC}\n"
   else
-    info "  Next step: ${BOLD}hermes chat${NC}"
+    printf "       ${DIM}Next:${NC}      ${BOLD}hermes chat${NC}\n"
   fi
   return 0
 }
@@ -704,7 +749,7 @@ if [[ "${AGENT_SELECTION}" == "auto" ]]; then
   else
     AGENT_SELECTION="hermes"
   fi
-  info "Auto-detected: ${AGENT_SELECTION}"
+  success "Auto-detected: ${AGENT_SELECTION}"
 fi
 
 case "${AGENT_SELECTION}" in
@@ -729,28 +774,41 @@ esac
 
 echo
 if (( STATUS == 0 )); then
-  printf "${BOLD}${GREEN}══════════════════════════════════════════════════${NC}\n"
-  printf "${BOLD}${GREEN}  ✨ MemOS Local installed successfully${NC}\n"
-  printf "${BOLD}${GREEN}══════════════════════════════════════════════════${NC}\n"
+  echo
+  printf "  ${BOLD}${GREEN}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}                                                  ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}   ✨  ${BOLD}${GREEN}MemOS Local installed successfully${NC}         ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}                                                  ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}└──────────────────────────────────────────────────┘${NC}\n"
   echo
   case "${AGENT_SELECTION}" in
     openclaw)
-      info "  Memory Viewer: http://127.0.0.1:${OPENCLAW_PORT}  (openclaw)"
-      info "  OpenClaw Web UI: http://localhost:18789"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}${NC}  ${DIM}(openclaw)${NC}\n"
+      printf "    ${GREEN}●${NC}  OpenClaw Web UI  ${CYAN}http://localhost:18789${NC}\n"
       ;;
     hermes)
-      info "  Memory Viewer: http://127.0.0.1:${HERMES_PORT}  (hermes)"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${HERMES_PORT}${NC}  ${DIM}(hermes)${NC}\n"
       ;;
     all)
-      info "  Memory Viewer (openclaw): http://127.0.0.1:${OPENCLAW_PORT}"
-      info "  Memory Viewer (hermes):   http://127.0.0.1:${HERMES_PORT}"
-      info "  OpenClaw Web UI:          http://localhost:18789"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}${NC}  ${DIM}(openclaw)${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${HERMES_PORT}${NC}  ${DIM}(hermes)${NC}\n"
+      printf "    ${GREEN}●${NC}  OpenClaw Web UI  ${CYAN}http://localhost:18789${NC}\n"
       ;;
   esac
+  echo
+  printf "  ${DIM}Docs: https://github.com/MemTensor/MemOS${NC}\n"
+  echo
   exit 0
 else
-  printf "${BOLD}${RED}══════════════════════════════════════════════════${NC}\n"
-  printf "${BOLD}${RED}  Install finished with errors — see ✗ lines above${NC}\n"
-  printf "${BOLD}${RED}══════════════════════════════════════════════════${NC}\n"
+  echo
+  printf "  ${BOLD}${RED}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}                                                  ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}   ${RED}Install finished with errors - see above${NC}       ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}                                                  ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}└──────────────────────────────────────────────────┘${NC}\n"
+  echo
   exit 1
 fi


### PR DESCRIPTION
## Summary

- **Fix box alignment**: emoji (🧠, ✨) occupy 2 display columns — standardize all boxes to 50-col interior with manual padding so right `│` aligns correctly
- **Fix "Terminated: 15" noise**: use `disown` for background smoke-test processes so bash doesn't print job-control messages on kill
- **Fix ANSI escape codes leaking**: switch `printf` from `%s` to `%b` so embedded `\033[…` sequences render as colors instead of literal text
- **Suppress npm postinstall noise**: redirect `npm install` output to avoid `> node scripts/postinstall.cjs` and `up to date in 12s` cluttering the install log
- **Add step numbering**: `[1] [2] [3]…` progress indicators make the install flow easy to follow
- **Viewer readiness spinner**: replace premature `lsof` shortcut with actual HTTP check (`curl`) + spinner with elapsed timer — prevents "installed successfully" when viewer isn't actually ready yet
- **Handle launchctl conflict**: when macOS `KeepAlive` auto-restarts the gateway after `openclaw gateway stop`, detect the already-running gateway instead of reporting a false error
- **Free stale Hermes port**: proactively kill leftover processes on `:18800` before smoke test to avoid "port already in use" skip
- **Improve interactive picker**: `[]` brackets, emoji per option (🦞 OpenClaw, 👩 Hermes, 📦 Both), right-aligned option keys
- **Rename banner**: `🧠 MemOS Local Plugin Installer`
- **Consolidate warnings**: better-sqlite3 Node 25+ warning reduced from 4 lines to 1 + tip

## Test plan

- [ ] Run `bash install.sh --version 2.0.0-beta.1` with both OpenClaw and Hermes installed
- [ ] Verify box borders align in terminal (banner, headers, success/error boxes)
- [ ] Verify no "Terminated" messages or raw `\033[` codes in output
- [ ] Verify viewer spinner waits for actual HTTP readiness
- [ ] Test interactive picker in TTY mode (options display correctly)
- [ ] Test non-interactive mode via pipe (`curl ... | bash -s -- --version ...`)