### PR TITLE
fix(bridge): preserve stdio connection on restart + increase import limit

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -91,6 +91,7 @@ async function main(): Promise<void> {
           host: config.viewer.bindHost,
           staticRoot: path.resolve(__dirname, "web/dist"),
           agent: args.agent,
+          daemon: true,
         },
       );
       process.stderr.write(

--- a/apps/memos-local-plugin/server/http.ts
+++ b/apps/memos-local-plugin/server/http.ts
@@ -197,7 +197,9 @@ async function dispatch(
   const key = `${method} ${pathname}`;
   const exact = routes.getExact(key);
   if (exact) {
-    const body = await readBody(req, options.maxBodyBytes ?? 1_048_576);
+    const isImport = pathname === "/api/v1/import";
+    const limit = isImport ? 104_857_600 : (options.maxBodyBytes ?? 1_048_576);
+    const body = await readBody(req, limit);
     const result = await exact({ req, res, url, body, deps, params: {} });
     if (!res.headersSent && result !== undefined) {
       writeJson(res, 200, result);

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -33,8 +33,12 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       try { await fs.unlink(dbFile + suffix); } catch { /* may not exist */ }
     }
     const agent = options.agent ?? "unknown";
-    if (agent !== "openclaw") {
-      // Hermes: spawn replacement daemon after clearing data
+    if (agent === "openclaw") {
+      setTimeout(() => process.exit(0), 300);
+      return { ok: true, restarting: true };
+    }
+    if (options.daemon) {
+      // Daemon mode: spawn replacement then exit.
       const nodePath = await import("node:path");
       const { fileURLToPath } = await import("node:url");
       const { spawn } = await import("node:child_process");
@@ -49,9 +53,13 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
         cwd: pluginRoot,
       });
       child.unref();
+      setTimeout(() => process.exit(0), 200);
+      return { ok: true, restarting: true };
     }
-    setTimeout(() => process.exit(0), 200);
-    return { ok: true, restarting: true };
+    // Stdio mode: DB is cleared but we re-init in-place to keep
+    // the hermes connection alive. Core will recreate DB on next write.
+    await deps.core.init();
+    return { ok: true, restarting: false, configSaved: true };
   });
 
   routes.set("POST /api/v1/admin/restart", async (_ctx) => {
@@ -60,10 +68,17 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
-    // Hermes (and others): exit first (releasing the port), then a
-    // small wrapper script spawns the new daemon. We use a shell
-    // one-liner that sleeps briefly (for port release) then starts
-    // the new daemon.
+    // Hermes: behavior depends on whether we're running as a standalone
+    // daemon or as a stdio bridge attached to a live hermes chat session.
+    if (!options.daemon) {
+      // Stdio mode: hermes chat is actively connected. DON'T exit —
+      // that would break the memory capture pipeline. Config is already
+      // saved to disk; health() reads model names from disk anyway.
+      // Changes requiring a process restart (model client swap) will
+      // take effect on the next `hermes chat` session.
+      return { ok: true, restarting: false, configSaved: true };
+    }
+    // Daemon mode: no stdio connection — safe to restart.
     const nodePath = await import("node:path");
     const { fileURLToPath } = await import("node:url");
     const { spawn } = await import("node:child_process");

--- a/apps/memos-local-plugin/server/types.ts
+++ b/apps/memos-local-plugin/server/types.ts
@@ -44,6 +44,11 @@ export interface ServerOptions {
    * installed on disk.
    */
   agent?: "openclaw" | "hermes";
+  /**
+   * True when running in --daemon mode (standalone viewer, no stdio).
+   * Controls whether admin/restart actually exits or just acknowledges.
+   */
+  daemon?: boolean;
 }
 
 export interface ServerHandle {

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -80,18 +80,30 @@ async function quickPollUp(maxAttempts = 10): Promise<boolean> {
 }
 
 /**
- * Config saved. Trigger a restart for any agent. The backend spawns a
- * fresh daemon bridge before exiting, so the viewer port comes back up
- * automatically for both OpenClaw (launchd) and Hermes (self-respawn).
+ * Config saved. Trigger a restart.
+ *
+ * - OpenClaw: always restarts (launchd respawns).
+ * - Hermes daemon mode: restarts (spawn new daemon, exit old).
+ * - Hermes stdio mode (hermes chat running): does NOT restart —
+ *   config is saved to disk, health() reads from disk, and the
+ *   memory capture pipeline stays intact. Just reload the page.
  */
 export async function triggerRestart(
   _opts: TriggerRestartOptions = {},
 ): Promise<void> {
   restartState.value = { phase: "restarting" };
+  let response: { restarting?: boolean } = { restarting: true };
   try {
-    await api.post("/api/v1/admin/restart");
+    response = await api.post<{ restarting?: boolean }>("/api/v1/admin/restart");
   } catch {
     // Server might already be going down
+  }
+
+  if (!response.restarting) {
+    // Stdio mode: server stayed up, config saved. Just reload.
+    window.location.href =
+      window.location.pathname + "?_t=" + Date.now();
+    return;
   }
 
   if (isOpenClaw()) {
@@ -103,7 +115,6 @@ export async function triggerRestart(
       restartState.value = { phase: "restartFailed" };
     }
   } else {
-    // Hermes: new daemon spawns before old exits, transition is fast.
     const ok = await quickPollUp(10);
     if (ok) {
       window.location.href =
@@ -115,10 +126,26 @@ export async function triggerRestart(
 }
 
 /**
- * Data cleared. Both agents self-respawn via the daemon mechanism.
+ * Data cleared. Same logic: daemon restarts, stdio stays alive.
  */
 export async function triggerCleared(): Promise<void> {
   restartState.value = { phase: "restarting" };
+
+  // The clear-data endpoint handles the restart logic server-side.
+  // If it returns restarting:false, the server stayed up (stdio mode).
+  let response: { restarting?: boolean } = { restarting: true };
+  try {
+    response = await api.post<{ restarting?: boolean }>("/api/v1/admin/clear-data");
+  } catch {
+    // might already be going down
+  }
+
+  if (!response.restarting) {
+    window.location.href =
+      window.location.pathname + "?_t=" + Date.now();
+    return;
+  }
+
   if (isOpenClaw()) {
     const ok = await pollHealthUntilUp(60);
     if (ok) {
@@ -128,8 +155,6 @@ export async function triggerCleared(): Promise<void> {
       restartState.value = { phase: "restartFailed" };
     }
   } else {
-    // Hermes: clear-data spawns a new daemon. Give it extra time
-    // since it also needs to re-create the DB on first boot.
     const ok = await quickPollUp(15);
     if (ok) {
       window.location.href =


### PR DESCRIPTION
## Summary

- **fix(bridge): don't kill bridge when hermes chat is connected** — When running in stdio mode (hermes chat actively connected), admin/restart and clear-data endpoints now stay alive instead of exiting. This prevents breaking the memory capture pipeline. Only daemon mode does the actual exit+respawn.
- **fix(server): increase import body limit to 100MB** — The default 1MB request body limit caused "bundle is not valid JSON" when importing large databases exported from another agent.

## Test plan

- [ ] While `hermes chat` is running, modify config in Settings → Save → verify hermes chat stays connected and memory capture continues working
- [ ] Import a large (>1MB) JSON bundle exported from openclaw into hermes — verify import succeeds