### PR TITLE
chore: add AGENTS_*.md to .gitignore

### DIFF
--- a/apps/memos-local-plugin/.gitignore
+++ b/apps/memos-local-plugin/.gitignore
@@ -16,3 +16,4 @@ coverage/
 # Local notes (developer scratch)
 .notes/
 TODO.local.md
+AGENTS_*.md


### PR DESCRIPTION
## Summary

- Add `AGENTS_*.md` to `.gitignore` to prevent developer-local agent instruction files from being committed