### PR TITLE
fix(core): eagerly null-out LLM client when host bridge is missing

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -68,6 +68,7 @@ import { runMigrations } from "../storage/migrator.js";
 import { makeRepos } from "../storage/repos/index.js";
 import { createEmbedder } from "../embedding/embedder.js";
 import { createLlmClient } from "../llm/client.js";
+import { getHostLlmBridge } from "../llm/host-bridge.js";
 
 import { createPipeline } from "./orchestrator.js";
 import type { PipelineDeps, PipelineHandle } from "./types.js";
@@ -161,6 +162,24 @@ export async function bootstrapMemoryCoreFull(
   } catch (err) {
     log.warn("llm.unavailable", {
       err: err instanceof Error ? err.message : String(err),
+    });
+    llm = null;
+  }
+
+  // When provider=host, the LLM client was created successfully but
+  // every call will fail at runtime if no HostLlmBridge is registered.
+  // Detect this eagerly and null-out the client so downstream modules
+  // see "no LLM" instead of burning retries on every reward/L2/skill
+  // tick. The adapter is responsible for calling registerHostLlmBridge()
+  // before core.init(); if it hasn't by now, it won't.
+  if (llm && llm.provider === "host" && !getHostLlmBridge()) {
+    log.warn("llm.host_bridge_missing", {
+      provider: "host",
+      impact: "LLM client created but no HostLlmBridge registered — " +
+        "every call would fail with LLM_UNAVAILABLE. " +
+        "Nulling out the client so reward/L2/skill/L3 skip cleanly. " +
+        "Configure a direct provider (openai_compatible, anthropic, gemini) " +
+        "or ensure the host adapter calls registerHostLlmBridge().",
     });
     llm = null;
   }


### PR DESCRIPTION
## Summary

修复 `llm.provider: host`（OpenClaw 默认配置）下 HostLlmBridge 未注入导致整条自我进化链路静默失效的问题。

## 问题

OpenClaw 默认配置 `llm.provider: host`，意思是"让宿主程序帮忙调用 AI 模型"。但实际上 OpenClaw 的 Plugin SDK 没有暴露 LLM completion 接口，adapter 中也没有（也无法）调用 `registerHostLlmBridge()`。

结果：
1. `createLlmClient({provider: "host"})` 成功创建了 client 对象（构造时不检查 bridge）
2. 下游模块看到 `llm !== null`，认为 LLM 可用
3. 每次调用时 `HostLlmProvider.complete()` 才发现 bridge 为 null，抛出 `LLM_UNAVAILABLE`
4. human-scorer / L2 induce / Skill crystallize / L3 abstract 全部走 catch 降级
5. **reward 永远 heuristic（rHuman=0）、经验/技能/环境认知全部跳过**

## 修复

在 `core/pipeline/memory-core.ts` 中，LLM client 创建后立即检测：
- 如果 `provider=host` 且 `getHostLlmBridge()` 为 null
- 输出明确的 `warn` 日志 `llm.host_bridge_missing`，说明影响和修复方法
- 将 `llm` 设为 `null`，让下游模块干净地走"无 LLM"路径

用户需要在 `config.yaml` 中把 `llm.provider` 改为直接可用的 provider（如 `openai_compatible`、`anthropic`、`gemini`）并配上 API key 和 endpoint。

## Test plan

- [ ] 默认 `host` provider + 无 bridge → 启动日志应出现 `llm.host_bridge_missing` warn
- [ ] 配置 `openai_compatible` provider + 有效 key → 正常工作，无新 warn
- [ ] health API 中 `llm.available` 应为 false（provider=host 无 bridge 时）