### PR TITLE
feat(viewer): per-turn memory grouping, hermes thinking capture, settings cleanup

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -111,6 +111,13 @@ class MemTensorProvider(MemoryProvider):
         # Tool calls accumulated via the Hermes `post_tool_call` plugin
         # hook — flushed alongside user/assistant text in `sync_turn`.
         self._tool_calls: list[dict[str, Any]] = []
+        # Reasoning text captured via the `post_llm_call` hook for the
+        # current turn. Hermes' MemoryProvider.sync_turn signature only
+        # carries the visible assistant text; reasoning lives on the
+        # `assistant` message's `reasoning` field. We capture it from
+        # `post_llm_call`'s `conversation_history` so the viewer can
+        # show the model's thinking like OpenClaw does.
+        self._turn_thinking: str = ""
         self._hook_registered = False
 
     # ─── Identity ─────────────────────────────────────────────────────────
@@ -212,8 +219,9 @@ class MemTensorProvider(MemoryProvider):
 
             mgr = get_plugin_manager()
             mgr._hooks.setdefault("post_tool_call", []).append(self._on_post_tool_call)
+            mgr._hooks.setdefault("post_llm_call", []).append(self._on_post_llm_call)
             self._hook_registered = True
-            logger.debug("MemOS: registered post_tool_call hook")
+            logger.debug("MemOS: registered post_tool_call + post_llm_call hooks")
         except Exception as err:
             logger.debug("MemOS: could not register tool hook — %s", err)
 
@@ -226,7 +234,13 @@ class MemTensorProvider(MemoryProvider):
         tool_call_id: str = "",
         **_kw: Any,
     ) -> None:
-        """Accumulate a tool call record for the current turn."""
+        """Accumulate a tool call record for the current turn.
+
+        We keep the host's ``tool_call_id`` on a private ``_id`` field so
+        ``_on_post_llm_call`` can later attach the assistant message's
+        ``reasoning`` (the model's "thinking before this tool") to the
+        right entry. The ``_id`` is stripped before the JSON-RPC send.
+        """
         self._tool_calls.append(
             {
                 "name": tool_name,
@@ -234,14 +248,86 @@ class MemTensorProvider(MemoryProvider):
                 if isinstance(args, dict)
                 else str(args or ""),
                 "output": (result or "")[:4000],
+                "_id": tool_call_id or "",
             }
         )
+
+    def _on_post_llm_call(
+        self,
+        *,
+        conversation_history: list[dict[str, Any]] | None = None,
+        user_message: str = "",
+        **_kw: Any,
+    ) -> None:
+        """Capture reasoning content from assistant messages in this turn.
+
+        Hermes' ``_build_assistant_message`` writes the model's reasoning
+        text into ``msg["reasoning"]`` (extended thinking, OpenAI o1
+        ``reasoning_content``, etc.). The default ``MemoryProvider.sync_turn``
+        only carries plain ``user_content`` / ``assistant_content``, so we
+        fish the reasoning out of the conversation history fired with the
+        ``post_llm_call`` hook and stash it for the upcoming ``sync_turn``.
+
+        We walk through assistant messages of the current turn (those
+        after the most recent user message). For each message that
+        contains ``reasoning`` AND ``tool_calls``, we attach the reasoning
+        as ``thinkingBefore`` to every captured tool call whose
+        ``tool_call_id`` matches one of the message's tool calls — this
+        is the model's chain-of-thought immediately before invoking that
+        tool. The final reasoning (the message that produced the user-
+        facing reply) becomes the turn-level ``agentThinking``.
+        """
+        if not conversation_history:
+            return
+
+        # Find the last user message and walk forward from there.
+        last_user_idx = -1
+        for i, msg in enumerate(conversation_history):
+            if msg.get("role") == "user":
+                last_user_idx = i
+
+        # Build a map: tool_call_id -> reasoning text.
+        thinking_by_id: dict[str, str] = {}
+        # Reasoning of the message that produced the final reply (no
+        # tool_calls in that message) becomes the turn-level thinking.
+        final_reasoning = ""
+
+        for msg in conversation_history[last_user_idx + 1 :]:
+            if msg.get("role") != "assistant":
+                continue
+            r = msg.get("reasoning")
+            r_str = r.strip() if isinstance(r, str) and r.strip() else ""
+            tcs = msg.get("tool_calls")
+            if isinstance(tcs, list) and tcs:
+                # Reasoning preceded these tool calls.
+                if r_str:
+                    for tc in tcs:
+                        tc_id = (tc.get("id") if isinstance(tc, dict) else None) or ""
+                        if tc_id:
+                            thinking_by_id[tc_id] = r_str
+            else:
+                # Plain assistant reply — overwrite final_reasoning so we
+                # keep the LATEST one (mirrors Hermes' ``last_reasoning``).
+                if r_str:
+                    final_reasoning = r_str
+
+        # Attach thinkingBefore to matching captured tool calls.
+        for tc in self._tool_calls:
+            tc_id = tc.get("_id") or ""
+            if tc_id and tc_id in thinking_by_id:
+                tc["thinkingBefore"] = thinking_by_id[tc_id]
+
+        self._turn_thinking = final_reasoning
 
     # ─── Turn-level hooks ─────────────────────────────────────────────────
 
     def on_turn_start(self, turn_number: int, message: str, **_kwargs: Any) -> None:  # type: ignore[override]
         self._turn_number = int(turn_number or 0)
         self._last_user_text = (message or "").strip()
+        # Reset per-turn buffers so reasoning / tool calls captured here
+        # belong only to this turn.
+        self._turn_thinking = ""
+        self._tool_calls = []
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:  # type: ignore[override]
         """Inject relevant memories ahead of the next model call.
@@ -297,15 +383,24 @@ class MemTensorProvider(MemoryProvider):
         user = user_content or self._last_user_text
         assistant = assistant_content or ""
         tool_calls = self._tool_calls
+        thinking = self._turn_thinking
         self._tool_calls = []
+        self._turn_thinking = ""
         logger.info(
-            "MemOS: sync_turn user=%d assistant=%d tools=%d",
+            "MemOS: sync_turn user=%d assistant=%d tools=%d thinking=%d",
             len(user),
             len(assistant),
             len(tool_calls),
+            len(thinking),
         )
         try:
-            self._turn_end(user, assistant, tool_calls, int(time.time() * 1000))
+            self._turn_end(
+                user,
+                assistant,
+                tool_calls,
+                int(time.time() * 1000),
+                agent_thinking=thinking,
+            )
         except Exception as err:
             logger.warning("MemOS: sync_turn turn.end failed — %s", err)
         if user_content:
@@ -764,21 +859,25 @@ class MemTensorProvider(MemoryProvider):
         assistant_content: str,
         tool_calls: list[dict[str, Any]],
         ts_ms: int,
+        *,
+        agent_thinking: str = "",
     ) -> None:
         if not self._bridge:
             return
-        self._bridge.request(
-            "turn.end",
-            {
-                "agent": "hermes",
-                "sessionId": self._session_id,
-                "episodeId": self._episode_id,
-                "agentText": assistant_content,
-                "userText": user_content,
-                "toolCalls": tool_calls,
-                "ts": ts_ms,
-            },
-        )
+        # Strip the private `_id` book-keeping field before sending.
+        clean_tool_calls = [{k: v for k, v in tc.items() if k != "_id"} for tc in tool_calls]
+        payload: dict[str, Any] = {
+            "agent": "hermes",
+            "sessionId": self._session_id,
+            "episodeId": self._episode_id,
+            "agentText": assistant_content,
+            "userText": user_content,
+            "toolCalls": clean_tool_calls,
+            "ts": ts_ms,
+        }
+        if agent_thinking:
+            payload["agentThinking"] = agent_thinking
+        self._bridge.request("turn.end", payload)
 
 
 # ─── Discovery entry points ───────────────────────────────────────────────

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -279,9 +279,15 @@ export interface MemoryCore {
     offset?: number;
     sessionId?: SessionId;
     q?: string;
+    /**
+     * When true, paginate by distinct `(episodeId, turnId)` groups so
+     * one user turn (query + tool sub-steps + reply) counts as one
+     * memory. Returns all traces belonging to the paginated turns.
+     */
+    groupByTurn?: boolean;
   }): Promise<TraceDTO[]>;
   /** Total trace rows matching the same filter (no limit/offset). */
-  countTraces(input?: { sessionId?: SessionId; q?: string }): Promise<number>;
+  countTraces(input?: { sessionId?: SessionId; q?: string; groupByTurn?: boolean }): Promise<number>;
 
   /**
    * Paged listing of the rich api_logs table ({@link ApiLogDTO}).

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -1646,19 +1646,26 @@ export function createMemoryCore(
   async function countTraces(input?: {
     sessionId?: SessionId;
     q?: string;
+    groupByTurn?: boolean;
   }): Promise<number> {
     ensureLive();
     const needle = (input?.q ?? "").trim().toLowerCase();
     if (!needle) {
-      return handle.repos.traces.count({ sessionId: input?.sessionId });
+      return input?.groupByTurn
+        ? handle.repos.traces.countTurns({ sessionId: input?.sessionId })
+        : handle.repos.traces.count({ sessionId: input?.sessionId });
     }
     // q substring scan — mirror `listTraces`. Walk all matching
     // traces from the repo (no limit) and apply the same filter.
     const rows = handle.repos.traces.list({ sessionId: input?.sessionId });
-    return rows.filter((r) => {
+    const matched = rows.filter((r) => {
       const hay = ((r.summary ?? "") + "\n" + r.userText + "\n" + r.agentText).toLowerCase();
       return hay.includes(needle);
-    }).length;
+    });
+    if (!input?.groupByTurn) return matched.length;
+    const turnKeys = new Set<string>();
+    for (const r of matched) turnKeys.add(`${r.episodeId ?? "_"}:${r.turnId}`);
+    return turnKeys.size;
   }
 
   async function listTraces(input?: {
@@ -1666,11 +1673,75 @@ export function createMemoryCore(
     offset?: number;
     sessionId?: SessionId;
     q?: string;
+    groupByTurn?: boolean;
   }): Promise<TraceDTO[]> {
     ensureLive();
     const limit = Math.max(1, Math.min(500, input?.limit ?? 50));
     const offset = Math.max(0, input?.offset ?? 0);
     const needle = (input?.q ?? "").trim().toLowerCase();
+
+    if (input?.groupByTurn) {
+      // Group-by-turn: paginate at the (episodeId, turnId) level so each
+      // "memory" on the Memories page corresponds to one user turn.
+      if (!needle) {
+        const turnKeys = handle.repos.traces.listTurnKeys({
+          sessionId: input?.sessionId,
+          limit,
+          offset,
+        });
+        const rows = handle.repos.traces.listByTurnKeys(turnKeys);
+        // The frontend's `buildGroups` preserves first-encounter order
+        // when bucketing traces by turnKey. We need newest turn first
+        // (matching `listTurnKeys` DESC order), with chronological order
+        // within each turn.
+        const turnOrder = new Map<string, number>();
+        turnKeys.forEach((k, i) =>
+          turnOrder.set(`${k.episodeId ?? "_"}:${k.turnId}`, i),
+        );
+        rows.sort((a, b) => {
+          const ka = `${a.episodeId ?? "_"}:${a.turnId}`;
+          const kb = `${b.episodeId ?? "_"}:${b.turnId}`;
+          const ia = turnOrder.get(ka) ?? 0;
+          const ib = turnOrder.get(kb) ?? 0;
+          if (ia !== ib) return ia - ib;
+          return a.ts - b.ts;
+        });
+        return rows.map(traceRowToDTO);
+      }
+      // Search + group: scan, filter, then paginate by distinct turn key.
+      const allRows = handle.repos.traces.list({ sessionId: input?.sessionId });
+      const matched = allRows.filter((r) => {
+        const hay = ((r.summary ?? "") + "\n" + r.userText + "\n" + r.agentText).toLowerCase();
+        return hay.includes(needle);
+      });
+      const seen = new Map<string, { episodeId: string | null; turnId: number; maxTs: number }>();
+      for (const r of matched) {
+        const k = `${r.episodeId ?? "_"}:${r.turnId}`;
+        const existing = seen.get(k);
+        if (!existing || r.ts > existing.maxTs) {
+          seen.set(k, { episodeId: r.episodeId, turnId: r.turnId, maxTs: r.ts });
+        }
+      }
+      const orderedKeys = [...seen.values()]
+        .sort((a, b) => b.maxTs - a.maxTs)
+        .slice(offset, offset + limit);
+      const turnOrder = new Map<string, number>();
+      orderedKeys.forEach((k, i) =>
+        turnOrder.set(`${k.episodeId ?? "_"}:${k.turnId}`, i),
+      );
+      const traces = matched
+        .filter((r) => turnOrder.has(`${r.episodeId ?? "_"}:${r.turnId}`))
+        .sort((a, b) => {
+          const ka = `${a.episodeId ?? "_"}:${a.turnId}`;
+          const kb = `${b.episodeId ?? "_"}:${b.turnId}`;
+          const ia = turnOrder.get(ka) ?? 0;
+          const ib = turnOrder.get(kb) ?? 0;
+          if (ia !== ib) return ia - ib;
+          return a.ts - b.ts;
+        });
+      return traces.map(traceRowToDTO);
+    }
+
     if (!needle) {
       const rows = handle.repos.traces.list({
         sessionId: input?.sessionId,
@@ -1860,8 +1931,14 @@ export function createMemoryCore(
         sourcePolicyIds: s.sourcePolicyIds ?? [],
       }));
 
+    // Count unique (episodeId, turnId) groups instead of raw traces so
+    // the Overview "memories" metric matches what the Memories page
+    // shows: 1 user turn = 1 memory (regardless of how many tool calls
+    // / sub-steps were captured for that turn).
+    const totalTurns = handle.repos.traces.countTurns();
+
     return {
-      total: traces.length,
+      total: totalTurns,
       writesToday,
       sessions: sessions.size,
       embeddings,

--- a/apps/memos-local-plugin/core/storage/repos/traces.ts
+++ b/apps/memos-local-plugin/core/storage/repos/traces.ts
@@ -151,6 +151,78 @@ export function makeTracesRepo(db: StorageDb) {
     },
 
     /**
+     * Count distinct (episode_id, turn_id) groups — i.e. "memory turns",
+     * where one user query + its tool sub-steps + final reply are
+     * counted as 1. Used by the Memories viewer for accurate pagination.
+     */
+    countTurns(filter: Omit<TraceListFilter, "limit" | "offset"> = {}): number {
+      const fragments: string[] = [];
+      const params: Record<string, unknown> = {};
+      if (filter.sessionId) {
+        fragments.push(`session_id = @session_id`);
+        params.session_id = filter.sessionId;
+      }
+      if (filter.episodeId) {
+        fragments.push(`episode_id = @episode_id`);
+        params.episode_id = filter.episodeId;
+      }
+      const where = joinWhere(fragments);
+      const sql = `SELECT COUNT(*) AS n FROM (SELECT DISTINCT episode_id, turn_id FROM traces ${where})`;
+      const row = db.prepare<typeof params, { n: number }>(sql).get(params);
+      return row?.n ?? 0;
+    },
+
+    /**
+     * List paginated turn keys (episode_id, turn_id) ordered by the
+     * turn's most recent trace timestamp DESC. The viewer uses this to
+     * fetch a page of "memories" (1 turn = 1 memory).
+     */
+    listTurnKeys(filter: TraceListFilter = {}): Array<{ episodeId: string | null; turnId: number; maxTs: number }> {
+      const fragments: string[] = [];
+      const params: Record<string, unknown> = {};
+      if (filter.sessionId) {
+        fragments.push(`session_id = @session_id`);
+        params.session_id = filter.sessionId;
+      }
+      if (filter.episodeId) {
+        fragments.push(`episode_id = @episode_id`);
+        params.episode_id = filter.episodeId;
+      }
+      const where = joinWhere(fragments);
+      const limit = Math.max(1, Math.min(500, filter.limit ?? 50));
+      const offset = Math.max(0, filter.offset ?? 0);
+      params.limit = limit;
+      params.offset = offset;
+      const sql = `SELECT episode_id, turn_id, MAX(ts) as max_ts FROM traces ${where} GROUP BY episode_id, turn_id ORDER BY max_ts DESC LIMIT @limit OFFSET @offset`;
+      const rows = db
+        .prepare<typeof params, { episode_id: string | null; turn_id: number; max_ts: number }>(sql)
+        .all(params);
+      return rows.map((r) => ({ episodeId: r.episode_id, turnId: r.turn_id, maxTs: r.max_ts }));
+    },
+
+    /**
+     * Fetch all traces belonging to the given (episodeId, turnId) pairs.
+     * Returned rows are ordered by ts ascending so the frontend can
+     * render the conversation in chronological order.
+     */
+    listByTurnKeys(keys: ReadonlyArray<{ episodeId: string | null; turnId: number }>): TraceRow[] {
+      if (keys.length === 0) return [];
+      const conditions: string[] = [];
+      const params: Record<string, unknown> = {};
+      keys.forEach((k, i) => {
+        if (k.episodeId == null) {
+          conditions.push(`(episode_id IS NULL AND turn_id = @turn_${i})`);
+        } else {
+          conditions.push(`(episode_id = @ep_${i} AND turn_id = @turn_${i})`);
+          params[`ep_${i}`] = k.episodeId;
+        }
+        params[`turn_${i}`] = k.turnId;
+      });
+      const sql = `SELECT ${COLUMNS.join(", ")} FROM traces WHERE ${conditions.join(" OR ")} ORDER BY ts ASC`;
+      return db.prepare<typeof params, RawTraceRow>(sql).all(params).map(mapRow);
+    },
+
+    /**
      * Vector top-K over `vec_summary` (or `vec_action` if `kind='action'`).
      * The caller passes any extra SQL filter (e.g. same-episode only).
      */

--- a/apps/memos-local-plugin/server/routes/trace.ts
+++ b/apps/memos-local-plugin/server/routes/trace.ts
@@ -33,22 +33,34 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
     const offset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? parsedOffset : 0;
     const sessionId = params.get("sessionId") || undefined;
     const q = params.get("q") || undefined;
+    // When `groupByTurn=true`, pagination treats each (episodeId, turnId)
+    // pair as one "memory" — matching the viewer's grouped display where
+    // a user query + its tool steps + final reply collapse into one card.
+    const groupByTurn = params.get("groupByTurn") === "true";
     const traces = await deps.core.listTraces({
       limit,
       offset,
       sessionId: sessionId as SessionId | undefined,
       q,
+      groupByTurn,
     });
     const total = await deps.core.countTraces({
       sessionId: sessionId as SessionId | undefined,
       q,
+      groupByTurn,
     });
+    // When grouping, `traces.length === limit` is no longer a reliable
+    // "has more" signal (a single turn can yield many traces). Use the
+    // total count instead to detect a next page.
+    const nextOffset = groupByTurn
+      ? offset + limit < total ? offset + limit : undefined
+      : traces.length === limit ? offset + limit : undefined;
     return {
       traces,
       limit,
       offset,
       total,
-      nextOffset: traces.length === limit ? offset + limit : undefined,
+      nextOffset,
     };
   });
 

--- a/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
@@ -111,6 +111,7 @@ export function MemoriesView() {
       const qs = new URLSearchParams();
       qs.set("limit", String(PAGE_SIZE));
       qs.set("offset", String(opts.page * PAGE_SIZE));
+      qs.set("groupByTurn", "true");
       if (opts.q) qs.set("q", opts.q);
       const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`);
       setTraces(res.traces);
@@ -161,6 +162,16 @@ export function MemoriesView() {
   const isGroupSelected = (g: MemoryGroup): boolean =>
     g.ids.length > 0 && g.ids.every((id) => selected.has(id));
 
+  // Number of selected memories (turns), not raw traces. A memory card
+  // contains all the tool sub-step traces of one user turn, so the
+  // batch-bar count and confirm prompts must report turns or the user
+  // sees inflated numbers.
+  const selectedGroupCount = useMemo(
+    () => groups.filter(isGroupSelected).length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [groups, selected],
+  );
+
   const toggleGroupSel = (g: MemoryGroup) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -178,7 +189,7 @@ export function MemoriesView() {
 
   const bulkDelete = async () => {
     if (selected.size === 0) return;
-    if (!confirm(t("memories.delete.bulkConfirm", { n: selected.size }))) return;
+    if (!confirm(t("memories.delete.bulkConfirm", { n: selectedGroupCount }))) return;
     try {
       const ids = [...selected];
       const res = await api.post<{ deleted: number }>(`/api/v1/traces/delete`, { ids });
@@ -233,7 +244,7 @@ export function MemoriesView() {
     const txt = lines.join("\n");
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(txt).then(
-        () => showToast(t("memories.copy.done", { n: selected.size })),
+        () => showToast(t("memories.copy.done", { n: selectedGroupCount })),
         () => showToast("Copy failed", "error"),
       );
     } else {
@@ -376,7 +387,7 @@ export function MemoriesView() {
       {selected.size > 0 && (
         <div class="batch-bar" role="region" aria-label="bulk actions">
           <span class="batch-bar__count">
-            {t("common.selected", { n: selected.size })}
+            {t("common.selected", { n: selectedGroupCount })}
           </span>
           <button class="btn btn--sm" onClick={selectPage}>
             <Icon name="check-square" size={14} />

--- a/apps/memos-local-plugin/web/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SettingsView.tsx
@@ -268,20 +268,6 @@ function ModelsTab({
         block={embedding}
         providers={EMBEDDING_PROVIDERS}
         type="embedding"
-        extra={
-          <Field label="Dimensions">
-            <input
-              class="input"
-              type="number"
-              value={embedding.dimensions ?? ""}
-              onInput={(e) =>
-                onPatchEmbedding({
-                  dimensions: Number((e.target as HTMLInputElement).value) || undefined,
-                })
-              }
-            />
-          </Field>
-        }
         onPatch={onPatchEmbedding}
       />
 
@@ -291,7 +277,6 @@ function ModelsTab({
         desc={t("settings.summarizer.desc")}
         block={llm}
         providers={LLM_PROVIDERS}
-        withTemperature
         type="summarizer"
         onPatch={onPatchLlm}
       />
@@ -302,7 +287,6 @@ function ModelsTab({
         desc={t("settings.skillEvolver.desc")}
         block={skillEvolver}
         providers={SKILL_PROVIDERS}
-        withTemperature
         type="skillEvolver"
         inheritsLabel={t("settings.skillEvolver.inherit")}
         onPatch={onPatchSkillEvolver}


### PR DESCRIPTION
## Summary

- **Memory page grouping**: paginate by `(episodeId, turnId)` so one user query + its tool sub-steps + assistant reply count as **one** memory, not N traces. Adds `countTurns` / `listTurnKeys` / `listByTurnKeys` to the traces repo and a `groupByTurn` flag to `/api/v1/traces`. Overview metric also switches to distinct-turn count for consistency.
- **Newest-first ordering**: fix issue where the freshest memory was rendered at the bottom of the page. `listByTurnKeys` now preserves the DESC order specified by `listTurnKeys`.
- **Bulk-action count**: the batch-bar and confirm prompts now show the number of **selected memory cards** (turns), not raw trace ids. Previously a single card with N tool calls inflated the number to N.
- **Hermes thinking capture**: register a `post_llm_call` hook in the Python provider. Walk `conversation_history` to attach each assistant message's `reasoning` as `thinkingBefore` on the matching tool calls (via `tool_call_id`); the final reply's reasoning becomes the turn's `agentThinking`. Brings Hermes to feature parity with OpenClaw for chain-of-thought display in the task drawer.
- **Settings cleanup**: hide rarely-used embedding `dimensions` field and the `temperature` inputs on the summarizer / skill-evolver model cards. Existing config.yaml values continue to apply.

## Test plan

- [ ] Memories page: chat with the agent, verify each user turn (with tool calls) shows up as a single card; pagination shows 20 cards per page; newest at top
- [ ] Bulk-select: tick 3 memory cards → batch bar shows "Selected 3" not e.g. "Selected 12"
- [ ] Hermes task drawer: open a task with tool calls → verify thinking bubbles appear before each tool call and before the final assistant reply
- [ ] Settings → AI models: verify dimensions / temperature inputs no longer appear