### PR TITLE
chore(session): raise arbitration threshold 0.65 → 0.8

### DIFF
--- a/apps/memos-local-plugin/core/session/relation-classifier.ts
+++ b/apps/memos-local-plugin/core/session/relation-classifier.ts
@@ -201,8 +201,15 @@ const STRONG_HEURISTIC_THRESHOLD = 0.85;
 const IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
 // ─── Low-confidence new_task threshold for arbitration ───────────────────
-
-const ARBITRATION_THRESHOLD = 0.65;
+//
+// Raised from 0.65 → 0.8 so the LLM has to be quite sure (confidence ≥ 0.8)
+// before its `new_task` verdict is taken at face value. Anything below that
+// goes through the second-pass arbitration prompt (which is biased toward
+// follow_up). Real-world observation: the primary classifier often returns
+// `new_task` at 0.65–0.75 for messages that are actually sub-tasks of the
+// same project — pulling the cut-off up reduces false topic splits at the
+// cost of one extra LLM call on borderline turns.
+const ARBITRATION_THRESHOLD = 0.8;
 
 // ─── Public factory ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Tighten the trust gate for the LLM's `new_task` verdict in `apps/memos-local-plugin/core/session/relation-classifier.ts` — bump `ARBITRATION_THRESHOLD` from `0.65` to `0.8`.
- Real-world traces show the primary relation classifier often returns `new_task` at 0.65–0.75 confidence for messages that are actually sub-tasks of the same project (e.g. *"那数据库怎么配"* right after *"配置Nginx"*). The old 0.65 cut-off let those slip through without a second-pass review, falsely splitting one logical task into two.
- Routing more borderline `new_task` predictions through the bias-toward-`follow_up` arbitration prompt costs one extra LLM call on those turns, but reduces false topic splits (each false split prematurely closes the episode and leaves a stale `lastEpisodeBySession` entry that the L2/L3/skill chain has to recover from later).

## Behaviour change

Only one knob changes; nothing about the public API, schema, or storage layout.

| Path | Before | After |
| --- | --- | --- |
| `core/session/relation-classifier.ts::ARBITRATION_THRESHOLD` | `0.65` | `0.8` |

Decision flow (unchanged structure, only the cut-off moves):

1. LLM returns `new_task` with `confidence < ARBITRATION_THRESHOLD` → run the second-pass arbitration prompt (biased toward `follow_up`).
2. Otherwise → take the LLM verdict at face value.

## Test plan

- [x] `npx vitest run tests/unit/session/relation-classifier.test.ts` — 16 tests passed (existing arbitration test uses a 0.5 confidence input which is below both old and new thresholds, so it still exercises the same path).
- [ ] Smoke check on a real session where consecutive sub-task messages were previously being mis-split — confirm `relation.classified` log now shows `signals: ["llm", "arbitration_override"]` for those turns and the episode stays open.