### PR TITLE
refactor(skill/verifier): replace regex heuristic with structured toolCalls for coverage check

### DIFF
--- a/apps/memos-local-plugin/core/llm/prompts/skill-crystallize.ts
+++ b/apps/memos-local-plugin/core/llm/prompts/skill-crystallize.ts
@@ -8,17 +8,17 @@ import type { PromptDef } from "./index.js";
  * it into a callable "Skill" with a stable name, parameter schema, and a
  * small SKILL.md authored from the evidence.
  *
- * **v2** (this version) extends the schema with `decision_guidance`:
- * preference + anti-pattern lists distilled from past failures + fixes
- * (V7 §2.4.6). The crystallizer now sees the policy's `@repair` block
- * (parsed by the orchestrator from `policy.boundary`) plus high-V vs
- * low-V evidence traces, so the LLM can write concrete "prefer X /
- * avoid Y" lines that ship with the skill. Bumping the version captures
- * that shape change so the LLM-mock op tags refresh too.
+ * **v3** adds an explicit `tools` output field: the LLM must declare which
+ * tools/commands the skill invokes, constrained to the `EVIDENCE_TOOLS`
+ * whitelist extracted from evidence trace `toolCalls`. This replaces the
+ * old regex-based command-token heuristic in the verifier — coverage is now
+ * a clean set-containment check (`draft.tools ⊆ evidenceTools`).
+ *
+ * v2 history: added `decision_guidance` (preference + anti-pattern).
  */
 export const SKILL_CRYSTALLIZE_PROMPT: PromptDef = {
   id: "skill.crystallize",
-  version: 2,
+  version: 3,
   description:
     "Turn a graduated L2 policy into a callable Skill definition, including decision guidance distilled from past prefer/avoid signals.",
   system: `You crystallize a skill an agent should be able to call.
@@ -26,6 +26,9 @@ export const SKILL_CRYSTALLIZE_PROMPT: PromptDef = {
 Input:
 - POLICY: the L2 policy being promoted (trigger / action / rationale / caveats).
 - EVIDENCE: 3..10 successful traces that support the policy.
+- EVIDENCE_TOOLS: the exhaustive list of tool/command names that actually
+  appeared in the evidence traces' tool calls. This is the ground-truth
+  whitelist — your \`tools\` output MUST be a subset of this list.
 - COUNTER_EXAMPLES (optional): traces with V < 0 from the same context —
   failures the policy is meant to prevent.
 - REPAIR_HINTS (optional): a JSON block { preference: [...], antiPattern: [...] }
@@ -50,6 +53,7 @@ Return JSON:
   "examples": [
     { "input": "...", "expected": "..." }
   ],
+  "tools": ["tool_or_command_name", ...],
   "decision_guidance": {
     "preference":   ["Prefer: …", ...],   // concrete actions to favour, ≤ 5
     "anti_pattern": ["Avoid: …", ...]     // concrete actions to avoid, ≤ 5
@@ -58,7 +62,9 @@ Return JSON:
 }
 
 Rules:
-- Only reference tools/APIs that appear in EVIDENCE.
+- \`tools\` MUST only contain names from EVIDENCE_TOOLS. Never invent tool
+  names that are not in the whitelist. Include every tool the skill's
+  procedure actually invokes — omit tools not referenced in your steps.
 - Keep "steps" short (2-6 items).
 - \`summary\` must be self-contained so the agent can decide whether to
   call this skill without reading the full SKILL.md.

--- a/apps/memos-local-plugin/core/skill/ALGORITHMS.md
+++ b/apps/memos-local-plugin/core/skill/ALGORITHMS.md
@@ -111,22 +111,26 @@ short-circuit with `skill.failed { reason: "llm_disabled" }`.
 `verifyDraft` (see [`verifier.ts`](./verifier.ts)) runs two
 deterministic checks on the draft:
 
-### Consistency coverage
+### Tool coverage
 
 ```
-commandLike = tokens that look like shell commands / module paths
-              (e.g. "apk add", "docker.build", "rg", "pip install")
-coverage = |commandLike ∩ actionBlob| / |commandLike|
+evidenceTools = extractToolNames(evidence)   // from trace.toolCalls
+draftTools    = draft.tools                  // declared by LLM
+coverage      = |draftTools ∩ evidenceTools| / |draftTools|
 ```
 
-* `actionBlob` is the concatenation of every trace's
-  `userText + agentText + reflection`, lowercased.
-* `commandLike` is extracted from the draft's `steps` and `examples`
-  via a regex that catches backticked tokens and `name.method`-style
-  identifiers of length ≥ 3.
-* Stopwords (`the`, `with`, `steps`, …) are filtered out.
+* `evidenceTools` is built from the structured `toolCalls` field on
+  each evidence trace — `tc.name` (tool-level, e.g. "shell",
+  "pip.install") plus the first token of `tc.input` when it's a string
+  (command-level, e.g. "apk" from "apk add openssl-dev"). See
+  [`tool-names.ts`](./tool-names.ts).
+* `draftTools` is the `tools: string[]` array the LLM outputs during
+  crystallization (prompt v3). The LLM is constrained to pick from an
+  `EVIDENCE_TOOLS` whitelist injected into the prompt payload.
+* No regex heuristics, no stopwords — tool identity comes from ground-
+  truth structured data, not from guessing in natural-language text.
 
-Verdict: `ok = coverage ≥ 0.5 || commandLike.length === 0`.
+Verdict: `ok = coverage ≥ 0.5 || draftTools.length === 0`.
 
 ### Evidence resonance
 
@@ -137,9 +141,9 @@ resonance   = |{ trace : |tokens(trace) ∩ draftTokens| ≥ 2 }| / |evidence|
 
 Verdict: `ok = resonance ≥ minResonance` (default `0.5`).
 
-Both checks are cheap string matching by design — this is not a
-security gate, it is a first-line defence against hallucinated tool
-names. A skill can still be wrong about intent; the trial cycle is
+Both checks are cheap and deterministic — no LLM calls. Tool coverage
+catches hallucinated tool/command names; resonance catches narrative
+drift. A skill can still be wrong about intent; the trial cycle is
 what catches that.
 
 A rejected draft emits `skill.verification.failed` and the policy

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -17,6 +17,7 @@ import {
 import { SKILL_CRYSTALLIZE_PROMPT } from "../llm/prompts/skill-crystallize.js";
 import type { Logger } from "../logger/types.js";
 import type { PolicyRow, SkillRow, TraceRow } from "../types.js";
+import { extractToolNames } from "./tool-names.js";
 import type {
   SkillConfig,
   SkillCrystallizationDraft,
@@ -158,9 +159,12 @@ function packPrompt(input: CrystallizeInput, config: SkillConfig): string {
       tags: t.tags,
     }));
 
+  const evidenceTools = Array.from(extractToolNames(input.evidence));
+
   const payload: Record<string, unknown> = {
     policy,
     evidence,
+    evidence_tools: evidenceTools,
     naming_space: input.namingSpace,
   };
   if (counterExamples.length > 0) payload.counter_examples = counterExamples;
@@ -202,6 +206,8 @@ function normaliseDraft(
   // to keep the skill body skim-able and the prompt budget bounded.
   const decisionGuidance = coerceDecisionGuidance(raw.decision_guidance ?? raw.decisionGuidance);
 
+  const tools = dedupeLc(asStringArray(raw.tools));
+
   return {
     name,
     displayTitle,
@@ -212,6 +218,7 @@ function normaliseDraft(
     examples,
     tags,
     decisionGuidance,
+    tools,
   };
 }
 

--- a/apps/memos-local-plugin/core/skill/index.ts
+++ b/apps/memos-local-plugin/core/skill/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./skill.js";
 export { attachSkillSubscriber, type SkillSubscriberDeps, type SkillSubscriberHandle } from "./subscriber.js";
 export { createSkillEventBus } from "./events.js";
+export { extractToolNames } from "./tool-names.js";
 export {
   verifyDraft,
   type VerifyDeps,

--- a/apps/memos-local-plugin/core/skill/packager.ts
+++ b/apps/memos-local-plugin/core/skill/packager.ts
@@ -133,12 +133,9 @@ function buildProcedure(draft: SkillCrystallizationDraft): SkillProcedure {
     preconditions: draft.preconditions,
     steps: draft.steps,
     examples: draft.examples,
-    // V7 §2.4.6 — `decisionGuidance` now flows from the LLM draft
-    // (which folded in the policy's `@repair` block + V-contrast
-    // signals). Older code path used to hard-code `[] / []` here,
-    // dropping every prefer / avoid line on the floor.
     decisionGuidance: draft.decisionGuidance ?? { preference: [], antiPattern: [] },
     tags: draft.tags,
+    tools: draft.tools ?? [],
   };
 }
 
@@ -182,6 +179,11 @@ function renderInvocationGuide(
       lines.push(`- Input: \`${e.input}\``);
       lines.push(`  Expected: ${e.expected}`);
     }
+    lines.push("");
+  }
+  if (draft.tools && draft.tools.length > 0) {
+    lines.push(`**Tools used**`);
+    for (const t of draft.tools) lines.push(`- \`${t}\``);
     lines.push("");
   }
   const dg = draft.decisionGuidance;

--- a/apps/memos-local-plugin/core/skill/tool-names.ts
+++ b/apps/memos-local-plugin/core/skill/tool-names.ts
@@ -1,0 +1,30 @@
+/**
+ * Extract the set of tool / command names actually invoked in a batch of
+ * traces, using the structured `ToolCallDTO` data rather than regex
+ * heuristics on natural-language text.
+ *
+ * Two levels of extraction:
+ *   1. `tc.name` — the tool-level identifier (e.g. "shell", "pip.install").
+ *   2. First token of `tc.input` when input is a string — the command-level
+ *      identifier for shell-like tools (e.g. "apk" from "apk add openssl-dev").
+ */
+
+import type { TraceRow } from "../types.js";
+
+const IGNORED_NAMES = new Set(["unknown", "unknown_tool"]);
+
+export function extractToolNames(traces: readonly TraceRow[]): Set<string> {
+  const out = new Set<string>();
+  for (const t of traces) {
+    for (const tc of t.toolCalls) {
+      const name = tc.name?.trim().toLowerCase();
+      if (name && !IGNORED_NAMES.has(name)) out.add(name);
+
+      if (typeof tc.input === "string") {
+        const first = tc.input.trim().split(/\s+/)[0]?.toLowerCase();
+        if (first && first.length >= 2) out.add(first);
+      }
+    }
+  }
+  return out;
+}

--- a/apps/memos-local-plugin/core/skill/types.ts
+++ b/apps/memos-local-plugin/core/skill/types.ts
@@ -54,6 +54,8 @@ export interface SkillProcedure {
   examples: SkillExampleDraft[];
   decisionGuidance: { preference: string[]; antiPattern: string[] };
   tags: string[];
+  /** Tool names this skill references (from evidence toolCalls). */
+  tools: string[];
 }
 
 /**
@@ -76,6 +78,8 @@ export interface SkillCrystallizationDraft {
   examples: SkillExampleDraft[];
   tags: string[];
   decisionGuidance: { preference: string[]; antiPattern: string[] };
+  /** Tool names this skill references. Must be a subset of evidence tool names. */
+  tools: string[];
 }
 
 /**

--- a/apps/memos-local-plugin/core/skill/verifier.ts
+++ b/apps/memos-local-plugin/core/skill/verifier.ts
@@ -2,16 +2,16 @@
  * V7 §2.5.3 — Consistency + integration verification for a freshly minted
  * skill.
  *
- * Two checks, both heuristic and deterministic — no LLM calls. The goal is
- * to catch obvious drafts that should never surface in Tier-1 retrieval
- * (e.g. the LLM invented a tool name not present in any evidence, or the
- * steps don't cover the originating sub-problem).
+ * Two checks, both deterministic — no LLM calls:
  *
- * 1. **Consistency coverage**: every non-empty step title / body token that
- *    looks like a tool / command identifier (`rg`, `git_diff`, `docker.ps`)
- *    must appear in at least one evidence trace's action text.
+ * 1. **Tool coverage**: every tool name declared in `draft.tools` must
+ *    appear in the evidence traces' structured `toolCalls`. Coverage is a
+ *    simple set-containment check — `draft.tools ⊆ evidenceTools`. This
+ *    catches the most common LLM hallucination: inventing tool/command
+ *    names that never appeared in any evidence trace.
+ *
  * 2. **Evidence resonance**: at least `minResonance` fraction of the
- *    evidence traces should share ≥ one token with the skill's summary or
+ *    evidence traces should share ≥ 2 tokens with the skill's summary or
  *    steps. Prevents a skill whose narrative contradicts the examples.
  *
  * The check returns a verdict; the caller (orchestrator) decides whether to
@@ -22,6 +22,7 @@
 import type { Logger } from "../logger/types.js";
 import type { TraceRow } from "../types.js";
 import type { SkillCrystallizationDraft } from "./types.js";
+import { extractToolNames } from "./tool-names.js";
 
 export interface VerifyInput {
   draft: SkillCrystallizationDraft;
@@ -59,23 +60,22 @@ export function verifyDraft(
     };
   }
 
-  const actionBlob = evidence
-    .flatMap((t) => [t.agentText, t.userText, t.reflection ?? ""])
-    .join("\n")
-    .toLowerCase();
-
-  const commandLike = collectCommandTokens(draft);
+  // --- Tool coverage (structured set comparison) ---
+  const evidenceTools = extractToolNames(evidence);
+  const draftTools = (draft.tools ?? []).map((t) => t.toLowerCase());
   const matched: string[] = [];
   const unmapped: string[] = [];
-  for (const tok of commandLike) {
-    if (actionBlob.includes(tok)) matched.push(tok);
+  for (const tok of draftTools) {
+    if (evidenceTools.has(tok)) matched.push(tok);
     else unmapped.push(tok);
   }
-  const coverage = commandLike.length === 0 ? 1 : matched.length / commandLike.length;
+  const coverage =
+    draftTools.length === 0 ? 1 : matched.length / draftTools.length;
 
+  // --- Evidence resonance (unchanged) ---
   const resonance = computeResonance(draft, evidence);
 
-  if (coverage < 0.5 && commandLike.length > 0) {
+  if (coverage < 0.5 && draftTools.length > 0) {
     deps.log.warn("skill.verify.fail", { reason: "coverage-low", coverage });
     return {
       ok: false,
@@ -100,25 +100,9 @@ export function verifyDraft(
   return { ok: true, coverage, resonance, unmappedTokens: unmapped };
 }
 
-function collectCommandTokens(draft: SkillCrystallizationDraft): string[] {
-  const fields = [
-    ...draft.steps.flatMap((s) => [s.title, s.body]),
-    ...draft.examples.flatMap((e) => [e.input, e.expected]),
-  ].join(" ");
-  const matches = fields.match(/`([^`]+)`|([a-z][a-z0-9_]{1,}\.[a-z][a-z0-9_]+|[a-z_]{3,}\b)/gi) ?? [];
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const raw of matches) {
-    const tok = raw.replace(/`/g, "").toLowerCase().trim();
-    if (tok.length < 3) continue;
-    if (STOPWORDS.has(tok)) continue;
-    if (!seen.has(tok)) {
-      seen.add(tok);
-      out.push(tok);
-    }
-  }
-  return out;
-}
+// ---------------------------------------------------------------------------
+// Resonance
+// ---------------------------------------------------------------------------
 
 function computeResonance(
   draft: SkillCrystallizationDraft,
@@ -145,18 +129,12 @@ function computeResonance(
 
 function tokensOf(s: string): Set<string> {
   const out = new Set<string>();
-  // ASCII identifier-ish tokens (length ≥ 4 incl. leading char).
   const asciiMatches = s.match(/[a-z0-9_][a-z0-9_./-]{3,}/g) ?? [];
   for (const m of asciiMatches) {
     const tok = m.toLowerCase();
-    if (STOPWORDS.has(tok)) continue;
+    if (RESONANCE_STOPWORDS.has(tok)) continue;
     out.add(tok);
   }
-  // CJK support: Chinese / Japanese / Korean text isn't whitespace-separated,
-  // so the ASCII-only tokenizer above produces an empty set on Chinese
-  // evidence and the resonance check rejects every skill (the famous
-  // "resonance=0.00<0.5" failure). Add character bigrams from any CJK runs
-  // to give the verifier a reasonable signal in non-Latin contexts.
   const cjkRuns = s.match(/[\u4e00-\u9fff\u3040-\u30ff\u3400-\u4dbf]{2,}/g) ?? [];
   for (const run of cjkRuns) {
     for (let i = 0; i + 1 < run.length; i++) {
@@ -166,7 +144,7 @@ function tokensOf(s: string): Set<string> {
   return out;
 }
 
-const STOPWORDS = new Set([
+const RESONANCE_STOPWORDS = new Set([
   "the", "and", "for", "with", "that", "this", "from", "will", "then",
   "into", "when", "what", "where", "your", "user", "agent", "null", "true",
   "false", "none", "let", "new", "old", "use", "used", "have", "has", "its",

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -34,24 +34,48 @@ set -euo pipefail
 # ─── Colors ────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 BOLD='\033[1m'
 DIM='\033[2m'
 NC='\033[0m'
 
-info()    { printf "${BLUE}%s${NC}\n" "$*"; }
-success() { printf "${GREEN}✓ %s${NC}\n" "$*"; }
-warn()    { printf "${YELLOW}⚠ %s${NC}\n" "$*" >&2; }
-error()   { printf "${RED}✗ %s${NC}\n" "$*" >&2; }
+info()    { printf "  ${BLUE}›${NC} %b\n" "$*"; }
+success() { printf "  ${GREEN}✔${NC} %b\n" "$*"; }
+warn()    { printf "  ${YELLOW}⚠${NC}  %b\n" "$*" >&2; }
+error()   { printf "  ${RED}✘${NC} %b\n" "$*" >&2; }
 die()     { error "$*"; exit 1; }
-header()  { printf "\n${BOLD}${BLUE}── %s ──${NC}\n\n" "$*"; }
+
+header() {
+  local text="$*"
+  local pad_total=$((46 - ${#text}))
+  (( pad_total < 0 )) && pad_total=0
+  local padding=""
+  local i; for ((i=0; i<pad_total; i++)); do padding+=" "; done
+  echo
+  printf "  ${BOLD}${BLUE}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}  ${BOLD}%s${NC}%s  ${BOLD}${BLUE}│${NC}\n" "${text}" "${padding}"
+  printf "  ${BOLD}${BLUE}└──────────────────────────────────────────────────┘${NC}\n"
+  echo
+}
+
+STEP_CURRENT=0
+step() {
+  STEP_CURRENT=$((STEP_CURRENT + 1))
+  printf "  ${BOLD}${CYAN}[%d]${NC} %s\n" "${STEP_CURRENT}" "$*"
+}
 
 banner() {
-  printf "\n${BOLD}${BLUE}╔════════════════════════════════════════════════════╗${NC}\n"
-  printf "${BOLD}${BLUE}║  🧠  MemOS Local — Reflect2Evolve V7 Installer    ║${NC}\n"
-  printf "${BOLD}${BLUE}╚════════════════════════════════════════════════════╝${NC}\n"
-  printf "${DIM}Layered L1/L2/L3 memory, skill crystallization, tier 1/2/3 retrieval.${NC}\n\n"
+  local ver="${VERSION_ARG:-latest}"
+  echo
+  printf "  ${BOLD}${BLUE}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}                                                  ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}   🧠  ${BOLD}MemOS Local Plugin Installer${NC}               ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}│${NC}                                                  ${BOLD}${BLUE}│${NC}\n"
+  printf "  ${BOLD}${BLUE}└──────────────────────────────────────────────────┘${NC}\n"
+  printf "  ${DIM}Package: ${NPM_PACKAGE}  ·  Version: ${ver}${NC}\n"
+  echo
 }
 
 # ─── Constants ─────────────────────────────────────────────────────────────
@@ -164,11 +188,8 @@ ensure_node() {
   # Node 25+ has no better-sqlite3 prebuilts → must compile. Warn the
   # user (but don't block; the rebuild step below tries regardless).
   if (( current >= 25 )); then
-    warn "Node $(node -v) has no better-sqlite3 prebuild — will compile from source."
-    warn "Ensure C++ build tools are available:"
-    warn "  macOS:  xcode-select --install"
-    warn "  Linux:  sudo apt install build-essential python3"
-    warn "Or switch to Node LTS (22/24) for prebuilt binaries: nvm install 22"
+    warn "Node $(node -v) — no better-sqlite3 prebuild available, will compile from source."
+    printf "       ${DIM}Tip: switch to Node LTS for prebuilt binaries:  nvm install 22${NC}\n" >&2
   fi
   success "Node.js $(node -v)"
 }
@@ -189,21 +210,31 @@ find_openclaw_cli() {
 AGENT_SELECTION=""
 pick_agents_interactively() {
   echo
-  printf "${BOLD}Detected agents:${NC}\n"
-  [[ "${HAS_OPENCLAW}" == "true" ]] && success "  OpenClaw   (${HOME}/.openclaw)" || printf "${DIM}  OpenClaw   (not installed)${NC}\n"
-  [[ "${HAS_HERMES}"   == "true" ]] && success "  Hermes     (${HOME}/.hermes)"   || printf "${DIM}  Hermes     (not installed)${NC}\n"
+  printf "  ${BOLD}Detected agents:${NC}\n"
+  if [[ "${HAS_OPENCLAW}" == "true" ]]; then
+    printf "    ${GREEN}●${NC}  OpenClaw   ${DIM}~/.openclaw${NC}\n"
+  else
+    printf "    ${DIM}○  OpenClaw   (not installed)${NC}\n"
+  fi
+  if [[ "${HAS_HERMES}" == "true" ]]; then
+    printf "    ${GREEN}●${NC}  Hermes     ${DIM}~/.hermes${NC}\n"
+  else
+    printf "    ${DIM}○  Hermes     (not installed)${NC}\n"
+  fi
   echo
-  printf "${BOLD}Install into which agent?${NC}\n"
-  printf "  [Enter]  auto-detect\n"
-  printf "  1        OpenClaw only\n"
-  printf "  2        Hermes only\n"
-  printf "  3        Both\n"
-  printf "  q        Quit\n"
-  printf "Choice: "
   local choice
   if [[ ! -t 0 ]]; then
-    echo "(non-interactive — auto-detect)"; choice=""
+    info "Non-interactive mode — auto-detecting agents"
+    choice=""
   else
+    printf "  ${BOLD}Install into which agent?${NC}\n\n"
+    printf "    ${DIM}[Enter]${NC}  🔍  Auto-detect\n"
+    printf "        ${DIM}[1]${NC}  🦞  OpenClaw only\n"
+    printf "        ${DIM}[2]${NC}  👩  Hermes only\n"
+    printf "        ${DIM}[3]${NC}  📦  Both\n"
+    printf "        ${DIM}[q]${NC}  🚪  Quit\n"
+    echo
+    printf "  Choice: "
     read -r choice || choice=""
   fi
   case "${choice}" in
@@ -230,26 +261,26 @@ resolve_tarball() {
     BUILT_TARBALL="$(cd "$(dirname "${VERSION_ARG}")" && pwd)/$(basename "${VERSION_ARG}")"
     SOURCE_KIND="path"
     SOURCE_SPEC="${BUILT_TARBALL}"
-    info "Using local tarball: ${BUILT_TARBALL}"
+    success "Using local tarball: ${BUILT_TARBALL}"
     return 0
   fi
 
   local spec
   if [[ -z "${VERSION_ARG}" ]]; then
     spec="${NPM_PACKAGE}"
-    info "Fetching latest ${NPM_PACKAGE} from npm..."
+    info "Downloading latest ${NPM_PACKAGE} from npm …"
   else
     spec="${NPM_PACKAGE}@${VERSION_ARG}"
-    info "Fetching ${spec} from npm..."
+    info "Downloading ${spec} from npm …"
   fi
   SOURCE_KIND="npm"
   SOURCE_SPEC="${spec}"
 
-  (cd "${STAGE_DIR}" && npm pack "${spec}" --loglevel=error >/dev/null)
+  (cd "${STAGE_DIR}" && npm pack "${spec}" --loglevel=error >/dev/null 2>&1)
   BUILT_TARBALL="$(ls "${STAGE_DIR}"/*.tgz 2>/dev/null | head -1)"
   [[ -n "${BUILT_TARBALL}" && -f "${BUILT_TARBALL}" ]] \
     || die "npm pack failed for ${spec}. Check the npm registry or pass a local path via --version ./pkg.tgz"
-  success "Package downloaded: $(basename "${BUILT_TARBALL}")"
+  success "Package ready: $(basename "${BUILT_TARBALL}")"
 }
 
 # ─── Deploy tarball into a prefix + rebuild native deps ───────────────────
@@ -265,7 +296,7 @@ resolve_tarball() {
 # so npm install stays fast on re-install.
 deploy_tarball_to_prefix() {
   local prefix="$1"
-  info "Deploying to ${prefix}..."
+  step "Deploying to ${prefix}"
   local saved_dir=""
   local preserve=(node_modules data logs skills daemon config.yaml .auth.json)
   if [[ -d "${prefix}" ]]; then
@@ -273,9 +304,6 @@ deploy_tarball_to_prefix() {
     local item
     for item in "${preserve[@]}"; do
       if [[ -e "${prefix}/${item}" ]]; then
-        # Move preserves permissions, symlinks, and is instantaneous
-        # on same-volume rename. mkdir -p parent to handle nested
-        # items (none today, but future-proof).
         mkdir -p "$(dirname "${saved_dir}/${item}")"
         mv "${prefix}/${item}" "${saved_dir}/${item}"
       fi
@@ -285,8 +313,6 @@ deploy_tarball_to_prefix() {
     tar xzf "${BUILT_TARBALL}" -C "${prefix}" --strip-components=1
     for item in "${preserve[@]}"; do
       if [[ -e "${saved_dir}/${item}" ]]; then
-        # Overwrite any placeholder (e.g. empty templates/data/.gitkeep)
-        # the tarball may have just extracted.
         rm -rf "${prefix}/${item}"
         mv "${saved_dir}/${item}" "${prefix}/${item}"
       fi
@@ -297,26 +323,25 @@ deploy_tarball_to_prefix() {
     tar xzf "${BUILT_TARBALL}" -C "${prefix}" --strip-components=1
   fi
   [[ -f "${prefix}/package.json" ]] || die "Extraction failed: ${prefix}/package.json missing"
+  success "Package extracted"
 
-  info "Installing npm dependencies..."
-  ( cd "${prefix}" && MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error )
+  step "Installing npm dependencies"
+  ( cd "${prefix}" && MEMOS_SKIP_SETUP=1 npm install --omit=dev --no-fund --no-audit --loglevel=error >/dev/null 2>&1 )
   [[ -d "${prefix}/node_modules" ]] || die "npm install failed in ${prefix}"
 
-  # Rebuild better-sqlite3 against the active Node ABI. Required on
-  # Node ≥ 25 (no prebuilds) and safe on Node 22/24 too.
   if [[ -d "${prefix}/node_modules/better-sqlite3" ]]; then
-    info "Rebuilding better-sqlite3 for Node $(node -v)..."
+    step "Rebuilding better-sqlite3 for Node $(node -v)"
     ( cd "${prefix}" && npm rebuild better-sqlite3 --loglevel=error >/dev/null 2>&1 ) \
       || ( cd "${prefix}" && npm rebuild better-sqlite3 --build-from-source --loglevel=error >/dev/null 2>&1 ) \
-      || warn "better-sqlite3 rebuild did not complete cleanly — see output above."
+      || warn "better-sqlite3 rebuild did not complete cleanly."
     if ( cd "${prefix}" && node -e "require('better-sqlite3')" >/dev/null 2>&1 ); then
-      success "better-sqlite3 loads"
+      success "better-sqlite3 native module OK"
     else
-      warn "better-sqlite3 native module not loadable — plugin will fail at startup."
-      warn "Fix: install build tools, then run: cd ${prefix} && npm rebuild better-sqlite3"
+      warn "better-sqlite3 not loadable — plugin will fail at startup."
+      printf "       ${DIM}Fix: cd ${prefix} && npm rebuild better-sqlite3${NC}\n" >&2
     fi
   fi
-  success "Dependencies installed"
+  success "Dependencies ready"
 }
 
 # ─── Generate runtime config.yaml ─────────────────────────────────────────
@@ -338,7 +363,7 @@ ensure_runtime_home() {
 
   local target="${home_dir}/config.yaml"
   if [[ -f "${target}" ]]; then
-    info "config.yaml at ${target} — left intact (delete it to regenerate)"
+    success "config.yaml exists — kept as-is"
   else
     cp "${template}" "${target}"
     chmod 600 "${target}"
@@ -346,52 +371,56 @@ ensure_runtime_home() {
   fi
 }
 
-# ─── Wait for viewer (adapted from legacy install.sh's spinner) ──────────
+# ─── Wait for viewer — spin until HTTP endpoint actually responds ─────────
 wait_for_viewer() {
   local port="$1"
   local url="http://127.0.0.1:${port}"
-  local deadline=$((SECONDS + 30))
+  local timeout="${2:-30}"
   local frames=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
   local idx=0
-  while (( SECONDS < deadline )); do
-    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 0.3 "${url}/" >/dev/null 2>&1; then
+  local elapsed=0
+  local spin_tick=0
+
+  while (( elapsed < timeout )); do
+    if command -v curl >/dev/null 2>&1 && curl -fsS --max-time 1 "${url}/" >/dev/null 2>&1; then
       printf "\r\033[K"
-      success "Memory Viewer ready: ${url}"
+      success "Memory Viewer is ready: ${CYAN}${url}${NC}"
       return 0
     fi
-    if command -v lsof >/dev/null 2>&1 && lsof -i ":${port}" -t >/dev/null 2>&1; then
-      printf "\r\033[K"
-      success "Memory Viewer listening on :${port} (may still be initialising)"
-      return 0
-    fi
-    printf "\r${BLUE}%s${NC} Waiting for Memory Viewer on :${port}... " "${frames[idx]}"
+    printf "\r  ${BLUE}%s${NC}  Starting Memory Viewer ${DIM}(%ds)${NC} …" "${frames[idx]}" "${elapsed}"
     idx=$(((idx + 1) % ${#frames[@]}))
-    sleep 0.2
+    sleep 0.12
+    spin_tick=$((spin_tick + 1))
+    if (( spin_tick % 8 == 0 )); then
+      elapsed=$((elapsed + 1))
+    fi
   done
   printf "\r\033[K"
+  warn "Memory Viewer not ready after ${timeout}s"
+  warn "Check: ${CYAN}${url}${NC}  Logs: ~/.openclaw/logs/ or ~/.hermes/memos-plugin/logs/"
   return 1
 }
 
 # ─── OpenClaw install ─────────────────────────────────────────────────────
 install_openclaw() {
-  header "OpenClaw install"
+  STEP_CURRENT=0
+  header "OpenClaw Install"
   local prefix="${HOME}/.openclaw/extensions/${PLUGIN_ID}"
   local home="${HOME}/.openclaw/memos-plugin"
   local config_path="${HOME}/.openclaw/openclaw.json"
   mkdir -p "${HOME}/.openclaw"
 
-  # 1. Stop gateway first — avoids SQLite + better-sqlite3 file locks.
   local oc_bin=""
   if oc_bin="$(find_openclaw_cli)"; then
-    info "Stopping OpenClaw gateway..."
+    step "Stopping OpenClaw gateway"
     "${oc_bin}" gateway stop >/dev/null 2>&1 || true
     sleep 1
+    success "Gateway stopped"
   fi
 
-  # 2. Deploy + rebuild native deps.
   deploy_tarball_to_prefix "${prefix}"
 
-  # 3. Runtime home + config.yaml.
+  step "Configuring runtime environment"
   ensure_runtime_home "openclaw" "${home}" "${prefix}"
 
   # 4. OpenClaw loads plugins via two artefacts:
@@ -422,8 +451,7 @@ install_openclaw() {
 }
 EOF
 
-  # 5. Patch ~/.openclaw/openclaw.json.
-  info "Patching ${config_path}..."
+  step "Patching ${config_path}"
   PLUGIN_ID="${PLUGIN_ID}" \
   INSTALL_PATH="${prefix}" \
   SOURCE_KIND="${SOURCE_KIND}" \
@@ -500,59 +528,86 @@ config.plugins.installs[pluginId] = installsEntry;
 
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
 NODE
-  success "openclaw.json patched (source: ${SOURCE_KIND}, slot: memory)"
+  success "openclaw.json patched"
 
-  # 6. Start gateway — surface failures instead of swallowing them.
   if [[ -z "${oc_bin}" ]]; then
     warn "openclaw CLI not on PATH — restart manually: openclaw gateway start"
     return 1
   fi
-  info "Starting OpenClaw gateway..."
+  step "Starting OpenClaw gateway"
   local start_out
   if ! start_out="$("${oc_bin}" gateway start 2>&1)"; then
-    error "openclaw gateway start failed:"
-    echo "${start_out}" | sed 's/^/  /' >&2
-    warn "Inspect ~/.openclaw/logs/gateway.err.log for the full reason."
-    return 1
+    # launchd KeepAlive may have already restarted the service after
+    # the stop above, making "gateway start" fail with a kickstart
+    # conflict. Check if the gateway is actually running before
+    # treating this as a real error.
+    if curl -fsS --max-time 2 "http://127.0.0.1:18789" >/dev/null 2>&1 \
+       || (command -v lsof >/dev/null 2>&1 && lsof -i ":18789" -t >/dev/null 2>&1); then
+      success "OpenClaw gateway already running"
+    else
+      error "openclaw gateway start failed:"
+      echo "${start_out}" | sed 's/^/       /' >&2
+      warn "Inspect ~/.openclaw/logs/gateway.err.log for the full reason."
+      return 1
+    fi
+  else
+    success "OpenClaw gateway started"
   fi
-  success "OpenClaw gateway started"
 
-  # 7. Wait for our viewer to answer.
+  step "Waiting for Memory Viewer"
   if wait_for_viewer "${OPENCLAW_PORT}"; then
+    echo
+    success "OpenClaw install complete"
+    printf "       ${DIM}Plugin:${NC}    %s\n" "${HOME}/.openclaw/extensions/${PLUGIN_ID}"
+    printf "       ${DIM}Viewer:${NC}    ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}/${NC}\n"
     return 0
   fi
   warn "Memory Viewer did not respond within 30s."
-  warn "Inspect ~/.openclaw/logs/gateway.err.log for plugin init errors."
+  printf "       ${DIM}Check: ~/.openclaw/logs/gateway.err.log${NC}\n" >&2
   return 1
 }
 
 # ─── Hermes install ───────────────────────────────────────────────────────
 install_hermes() {
-  header "Hermes install"
+  STEP_CURRENT=0
+  header "Hermes Install"
   local prefix="${HOME}/.hermes/memos-plugin"
   local home="${prefix}"
   local config_file="${HOME}/.hermes/config.yaml"
   local adapter_dir="${prefix}/adapters/hermes"
   mkdir -p "${HOME}/.hermes"
 
-  # Stop old bridge + hermes so new config applies.
   pkill -f "bridge.cts" >/dev/null 2>&1 || true
   local was_running="false"
   if pgrep -f "/bin/hermes" >/dev/null 2>&1; then
-    info "Stopping running hermes process..."
+    step "Stopping running Hermes process"
     pkill -f "/bin/hermes" >/dev/null 2>&1 || true
     sleep 2
     pgrep -f "/bin/hermes" >/dev/null 2>&1 && pkill -9 -f "/bin/hermes" >/dev/null 2>&1 || true
     was_running="true"
+    success "Hermes stopped"
+  fi
+
+  # Free Hermes' viewer port if something (e.g. a stale bridge from
+  # a prior install, or the OpenClaw gateway reload) left it occupied.
+  if command -v lsof >/dev/null 2>&1; then
+    local stale_pid
+    stale_pid="$(lsof -i ":${HERMES_PORT}" -t 2>/dev/null || true)"
+    if [[ -n "${stale_pid}" ]]; then
+      kill ${stale_pid} >/dev/null 2>&1 || true
+      sleep 1
+    fi
   fi
 
   deploy_tarball_to_prefix "${prefix}"
+
+  step "Configuring runtime environment"
   ensure_runtime_home "hermes" "${home}" "${prefix}"
 
   echo "${prefix}/bridge.cts" > "${adapter_dir}/bridge_path.txt"
-  success "Recorded bridge path"
+  success "Bridge path recorded"
 
-  # Locate Hermes Python venv.
+  step "Locating Hermes Python environment"
   local python_bin=""
   if command -v hermes >/dev/null 2>&1; then
     local shebang; shebang="$(head -1 "$(command -v hermes)" 2>/dev/null || true)"
@@ -564,9 +619,8 @@ install_hermes() {
   fi
   [[ -z "${python_bin}" || ! -x "${python_bin}" ]] && python_bin="$(command -v python3 || true)"
   [[ -n "${python_bin}" && -x "${python_bin}" ]] || die "Cannot locate Python for Hermes."
-  success "Hermes Python: ${python_bin}"
+  success "Python: ${python_bin}"
 
-  # plugins/memory discovery.
   local plugin_dir=""
   plugin_dir="$("${python_bin}" -c "
 from pathlib import Path
@@ -582,18 +636,18 @@ except Exception:
     done
   fi
   [[ -n "${plugin_dir}" && -d "${plugin_dir}" ]] || die "plugins/memory not found"
-  success "Hermes plugins/memory: ${plugin_dir}"
+  success "plugins/memory: ${plugin_dir}"
 
-  # Symlink memtensor provider.
+  step "Linking memtensor provider"
   local target="${plugin_dir}/memtensor"
   if [[ -L "${target}" ]]; then rm "${target}"
   elif [[ -e "${target}" ]]; then rm -rf "${target}"
   fi
   ln -s "${adapter_dir}/memos_provider" "${target}"
   cp "${adapter_dir}/plugin.yaml" "${adapter_dir}/memos_provider/plugin.yaml" 2>/dev/null || true
-  success "Symlinked memtensor provider → ${target}"
+  success "Symlinked → ${target}"
 
-  # Verify + patch config.yaml.
+  step "Verifying provider & patching config"
   local verify
   verify="$("${python_bin}" -c "
 from plugins.memory import load_memory_provider
@@ -628,16 +682,12 @@ CFGEOF
     success "Created ${config_file}"
   fi
 
-  # 8. Smoke test — boot the bridge briefly and confirm the viewer
-  #    actually answers on Hermes' fixed port. Catches TS loader /
-  #    native-module failures at install time rather than at first
-  #    `hermes chat`. Skipped only when something else already owns
-  #    :${HERMES_PORT} (rare — that port is reserved for hermes).
+  # Smoke test — boot the bridge briefly and confirm the viewer
+  # actually answers on Hermes' fixed port.
   if command -v lsof >/dev/null 2>&1 && lsof -i ":${HERMES_PORT}" -t >/dev/null 2>&1; then
-    warn "Port :${HERMES_PORT} is already in use — skipping smoke test."
-    warn "  Hermes' viewer needs this port. Free it (e.g. lsof -i :${HERMES_PORT}) and re-run."
+    warn "Port :${HERMES_PORT} already in use — skipping smoke test."
   else
-    info "Running bridge smoke test..."
+    step "Running bridge smoke test"
     local tsx_bin="${prefix}/node_modules/.bin/tsx"
     local bridge_cts="${prefix}/bridge.cts"
     if [[ -x "${tsx_bin}" && -f "${bridge_cts}" ]]; then
@@ -645,46 +695,41 @@ CFGEOF
       smoke_log="$(mktemp)"
       smoke_fifo="$(mktemp -u)"
       mkfifo "${smoke_fifo}"
-      # Keep stdin open via a FIFO backed by a long-running writer.
-      # Without this, the bridge detects end-of-stdin on launch and
-      # exits cleanly before the viewer can bind the port.
+      # Keep stdin open via a FIFO so the bridge doesn't exit on EOF.
       sleep 60 > "${smoke_fifo}" &
       sleeper_pid=$!
+      disown "${sleeper_pid}" 2>/dev/null || true
       ( cd "${prefix}" && "${tsx_bin}" "${bridge_cts}" --agent=hermes <"${smoke_fifo}" >"${smoke_log}" 2>&1 ) &
       smoke_pid=$!
+      disown "${smoke_pid}" 2>/dev/null || true
 
       if wait_for_viewer "${HERMES_PORT}"; then
         success "Bridge smoke test passed"
       else
         error "Memory Viewer did not respond within 30s."
-        warn "Smoke-test output (tail):"
-        tail -n 40 "${smoke_log}" 2>/dev/null | sed 's/^/  /' >&2 || true
-        warn "Re-install your plugin dependencies ( cd ${prefix} && npm install ) and re-run."
+        warn "Re-install dependencies and re-run: cd ${prefix} && npm install"
         kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-        sleep 1
         kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
         rm -f "${smoke_log}" "${smoke_fifo}"
         return 1
       fi
 
-      # Shut the probe down; hermes will spawn its own bridge on demand.
       kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-      sleep 1
       kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
       rm -f "${smoke_log}" "${smoke_fifo}"
     else
-      warn "tsx not found at ${tsx_bin}; skipping smoke test (dependencies may be incomplete)."
+      warn "tsx not found — skipping smoke test."
     fi
   fi
 
   echo
   success "Hermes install complete"
-  info "  Plugin:    ${prefix}"
-  info "  Viewer:    http://127.0.0.1:${HERMES_PORT}/ (starts on first \`hermes chat\`)"
+  printf "       ${DIM}Plugin:${NC}    %s\n" "${prefix}"
+  printf "       ${DIM}Viewer:${NC}    ${CYAN}http://127.0.0.1:${HERMES_PORT}/${NC}\n"
   if [[ "${was_running}" == "true" ]]; then
-    info "  Next step: ${BOLD}hermes chat${NC} ${DIM}(hermes was stopped — relaunch to apply)${NC}"
+    printf "       ${DIM}Next:${NC}      ${BOLD}hermes chat${NC}  ${DIM}(was stopped — relaunch to apply)${NC}\n"
   else
-    info "  Next step: ${BOLD}hermes chat${NC}"
+    printf "       ${DIM}Next:${NC}      ${BOLD}hermes chat${NC}\n"
   fi
   return 0
 }
@@ -704,7 +749,7 @@ if [[ "${AGENT_SELECTION}" == "auto" ]]; then
   else
     AGENT_SELECTION="hermes"
   fi
-  info "Auto-detected: ${AGENT_SELECTION}"
+  success "Auto-detected: ${AGENT_SELECTION}"
 fi
 
 case "${AGENT_SELECTION}" in
@@ -729,28 +774,41 @@ esac
 
 echo
 if (( STATUS == 0 )); then
-  printf "${BOLD}${GREEN}══════════════════════════════════════════════════${NC}\n"
-  printf "${BOLD}${GREEN}  ✨ MemOS Local installed successfully${NC}\n"
-  printf "${BOLD}${GREEN}══════════════════════════════════════════════════${NC}\n"
+  echo
+  printf "  ${BOLD}${GREEN}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}                                                  ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}   ✨  ${BOLD}${GREEN}MemOS Local installed successfully${NC}         ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}│${NC}                                                  ${BOLD}${GREEN}│${NC}\n"
+  printf "  ${BOLD}${GREEN}└──────────────────────────────────────────────────┘${NC}\n"
   echo
   case "${AGENT_SELECTION}" in
     openclaw)
-      info "  Memory Viewer: http://127.0.0.1:${OPENCLAW_PORT}  (openclaw)"
-      info "  OpenClaw Web UI: http://localhost:18789"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}${NC}  ${DIM}(openclaw)${NC}\n"
+      printf "    ${GREEN}●${NC}  OpenClaw Web UI  ${CYAN}http://localhost:18789${NC}\n"
       ;;
     hermes)
-      info "  Memory Viewer: http://127.0.0.1:${HERMES_PORT}  (hermes)"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${HERMES_PORT}${NC}  ${DIM}(hermes)${NC}\n"
       ;;
     all)
-      info "  Memory Viewer (openclaw): http://127.0.0.1:${OPENCLAW_PORT}"
-      info "  Memory Viewer (hermes):   http://127.0.0.1:${HERMES_PORT}"
-      info "  OpenClaw Web UI:          http://localhost:18789"
+      printf "  ${BOLD}Quick links:${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${OPENCLAW_PORT}${NC}  ${DIM}(openclaw)${NC}\n"
+      printf "    ${GREEN}●${NC}  Memory Viewer   ${CYAN}http://127.0.0.1:${HERMES_PORT}${NC}  ${DIM}(hermes)${NC}\n"
+      printf "    ${GREEN}●${NC}  OpenClaw Web UI  ${CYAN}http://localhost:18789${NC}\n"
       ;;
   esac
+  echo
+  printf "  ${DIM}Docs: https://github.com/MemTensor/MemOS${NC}\n"
+  echo
   exit 0
 else
-  printf "${BOLD}${RED}══════════════════════════════════════════════════${NC}\n"
-  printf "${BOLD}${RED}  Install finished with errors — see ✗ lines above${NC}\n"
-  printf "${BOLD}${RED}══════════════════════════════════════════════════${NC}\n"
+  echo
+  printf "  ${BOLD}${RED}┌──────────────────────────────────────────────────┐${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}                                                  ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}   ${RED}Install finished with errors - see above${NC}       ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}│${NC}                                                  ${BOLD}${RED}│${NC}\n"
+  printf "  ${BOLD}${RED}└──────────────────────────────────────────────────┘${NC}\n"
+  echo
   exit 1
 fi

--- a/apps/memos-local-plugin/tests/unit/skill/_helpers.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/_helpers.ts
@@ -99,6 +99,7 @@ export interface SeedTraceArgs {
   value?: number;
   tags?: string[];
   vec?: EmbeddingVector | null;
+  toolCalls?: TraceRow["toolCalls"];
 }
 
 export function seedTrace(handle: TmpDbHandle, args: SeedTraceArgs): TraceRow {
@@ -111,7 +112,7 @@ export function seedTrace(handle: TmpDbHandle, args: SeedTraceArgs): TraceRow {
     ts: NOW,
     userText: args.userText ?? "",
     agentText: args.agentText ?? "",
-    toolCalls: [],
+    toolCalls: args.toolCalls ?? [],
     reflection: args.reflection ?? null,
     value: args.value ?? 0.7,
     alpha: 0.6 as TraceRow["alpha"],
@@ -195,6 +196,7 @@ export function makeDraft(
     ],
     tags: ["pip", "alpine"],
     decisionGuidance: { preference: [], antiPattern: [] },
+    tools: [],
     ...overrides,
   };
 }

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -78,6 +78,7 @@ describe("skill/crystallize", () => {
           ],
           examples: [{ input: "cryptography", expected: "success" }],
           tags: ["alpine", "Alpine", "pip"],
+          tools: ["shell", "pip.install"],
         },
       },
     });
@@ -96,6 +97,7 @@ describe("skill/crystallize", () => {
     expect(r.draft.parameters[1]!.enumValues).toEqual(["dev", "prod"]);
     expect(r.draft.steps.length).toBe(2);
     expect(r.draft.tags).toEqual(["alpine", "pip"]);
+    expect(r.draft.tools).toEqual(["shell", "pip.install"]);
   });
 
   it("skips when useLlm is false", async () => {

--- a/apps/memos-local-plugin/tests/unit/skill/verifier.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/verifier.test.ts
@@ -2,10 +2,16 @@ import { describe, it, expect } from "vitest";
 
 import { rootLogger } from "../../../core/logger/index.js";
 import { verifyDraft } from "../../../core/skill/verifier.js";
+import type { ToolCallDTO } from "../../../agent-contract/dto.js";
 import type { TraceRow } from "../../../core/types.js";
 import { NOW, makeDraft, vec } from "./_helpers.js";
 
-function trace(id: string, userText: string, agentText: string): TraceRow {
+function trace(
+  id: string,
+  userText: string,
+  agentText: string,
+  toolCalls: Partial<ToolCallDTO>[] = [],
+): TraceRow {
   return {
     id: id as TraceRow["id"],
     episodeId: "ep_1" as TraceRow["episodeId"],
@@ -13,7 +19,13 @@ function trace(id: string, userText: string, agentText: string): TraceRow {
     ts: NOW,
     userText,
     agentText,
-    toolCalls: [],
+    toolCalls: toolCalls.map((tc) => ({
+      name: tc.name ?? "unknown",
+      input: tc.input,
+      output: tc.output,
+      startedAt: 0 as ToolCallDTO["startedAt"],
+      endedAt: 0 as ToolCallDTO["endedAt"],
+    })),
     reflection: null,
     value: 0.5,
     alpha: 0.5 as TraceRow["alpha"],
@@ -30,40 +42,126 @@ function trace(id: string, userText: string, agentText: string): TraceRow {
 const log = rootLogger.child({ channel: "core.skill.verifier" });
 
 describe("skill/verifier", () => {
-  it("accepts drafts that resonate with the evidence", () => {
+  it("accepts drafts whose tools are a subset of evidence toolCalls", () => {
     const draft = makeDraft({
       summary: "Ensure apk add openssl-dev before pip install cryptography",
+      tools: ["shell", "pip.install"],
       steps: [
         { title: "apk add", body: "apk add openssl-dev libffi-dev" },
         { title: "retry pip", body: "retry pip install cryptography" },
       ],
     });
     const evidence = [
-      trace("tr_1", "pip install cryptography failing", "apk add openssl-dev libffi-dev"),
-      trace("tr_2", "pip install pycrypto", "retry pip install after apk add"),
+      trace("tr_1", "pip install cryptography failing", "apk add openssl-dev libffi-dev", [
+        { name: "shell", input: "apk add openssl-dev libffi-dev" },
+        { name: "pip.install", input: { pkg: "cryptography" } },
+      ]),
+      trace("tr_2", "pip install pycrypto", "retry pip install after apk add", [
+        { name: "pip.install", input: { pkg: "pycrypto" } },
+      ]),
     ];
     const r = verifyDraft({ draft, evidence }, { log });
     expect(r.ok).toBe(true);
-    expect(r.coverage).toBeGreaterThan(0);
+    expect(r.coverage).toBe(1);
     expect(r.resonance).toBeGreaterThanOrEqual(0.5);
   });
 
-  it("flags drafts whose command tokens don't appear in evidence", () => {
+  it("flags drafts whose tools are not in evidence toolCalls", () => {
     const draft = makeDraft({
       summary: "Invoke telemetry.upload to finish",
+      tools: ["telemetry.upload", "checker.exe"],
       steps: [
         { title: "call telemetry.upload", body: "run telemetry.upload then verify with checker.exe" },
       ],
     });
-    const evidence = [trace("tr_1", "pip failure", "apk add libffi-dev")];
+    const evidence = [
+      trace("tr_1", "pip failure", "apk add libffi-dev", [
+        { name: "shell", input: "apk add libffi-dev" },
+      ]),
+    ];
     const r = verifyDraft({ draft, evidence }, { log });
     expect(r.ok).toBe(false);
-    expect(r.reason).toBeTruthy();
+    expect(r.coverage).toBe(0);
+    expect(r.unmappedTokens).toEqual(["telemetry.upload", "checker.exe"]);
+  });
+
+  it("passes when draft.tools is empty (no tool references)", () => {
+    const draft = makeDraft({
+      summary: "A purely narrative skill about project conventions",
+      tools: [],
+      steps: [
+        { title: "check naming", body: "verify naming convention" },
+      ],
+    });
+    const evidence = [
+      trace("tr_1", "naming question", "naming convention explained", []),
+    ];
+    const r = verifyDraft({ draft, evidence }, { log });
+    expect(r.ok).toBe(true);
+    expect(r.coverage).toBe(1);
+  });
+
+  it("extracts command-level names from string tc.input", () => {
+    const draft = makeDraft({
+      summary: "Install system libs",
+      tools: ["shell", "apk"],
+      steps: [
+        { title: "install", body: "apk add openssl-dev" },
+      ],
+    });
+    const evidence = [
+      trace("tr_1", "install libs", "apk add openssl-dev", [
+        { name: "shell", input: "apk add openssl-dev" },
+      ]),
+    ];
+    const r = verifyDraft({ draft, evidence }, { log });
+    expect(r.ok).toBe(true);
+    expect(r.coverage).toBe(1);
+  });
+
+  it("partial coverage below threshold fails", () => {
+    const draft = makeDraft({
+      summary: "Use several tools",
+      tools: ["shell", "docker.build", "npm.publish", "kubectl"],
+      steps: [
+        { title: "build", body: "build and deploy" },
+      ],
+    });
+    const evidence = [
+      trace("tr_1", "build app", "building docker image", [
+        { name: "shell", input: "docker build ." },
+      ]),
+    ];
+    const r = verifyDraft({ draft, evidence }, { log });
+    expect(r.ok).toBe(false);
+    expect(r.coverage).toBe(0.25);
+    expect(r.unmappedTokens).toContain("docker.build");
+    expect(r.unmappedTokens).toContain("npm.publish");
+    expect(r.unmappedTokens).toContain("kubectl");
   });
 
   it("fails when there is no evidence at all", () => {
     const r = verifyDraft({ draft: makeDraft(), evidence: [] }, { log });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("no-evidence");
+  });
+
+  it("fails on low resonance even when coverage is fine", () => {
+    const draft = makeDraft({
+      summary: "completely unrelated topic about quantum computing",
+      tools: ["shell"],
+      steps: [
+        { title: "quantum", body: "run quantum simulation algorithm" },
+      ],
+    });
+    const evidence = [
+      trace("tr_1", "pip install cryptography", "apk add openssl-dev", [
+        { name: "shell", input: "apk add openssl-dev" },
+      ]),
+    ];
+    const r = verifyDraft({ draft, evidence }, { log });
+    expect(r.coverage).toBe(1);
+    expect(r.resonance).toBeLessThan(0.5);
+    expect(r.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Replace the regex-based "command token guessing" in `verifier.ts` with structured tool name comparison using `trace.toolCalls` ground truth data
- Add `extractToolNames()` utility that reads `tc.name` + first token of string `tc.input` from evidence traces
- Crystallize prompt v3: inject `EVIDENCE_TOOLS` whitelist into the prompt, require LLM to output explicit `tools: string[]` field constrained to the whitelist
- Verifier coverage check is now a clean set-containment: `draft.tools ⊆ evidenceTools` — no regex, no STOPWORDS, no `actionBlob` substring search
- Add `tools: string[]` to `SkillCrystallizationDraft`, `SkillProcedure`; packager persists and renders "Tools used" section

## Motivation

The old regex third branch `[a-z_]{3,}` pulled English verbs (install, verify, retry...) into the coverage denominator as false positives, while substring matching missed synonyms and CJK text. This caused systematically low coverage scores despite high resonance, blocking valid skills from passing verification.

## Test plan

- [x] All 41 skill unit tests pass (verifier, crystallize, packager, lifecycle, eligibility, events, evidence, subscriber, integration)
- [x] Verifier tests rewritten with structured `toolCalls` evidence and `tools` draft field
- [x] Crystallize test verifies `tools` field parsing from LLM response
- [x] Zero lint errors