### PR TITLE
feat(viewer): UI improvements, global search, Hermes daemon mode

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
     pathToEsmUrl(path.resolve(__dirname, "server/http.ts"))
   )) as typeof import("./server/http.js");
 
-  const pkgVersion = "2.0.0-alpha.1";
+  const pkgVersion = require("./package.json").version;
   const { core, config, home } = await bootstrapMemoryCoreFull({
     agent: args.agent,
     pkgVersion,

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -69,16 +69,63 @@ async function main(): Promise<void> {
   });
   await core.init();
 
-  // Default transport: stdio. Daemon + TCP support arrives in V1.1.
-  const stdio = startStdioServer({ core });
-
-  // Per-agent fixed viewer port. We deliberately ignore
-  // `config.viewer.port` so old config.yaml files (which baked in
-  // the legacy single-port :18799) don't collide between agents.
-  // Users who really want a different port should `lsof`/`nc` the
-  // collision themselves rather than edit a YAML field.
+  // Per-agent fixed viewer port.
   const AGENT_DEFAULT_PORTS = { openclaw: 18799, hermes: 18800 } as const;
   const viewerPort = AGENT_DEFAULT_PORTS[args.agent];
+
+  // ─── Daemon mode ──────────────────────────────────────────────
+  // When started with `--daemon`, skip stdio and run as a pure HTTP
+  // viewer daemon. Used by install.sh (post-install) and admin/restart
+  // (self-restart) to keep the Memory Viewer always available.
+  if (args.daemon) {
+    let viewer: import("./server/types.js").ServerHandle | null = null;
+    try {
+      viewer = await startHttpServer(
+        {
+          core,
+          home,
+          logTail: () => memoryBuffer().tail({ limit: 200 }),
+        },
+        {
+          port: viewerPort,
+          host: config.viewer.bindHost,
+          staticRoot: path.resolve(__dirname, "web/dist"),
+          agent: args.agent,
+        },
+      );
+      process.stderr.write(
+        `bridge: daemon viewer live at ${viewer.url} (agent=${args.agent})\n`,
+      );
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code === "EADDRINUSE") {
+        process.stderr.write(
+          `bridge: daemon port :${viewerPort} already in use — exiting.\n`,
+        );
+        await core.shutdown();
+        process.exit(1);
+      }
+      process.stderr.write(
+        `bridge: daemon viewer failed: ${(err as Error)?.message ?? String(err)}\n`,
+      );
+      await core.shutdown();
+      process.exit(1);
+    }
+
+    const shutdownDaemon = async (sig: string) => {
+      process.stderr.write(`bridge: daemon received ${sig}, shutting down\n`);
+      try { await viewer!.close(); } catch { /* best-effort */ }
+      await core.shutdown();
+      process.exit(0);
+    };
+    process.on("SIGINT", () => void shutdownDaemon("SIGINT"));
+    process.on("SIGTERM", () => void shutdownDaemon("SIGTERM"));
+    // Process stays alive via the HTTP server's ref'd socket.
+    return;
+  }
+
+  // ─── Normal (stdio) mode ──────────────────────────────────────
+  const stdio = startStdioServer({ core });
 
   // Try to bind the viewer port. EADDRINUSE → stay headless.
   let viewer: import("./server/types.js").ServerHandle | null = null;
@@ -135,27 +182,19 @@ async function main(): Promise<void> {
 
   // If a viewer is running, keep the process alive as a daemon so the
   // memory panel stays accessible between `hermes chat` sessions.
-  // The next `hermes chat` will spawn a new headless bridge (EADDRINUSE
-  // on the viewer port); this daemon stays for the viewer only.
   if (viewer && !viewer.closed) {
     process.stderr.write(
       `bridge: stdin closed but viewer is still serving at ${viewer.url} — ` +
         `staying alive as daemon. Send SIGTERM to stop.\n`,
     );
-    // Unref'd interval keeps the event loop alive without preventing
-    // graceful exit on SIGTERM/SIGINT (handled above).
     const keepalive = setInterval(() => {
       if (viewer!.closed) {
         clearInterval(keepalive);
         void core.shutdown().then(() => process.exit(0));
       }
     }, 5_000);
-    // Don't let the keepalive timer keep the process alive if
-    // everything else (viewer, core) has been torn down.
     (keepalive as unknown as { unref?: () => void }).unref?.();
-    // ...but DO ref the viewer's server socket so the process stays
-    // alive for HTTP requests. The server is already ref'd by default.
-    return; // don't fall through to shutdown + exit
+    return;
   }
 
   // No viewer (headless bridge) — clean exit.

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -417,7 +417,12 @@ export function createMemoryCore(
           role: inferTurnRole(tc),
           action: phase === "lite" ? ("stored" as const) : ("reflected" as const),
           summary: tc.reflection?.text ?? null,
-          content: (tc.userText || tc.agentText || "").slice(0, 400),
+          content: (
+            tc.userText ||
+            tc.agentText ||
+            summarizeToolCalls(tc.toolCalls) ||
+            ""
+          ).slice(0, 400),
           traceId: tc.traceId,
         }));
         handle.repos.apiLogs.insert({
@@ -555,6 +560,40 @@ export function createMemoryCore(
   }
 
   async function health(): Promise<CoreHealth> {
+    // Read the latest on-disk config so that model names reflect what
+    // the user last saved, even before a restart applies the change.
+    let diskConfig: Record<string, unknown> | null = null;
+    try {
+      const { loadConfig } = await import("../config/index.js");
+      const { config } = await loadConfig(handle.home);
+      diskConfig = config as unknown as Record<string, unknown>;
+    } catch {
+      /* fall through to in-memory */
+    }
+
+    const llmInfo = llmHealth(handle.llm, latestTraceTs());
+    const embedderInfo = embedderHealth(handle.embedder, latestTraceTs());
+    const skillEvolverInfo = resolveSkillEvolver(
+      diskConfig ?? handle.config,
+      handle.llm,
+      latestTraceTs(),
+    );
+
+    // Override model names from disk config if they differ from the
+    // in-memory client (user saved new settings but hasn't restarted).
+    if (diskConfig) {
+      const diskLlm = diskConfig.llm as { model?: string; provider?: string } | undefined;
+      if (diskLlm?.model && diskLlm.model !== llmInfo.model) {
+        llmInfo.model = diskLlm.model;
+        if (diskLlm.provider) llmInfo.provider = diskLlm.provider;
+      }
+      const diskEmb = diskConfig.embedding as { model?: string; provider?: string } | undefined;
+      if (diskEmb?.model && diskEmb.model !== embedderInfo.model) {
+        embedderInfo.model = diskEmb.model;
+        if (diskEmb.provider) embedderInfo.provider = diskEmb.provider;
+      }
+    }
+
     return {
       ok: initialized && !shutDown,
       version: pkgVersion,
@@ -567,17 +606,9 @@ export function createMemoryCore(
         skills: home.skillsDir,
         logs: home.logsDir,
       },
-      // V7 overview card: fall back to the newest captured trace as
-      // a proxy for "LLM + embedder were OK recently" when the live
-      // `stats().lastOkAt` counter hasn't yet been populated in this
-      // process. Every captured trace is proof that reflection / α
-      // scoring (LLM) and summary embedding (embedder) both
-      // succeeded at that moment — so reading the DB max ts gives a
-      // correct, non-fabricated lower bound that survives plugin
-      // restarts without misleading the user.
-      llm: llmHealth(handle.llm, latestTraceTs()),
-      embedder: embedderHealth(handle.embedder, latestTraceTs()),
-      skillEvolver: resolveSkillEvolver(handle.config, handle.llm, latestTraceTs()),
+      llm: llmInfo,
+      embedder: embedderInfo,
+      skillEvolver: skillEvolverInfo,
     };
   }
 
@@ -1383,6 +1414,8 @@ export function createMemoryCore(
         tags: tagSet.size > 0 ? Array.from(tagSet).sort() : undefined,
         skillStatus: derivation.status,
         skillReason: derivation.reason,
+        skillReasonKey: derivation.reasonKey,
+        skillReasonParams: derivation.reasonParams,
         linkedSkillId: derivation.linkedSkillId,
         closeReason,
         abandonReason,
@@ -2490,37 +2523,52 @@ export function deriveSkillStatus(
 ): {
   status: EpisodeListItemDTO["skillStatus"];
   reason: string | null;
+  reasonKey: string | null;
+  reasonParams: Record<string, string> | null;
   linkedSkillId: SkillId | null;
 } {
   if (ep.status === "open") {
-    return { status: "queued", reason: "任务仍在进行中，技能流水线尚未启动", linkedSkillId: null };
+    return {
+      status: "queued",
+      reason: "任务仍在进行中，技能流水线尚未启动",
+      reasonKey: "tasks.skillReason.queued.inProgress",
+      reasonParams: null,
+      linkedSkillId: null,
+    };
   }
   if (ep.rTask == null) {
     return {
       status: "queued",
       reason: "Reward 评分尚未完成，技能流水线将在评分后启动",
+      reasonKey: "tasks.skillReason.queued.rewardPending",
+      reasonParams: null,
       linkedSkillId: null,
     };
   }
   if (ep.rTask <= R_NEGATIVE_FLOOR) {
     return {
       status: "skipped",
-      reason: `任务评分为明显负分 (R=${ep.rTask.toFixed(2)})，视为反例；不会沉淀出新的 L2 经验或技能，但原始 L1 轨迹会作为反面教材保留，在后续 Decision Repair 中生成 anti-pattern 规避下次同类错误`,
+      reason: `任务评分为明显负分 (R=${ep.rTask.toFixed(2)})，视为反例`,
+      reasonKey: "tasks.skillReason.skipped",
+      reasonParams: { rTask: ep.rTask.toFixed(2) },
       linkedSkillId: null,
     };
   }
   if (ep.rTask < R_BELOW_THRESHOLD) {
     return {
       status: "not_generated",
-      reason: `任务评分 R=${ep.rTask.toFixed(2)} 未达到沉淀阈值 (≥ ${R_BELOW_THRESHOLD.toFixed(2)})——对话本身正常，只是还不够强到能泛化成 L2 经验；多做几个相似任务后会自动积累`,
+      reason: `任务评分 R=${ep.rTask.toFixed(2)} 未达到沉淀阈值`,
+      reasonKey: "tasks.skillReason.not_generated.belowThreshold",
+      reasonParams: { rTask: ep.rTask.toFixed(2), threshold: R_BELOW_THRESHOLD.toFixed(2) },
       linkedSkillId: null,
     };
   }
   if (relatedPolicies.length === 0) {
     return {
       status: "not_generated",
-      reason:
-        "暂未归纳出 L2 经验——单个任务无法跨任务泛化；需要至少 2 个相似任务（minEpisodesForInduction），且 V 值 ≥ 0.1 才能触发 L2 诱导，之后支撑 ≥ 3 个相似任务才会结晶为技能",
+      reason: "暂未归纳出 L2 经验",
+      reasonKey: "tasks.skillReason.not_generated.noPolicy",
+      reasonParams: null,
       linkedSkillId: null,
     };
   }
@@ -2528,39 +2576,72 @@ export function deriveSkillStatus(
   const policyBucket = skillsByPolicy.get(best.id) ?? [];
   if (policyBucket.length > 0) {
     const active = policyBucket.find((s) => s.status !== "archived") ?? policyBucket[0]!;
+    const isUpgraded = best.updatedAt > active.updatedAt;
     return {
-      status: best.updatedAt > active.updatedAt ? "upgraded" : "generated",
+      status: isUpgraded ? "upgraded" : "generated",
       reason: `技能「${active.name ?? active.id}」已从经验 ${best.id.slice(0, 8)} 结晶`,
+      reasonKey: isUpgraded ? "tasks.skillReason.upgraded" : "tasks.skillReason.generated",
+      reasonParams: { skillName: active.name ?? active.id, policyId: best.id.slice(0, 8) },
       linkedSkillId: active.id as SkillId,
     };
   }
   if (best.status !== "active") {
     return {
       status: "queued",
-      reason: `经验 ${best.id.slice(0, 8)} 状态为 ${best.status}——需要更多支撑任务才能结晶为技能（当前 support=${best.support ?? 0}，需 ≥3）`,
+      reason: `经验 ${best.id.slice(0, 8)} 需要更多支撑任务`,
+      reasonKey: "tasks.skillReason.queued.policyPending",
+      reasonParams: { support: String(best.support ?? 0) },
       linkedSkillId: null,
     };
   }
   return {
     status: "queued",
-    reason: `经验 ${best.id.slice(0, 8)} 已就绪（gain=${best.gain.toFixed(2)}，support=${best.support ?? 0}），技能结晶将在下次 reward 评分后自动触发`,
+    reason: `经验 ${best.id.slice(0, 8)} 已就绪`,
+    reasonKey: "tasks.skillReason.queued.ready",
+    reasonParams: { gain: best.gain.toFixed(2), support: String(best.support ?? 0) },
     linkedSkillId: null,
   };
+}
+
+/**
+ * Produce a short content string from toolCalls when userText/agentText
+ * are both empty (sub-steps after the first in a multi-tool turn).
+ */
+function summarizeToolCalls(
+  toolCalls?: readonly { name?: string; output?: unknown }[] | null,
+): string {
+  if (!toolCalls || toolCalls.length === 0) return "";
+  return toolCalls
+    .map((tc) => {
+      const name = tc.name ?? "tool";
+      const out = typeof tc.output === "string"
+        ? tc.output.slice(0, 200)
+        : tc.output != null
+        ? JSON.stringify(tc.output).slice(0, 200)
+        : "";
+      return out ? `[${name}] ${out}` : `[${name}]`;
+    })
+    .join("\n");
 }
 
 /**
  * Heuristic role inference for api_logs "memory_add" rows — mirrors
  * the legacy plugin's behaviour where each captured turn showed up
  * labelled `user` / `assistant` / `tool` on the Logs page.
+ *
+ * Priority: if the step carries userText (the user's query), label it
+ * "user" even when toolCalls are present — this is the first sub-step
+ * of a multi-tool turn and semantically represents the user request.
  */
 function inferTurnRole(step: {
   userText?: string;
   agentText?: string;
   toolCalls?: readonly unknown[];
 }): "user" | "assistant" | "tool" | "other" {
-  if ((step.toolCalls?.length ?? 0) > 0) return "tool";
   const u = (step.userText ?? "").length;
   const a = (step.agentText ?? "").length;
+  if (u > 0 && (step.toolCalls?.length ?? 0) > 0) return "user";
+  if ((step.toolCalls?.length ?? 0) > 0) return "tool";
   if (u >= a && u > 0) return "user";
   if (a > 0) return "assistant";
   return "other";

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -687,38 +687,26 @@ CFGEOF
   if command -v lsof >/dev/null 2>&1 && lsof -i ":${HERMES_PORT}" -t >/dev/null 2>&1; then
     warn "Port :${HERMES_PORT} already in use — skipping smoke test."
   else
-    step "Running bridge smoke test"
+    step "Starting Memory Viewer daemon"
     local tsx_bin="${prefix}/node_modules/.bin/tsx"
     local bridge_cts="${prefix}/bridge.cts"
     if [[ -x "${tsx_bin}" && -f "${bridge_cts}" ]]; then
-      local smoke_log smoke_fifo smoke_pid sleeper_pid
-      smoke_log="$(mktemp)"
-      smoke_fifo="$(mktemp -u)"
-      mkfifo "${smoke_fifo}"
-      # Keep stdin open via a FIFO so the bridge doesn't exit on EOF.
-      sleep 60 > "${smoke_fifo}" &
-      sleeper_pid=$!
-      disown "${sleeper_pid}" 2>/dev/null || true
-      ( cd "${prefix}" && "${tsx_bin}" "${bridge_cts}" --agent=hermes <"${smoke_fifo}" >"${smoke_log}" 2>&1 ) &
-      smoke_pid=$!
-      disown "${smoke_pid}" 2>/dev/null || true
+      local daemon_log="${prefix}/logs/daemon-start.log"
+      mkdir -p "${prefix}/logs"
+      # Launch bridge in --daemon mode (pure HTTP, no stdio).
+      # The process stays alive to serve the Memory Viewer.
+      ( cd "${prefix}" && nohup "${tsx_bin}" "${bridge_cts}" --agent=hermes --daemon >"${daemon_log}" 2>&1 ) &
+      disown $! 2>/dev/null || true
 
       if wait_for_viewer "${HERMES_PORT}"; then
-        success "Bridge smoke test passed"
+        success "Memory Viewer daemon running"
       else
         error "Memory Viewer did not respond within 30s."
         warn "Re-install dependencies and re-run: cd ${prefix} && npm install"
-        kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-        kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-        rm -f "${smoke_log}" "${smoke_fifo}"
         return 1
       fi
-
-      kill "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-      kill -9 "${smoke_pid}" "${sleeper_pid}" >/dev/null 2>&1 || true
-      rm -f "${smoke_log}" "${smoke_fifo}"
     else
-      warn "tsx not found — skipping smoke test."
+      warn "tsx not found — skipping daemon start."
     fi
   fi
 

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -42,8 +42,10 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
-    // Hermes (and others): spawn a replacement daemon bridge before
-    // exiting so the viewer port is re-bound with fresh config.
+    // Hermes (and others): exit first (releasing the port), then a
+    // small wrapper script spawns the new daemon. We use a shell
+    // one-liner that sleeps briefly (for port release) then starts
+    // the new daemon.
     const nodePath = await import("node:path");
     const { fileURLToPath } = await import("node:url");
     const { spawn } = await import("node:child_process");
@@ -51,13 +53,15 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
     const pluginRoot = nodePath.resolve(nodePath.dirname(thisFile), "../..");
     const tsxBin = nodePath.join(pluginRoot, "node_modules/.bin/tsx");
     const bridgeScript = nodePath.join(pluginRoot, "bridge.cts");
-    const child = spawn(tsxBin, [bridgeScript, `--agent=${agent}`, "--daemon"], {
+
+    const cmd = `sleep 1 && "${tsxBin}" "${bridgeScript}" --agent=${agent} --daemon`;
+    const child = spawn("bash", ["-c", cmd], {
       detached: true,
       stdio: "ignore",
       cwd: pluginRoot,
     });
     child.unref();
-    setTimeout(() => process.exit(0), 600);
+    setTimeout(() => process.exit(0), 200);
     return { ok: true, restarting: true };
   });
 }

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -42,7 +42,9 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
-    // Hermes / other hosts: no-op — the viewer shows a manual-restart toast.
-    return { ok: true, restarting: false, note: "config persisted; restart the agent process to apply" };
+    // Hermes: the bridge IS the current process. Exit so that the next
+    // `hermes chat` invocation spawns a fresh bridge with updated config.
+    setTimeout(() => process.exit(0), 300);
+    return { ok: true, restarting: true };
   });
 }

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -12,8 +12,9 @@
  *       Agent-aware restart. For OpenClaw the plugin lives inside the
  *       gateway process, which is managed by macOS launchd — calling
  *       `process.exit(0)` causes launchd to respawn it automatically.
- *       For Hermes and other hosts, the endpoint is a no-op (the
- *       viewer shows a manual-restart toast instead).
+ *       For Hermes: spawn a new bridge in --daemon mode, then exit the
+ *       current process. The new daemon takes over the viewer port so
+ *       the Memory Viewer stays available without user intervention.
  */
 import type { ServerDeps, ServerOptions } from "../types.js";
 import type { Routes } from "./registry.js";
@@ -38,13 +39,25 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
   routes.set("POST /api/v1/admin/restart", async (_ctx) => {
     const agent = options.agent ?? "unknown";
     if (agent === "openclaw") {
-      // OpenClaw gateway is managed by launchd — exit and let it respawn.
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
-    // Hermes: the bridge IS the current process. Exit so that the next
-    // `hermes chat` invocation spawns a fresh bridge with updated config.
-    setTimeout(() => process.exit(0), 300);
+    // Hermes (and others): spawn a replacement daemon bridge before
+    // exiting so the viewer port is re-bound with fresh config.
+    const nodePath = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const { spawn } = await import("node:child_process");
+    const thisFile = fileURLToPath(import.meta.url);
+    const pluginRoot = nodePath.resolve(nodePath.dirname(thisFile), "../..");
+    const tsxBin = nodePath.join(pluginRoot, "node_modules/.bin/tsx");
+    const bridgeScript = nodePath.join(pluginRoot, "bridge.cts");
+    const child = spawn(tsxBin, [bridgeScript, `--agent=${agent}`, "--daemon"], {
+      detached: true,
+      stdio: "ignore",
+      cwd: pluginRoot,
+    });
+    child.unref();
+    setTimeout(() => process.exit(0), 600);
     return { ok: true, restarting: true };
   });
 }

--- a/apps/memos-local-plugin/server/routes/session.ts
+++ b/apps/memos-local-plugin/server/routes/session.ts
@@ -57,6 +57,7 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
 
   routes.set("GET /api/v1/episodes", async (ctx) => {
     const sessionId = (ctx.url.searchParams.get("sessionId") as SessionId | null) ?? undefined;
+    const q = (ctx.url.searchParams.get("q") || "").trim().toLowerCase();
     const rawLimit = numberOrUndefined(ctx.url.searchParams.get("limit"));
     const rawOffset = numberOrUndefined(ctx.url.searchParams.get("offset"));
     const limit = rawLimit && rawLimit > 0 ? rawLimit : 50;
@@ -76,7 +77,24 @@ export function registerSessionRoutes(routes: Routes, deps: ServerDeps): void {
         nextOffset: episodeIds.length === limit ? offset + limit : undefined,
       };
     }
-    const episodes = await deps.core.listEpisodeRows({ sessionId, limit, offset });
+    let episodes = await deps.core.listEpisodeRows({
+      sessionId,
+      limit: q ? 200 : limit,
+      offset: q ? 0 : offset,
+    });
+    if (q) {
+      episodes = episodes.filter(
+        (ep: { preview?: string }) => ep.preview && ep.preview.toLowerCase().includes(q),
+      );
+      const paged = episodes.slice(offset, offset + limit);
+      return {
+        episodes: paged,
+        limit,
+        offset,
+        total: episodes.length,
+        nextOffset: episodes.length > offset + limit ? offset + limit : undefined,
+      };
+    }
     return {
       episodes,
       limit,

--- a/apps/memos-local-plugin/server/routes/skill.ts
+++ b/apps/memos-local-plugin/server/routes/skill.ts
@@ -14,14 +14,20 @@ import { parseJson, writeError, type Routes } from "./registry.js";
 export function registerSkillRoutes(routes: Routes, deps: ServerDeps): void {
   routes.set("GET /api/v1/skills", async (ctx) => {
     const status = (ctx.url.searchParams.get("status") as SkillDTO["status"] | null) ?? undefined;
+    const q = (ctx.url.searchParams.get("q") || "").trim().toLowerCase();
     // Viewer needs prev/next pagination — ask for one extra page so we
     // can tell the client whether there's more without a count query.
     const pageSize = limitOrUndefined(ctx.url.searchParams.get("limit")) ?? 50;
     const offset = Math.max(0, Number(ctx.url.searchParams.get("offset") ?? 0) || 0);
-    const all = await deps.core.listSkills({ status, limit: pageSize + offset + 1 });
+    let all = await deps.core.listSkills({ status, limit: q ? 5000 : pageSize + offset + 1 });
+    if (q) {
+      all = all.filter(
+        (s) => s.name.toLowerCase().includes(q) || s.invocationGuide.toLowerCase().includes(q),
+      );
+    }
     const page = all.slice(offset, offset + pageSize);
     const hasMore = all.length > offset + pageSize;
-    const total = await deps.core.countSkills({ status });
+    const total = q ? all.length : await deps.core.countSkills({ status });
     return {
       skills: page,
       limit: pageSize,

--- a/apps/memos-local-plugin/web/src/components/Header.tsx
+++ b/apps/memos-local-plugin/web/src/components/Header.tsx
@@ -1,41 +1,183 @@
 /**
- * Top bar — brand (logo + version pill), global search, peer agents,
- * theme + language switchers. The notification bell was removed in
- * favour of inline toasts; per-event status now surfaces in Logs/Live.
+ * Top bar — brand (logo + version pill), global search with categorized
+ * dropdown, peer agents, theme + language switchers.
  */
-import { useState, useEffect } from "preact/hooks";
+import { useState, useEffect, useRef, useCallback } from "preact/hooks";
 import { t } from "../stores/i18n";
 import { health } from "../stores/health";
 import { peers, discoverPeers } from "../stores/peers";
-import { Icon } from "./Icon";
+import { Icon, type IconName } from "./Icon";
 import { navigate } from "../stores/router";
 import { ThemeLangFooter } from "./ThemeLangFooter";
+import { api } from "../api/client";
+
+interface SearchCategory {
+  key: string;
+  icon: IconName;
+  labelKey: string;
+  route: string;
+  items: { id: string; text: string }[];
+  loading: boolean;
+}
 
 export function Header() {
   const h = health.value;
   const [searchQ, setSearchQ] = useState("");
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [categories, setCategories] = useState<SearchCategory[]>([]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const runSearch = (e: Event) => {
     e.preventDefault();
     const q = searchQ.trim();
     if (!q) return;
+    setShowDropdown(false);
     navigate("/memories", { q });
   };
 
-  // Discover other agent viewers running on nearby ports once after
-  // health is known. Updates `peers` for the agent switcher.
+  const fetchResults = useCallback(async (q: string) => {
+    if (abortRef.current) abortRef.current.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
+    const empty: SearchCategory[] = [
+      { key: "memories", icon: "brain-circuit", labelKey: "nav.memories", route: "/memories", items: [], loading: true },
+      { key: "tasks", icon: "list-checks", labelKey: "nav.tasks", route: "/tasks", items: [], loading: true },
+      { key: "skills", icon: "wand-sparkles", labelKey: "nav.skills", route: "/skills", items: [], loading: true },
+      { key: "policies", icon: "sparkles", labelKey: "nav.policies", route: "/policies", items: [], loading: true },
+      { key: "world-models", icon: "globe", labelKey: "nav.worldModels", route: "/world-models", items: [], loading: true },
+    ];
+    setCategories(empty);
+    setShowDropdown(true);
+
+    const signal = ctrl.signal;
+    const limit = 3;
+
+    const fetchers = [
+      api
+        .get<{ traces: { id: string; summary?: string; userText?: string }[] }>(
+          `/api/v1/traces?q=${encodeURIComponent(q)}&limit=${limit}`,
+          { signal },
+        )
+        .then((r) =>
+          (r.traces ?? []).map((t) => ({
+            id: t.id,
+            text: (t.summary || t.userText || "").slice(0, 80),
+          })),
+        )
+        .catch(() => [] as { id: string; text: string }[]),
+
+      api
+        .get<{ episodes: { id: string; preview?: string }[] }>(
+          `/api/v1/episodes?q=${encodeURIComponent(q)}&limit=${limit}`,
+          { signal },
+        )
+        .then((r) =>
+          (r.episodes ?? []).map((ep) => ({
+            id: ep.id,
+            text: (ep.preview || "").slice(0, 80),
+          })),
+        )
+        .catch(() => [] as { id: string; text: string }[]),
+
+      api
+        .get<{ skills: { id: string; name: string }[] }>(
+          `/api/v1/skills?q=${encodeURIComponent(q)}&limit=${limit}`,
+          { signal },
+        )
+        .then((r) =>
+          (r.skills ?? []).map((s) => ({
+            id: s.id,
+            text: s.name,
+          })),
+        )
+        .catch(() => [] as { id: string; text: string }[]),
+
+      api
+        .get<{ policies: { id: string; title?: string; trigger?: string }[] }>(
+          `/api/v1/policies?q=${encodeURIComponent(q)}&limit=${limit}`,
+          { signal },
+        )
+        .then((r) =>
+          (r.policies ?? []).map((p) => ({
+            id: p.id,
+            text: (p.title || p.trigger || "").slice(0, 80),
+          })),
+        )
+        .catch(() => [] as { id: string; text: string }[]),
+
+      api
+        .get<{ worldModels: { id: string; title?: string }[] }>(
+          `/api/v1/world-models?q=${encodeURIComponent(q)}&limit=${limit}`,
+          { signal },
+        )
+        .then((r) =>
+          (r.worldModels ?? []).map((w) => ({
+            id: w.id,
+            text: (w.title || "").slice(0, 80),
+          })),
+        )
+        .catch(() => [] as { id: string; text: string }[]),
+    ];
+
+    const results = await Promise.allSettled(fetchers);
+    if (signal.aborted) return;
+
+    setCategories((prev) =>
+      prev.map((cat, i) => ({
+        ...cat,
+        items: results[i].status === "fulfilled" ? results[i].value : [],
+        loading: false,
+      })),
+    );
+  }, []);
+
+  useEffect(() => {
+    const q = searchQ.trim();
+    if (!q) {
+      setShowDropdown(false);
+      setCategories([]);
+      return;
+    }
+    const timer = setTimeout(() => void fetchResults(q), 250);
+    return () => clearTimeout(timer);
+  }, [searchQ, fetchResults]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleItemClick = (cat: SearchCategory, itemId: string) => {
+    setShowDropdown(false);
+    setSearchQ("");
+    navigate(cat.route, { q: searchQ.trim() });
+  };
+
+  const handleCategoryMore = (cat: SearchCategory) => {
+    setShowDropdown(false);
+    setSearchQ("");
+    navigate(cat.route, { q: searchQ.trim() });
+  };
+
   const peerList = peers.value;
   useEffect(() => {
     if (!h?.agent) return;
     void discoverPeers();
   }, [h?.agent]);
 
+  const totalResults = categories.reduce((sum, c) => sum + c.items.length, 0);
+  const anyLoading = categories.some((c) => c.loading);
+
   return (
     <div class="topbar">
       <div class="topbar__brand">
-        {/*
-         * Brand: local MemOS logo + a small OpenClaw/Hermes agent icon.
-         */}
         <span class="topbar__brand-mark" aria-hidden="true">
           <img
             src="logo.svg"
@@ -56,14 +198,6 @@ export function Header() {
             aria-label={h.agent}
             style="margin-left:var(--sp-2);display:inline-flex;align-items:center"
           >
-            {/*
-             * Match the MemOS brand pill's visible glyph size (24×24).
-             * Previously the agent mark was 22×22 and sat naked —
-             * without the indigo container `.topbar__brand-mark` the
-             * eye perceives a smaller silhouette. Bumping the image to
-             * 28 closes the gap so MemOS and OpenClaw/Hermes marks
-             * read as equal in the top bar.
-             */}
             <img
               src={h.agent === "hermes" ? "hermes-logo.svg" : "openclaw-logo.svg"}
               alt={h.agent}
@@ -96,7 +230,7 @@ export function Header() {
         )}
       </div>
 
-      <div class="topbar__center">
+      <div class="topbar__center" ref={containerRef}>
         <form
           role="search"
           class="topbar__search-form"
@@ -118,9 +252,58 @@ export function Header() {
               aria-label={t("common.search")}
               value={searchQ}
               onInput={(e) => setSearchQ((e.target as HTMLInputElement).value)}
+              onFocus={() => {
+                if (searchQ.trim() && categories.length > 0) setShowDropdown(true);
+              }}
             />
           </label>
         </form>
+
+        {showDropdown && (
+          <div class="search-dropdown">
+            {anyLoading && totalResults === 0 && (
+              <div class="search-dropdown__loading">
+                <Icon name="loader-2" size={14} />
+                <span>{t("common.search")}...</span>
+              </div>
+            )}
+            {!anyLoading && totalResults === 0 && (
+              <div class="search-dropdown__empty">
+                {t("header.search.noResults")}
+              </div>
+            )}
+            {categories
+              .filter((c) => c.items.length > 0)
+              .map((cat) => (
+                <div class="search-dropdown__section" key={cat.key}>
+                  <div class="search-dropdown__section-header">
+                    <Icon name={cat.icon} size={14} />
+                    <span>{t(cat.labelKey as any)}</span>
+                  </div>
+                  <ul class="search-dropdown__list">
+                    {cat.items.map((item) => (
+                      <li key={item.id}>
+                        <button
+                          class="search-dropdown__item"
+                          onClick={() => handleItemClick(cat, item.id)}
+                        >
+                          <span class="search-dropdown__item-text">
+                            {item.text || item.id}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    class="search-dropdown__more"
+                    onClick={() => handleCategoryMore(cat)}
+                  >
+                    {t("header.search.viewAll")} →
+                  </button>
+                </div>
+              ))}
+          </div>
+        )}
       </div>
 
       <div class="topbar__actions">

--- a/apps/memos-local-plugin/web/src/components/Markdown.tsx
+++ b/apps/memos-local-plugin/web/src/components/Markdown.tsx
@@ -1,0 +1,127 @@
+/**
+ * Lightweight Markdown renderer for chat bubbles.
+ *
+ * Converts a subset of Markdown to HTML without external dependencies.
+ * Supports: fenced code blocks, inline code, bold, italic, headers,
+ * links, unordered/ordered lists, and line breaks.
+ *
+ * Security: output is sanitized (no raw HTML passthrough).
+ */
+
+const ESC: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ESC[c] ?? c);
+}
+
+function renderMarkdown(src: string): string {
+  const lines = src.split("\n");
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    // Fenced code block
+    if (line.startsWith("```")) {
+      const lang = line.slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i]!.startsWith("```")) {
+        codeLines.push(lines[i]!);
+        i++;
+      }
+      i++; // skip closing ```
+      const langAttr = lang ? ` class="language-${esc(lang)}"` : "";
+      out.push(
+        `<pre class="md-pre"><code${langAttr}>${esc(codeLines.join("\n"))}</code></pre>`,
+      );
+      continue;
+    }
+
+    // Heading
+    const headingMatch = line.match(/^(#{1,4})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1]!.length;
+      out.push(`<h${level + 2} class="md-heading">${inlineFormat(headingMatch[2]!)}</h${level + 2}>`);
+      i++;
+      continue;
+    }
+
+    // Unordered list
+    if (/^[\-\*]\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[\-\*]\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^[\-\*]\s+/, ""));
+        i++;
+      }
+      out.push(
+        `<ul class="md-list">${items.map((it) => `<li>${inlineFormat(it)}</li>`).join("")}</ul>`,
+      );
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\.\s+/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i]!)) {
+        items.push(lines[i]!.replace(/^\d+\.\s+/, ""));
+        i++;
+      }
+      out.push(
+        `<ol class="md-list">${items.map((it) => `<li>${inlineFormat(it)}</li>`).join("")}</ol>`,
+      );
+      continue;
+    }
+
+    // Empty line = paragraph break
+    if (line.trim() === "") {
+      out.push("<br/>");
+      i++;
+      continue;
+    }
+
+    // Normal paragraph
+    out.push(`<p class="md-p">${inlineFormat(line)}</p>`);
+    i++;
+  }
+
+  return out.join("");
+}
+
+function inlineFormat(text: string): string {
+  let s = esc(text);
+  // Inline code
+  s = s.replace(/`([^`]+)`/g, '<code class="md-code">$1</code>');
+  // Bold
+  s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/__(.+?)__/g, "<strong>$1</strong>");
+  // Italic
+  s = s.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  s = s.replace(/_(.+?)_/g, "<em>$1</em>");
+  // Strikethrough
+  s = s.replace(/~~(.+?)~~/g, "<del>$1</del>");
+  // Links
+  s = s.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener">$1</a>',
+  );
+  return s;
+}
+
+export function Markdown({ text }: { text: string }) {
+  if (!text) return null;
+  const html = renderMarkdown(text);
+  return (
+    <div
+      class="md-content"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -40,9 +40,11 @@ const en = {
   "nav.section.system": "System",
 
   // Header.
-  "header.brand": "MemOS Local",
-  "header.subtitle": "Local memory viewer",
+  "header.brand": "MemOS",
+  "header.subtitle": "Memory viewer",
   "header.search.placeholder": "Search anywhere…",
+  "header.search.noResults": "No results found",
+  "header.search.viewAll": "View all",
   "header.lang.en": "EN",
   "header.lang.zh": "中",
   "header.theme.light": "Switch to light",
@@ -412,6 +414,26 @@ const en = {
   "tasks.skill.not_generated": "Below induction threshold",
   "tasks.skill.skipped": "Scored as negative example (R ≤ -0.5)",
   "tasks.skill.openSkill": "Open skill",
+  "tasks.skillReason.queued.inProgress":
+    "Task still in progress; skill pipeline has not started yet.",
+  "tasks.skillReason.queued.rewardPending":
+    "Reward scoring not yet complete; skill pipeline will start after scoring.",
+  "tasks.skillReason.queued.policyPending":
+    "Experience is not yet active — needs more supporting tasks to crystallize into a skill (current support: {support}, required: ≥ 3).",
+  "tasks.skillReason.queued.ready":
+    "Experience is ready (gain={gain}, support={support}); skill crystallization will trigger automatically after the next reward scoring.",
+  "tasks.skillReason.skipped":
+    "Task scored significantly negative (R={rTask}), treated as counterexample; no L2 experience or skill will be derived, but L1 traces are retained as negative examples for future Decision Repair.",
+  "tasks.skillReason.not_generated.belowThreshold":
+    "Task score R={rTask} is below the induction threshold (≥ {threshold}) — the conversation was normal, but not strong enough to generalize into an L2 experience; similar tasks will accumulate over time.",
+  "tasks.skillReason.not_generated.noPolicy":
+    "No L2 experience induced yet — a single task cannot generalize across tasks; requires at least 2 similar tasks (minEpisodesForInduction) with V ≥ 0.1 to trigger L2 induction, then ≥ 3 supporting tasks to crystallize into a skill.",
+  "tasks.skillReason.generated":
+    "Skill \"{skillName}\" crystallized from experience {policyId}.",
+  "tasks.skillReason.upgraded":
+    "Skill \"{skillName}\" upgraded from experience {policyId}.",
+  "tasks.abandonReason.uncleanExit":
+    "Plugin did not exit cleanly last time; incomplete tasks were automatically closed on startup.",
 
   // Skills.
   "skills.title": "Skills",
@@ -609,6 +631,7 @@ const en = {
   "settings.skill.desc":
     "Model that turns proven experiences into reusable skills and keeps environment knowledge up to date.",
   "settings.hub.enabled": "Enable team sharing",
+  "settings.hub.subtitle": "Share your skills and (optionally) memories with teammates.",
   "settings.hub.role": "Role",
   "settings.hub.role.hub": "Host a hub",
   "settings.hub.role.client": "Join a hub",
@@ -656,9 +679,11 @@ const zh: Record<TranslationKey, string> = {
   "nav.section.insights": "洞察",
   "nav.section.system": "系统",
 
-  "header.brand": "MemOS 本地",
-  "header.subtitle": "本地记忆面板",
+  "header.brand": "MemOS",
+  "header.subtitle": "记忆面板",
   "header.search.placeholder": "全局搜索…",
+  "header.search.noResults": "未找到匹配结果",
+  "header.search.viewAll": "查看全部",
   "header.lang.en": "EN",
   "header.lang.zh": "中",
   "header.theme.light": "切换为浅色",
@@ -995,6 +1020,26 @@ const zh: Record<TranslationKey, string> = {
   "tasks.skill.not_generated": "未达沉淀阈值",
   "tasks.skill.skipped": "本任务评为反例 (R ≤ -0.5)",
   "tasks.skill.openSkill": "打开技能",
+  "tasks.skillReason.queued.inProgress":
+    "任务仍在进行中，技能流水线尚未启动。",
+  "tasks.skillReason.queued.rewardPending":
+    "Reward 评分尚未完成，技能流水线将在评分后启动。",
+  "tasks.skillReason.queued.policyPending":
+    "经验尚未激活——需要更多支撑任务才能结晶为技能（当前 support={support}，需 ≥3）。",
+  "tasks.skillReason.queued.ready":
+    "经验已就绪（gain={gain}，support={support}），技能结晶将在下次 reward 评分后自动触发。",
+  "tasks.skillReason.skipped":
+    "任务评分为明显负分 (R={rTask})，视为反例；不会沉淀出新的 L2 经验或技能，但原始 L1 轨迹会作为反面教材保留，在后续 Decision Repair 中生成规避建议。",
+  "tasks.skillReason.not_generated.belowThreshold":
+    "任务评分 R={rTask} 未达到沉淀阈值 (≥ {threshold})——对话本身正常，只是还不够强到能泛化成 L2 经验；多做几个相似任务后会自动积累。",
+  "tasks.skillReason.not_generated.noPolicy":
+    "暂未归纳出 L2 经验——单个任务无法跨任务泛化；需要至少 2 个相似任务（minEpisodesForInduction），且 V 值 ≥ 0.1 才能触发 L2 诱导，之后支撑 ≥ 3 个相似任务才会结晶为技能。",
+  "tasks.skillReason.generated":
+    "技能「{skillName}」已从经验 {policyId} 结晶。",
+  "tasks.skillReason.upgraded":
+    "技能「{skillName}」已从经验 {policyId} 升级。",
+  "tasks.abandonReason.uncleanExit":
+    "插件上次未正常退出，启动时自动关闭未完成的任务。",
 
   "skills.title": "技能",
   "skills.subtitle": "从成功任务中沉淀出来、可以重复调用的能力。",
@@ -1177,6 +1222,7 @@ const zh: Record<TranslationKey, string> = {
   "settings.skill.title": "技能进化",
   "settings.skill.desc": "用于把稳定的经验转成可调用技能，并维护环境认知的模型。",
   "settings.hub.enabled": "启用团队分享",
+  "settings.hub.subtitle": "与团队成员分享你的技能和（可选的）记忆。",
   "settings.hub.role": "角色",
   "settings.hub.role.hub": "托管 Hub",
   "settings.hub.role.client": "加入 Hub",

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -80,19 +80,22 @@ async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
 }
 
 /**
- * Config saved. For OpenClaw: auto-restart with spinner overlay.
- * For Hermes/others: show a dismissible toast.
+ * Config saved. Trigger a restart for any agent — the backend now
+ * exits on POST /api/v1/admin/restart for both OpenClaw and Hermes.
+ * OpenClaw: launchd respawns automatically → poll until up → reload.
+ * Hermes: bridge exits → viewer goes down → show toast telling user
+ * to run `hermes chat` again.
  */
 export async function triggerRestart(
   _opts: TriggerRestartOptions = {},
 ): Promise<void> {
+  restartState.value = { phase: "restarting" };
+  try {
+    await api.post("/api/v1/admin/restart");
+  } catch {
+    // Server might already be going down
+  }
   if (isOpenClaw()) {
-    restartState.value = { phase: "restarting" };
-    try {
-      await api.post("/api/v1/admin/restart");
-    } catch {
-      // Server might already be going down
-    }
     const ok = await pollHealthUntilUp(60);
     if (ok) {
       window.location.href =
@@ -101,7 +104,7 @@ export async function triggerRestart(
       restartState.value = { phase: "restartFailed" };
     }
   } else {
-    restartState.value = { phase: "saved" };
+    restartState.value = { phase: "saved", message: "restartHermes" };
     scheduleDismiss();
   }
 }

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -3,15 +3,15 @@
  *
  * Unified flow for all agents: POST `/api/v1/admin/restart` triggers
  * the backend to spawn a fresh daemon bridge and exit. The frontend
- * shows a full-screen spinner and polls `/api/v1/health` until the new
- * process is live, then reloads the page.
+ * polls `/api/v1/health` until the new process is live, then reloads.
  *
- *   - OpenClaw: launchd respawns the gateway automatically.
+ *   - OpenClaw: launchd respawns the gateway — may take a few seconds.
  *   - Hermes: the restart endpoint spawns `bridge.cts --daemon` before
- *     exiting, so the viewer comes back without user intervention.
+ *     exiting, so the viewer comes back almost immediately.
  */
 import { signal } from "@preact/signals";
 import { api } from "../api/client";
+import { health } from "./health";
 
 export type RestartPhase =
   | "idle"
@@ -27,6 +27,10 @@ export const restartState = signal<{ phase: RestartPhase; message?: string }>({
 
 export interface TriggerRestartOptions {
   kick?: "restart-endpoint" | "skip";
+}
+
+function isOpenClaw(): boolean {
+  return health.value?.agent === "openclaw";
 }
 
 async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
@@ -59,6 +63,23 @@ async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
 }
 
 /**
+ * Quick health check — just verify the server responds once.
+ * Used for Hermes where the new daemon is already up before the old exits.
+ */
+async function quickPollUp(maxAttempts = 10): Promise<boolean> {
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise((r) => setTimeout(r, 800));
+    try {
+      const res = await fetch("/api/v1/health");
+      if (res.ok || res.status === 401 || res.status === 403) return true;
+    } catch {
+      /* server still transitioning */
+    }
+  }
+  return false;
+}
+
+/**
  * Config saved. Trigger a restart for any agent. The backend spawns a
  * fresh daemon bridge before exiting, so the viewer port comes back up
  * automatically for both OpenClaw (launchd) and Hermes (self-respawn).
@@ -72,12 +93,24 @@ export async function triggerRestart(
   } catch {
     // Server might already be going down
   }
-  const ok = await pollHealthUntilUp(60);
-  if (ok) {
-    window.location.href =
-      window.location.pathname + "?_t=" + Date.now();
+
+  if (isOpenClaw()) {
+    const ok = await pollHealthUntilUp(60);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
   } else {
-    restartState.value = { phase: "restartFailed" };
+    // Hermes: new daemon spawns before old exits, transition is fast.
+    const ok = await quickPollUp(10);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
   }
 }
 
@@ -86,20 +119,26 @@ export async function triggerRestart(
  */
 export async function triggerCleared(): Promise<void> {
   restartState.value = { phase: "restarting" };
-  const ok = await pollHealthUntilUp(60);
-  if (ok) {
-    window.location.href =
-      window.location.pathname + "?_t=" + Date.now();
+  if (isOpenClaw()) {
+    const ok = await pollHealthUntilUp(60);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
   } else {
-    restartState.value = { phase: "restartFailed" };
+    const ok = await quickPollUp(10);
+    if (ok) {
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } else {
+      restartState.value = { phase: "restartFailed" };
+    }
   }
 }
 
 /** Dismiss the banner immediately (e.g. user clicked the close button). */
 export function dismissRestartBanner(): void {
-  if (dismissTimer) {
-    clearTimeout(dismissTimer);
-    dismissTimer = null;
-  }
   restartState.value = { phase: "idle" };
 }

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -1,22 +1,17 @@
 /**
  * Config-save restart state manager.
  *
- * Two distinct flows based on agent type:
+ * Unified flow for all agents: POST `/api/v1/admin/restart` triggers
+ * the backend to spawn a fresh daemon bridge and exit. The frontend
+ * shows a full-screen spinner and polls `/api/v1/health` until the new
+ * process is live, then reloads the page.
  *
- *   - **OpenClaw**: the plugin runs inside the `openclaw-gateway` process
- *     which is managed by macOS launchd. We POST `/api/v1/admin/restart`
- *     to trigger `process.exit(0)`, launchd respawns the gateway, and
- *     we poll `/api/v1/health` until the service comes back, then reload.
- *     During this time a full-screen spinner overlay is shown.
- *
- *   - **Hermes**: the bridge is spawned via Python `subprocess.Popen` on
- *     demand; once it exits, hermes doesn't bring it back until the next
- *     `hermes chat` invocation. So we only show a dismissible toast
- *     telling the user to restart manually.
+ *   - OpenClaw: launchd respawns the gateway automatically.
+ *   - Hermes: the restart endpoint spawns `bridge.cts --daemon` before
+ *     exiting, so the viewer comes back without user intervention.
  */
 import { signal } from "@preact/signals";
 import { api } from "../api/client";
-import { health } from "./health";
 
 export type RestartPhase =
   | "idle"
@@ -30,24 +25,8 @@ export const restartState = signal<{ phase: RestartPhase; message?: string }>({
   phase: "idle",
 });
 
-const TOAST_DISMISS_MS = 8_000;
-
-let dismissTimer: ReturnType<typeof setTimeout> | null = null;
-
-function scheduleDismiss(): void {
-  if (dismissTimer) clearTimeout(dismissTimer);
-  dismissTimer = setTimeout(() => {
-    restartState.value = { phase: "idle" };
-    dismissTimer = null;
-  }, TOAST_DISMISS_MS);
-}
-
 export interface TriggerRestartOptions {
   kick?: "restart-endpoint" | "skip";
-}
-
-function isOpenClaw(): boolean {
-  return health.value?.agent === "openclaw";
 }
 
 async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
@@ -80,11 +59,9 @@ async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
 }
 
 /**
- * Config saved. Trigger a restart for any agent — the backend now
- * exits on POST /api/v1/admin/restart for both OpenClaw and Hermes.
- * OpenClaw: launchd respawns automatically → poll until up → reload.
- * Hermes: bridge exits → viewer goes down → show toast telling user
- * to run `hermes chat` again.
+ * Config saved. Trigger a restart for any agent. The backend spawns a
+ * fresh daemon bridge before exiting, so the viewer port comes back up
+ * automatically for both OpenClaw (launchd) and Hermes (self-respawn).
  */
 export async function triggerRestart(
   _opts: TriggerRestartOptions = {},
@@ -95,37 +72,26 @@ export async function triggerRestart(
   } catch {
     // Server might already be going down
   }
-  if (isOpenClaw()) {
-    const ok = await pollHealthUntilUp(60);
-    if (ok) {
-      window.location.href =
-        window.location.pathname + "?_t=" + Date.now();
-    } else {
-      restartState.value = { phase: "restartFailed" };
-    }
+  const ok = await pollHealthUntilUp(60);
+  if (ok) {
+    window.location.href =
+      window.location.pathname + "?_t=" + Date.now();
   } else {
-    restartState.value = { phase: "saved", message: "restartHermes" };
-    scheduleDismiss();
+    restartState.value = { phase: "restartFailed" };
   }
 }
 
 /**
- * Data cleared. For OpenClaw: auto-restart with spinner.
- * For Hermes/others: show toast.
+ * Data cleared. Both agents self-respawn via the daemon mechanism.
  */
 export async function triggerCleared(): Promise<void> {
-  if (isOpenClaw()) {
-    restartState.value = { phase: "restarting" };
-    const ok = await pollHealthUntilUp(60);
-    if (ok) {
-      window.location.href =
-        window.location.pathname + "?_t=" + Date.now();
-    } else {
-      restartState.value = { phase: "restartFailed" };
-    }
+  restartState.value = { phase: "restarting" };
+  const ok = await pollHealthUntilUp(60);
+  if (ok) {
+    window.location.href =
+      window.location.pathname + "?_t=" + Date.now();
   } else {
-    restartState.value = { phase: "cleared" };
-    scheduleDismiss();
+    restartState.value = { phase: "restartFailed" };
   }
 }
 

--- a/apps/memos-local-plugin/web/src/styles/components.css
+++ b/apps/memos-local-plugin/web/src/styles/components.css
@@ -1210,7 +1210,6 @@
   line-height: 1.6;
   padding: 10px 14px;
   border-radius: 12px 12px 12px 4px;
-  white-space: pre-wrap;
   word-break: break-word;
 }
 .chat-item--user .chat-item__bubble {
@@ -1359,6 +1358,70 @@
 }
 .chat-item__bubble--error .chat-item__tool-header {
   color: var(--red);
+}
+
+/* ── Markdown content in chat bubbles ─────────────────────────── */
+.md-content {
+  overflow: hidden;
+}
+.md-content .md-p {
+  margin: 0 0 0.4em 0;
+}
+.md-content .md-p:last-child {
+  margin-bottom: 0;
+}
+.md-content .md-heading {
+  margin: 0.6em 0 0.3em 0;
+  font-size: 1em;
+  font-weight: var(--fw-semi);
+}
+.md-content .md-code {
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+}
+.md-content .md-pre {
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--sp-3);
+  margin: 0.5em 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.md-content .md-pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+.md-content .md-list {
+  margin: 0.4em 0;
+  padding-left: 1.4em;
+}
+.md-content .md-list li {
+  margin: 0.15em 0;
+}
+.md-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.md-content a:hover {
+  opacity: 0.8;
+}
+.md-content strong {
+  font-weight: var(--fw-semi);
+}
+.md-content br + br {
+  display: none;
 }
 
 /* "Thinking" pill on memory cards — same indigo as the chat bubble. */

--- a/apps/memos-local-plugin/web/src/styles/layout.css
+++ b/apps/memos-local-plugin/web/src/styles/layout.css
@@ -172,9 +172,9 @@ body {
   flex: 1;
   min-width: 0;
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding: 0 var(--sp-8);
+  padding: 0 var(--sp-3);
+  position: relative;
 }
 
 .topbar__search-form {
@@ -187,7 +187,6 @@ body {
 .topbar__search {
   position: relative;
   display: block;
-  max-width: 420px;
   width: 100%;
 }
 .topbar__search input {
@@ -227,6 +226,97 @@ body {
   display: block;
   /* Lucide “search” mass sits slightly above the 24×24 optical center. */
   transform: translateY(1px);
+}
+
+/* ─── Search Dropdown ─── */
+.search-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: 480px;
+  overflow-y: auto;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg, 0 8px 32px rgba(0,0,0,.12));
+  z-index: 1000;
+  padding: var(--sp-2) 0;
+}
+.search-dropdown__loading,
+.search-dropdown__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-2);
+  padding: var(--sp-4);
+  color: var(--fg-dim);
+  font-size: var(--fs-sm);
+}
+.search-dropdown__loading .icon {
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.search-dropdown__section {
+  padding: var(--sp-1) 0;
+}
+.search-dropdown__section + .search-dropdown__section {
+  border-top: 1px solid var(--border);
+}
+.search-dropdown__section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semi);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.search-dropdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.search-dropdown__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--sp-2) var(--sp-4) var(--sp-2) calc(var(--sp-4) + 14px + var(--sp-2));
+  background: none;
+  border: none;
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: background var(--dur-xs);
+  line-height: 1.4;
+}
+.search-dropdown__item:hover {
+  background: var(--bg-hover);
+}
+.search-dropdown__item-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.search-dropdown__more {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--sp-1) var(--sp-4) var(--sp-1) calc(var(--sp-4) + 14px + var(--sp-2));
+  background: none;
+  border: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--fs-xs);
+  cursor: pointer;
+  transition: opacity var(--dur-xs);
+}
+.search-dropdown__more:hover {
+  opacity: 0.8;
 }
 
 .topbar__actions {

--- a/apps/memos-local-plugin/web/src/views/HelpView.tsx
+++ b/apps/memos-local-plugin/web/src/views/HelpView.tsx
@@ -17,109 +17,212 @@ interface HelpSection {
   fields: HelpField[];
 }
 
-const SECTIONS: HelpSection[] = [
-  {
-    icon: "brain-circuit",
-    title: "记忆",
-    intro:
-      "记忆页展示每一步执行的原始记录。每条记忆带有系统自动回填的数值信号，代表这条记忆的重要性和权重。",
-    fields: [
-      {
-        label: "价值 V",
-        hint: "[-1, 1]",
-        desc: "这条记忆对任务成功的贡献程度。正值 = 有帮助，负值 = 反例；绝对值越大权重越大。",
-      },
-      {
-        label: "反思权重 α",
-        hint: "[0, 1]",
-        desc: "这一步反思的质量。识别出关键发现的步骤 α 高（0.6–0.8），正常推进中等（0.3–0.5），盲目试错低（0–0.2）。",
-      },
-      {
-        label: "用户反馈分 R_human",
-        hint: "[-1, 1]",
-        desc: "用户对整个任务的满意度评分。只在用户给出明确反馈后才会出现。",
-      },
-      {
-        label: "优先级",
-        desc: "检索排序权重。价值高且较新的记忆优先级高、被召回的机会更大；老旧或低价值记忆自然下沉但不会被删除。",
-      },
-      {
-        label: "本任务的其他步骤",
-        desc: "同一个任务下，按时间顺序排列的其他步骤记忆。",
-      },
-    ],
-  },
-  {
-    icon: "list-checks",
-    title: "任务",
-    intro:
-      "任务页展示每一段聚焦的对话（一次完整的问→答过程）。点击可以看到完整对话和对应的技能流水线进度。",
-    fields: [
-      {
-        label: "状态",
-        desc:
-          "进行中 / 已完成 / 已跳过 / 失败。已跳过 = 对话过短无法形成有效记忆。失败 = 评分为负，本任务的记录会作为反例保留。",
-      },
-      {
-        label: "技能流水线",
-        desc:
-          "代表本任务在技能结晶流水线上的状态：等待中 / 生成中 / 已生成 / 已升级 / 未达沉淀阈值。",
-      },
-      { label: "任务评分 R_task", desc: "用户满意度的数值化表达。正值越大 = 越满意。" },
-      { label: "对话轮次", desc: "本任务的问答轮数。" },
-    ],
-  },
-  {
-    icon: "wand-sparkles",
-    title: "技能",
-    intro:
-      "技能是从经验中结晶出来的可调用能力。当新任务到来时，系统会自动匹配最相关的技能并注入给助手。",
-    fields: [
-      { label: "状态", desc: "已启用 = 已通过验证可被调用；候选 = 还在等待更多证据；已归档 = 已停用不参与检索。" },
-      { label: "可靠性 η", desc: "调用这条技能比不调用时的平均效果提升。η 越高越值得调用。" },
-      { label: "增益 gain", desc: "结晶时统计的策略平均收益。" },
-      { label: "支撑任务数 support", desc: "有多少个独立任务支撑了这条技能。" },
-      { label: "版本 version", desc: "每次重建 +1。" },
-      {
-        label: "进化时间线",
-        desc: "记录技能生命周期：开始结晶 → 结晶完成 → 重建 → η 更新 → 状态变更 → 归档。",
-      },
-    ],
-  },
-  {
-    icon: "sparkles",
-    title: "经验",
-    intro:
-      "经验是从多个相似任务中归纳出的可复用策略。它不直接注入给助手，而是通过结晶成技能后间接生效。",
-    fields: [
-      { label: "触发 trigger", desc: "在什么场景下应该启用这条经验。" },
-      { label: "流程 procedure", desc: "应该执行什么步骤。" },
-      { label: "验证 verification", desc: "怎么判断这条经验是否被成功执行。" },
-      { label: "边界 boundary", desc: "适用范围和排除范围。" },
-      { label: "支撑任务数 / 增益", desc: "支撑的独立任务数和平均价值增益。用于决定是否结晶为技能。" },
-      {
-        label: "决策指引（推荐做法 / 避免做法）",
-        desc:
-          "系统从用户反馈中提取的行动建议。同一场景下不同做法的效果显著分化时，自动生成「优先做 X，避免做 Y」。",
-      },
-    ],
-  },
-  {
-    icon: "globe",
-    title: "环境认知",
-    intro:
-      "环境认知是系统对你工作环境的压缩理解。有了它，助手可以直接凭记忆导航而不必每次重新探索。",
-    fields: [
-      { label: "空间结构", desc: "环境中什么东西在哪 — 目录、服务拓扑、配置文件位置等。" },
-      { label: "行为规律", desc: "环境对动作的典型响应 — 如「这个 API 返回 JSON」「构建必须先 compile 再 link」。" },
-      { label: "约束与禁忌", desc: "什么不能做 — 如「这个目录是只读的」「Alpine 上别用 binary wheel」。" },
-      { label: "关联经验数", desc: "支撑这条认知的经验数量。数量越多说明该结构越稳定。" },
-    ],
-  },
-];
+function getSections(isZh: boolean): HelpSection[] {
+  return [
+    {
+      icon: "brain-circuit",
+      title: isZh ? "记忆" : "Memories",
+      intro: isZh
+        ? "记忆页展示每一步执行的原始记录。每条记忆带有系统自动回填的数值信号，代表这条记忆的重要性和权重。"
+        : "The Memories page shows the raw trace of every execution step. Each memory carries system-backfilled numerical signals representing its importance and weight.",
+      fields: [
+        {
+          label: isZh ? "价值 V" : "Value V",
+          hint: "[-1, 1]",
+          desc: isZh
+            ? "这条记忆对任务成功的贡献程度。正值 = 有帮助，负值 = 反例；绝对值越大权重越大。"
+            : "How much this memory contributed to task success. Positive = helpful, negative = counterexample; larger absolute value = higher weight.",
+        },
+        {
+          label: isZh ? "反思权重 α" : "Reflection weight α",
+          hint: "[0, 1]",
+          desc: isZh
+            ? "这一步反思的质量。识别出关键发现的步骤 α 高（0.6–0.8），正常推进中等（0.3–0.5），盲目试错低（0–0.2）。"
+            : "Quality of this step's reflection. Steps with key findings have high α (0.6–0.8), normal progress is medium (0.3–0.5), blind trial-and-error is low (0–0.2).",
+        },
+        {
+          label: isZh ? "用户反馈分 R_human" : "User feedback R_human",
+          hint: "[-1, 1]",
+          desc: isZh
+            ? "用户对整个任务的满意度评分。只在用户给出明确反馈后才会出现。"
+            : "User satisfaction score for the entire task. Only appears after explicit user feedback.",
+        },
+        {
+          label: isZh ? "优先级" : "Priority",
+          desc: isZh
+            ? "检索排序权重。价值高且较新的记忆优先级高、被召回的机会更大；老旧或低价值记忆自然下沉但不会被删除。"
+            : "Retrieval sort weight. High-value recent memories rank higher and are more likely to be recalled; old or low-value memories naturally sink but are never deleted.",
+        },
+        {
+          label: isZh ? "本任务的其他步骤" : "Other steps in this task",
+          desc: isZh
+            ? "同一个任务下，按时间顺序排列的其他步骤记忆。"
+            : "Other step memories under the same task, ordered chronologically.",
+        },
+      ],
+    },
+    {
+      icon: "list-checks",
+      title: isZh ? "任务" : "Tasks",
+      intro: isZh
+        ? "任务页展示每一段聚焦的对话（一次完整的问→答过程）。点击可以看到完整对话和对应的技能流水线进度。"
+        : "The Tasks page shows each focused conversation (a complete Q→A session). Click to see the full dialogue and its skill pipeline progress.",
+      fields: [
+        {
+          label: isZh ? "状态" : "Status",
+          desc: isZh
+            ? "进行中 / 已完成 / 已跳过 / 失败。已跳过 = 对话过短无法形成有效记忆。失败 = 评分为负，本任务的记录会作为反例保留。"
+            : "In progress / Completed / Skipped / Failed. Skipped = conversation too short to form valid memories. Failed = negative score, records kept as counterexamples.",
+        },
+        {
+          label: isZh ? "技能流水线" : "Skill pipeline",
+          desc: isZh
+            ? "代表本任务在技能结晶流水线上的状态：等待中 / 生成中 / 已生成 / 已升级 / 未达沉淀阈值。"
+            : "This task's status in the skill crystallization pipeline: Pending / Generating / Generated / Upgraded / Below threshold.",
+        },
+        {
+          label: isZh ? "任务评分 R_task" : "Task score R_task",
+          desc: isZh
+            ? "用户满意度的数值化表达。正值越大 = 越满意。"
+            : "Numerical expression of user satisfaction. Higher positive value = more satisfied.",
+        },
+        {
+          label: isZh ? "对话轮次" : "Turns",
+          desc: isZh
+            ? "本任务的问答轮数。"
+            : "Number of Q&A turns in this task.",
+        },
+      ],
+    },
+    {
+      icon: "wand-sparkles",
+      title: isZh ? "技能" : "Skills",
+      intro: isZh
+        ? "技能是从经验中结晶出来的可调用能力。当新任务到来时，系统会自动匹配最相关的技能并注入给助手。"
+        : "Skills are callable abilities crystallized from experiences. When a new task arrives, the system automatically matches the most relevant skills and injects them into the assistant.",
+      fields: [
+        {
+          label: isZh ? "状态" : "Status",
+          desc: isZh
+            ? "已启用 = 已通过验证可被调用；候选 = 还在等待更多证据；已归档 = 已停用不参与检索。"
+            : "Active = verified and callable; Candidate = awaiting more evidence; Archived = disabled, excluded from retrieval.",
+        },
+        {
+          label: isZh ? "可靠性 η" : "Reliability η",
+          desc: isZh
+            ? "调用这条技能比不调用时的平均效果提升。η 越高越值得调用。"
+            : "Average performance improvement when invoking this skill vs. not. Higher η = more worth invoking.",
+        },
+        {
+          label: isZh ? "增益 gain" : "Gain",
+          desc: isZh
+            ? "结晶时统计的策略平均收益。"
+            : "Average strategic return computed during crystallization.",
+        },
+        {
+          label: isZh ? "支撑任务数 support" : "Support count",
+          desc: isZh
+            ? "有多少个独立任务支撑了这条技能。"
+            : "Number of independent tasks that support this skill.",
+        },
+        {
+          label: isZh ? "版本 version" : "Version",
+          desc: isZh
+            ? "每次重建 +1。"
+            : "Increments by 1 on each rebuild.",
+        },
+        {
+          label: isZh ? "进化时间线" : "Evolution timeline",
+          desc: isZh
+            ? "记录技能生命周期：开始结晶 → 结晶完成 → 重建 → η 更新 → 状态变更 → 归档。"
+            : "Records the skill lifecycle: start crystallization → crystallization complete → rebuild → η update → status change → archive.",
+        },
+      ],
+    },
+    {
+      icon: "sparkles",
+      title: isZh ? "经验" : "Experiences",
+      intro: isZh
+        ? "经验是从多个相似任务中归纳出的可复用策略。它不直接注入给助手，而是通过结晶成技能后间接生效。"
+        : "Experiences are reusable strategies induced from multiple similar tasks. They don't inject into the assistant directly but take effect indirectly after crystallizing into skills.",
+      fields: [
+        {
+          label: isZh ? "触发 trigger" : "Trigger",
+          desc: isZh
+            ? "在什么场景下应该启用这条经验。"
+            : "Under what scenario this experience should be activated.",
+        },
+        {
+          label: isZh ? "流程 procedure" : "Procedure",
+          desc: isZh
+            ? "应该执行什么步骤。"
+            : "What steps should be executed.",
+        },
+        {
+          label: isZh ? "验证 verification" : "Verification",
+          desc: isZh
+            ? "怎么判断这条经验是否被成功执行。"
+            : "How to determine if this experience was successfully applied.",
+        },
+        {
+          label: isZh ? "边界 boundary" : "Boundary",
+          desc: isZh
+            ? "适用范围和排除范围。"
+            : "Applicable scope and exclusions.",
+        },
+        {
+          label: isZh ? "支撑任务数 / 增益" : "Support count / Gain",
+          desc: isZh
+            ? "支撑的独立任务数和平均价值增益。用于决定是否结晶为技能。"
+            : "Number of supporting independent tasks and average value gain. Used to decide whether to crystallize into a skill.",
+        },
+        {
+          label: isZh ? "决策指引（推荐做法 / 避免做法）" : "Decision guidance (do / avoid)",
+          desc: isZh
+            ? "系统从用户反馈中提取的行动建议。同一场景下不同做法的效果显著分化时，自动生成「优先做 X，避免做 Y」。"
+            : "Action recommendations extracted from user feedback. When different approaches in the same scenario show significant divergence, the system auto-generates 'prefer X, avoid Y'.",
+        },
+      ],
+    },
+    {
+      icon: "globe",
+      title: isZh ? "环境认知" : "Environment Knowledge",
+      intro: isZh
+        ? "环境认知是系统对你工作环境的压缩理解。有了它，助手可以直接凭记忆导航而不必每次重新探索。"
+        : "Environment knowledge is the system's compressed understanding of your working environment. With it, the assistant can navigate from memory without re-exploring every time.",
+      fields: [
+        {
+          label: isZh ? "空间结构" : "Spatial structure",
+          desc: isZh
+            ? "环境中什么东西在哪 — 目录、服务拓扑、配置文件位置等。"
+            : "What's where in the environment — directories, service topology, config file locations, etc.",
+        },
+        {
+          label: isZh ? "行为规律" : "Behavioral patterns",
+          desc: isZh
+            ? "环境对动作的典型响应 — 如「这个 API 返回 JSON」「构建必须先 compile 再 link」。"
+            : "Typical environment responses to actions — e.g. 'this API returns JSON', 'build must compile then link'.",
+        },
+        {
+          label: isZh ? "约束与禁忌" : "Constraints & taboos",
+          desc: isZh
+            ? "什么不能做 — 如「这个目录是只读的」「Alpine 上别用 binary wheel」。"
+            : "What must not be done — e.g. 'this directory is read-only', 'don't use binary wheels on Alpine'.",
+        },
+        {
+          label: isZh ? "关联经验数" : "Related experience count",
+          desc: isZh
+            ? "支撑这条认知的经验数量。数量越多说明该结构越稳定。"
+            : "Number of experiences supporting this knowledge entry. More = more stable structure.",
+        },
+      ],
+    },
+  ];
+}
 
 export function HelpView() {
   const isZh = locale.value === "zh";
+  const SECTIONS = getSections(isZh);
   return (
     <>
       <div class="view-header">

--- a/apps/memos-local-plugin/web/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SettingsView.tsx
@@ -531,7 +531,7 @@ function HubTab({
         <div>
           <h3 class="card__title">{t("settings.hub.enabled")}</h3>
           <p class="card__subtitle">
-            Share your skills and (optionally) memories with teammates.
+            {t("settings.hub.subtitle")}
           </p>
         </div>
         <ToggleSwitch

--- a/apps/memos-local-plugin/web/src/views/TasksView.tsx
+++ b/apps/memos-local-plugin/web/src/views/TasksView.tsx
@@ -36,6 +36,8 @@ interface EpisodeRow {
     | "skipped"
     | null;
   skillReason?: string | null;
+  skillReasonKey?: string | null;
+  skillReasonParams?: Record<string, string> | null;
   linkedSkillId?: string | null;
   closeReason?: "finalized" | "abandoned" | null;
   abandonReason?: string | null;
@@ -272,7 +274,9 @@ export function TasksView() {
                     {showSkillStatus && (
                       <span
                         class={`pill pill--skill-${r.skillStatus}`}
-                        title={r.skillReason ?? undefined}
+                        title={r.skillReasonKey
+                          ? t(r.skillReasonKey as any, r.skillReasonParams ?? undefined)
+                          : r.skillReason ?? undefined}
                       >
                         {t(`tasks.skill.${r.skillStatus}` as never)}
                       </span>
@@ -410,6 +414,9 @@ function statusReason(r: EpisodeRow): string | null {
   if (s === "active" || s === "completed") return null;
 
   if (r.abandonReason && r.abandonReason.trim().length > 0) {
+    if (r.abandonReason.includes("插件上次未正常退出")) {
+      return t("tasks.abandonReason.uncleanExit" as any);
+    }
     return r.abandonReason;
   }
 
@@ -593,12 +600,14 @@ function TaskDrawer({
                   </button>
                 )}
               </div>
-              {episode.skillReason && (
+              {(episode.skillReasonKey || episode.skillReason) && (
                 <p
                   class="muted"
                   style="font-size:var(--fs-sm);line-height:1.6;margin:0"
                 >
-                  {episode.skillReason}
+                  {episode.skillReasonKey
+                    ? t(episode.skillReasonKey as any, episode.skillReasonParams ?? undefined)
+                    : episode.skillReason}
                 </p>
               )}
             </section>

--- a/apps/memos-local-plugin/web/src/views/tasks-chat.tsx
+++ b/apps/memos-local-plugin/web/src/views/tasks-chat.tsx
@@ -20,6 +20,7 @@
  */
 import type { JSX } from "preact";
 import { Icon } from "../components/Icon";
+import { Markdown } from "../components/Markdown";
 import { t } from "../stores/i18n";
 import type { ChatMsg, ChatRole } from "./tasks-chat-data";
 
@@ -154,10 +155,12 @@ export function ChatBubble({ msg }: { msg: ChatMsg }) {
           <ToolBubble msg={msg} />
         ) : msg.role === "thinking" ? (
           <div class="chat-item__bubble chat-item__bubble--thinking">
-            {msg.text}
+            <Markdown text={msg.text} />
           </div>
         ) : (
-          <div class="chat-item__bubble">{msg.text}</div>
+          <div class="chat-item__bubble">
+            <Markdown text={msg.text} />
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Global search**: real-time categorized dropdown showing top 3 results per category (memories, tasks, skills, experiences, env knowledge) as the user types
- **Hermes daemon mode**: Memory Viewer now stays alive persistently — install.sh keeps it running, config save auto-restarts via self-respawn (like OpenClaw's launchd)
- **i18n fixes**: Help page fully bilingual, team sharing subtitle, task skill pipeline reasons all localized
- **Markdown chat**: user/assistant/thinking bubbles in task drawer now render as Markdown
- **Bug fixes**: memory_add log content for tool sub-steps, version mismatch (bridge.cts reads package.json), health endpoint reads disk config for model names
- **Search bar**: expanded to fill full topbar width
- **Brand text**: simplified to "MemOS / 记忆面板"

## Test plan

- [ ] Install via `install.sh --version ./pkg.tgz` for Hermes — verify daemon stays up after install
- [ ] Open Memory Viewer at :18800 — verify global search dropdown shows results
- [ ] Switch language to English — verify Help page, task skill reasons display in English
- [ ] Open task drawer — verify chat bubbles render markdown (code blocks, bold, links)
- [ ] Modify model config in Settings → Save — verify viewer auto-restarts without manual intervention
- [ ] Run `hermes chat` while daemon is running — verify it operates in headless mode