### PR TITLE
fix(core): emit warn logs when LLM unavailable + configurable tool-heavy skip thresholds

### DIFF
--- a/apps/memos-local-plugin/core/config/defaults.ts
+++ b/apps/memos-local-plugin/core/config/defaults.ts
@@ -98,6 +98,8 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
       llmConcurrency: 2,
       minExchangesForCompletion: 2,
       minContentCharsForCompletion: 80,
+      toolHeavyRatio: 0.7,
+      minAssistantCharsForToolHeavy: 80,
     },
     l2Induction: {
       minSimilarity: 0.65,

--- a/apps/memos-local-plugin/core/config/schema.ts
+++ b/apps/memos-local-plugin/core/config/schema.ts
@@ -158,6 +158,19 @@ const AlgorithmSchema = Type.Object({
      * that still accepts short CJK prompts.
      */
     minContentCharsForCompletion: NumberInRange(80, 0, 4_000),
+    /**
+     * Fraction of turns that are tool calls above which an episode is
+     * considered "tool-heavy". When combined with low assistant text
+     * the episode is skipped as noise. Default 0.7 (70%).
+     */
+    toolHeavyRatio: NumberInRange(0.7, 0, 1),
+    /**
+     * Minimum total assistant content chars to keep an episode that
+     * would otherwise be flagged by the tool-heavy heuristic. If the
+     * assistant wrote at least this many characters the episode is
+     * scored normally even if tool calls dominate. Default 80.
+     */
+    minAssistantCharsForToolHeavy: NumberInRange(80, 0, 10_000),
   }, { default: {} }),
   l2Induction: Type.Object({
     /** Cosine ≥ this to associate a new trace with an existing L2 policy. */

--- a/apps/memos-local-plugin/core/memory/l2/induce.ts
+++ b/apps/memos-local-plugin/core/memory/l2/induce.ts
@@ -58,7 +58,14 @@ export async function induceDraft(
   deps: InduceDeps,
 ): Promise<InductionDraftResult> {
   const { llm, log } = deps;
-  if (!llm) return { ok: false, reason: "llm_disabled" };
+  if (!llm) {
+    log.warn("l2.induce.llm_unavailable", {
+      signatureLabel: input.signatureLabel,
+      evidenceCount: input.evidenceTraces.length,
+      fallback: "skipped",
+    });
+    return { ok: false, reason: "llm_disabled" };
+  }
 
   const userPayload = packTraces(input.evidenceTraces, input.charCap, input.signatureLabel);
 

--- a/apps/memos-local-plugin/core/memory/l3/abstract.ts
+++ b/apps/memos-local-plugin/core/memory/l3/abstract.ts
@@ -54,6 +54,14 @@ export async function abstractDraft(
 ): Promise<L3AbstractionDraftResult> {
   const { llm, log, config } = deps;
   if (!config.useLlm || !llm) {
+    const reason = !config.useLlm
+      ? "useLlm disabled in config"
+      : "llm client is null (provider not attached?)";
+    log.warn("l3.abstract.llm_unavailable", {
+      clusterPolicies: input.cluster.policies.length,
+      reason,
+      fallback: "skipped",
+    });
     return { ok: false, reason: "llm_disabled" };
   }
 

--- a/apps/memos-local-plugin/core/reward/human-scorer.ts
+++ b/apps/memos-local-plugin/core/reward/human-scorer.ts
@@ -49,12 +49,16 @@ export async function scoreHuman(input: HumanScoreInput, opts: ScoreOpts): Promi
 
   const hasLlm = Boolean(opts.cfg.llmScoring && opts.llm);
   if (!hasLlm) {
-    const h = heuristicScore(input.feedback);
-    log.debug("score.heuristic", {
+    const reason = !opts.cfg.llmScoring
+      ? "llmScoring disabled in config"
+      : "llm client is null (provider not attached?)";
+    log.warn("score.llm_unavailable", {
       episodeId: input.episodeSummary.episodeId,
+      reason,
       feedbackCount: input.feedback.length,
-      rHuman: h.rHuman,
+      fallback: "heuristic",
     });
+    const h = heuristicScore(input.feedback);
     return h;
   }
 

--- a/apps/memos-local-plugin/core/reward/reward.ts
+++ b/apps/memos-local-plugin/core/reward/reward.ts
@@ -65,6 +65,13 @@ export function createRewardRunner(deps: RewardDeps): RewardRunner {
   const log = rootLogger.child({ channel: "core.reward" });
   const now = deps.now ?? Date.now;
 
+  if (!deps.llm) {
+    log.warn("reward.llm_unavailable", {
+      impact: "R_human will use heuristic fallback (always 0 without explicit feedback); L2/Skill/L3 pipelines will be skipped",
+      fix: "configure a working LLM provider in config.yaml or ensure the host bridge is attached",
+    });
+  }
+
   async function run(input: RewardInput): Promise<RewardResult> {
     const startedAt = now() as EpochMs;
     const warnings: RewardResult["warnings"] = [];
@@ -373,7 +380,7 @@ function looksLikeTrivialContent(text: string): boolean {
 function decideSkipReason(
   snapshot: import("../session/types.js").EpisodeSnapshot,
   traces: readonly TraceRow[],
-  cfg: Pick<RewardConfig, "minExchangesForCompletion" | "minContentCharsForCompletion">,
+  cfg: Pick<RewardConfig, "minExchangesForCompletion" | "minContentCharsForCompletion" | "toolHeavyRatio" | "minAssistantCharsForToolHeavy">,
 ): string | null {
   // Prefer the live snapshot's turn list; fall back to traces when the
   // snapshot came from a SQLite row (no turns materialised).
@@ -476,12 +483,14 @@ function decideSkipReason(
     (sum, c) => sum + c.length,
     0,
   );
+  const toolHeavyRatio = cfg.toolHeavyRatio ?? 0.7;
+  const minAssistantChars = cfg.minAssistantCharsForToolHeavy ?? 80;
   if (
     toolTurns > 0 &&
     totalTurns > 0 &&
-    toolTurns >= totalTurns * 0.7 &&
+    toolTurns >= totalTurns * toolHeavyRatio &&
     userTurns <= 1 &&
-    assistantContentChars < 80
+    assistantContentChars < minAssistantChars
   ) {
     return `该任务主要由工具执行结果组成（${toolTurns}/${totalTurns} 条），缺少足够的用户交互内容。`;
   }

--- a/apps/memos-local-plugin/core/reward/types.ts
+++ b/apps/memos-local-plugin/core/reward/types.ts
@@ -52,6 +52,17 @@ export interface RewardConfig {
    * CJK or English prompt + reply, cheap enough to run offline.
    */
   minContentCharsForCompletion: number;
+  /**
+   * Fraction of turns that are tool calls above which an episode is
+   * flagged as "tool-heavy" (combined with low assistant text → skip).
+   * Default 0.7.
+   */
+  toolHeavyRatio: number;
+  /**
+   * Minimum total assistant content chars needed to keep an episode
+   * that the tool-heavy heuristic would otherwise skip. Default 80.
+   */
+  minAssistantCharsForToolHeavy: number;
 }
 
 // ─── User feedback inputs ──────────────────────────────────────────────────

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -71,7 +71,14 @@ export async function crystallizeDraft(
   }
 
   if (!config.useLlm || !llm) {
-    log.info("skill.crystallize.llm_disabled", { policyId: input.policy.id });
+    const reason = !config.useLlm
+      ? "useLlm disabled in config"
+      : "llm client is null (provider not attached?)";
+    log.warn("skill.crystallize.llm_unavailable", {
+      policyId: input.policy.id,
+      reason,
+      fallback: "skipped",
+    });
     return { ok: false, skippedReason: "llm-disabled" };
   }
 

--- a/apps/memos-local-plugin/tests/unit/reward/reward.integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/reward/reward.integration.test.ts
@@ -39,6 +39,8 @@ function cfg(): RewardConfig {
     // disable the triviality gate; real usage defaults to 2.
     minExchangesForCompletion: 0,
     minContentCharsForCompletion: 0,
+    toolHeavyRatio: 0.7,
+    minAssistantCharsForToolHeavy: 80,
   };
 }
 

--- a/apps/memos-local-plugin/tests/unit/reward/subscriber.test.ts
+++ b/apps/memos-local-plugin/tests/unit/reward/subscriber.test.ts
@@ -64,6 +64,8 @@ function cfg(windowSec = 0): RewardConfig {
     llmConcurrency: 1,
     minExchangesForCompletion: 0,
     minContentCharsForCompletion: 0,
+    toolHeavyRatio: 0.7,
+    minAssistantCharsForToolHeavy: 80,
   };
 }
 


### PR DESCRIPTION
## Summary

- 修复所有 LLM 依赖模块在 LLM 客户端为空时**静默降级**的问题，改为输出 `warn` 级别日志，便于诊断"自我进化链路未跑通"的根因
- 将 `decideSkipReason` 中硬编码的工具密集型判断阈值（`toolTurns >= totalTurns * 0.7` 和 `assistantContentChars < 80`）提取为可配置参数

## 背景

TaskCLI demo 测试（2026-04-27）发现：当 OpenClaw 的 HostLlmBridge 未注入时，`memos-local-plugin` 内部 LLM 客户端为空，导致 reward/L2/Skill/L3 全部静默退化为 heuristic/跳过，但日志中几乎看不到任何提示。此外 `decideSkipReason` 的工具密集型启发式在 OpenClaw 大量使用工具的场景下误判过多 episode 为 skip。

## Changes

| 文件 | 改动 |
|------|------|
| `core/reward/human-scorer.ts` | `debug` → `warn` `score.llm_unavailable`，附原因 |
| `core/memory/l2/induce.ts` | 新增 `warn` `l2.induce.llm_unavailable`（之前无日志） |
| `core/skill/crystallize.ts` | `info` → `warn` `skill.crystallize.llm_unavailable`，附原因 |
| `core/memory/l3/abstract.ts` | 新增 `warn` `l3.abstract.llm_unavailable`（之前无日志） |
| `core/reward/reward.ts` | 新增一次性 `warn` `reward.llm_unavailable`；`decideSkipReason` 读取可配阈值 |
| `core/reward/types.ts` | `RewardConfig` 新增 `toolHeavyRatio` + `minAssistantCharsForToolHeavy` |
| `core/config/schema.ts` | 注册两个新的 reward 配置字段 |
| `core/config/defaults.ts` | 设置默认值 0.7 / 80（保持向后兼容） |
| `tests/unit/reward/*.test.ts` | 补充新字段到测试 mock |

## Test plan

- [ ] 配置 `llm.provider: host` 但不注入 bridge → 日志应出现 `reward.llm_unavailable`、`score.llm_unavailable`、`l2.induce.llm_unavailable` 等 warn
- [ ] 配置正常 LLM → 无新增 warn，行为不变
- [ ] 在 `config.yaml` 设置 `algorithm.reward.toolHeavyRatio: 0.9` → 工具密集型 episode 不再被误判 skip
- [ ] 现有单元测试通过（`tests/unit/reward/`）