### PR TITLE
fix(bridge): clear-data also spawns daemon, agent-aware error hints

### DIFF
--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -32,7 +32,25 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
     for (const suffix of ["", "-wal", "-shm"]) {
       try { await fs.unlink(dbFile + suffix); } catch { /* may not exist */ }
     }
-    setTimeout(() => process.exit(0), 300);
+    const agent = options.agent ?? "unknown";
+    if (agent !== "openclaw") {
+      // Hermes: spawn replacement daemon after clearing data
+      const nodePath = await import("node:path");
+      const { fileURLToPath } = await import("node:url");
+      const { spawn } = await import("node:child_process");
+      const thisFile = fileURLToPath(import.meta.url);
+      const pluginRoot = nodePath.resolve(nodePath.dirname(thisFile), "../..");
+      const tsxBin = nodePath.join(pluginRoot, "node_modules/.bin/tsx");
+      const bridgeScript = nodePath.join(pluginRoot, "bridge.cts");
+      const cmd = `sleep 1 && "${tsxBin}" "${bridgeScript}" --agent=${agent} --daemon`;
+      const child = spawn("bash", ["-c", cmd], {
+        detached: true,
+        stdio: "ignore",
+        cwd: pluginRoot,
+      });
+      child.unref();
+    }
+    setTimeout(() => process.exit(0), 200);
     return { ok: true, restarting: true };
   });
 

--- a/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
+++ b/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
@@ -23,9 +23,10 @@ function FullScreenSpinner() {
         ? t("restart.waitingUp")
         : t("restart.restarting");
 
+  const agentType = health.value?.agent === "openclaw" ? "openclaw" : "hermes";
   const hint =
     s.phase === "restartFailed"
-      ? t("restart.failedHint")
+      ? t(`restart.failedHint.${agentType}` as any)
       : t("restart.autoRefresh");
 
   return (

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -164,8 +164,10 @@ const en = {
   "restart.waitingUp": "Waiting for the service to come back online…",
   "restart.autoRefresh": "The page will refresh automatically once the service is ready.",
   "restart.failed": "Restart didn't complete — the service didn't come back in time.",
-  "restart.failedHint":
+  "restart.failedHint.openclaw":
     "Try manually: openclaw gateway stop && openclaw gateway start",
+  "restart.failedHint.hermes":
+    "Try manually: pkill -f bridge.cts && hermes chat",
   "common.selectAll": "Select all",
   "common.deleteSelected": "Delete selected",
 
@@ -794,8 +796,10 @@ const zh: Record<TranslationKey, string> = {
   "restart.waitingUp": "正在等待服务重新上线…",
   "restart.autoRefresh": "服务就绪后页面将自动刷新。",
   "restart.failed": "重启超时 — 服务未能在预期时间内恢复。",
-  "restart.failedHint":
+  "restart.failedHint.openclaw":
     "请手动重启：openclaw gateway stop && openclaw gateway start",
+  "restart.failedHint.hermes":
+    "请手动重启：pkill -f bridge.cts && hermes chat",
   "common.selectAll": "全选",
   "common.deleteSelected": "删除所选",
 

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -128,7 +128,9 @@ export async function triggerCleared(): Promise<void> {
       restartState.value = { phase: "restartFailed" };
     }
   } else {
-    const ok = await quickPollUp(10);
+    // Hermes: clear-data spawns a new daemon. Give it extra time
+    // since it also needs to re-create the DB on first boot.
+    const ok = await quickPollUp(15);
     if (ok) {
       window.location.href =
         window.location.pathname + "?_t=" + Date.now();


### PR DESCRIPTION
## Summary

- admin/clear-data: Hermes now spawns replacement daemon after clearing DB (same self-respawn pattern as admin/restart)
- triggerCleared: increased poll attempts for Hermes (DB re-creation needs extra time)
- RestartOverlay: show agent-specific manual restart hint on failure (Hermes: `pkill -f bridge.cts && hermes chat`)

## Test plan

- [ ] On Hermes viewer, go to Settings → Clear All Data → verify viewer auto-recovers
- [ ] If restart times out, verify error message shows Hermes-specific hint instead of OpenClaw gateway command