### PR TITLE
fix(viewer): localize legacy DB migration scan results

### DIFF
--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -590,6 +590,10 @@ const en = {
     "Scan the legacy plugin's SQLite database for the currently running agent (openclaw → ~/.openclaw/memos-local, hermes → ~/.hermes/memos-state/memos-local) and copy matching rows into the new store. Non-destructive — the legacy file stays put.",
   "import.migrate.scan": "Scan legacy DB",
   "import.migrate.run": "Run migration",
+  "import.migrate.found":
+    "Found legacy {agent} DB at {path}. Candidates — traces: {traces}, skills: {skills}, tasks: {tasks}.",
+  "import.migrate.notFoundAt": "No legacy database found at {path}.",
+  "import.migrate.notFound": "No legacy database found.",
 
   // Admin.
   "admin.title": "Team administration",
@@ -1190,6 +1194,10 @@ const zh: Record<TranslationKey, string> = {
     "扫描当前运行 agent 对应的旧插件 SQLite 数据库（openclaw → ~/.openclaw/memos-local，hermes → ~/.hermes/memos-state/memos-local），把匹配的记录拷贝到新存储。非破坏性，旧文件不动。",
   "import.migrate.scan": "扫描旧数据库",
   "import.migrate.run": "执行迁移",
+  "import.migrate.found":
+    "在 {path} 找到 {agent} 旧数据库。可迁移条目 — 记忆：{traces}，技能：{skills}，任务：{tasks}。",
+  "import.migrate.notFoundAt": "在 {path} 没有找到旧数据库。",
+  "import.migrate.notFound": "没有找到旧数据库。",
 
   "admin.title": "团队管理",
   "admin.subtitle": "管理团队分享的用户、群组与待审批。",

--- a/apps/memos-local-plugin/web/src/views/ImportView.tsx
+++ b/apps/memos-local-plugin/web/src/views/ImportView.tsx
@@ -234,8 +234,16 @@ function MigrateCard() {
       {scan && (
         <div class="muted" style="margin-top:var(--sp-3);font-size:var(--fs-sm)">
           {scan.found
-            ? `Found legacy ${scan.agent ?? ""} DB at ${scan.path}. Candidates — traces: ${scan.candidates?.traces ?? 0}, skills: ${scan.candidates?.skills ?? 0}, tasks: ${scan.candidates?.tasks ?? 0}.`
-            : `No legacy database found${scan.path ? ` at ${scan.path}` : ""}.`}
+            ? t("import.migrate.found", {
+                agent: scan.agent ?? "",
+                path: scan.path ?? "",
+                traces: scan.candidates?.traces ?? 0,
+                skills: scan.candidates?.skills ?? 0,
+                tasks: scan.candidates?.tasks ?? 0,
+              })
+            : scan.path
+              ? t("import.migrate.notFoundAt", { path: scan.path })
+              : t("import.migrate.notFound")}
         </div>
       )}
       {result && (


### PR DESCRIPTION
## Summary

The "Found legacy hermes DB at ..." and "No legacy database found" messages on the Import page were hard-coded English strings. They now use i18n so users in Chinese mode see proper translations.

Verified the legacy hermes DB path is correct: \`~/.hermes/memos-state/memos-local/memos.db\` (matches the legacy plugin's \`stateDir/memos-local/memos.db\` convention from openclaw-local-plugin-20260408).

## Test plan

- [ ] Switch viewer to Chinese mode → Import page → click "扫描旧数据库" → verify result message is in Chinese
- [ ] Switch back to English mode → result message is in English