### PR TITLE
feat(viewer): auto-restart OpenClaw gateway after config save

### DIFF
--- a/apps/memos-local-plugin/.gitignore
+++ b/apps/memos-local-plugin/.gitignore
@@ -17,3 +17,4 @@ coverage/
 .notes/
 TODO.local.md
 AGENTS_*.md
+.test_*

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -9,21 +9,16 @@
  *       toast so the user knows what to do next.
  *
  *   POST /api/v1/admin/restart
- *       LEGACY no-op kept for back-compat with older viewer bundles.
- *       Earlier this endpoint called `process.exit(0)` on the
- *       assumption that the host would respawn the plugin process —
- *       but neither OpenClaw nor Hermes does that automatically, so
- *       the viewer just sat in a "waiting for service to come back"
- *       overlay until it timed out. Modern viewers don't call this;
- *       they just rely on `PATCH /api/v1/config` having persisted
- *       the new YAML to disk and prompt the user to restart their
- *       agent process manually. The endpoint still answers OK so
- *       any older bundle in the wild doesn't error out.
+ *       Agent-aware restart. For OpenClaw the plugin lives inside the
+ *       gateway process, which is managed by macOS launchd — calling
+ *       `process.exit(0)` causes launchd to respawn it automatically.
+ *       For Hermes and other hosts, the endpoint is a no-op (the
+ *       viewer shows a manual-restart toast instead).
  */
-import type { ServerDeps } from "../types.js";
+import type { ServerDeps, ServerOptions } from "../types.js";
 import type { Routes } from "./registry.js";
 
-export function registerAdminRoutes(routes: Routes, deps: ServerDeps): void {
+export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: ServerOptions = {}): void {
   routes.set("POST /api/v1/admin/clear-data", async (_ctx) => {
     const dbFile = deps.home?.dbFile;
     if (!dbFile) {
@@ -33,19 +28,21 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps): void {
     try {
       await deps.core.shutdown();
     } catch { /* best-effort */ }
-    // Remove the SQLite DB file and its WAL/SHM sidecars.
     for (const suffix of ["", "-wal", "-shm"]) {
       try { await fs.unlink(dbFile + suffix); } catch { /* may not exist */ }
     }
-    // Exit so the next agent boot creates a clean DB. The viewer
-    // toast advises the user to restart the agent manually.
     setTimeout(() => process.exit(0), 300);
     return { ok: true, restarting: true };
   });
 
   routes.set("POST /api/v1/admin/restart", async (_ctx) => {
-    // No-op (see header comment). Kept for back-compat — older viewer
-    // bundles still POST here after saving config; we just ack.
+    const agent = options.agent ?? "unknown";
+    if (agent === "openclaw") {
+      // OpenClaw gateway is managed by launchd — exit and let it respawn.
+      setTimeout(() => process.exit(0), 300);
+      return { ok: true, restarting: true };
+    }
+    // Hermes / other hosts: no-op — the viewer shows a manual-restart toast.
     return { ok: true, restarting: false, note: "config persisted; restart the agent process to apply" };
   });
 }

--- a/apps/memos-local-plugin/server/routes/registry.ts
+++ b/apps/memos-local-plugin/server/routes/registry.ts
@@ -175,7 +175,7 @@ export function buildRoutes(
   registerMigrateRoutes(routes, deps, options);
   registerHubAdminRoutes(routes, deps);
   registerAuthRoutes(routes, deps, options);
-  registerAdminRoutes(routes, deps);
+  registerAdminRoutes(routes, deps, options);
   registerModelsRoutes(routes, deps);
   registerApiLogsRoutes(routes, deps);
   registerDiagRoutes(routes, deps);

--- a/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
+++ b/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
@@ -1,28 +1,85 @@
 /**
- * Lightweight bottom-of-screen toast announcing "config saved" or
- * "data cleared". Shown for ~8 s, then auto-dismisses.
+ * Restart overlay — two UX modes:
  *
- * Replaces the full-screen restart overlay used by earlier versions:
- * we no longer try to restart the plugin process from the viewer
- * (see `stores/restart.ts` for the rationale), so there's no more
- * "waiting for service to come back" UX. The agent process picks up
- * the new YAML on its own next boot; the toast tells the user that
- * needs to happen manually.
+ *   - **OpenClaw** (auto-restart): full-screen spinner overlay styled after
+ *     the legacy `memos-local-openclaw` viewer. The gateway is being
+ *     restarted; we poll health and reload automatically.
+ *
+ *   - **Hermes / generic** (manual restart): bottom-of-screen toast that
+ *     tells the user to restart the agent process themselves.
  */
 import { restartState, dismissRestartBanner } from "../stores/restart";
 import { health } from "../stores/health";
 import { t } from "../stores/i18n";
 import { Icon } from "./Icon";
 
-export function RestartOverlay() {
+function FullScreenSpinner() {
   const s = restartState.value;
-  if (s.phase === "idle") return null;
 
+  const message =
+    s.phase === "restartFailed"
+      ? t("restart.failed")
+      : s.phase === "waitingUp"
+        ? t("restart.waitingUp")
+        : t("restart.restarting");
+
+  const hint =
+    s.phase === "restartFailed"
+      ? t("restart.failedHint")
+      : t("restart.autoRefresh");
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      style={`
+        position:fixed;inset:0;z-index:99999;
+        display:flex;flex-direction:column;align-items:center;justify-content:center;
+        background:rgba(0,0,0,.55);backdrop-filter:blur(6px);
+        color:#fff;font-family:inherit;
+      `}
+    >
+      <div
+        style={`
+          display:flex;flex-direction:column;align-items:center;
+          gap:16px;max-width:400px;text-align:center;
+        `}
+      >
+        {s.phase !== "restartFailed" ? (
+          <div
+            style={`
+              width:36px;height:36px;
+              border:3px solid rgba(255,255,255,.2);
+              border-top-color:#fff;
+              border-radius:50%;
+              animation:restartSpin 1s linear infinite;
+            `}
+          />
+        ) : (
+          <Icon name="circle-alert" size={36} />
+        )}
+        <div style="font-size:15px;font-weight:600">{message}</div>
+        <div style="font-size:12px;opacity:.6">{hint}</div>
+        {s.phase === "restartFailed" && (
+          <button
+            class="btn btn--ghost btn--sm"
+            onClick={dismissRestartBanner}
+            style="color:#fff;border-color:rgba(255,255,255,.3);margin-top:8px"
+          >
+            {t("common.close")}
+          </button>
+        )}
+      </div>
+      <style>{`@keyframes restartSpin{to{transform:rotate(360deg)}}`}</style>
+    </div>
+  );
+}
+
+function Toast() {
+  const s = restartState.value;
   const agent = health.value?.agent ?? "agent";
   const restartHint =
-    agent === "openclaw"
-      ? t("restart.hint.openclaw")
-      : agent === "hermes"
+    agent === "hermes"
       ? t("restart.hint.hermes")
       : t("restart.hint.generic");
 
@@ -67,4 +124,19 @@ export function RestartOverlay() {
       </div>
     </div>
   );
+}
+
+export function RestartOverlay() {
+  const s = restartState.value;
+  if (s.phase === "idle") return null;
+
+  if (
+    s.phase === "restarting" ||
+    s.phase === "waitingUp" ||
+    s.phase === "restartFailed"
+  ) {
+    return <FullScreenSpinner />;
+  }
+
+  return <Toast />;
 }

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -158,6 +158,12 @@ const en = {
     "Restart Hermes to apply: stop and rerun `hermes chat`",
   "restart.hint.generic":
     "Restart this agent's process to load the new configuration.",
+  "restart.restarting": "Configuration saved. Service is restarting…",
+  "restart.waitingUp": "Waiting for the service to come back online…",
+  "restart.autoRefresh": "The page will refresh automatically once the service is ready.",
+  "restart.failed": "Restart didn't complete — the service didn't come back in time.",
+  "restart.failedHint":
+    "Try manually: openclaw gateway stop && openclaw gateway start",
   "common.selectAll": "Select all",
   "common.deleteSelected": "Delete selected",
 
@@ -759,6 +765,12 @@ const zh: Record<TranslationKey, string> = {
   "restart.hint.hermes":
     "请重启 Hermes 后生效：停止后重新执行 `hermes chat`",
   "restart.hint.generic": "请重启该 agent 进程以加载新配置。",
+  "restart.restarting": "配置已保存，服务正在重启…",
+  "restart.waitingUp": "正在等待服务重新上线…",
+  "restart.autoRefresh": "服务就绪后页面将自动刷新。",
+  "restart.failed": "重启超时 — 服务未能在预期时间内恢复。",
+  "restart.failedHint":
+    "请手动重启：openclaw gateway stop && openclaw gateway start",
   "common.selectAll": "全选",
   "common.deleteSelected": "删除所选",
 

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -1,37 +1,30 @@
 /**
- * Lightweight "config saved" banner state.
+ * Config-save restart state manager.
  *
- * Why this is no longer a real restart coordinator
- * ================================================
- * Earlier versions of this file POSTed `/api/v1/admin/restart`,
- * which made the plugin call `process.exit(0)` on the assumption
- * that the host (OpenClaw gateway / Hermes Python) would respawn
- * the viewer process. That assumption is wrong:
+ * Two distinct flows based on agent type:
  *
- *   - OpenClaw's plugin runs *inside* the `openclaw-gateway` process,
- *     so `process.exit(0)` kills the whole gateway. macOS launchd
- *     re-bootstraps the LaunchAgent eventually, but easily later
- *     than the 90 s health-poll deadline.
- *   - Hermes' bridge is spawned via Python `subprocess.Popen` on
- *     demand; once the bridge exits, hermes doesn't try to bring it
- *     back until the next `hermes chat` invocation.
+ *   - **OpenClaw**: the plugin runs inside the `openclaw-gateway` process
+ *     which is managed by macOS launchd. We POST `/api/v1/admin/restart`
+ *     to trigger `process.exit(0)`, launchd respawns the gateway, and
+ *     we poll `/api/v1/health` until the service comes back, then reload.
+ *     During this time a full-screen spinner overlay is shown.
  *
- * Result: the overlay almost always ended in
- *   "Restart didn't complete — service didn't come back in time"
- * even though the config patch on disk had succeeded. Confusing.
- *
- * The honest behaviour is much simpler:
- *
- *   1. The PATCH `/api/v1/config` request already wrote the new
- *      values to `~/.<agent>/memos-plugin/config.yaml`.
- *   2. Show a short "Saved — restart <agent> to apply" toast for a
- *      few seconds. No process exit, no polling, no overlay.
- *   3. The user runs `openclaw gateway stop && start` or relaunches
- *      `hermes chat`; the new bridge picks up the YAML on boot.
+ *   - **Hermes**: the bridge is spawned via Python `subprocess.Popen` on
+ *     demand; once it exits, hermes doesn't bring it back until the next
+ *     `hermes chat` invocation. So we only show a dismissible toast
+ *     telling the user to restart manually.
  */
 import { signal } from "@preact/signals";
+import { api } from "../api/client";
+import { health } from "./health";
 
-export type RestartPhase = "idle" | "saved" | "cleared";
+export type RestartPhase =
+  | "idle"
+  | "saved"
+  | "cleared"
+  | "restarting"
+  | "waitingUp"
+  | "restartFailed";
 
 export const restartState = signal<{ phase: RestartPhase; message?: string }>({
   phase: "idle",
@@ -50,32 +43,87 @@ function scheduleDismiss(): void {
 }
 
 export interface TriggerRestartOptions {
-  /** Kept for back-compat; ignored. */
   kick?: "restart-endpoint" | "skip";
 }
 
+function isOpenClaw(): boolean {
+  return health.value?.agent === "openclaw";
+}
+
+async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
+  let phase: "waitDown" | "waitUp" = "waitDown";
+  const MAX_WAIT_DOWN = 8;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const delay = phase === "waitDown" ? 1500 : 2500;
+    await new Promise((r) => setTimeout(r, delay));
+    try {
+      const res = await fetch("/api/v1/health");
+      if (phase === "waitDown") {
+        if (res.ok || res.status === 401 || res.status === 403) {
+          if (attempt >= MAX_WAIT_DOWN) return true;
+        } else {
+          phase = "waitUp";
+          restartState.value = { phase: "waitingUp" };
+        }
+      } else {
+        if (res.ok || res.status === 401 || res.status === 403) return true;
+      }
+    } catch {
+      if (phase === "waitDown") {
+        phase = "waitUp";
+        restartState.value = { phase: "waitingUp" };
+      }
+    }
+  }
+  return false;
+}
+
 /**
- * Show the "config saved, restart agent to apply" banner.
- *
- * Used by Settings → 保存; the upstream `PATCH /api/v1/config` call
- * has already persisted the YAML before we get here.
+ * Config saved. For OpenClaw: auto-restart with spinner overlay.
+ * For Hermes/others: show a dismissible toast.
  */
 export async function triggerRestart(
   _opts: TriggerRestartOptions = {},
 ): Promise<void> {
-  restartState.value = { phase: "saved" };
-  scheduleDismiss();
+  if (isOpenClaw()) {
+    restartState.value = { phase: "restarting" };
+    try {
+      await api.post("/api/v1/admin/restart");
+    } catch {
+      // Server might already be going down
+    }
+    const ok = await pollHealthUntilUp(60);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
+  } else {
+    restartState.value = { phase: "saved" };
+    scheduleDismiss();
+  }
 }
 
 /**
- * Show the "data cleared, restart agent to start fresh" banner.
- *
- * Used by Settings → 危险区 → 清空所有数据. The server has wiped the
- * SQLite file; the next agent boot will recreate an empty DB.
+ * Data cleared. For OpenClaw: auto-restart with spinner.
+ * For Hermes/others: show toast.
  */
-export function triggerCleared(): void {
-  restartState.value = { phase: "cleared" };
-  scheduleDismiss();
+export async function triggerCleared(): Promise<void> {
+  if (isOpenClaw()) {
+    restartState.value = { phase: "restarting" };
+    const ok = await pollHealthUntilUp(60);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
+  } else {
+    restartState.value = { phase: "cleared" };
+    scheduleDismiss();
+  }
 }
 
 /** Dismiss the banner immediately (e.g. user clicked the close button). */

--- a/apps/memos-local-plugin/web/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SettingsView.tsx
@@ -108,8 +108,9 @@ export function SettingsView({ initialTab }: { initialTab?: Tab } = {}) {
     try {
       await api.patch<ResolvedConfig>("/api/v1/config", dirty);
       setDirty({});
-      // Kick off the restart overlay — it handles the poll loop + reload.
       await triggerRestart();
+      // For Hermes/generic the page stays; reset the button state.
+      setSaving("idle");
     } catch (err) {
       setError((err as Error).message);
       setSaving("idle");
@@ -830,7 +831,7 @@ function DangerZoneSection() {
       await api.post("/api/v1/admin/clear-data", {});
       setConfirming(false);
       setClearing(false);
-      triggerCleared();
+      await triggerCleared();
     } catch {
       setClearing(false);
       setConfirming(false);


### PR DESCRIPTION
## Summary

- **OpenClaw**: 在记忆面板保存模型配置后，自动触发 gateway 重启（通过 `process.exit(0)` + launchd respawn），前端展示全屏转圈圈 loading 页面（参考旧版 `memos-local-openclaw` 样式），轮询 `/api/v1/health` 直到服务恢复后自动刷新页面
- **Hermes**: 保持原有的底部 toast 提示，告知用户手动重启 `hermes chat`
- 后端 `POST /api/v1/admin/restart` 端点现在根据 agent 类型区分行为：OpenClaw 执行真正的进程退出，Hermes 仍为 no-op

## Test plan

- [ ] OpenClaw: 设置页修改模型配置 → 保存 → 全屏转圈圈 → gateway 自动重启 → 页面自动刷新
- [ ] Hermes: 设置页修改配置 → 保存 → 底部 toast 提示手动重启
- [ ] 超时场景: gateway 未恢复 → 显示失败提示 + 手动重启命令