### PR TITLE
fix(hermes): reload model config without daemon restart

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -23,6 +23,7 @@ import { SqliteStore } from "./src/storage/sqlite";
 import { Embedder } from "./src/embedding";
 import { ViewerServer } from "./src/viewer/server";
 import { Telemetry } from "./src/telemetry";
+import type { MemosLocalConfig, PluginContext } from "./src/types";
 
 // ─── Types ───
 
@@ -80,13 +81,13 @@ function parseConfig(): PluginInitOptions & { branding?: Record<string, string> 
 }
 
 /**
- * Read embedding config from the openclaw.json config file(s).
+ * Read the plugin config from openclaw.json config file(s).
  * Checks the memos state dir first (where the viewer saves), then ~/.openclaw.
  */
-function readEmbeddingConfigFromFile(
+function readPluginConfigFromFile(
   stateDir: string,
   log: ReturnType<typeof createLogger>,
-): Record<string, unknown> | undefined {
+): Partial<MemosLocalConfig> | undefined {
   const home = process.env.HOME || process.env.USERPROFILE || "";
   const candidates = [
     process.env.OPENCLAW_CONFIG_PATH,
@@ -103,14 +104,54 @@ function readEmbeddingConfigFromFile(
       for (const [name, entry] of Object.entries(entries)) {
         if (!name.toLowerCase().includes("memos")) continue;
         const cfg = (entry as any)?.config ?? {};
-        if (cfg.embedding?.provider) {
-          log.info(`Read embedding config from ${cfgPath}: provider=${cfg.embedding.provider}`);
-          return cfg.embedding;
+        if (cfg && Object.keys(cfg).length > 0) {
+          log.info(
+            `Read plugin config from ${cfgPath}: embedding=${cfg.embedding?.provider ?? "none"}, summarizer=${cfg.summarizer?.provider ?? "none"}, skillSummarizer=${cfg.skillEvolution?.summarizer?.provider ?? "none"}`,
+          );
+          return cfg as Partial<MemosLocalConfig>;
         }
       }
     } catch { /* skip unreadable files */ }
   }
   return undefined;
+}
+
+function mergeRuntimeConfig(
+  baseConfig: Partial<MemosLocalConfig> | undefined,
+  fileConfig: Partial<MemosLocalConfig> | undefined,
+): Partial<MemosLocalConfig> | undefined {
+  if (!baseConfig && !fileConfig) return undefined;
+  const merged: Partial<MemosLocalConfig> = {
+    ...(baseConfig ?? {}),
+    ...(fileConfig ?? {}),
+  };
+  if (baseConfig?.telemetry || fileConfig?.telemetry) {
+    merged.telemetry = {
+      ...(baseConfig?.telemetry ?? {}),
+      ...(fileConfig?.telemetry ?? {}),
+    };
+  }
+  return merged;
+}
+
+function buildRuntimeOptions(
+  configOpts: PluginInitOptions & { branding?: Record<string, string> },
+  stateDir: string,
+  log: ReturnType<typeof createLogger>,
+): { opts: PluginInitOptions; ctx: PluginContext } {
+  const fileConfig = readPluginConfigFromFile(stateDir, log);
+  const config = mergeRuntimeConfig(configOpts.config, fileConfig);
+  const workspaceDir = configOpts.workspaceDir ?? process.cwd();
+  const opts: PluginInitOptions = {
+    stateDir,
+    workspaceDir,
+    config,
+    log,
+  };
+  return {
+    opts,
+    ctx: buildContext(stateDir, workspaceDir, config, log),
+  };
 }
 
 function buildPromptSection(hits: Array<{ summary: string; original_excerpt?: string; score: number }>): string {
@@ -255,13 +296,9 @@ async function handleRequest(plugin: MemosLocalPlugin, method: string, params: R
 async function runStdio(): Promise<void> {
   const configOpts = parseConfig();
   const log = createLogger();
+  const stateDir = configOpts.stateDir ?? `${process.env.HOME}/.openharness/memos-state`;
 
-  const opts: PluginInitOptions = {
-    stateDir: configOpts.stateDir,
-    workspaceDir: configOpts.workspaceDir ?? process.cwd(),
-    config: configOpts.config,
-    log,
-  };
+  const { opts, ctx } = buildRuntimeOptions(configOpts, stateDir, log);
 
   let plugin: MemosLocalPlugin;
   try {
@@ -272,10 +309,8 @@ async function runStdio(): Promise<void> {
     process.exit(1);
   }
 
-  const stateDir = configOpts.stateDir ?? `${process.env.HOME}/.openharness/memos-state`;
   const pluginDir = detectPluginDir();
   const pluginVersion = readPluginVersion(pluginDir);
-  const ctx = buildContext(stateDir, process.cwd(), configOpts.config, log);
   const telemetry = new Telemetry(ctx.config.telemetry ?? {}, stateDir, pluginVersion, log, pluginDir);
   telemetry.trackPluginStarted(ctx.config.embedding?.provider ?? "local", ctx.config.summarizer?.provider ?? "none");
 
@@ -329,16 +364,11 @@ async function runDaemon(tcpPort: number, viewerPort: number): Promise<void> {
   const log = createLogger();
   const stateDir = configOpts.stateDir ?? `${process.env.HOME}/.openharness/memos-state`;
 
-  const opts: PluginInitOptions = {
-    stateDir,
-    workspaceDir: configOpts.workspaceDir ?? process.cwd(),
-    config: configOpts.config,
-    log,
-  };
+  let runtime = buildRuntimeOptions(configOpts, stateDir, log);
 
   let plugin: MemosLocalPlugin;
   try {
-    plugin = initPlugin(opts);
+    plugin = initPlugin(runtime.opts);
     log.info("Bridge: plugin initialized (daemon mode)");
   } catch (err) {
     process.stderr.write(`[fatal] Failed to initialize plugin: ${err}\n`);
@@ -347,7 +377,7 @@ async function runDaemon(tcpPort: number, viewerPort: number): Promise<void> {
 
   const pluginDir = detectPluginDir();
   const pluginVersion = readPluginVersion(pluginDir);
-  const ctx = buildContext(stateDir, process.cwd(), configOpts.config, log);
+  let ctx = runtime.ctx;
   const telemetry = new Telemetry(ctx.config.telemetry ?? {}, stateDir, pluginVersion, log, pluginDir);
   telemetry.trackPluginStarted(ctx.config.embedding?.provider ?? "local", ctx.config.summarizer?.provider ?? "none");
 
@@ -438,20 +468,29 @@ async function runDaemon(tcpPort: number, viewerPort: number): Promise<void> {
 
   // Hot-reload config on SIGUSR1 (used by viewer after saving settings).
   // In Node.js, SIGUSR1 normally starts the debugger — we override it to
-  // re-read the config file and swap in an updated Embedder so changes
-  // take effect without a full daemon restart.
-  process.on("SIGUSR1", () => {
+  // re-read the full plugin config and rebuild runtime dependencies so
+  // embedding, summarizer, and skill-evolution model changes all apply.
+  process.on("SIGUSR1", async () => {
     log.info("SIGUSR1 received — hot-reloading config from file...");
     try {
-      const embeddingCfg = readEmbeddingConfigFromFile(stateDir, log);
-      if (embeddingCfg && viewer) {
-        const resolvedCfg = buildContext(stateDir, process.cwd(), { embedding: embeddingCfg }, log);
-        const newEmbedder = new Embedder(resolvedCfg.config.embedding, log);
-        viewer.updateEmbedder(newEmbedder);
-        log.info(`Config hot-reloaded: embedding provider=${newEmbedder.provider}`);
-      } else {
-        log.info("No embedding config change detected or viewer not available");
+      const nextRuntime = buildRuntimeOptions(configOpts, stateDir, log);
+      const nextPlugin = initPlugin(nextRuntime.opts);
+      const previousPlugin = plugin;
+      plugin = nextPlugin;
+      runtime = nextRuntime;
+      ctx = nextRuntime.ctx;
+
+      if (viewer) {
+        const newEmbedder = new Embedder(ctx.config.embedding, log);
+        viewer.updateRuntime(newEmbedder, ctx);
       }
+
+      await previousPlugin.shutdown().catch((err) => {
+        log.warn(`Previous runtime shutdown after hot-reload failed: ${err}`);
+      });
+      log.info(
+        `Config hot-reloaded: embedding=${ctx.config.embedding?.provider ?? "local"}, summarizer=${ctx.config.summarizer?.provider ?? "none"}, skillSummarizer=${ctx.config.skillEvolution?.summarizer?.provider ?? "none"}`,
+      );
     } catch (err) {
       log.warn(`SIGUSR1 config hot-reload failed: ${err}`);
     }

--- a/apps/memos-local-plugin/src/viewer/server.ts
+++ b/apps/memos-local-plugin/src/viewer/server.ts
@@ -125,7 +125,7 @@ export class ViewerServer {
   private readonly authFile: string;
   private readonly resetTokenFile: string;
   private readonly auth: AuthState;
-  private readonly ctx?: PluginContext;
+  private ctx?: PluginContext;
   private readonly cookieName: string;
   private readonly defaultHubPort: number;
   private readonly branding?: ViewerBranding;
@@ -607,6 +607,15 @@ export class ViewerServer {
   updateEmbedder(newEmbedder: Embedder): void {
     this.embedder = newEmbedder;
     this.log.info(`Embedder hot-reloaded: provider=${newEmbedder.provider}`);
+  }
+
+  /** Replace runtime dependencies after daemon config hot-reload. */
+  updateRuntime(newEmbedder: Embedder, newCtx: PluginContext): void {
+    this.embedder = newEmbedder;
+    this.ctx = newCtx;
+    this.log.info(
+      `Viewer runtime hot-reloaded: embedding=${newEmbedder.provider}, summarizer=${newCtx.config.summarizer?.provider ?? "none"}, skillSummarizer=${newCtx.config.skillEvolution?.summarizer?.provider ?? "none"}`,
+    );
   }
 
   // ─── Data APIs ───


### PR DESCRIPTION
Reload the full plugin model configuration when the viewer saves settings, so embedding, summarizer, and skill evolution model changes take effect immediately. Rebuild the bridge runtime and refresh the viewer runtime context to keep LLM filtering and skill generation aligned with the latest saved config.

## Description

**Summary:** After the viewer persists plugin settings to OpenClaw config, the bridge process receives `SIGUSR1`, re-reads config from disk, re-initializes the plugin runtime, and the viewer refreshes its embedder and `PluginContext` so new embedding / summarizer / skill-evolution settings apply without a full manual restart.

**Problem:** Saving model-related settings in the viewer updated `openclaw.json` but the in-memory bridge and viewer could keep using the previous embedder and LLM-backed paths (e.g. filtering, skill evolution), so changes did not take effect until the process was restarted.

**Implementation:**
- **`src/viewer/server.ts`:** On successful config save, respond to the client and schedule `process.kill(process.pid, "SIGUSR1")` after a short delay (`jsonResponseAndRestart`) so the HTTP response completes before reload.
- **`bridge.cts`:** `SIGUSR1` handler rebuilds runtime via `buildRuntimeOptions` + `initPlugin`, swaps the active plugin instance, updates `ctx`, constructs a new `Embedder` from the merged config, calls `viewer.updateRuntime(newEmbedder, ctx)`, then shuts down the previous plugin instance.
- **`ViewerServer`:** `updateRuntime` / embedder hot-reload hooks keep the viewer’s server-side state aligned with the new config.

**Dependencies:** None beyond existing runtime (Node bridge + viewer). Hermes / OpenHarness launchers must run the same bridge process that owns the viewer (daemon mode) for `SIGUSR1` to apply to the correct PID.

Related Issue (Required): Fixes #issue_number

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Manual verification in daemon mode:

1. Start the bridge with viewer enabled.
2. Open viewer → Settings → change embedding provider/model (and/or summarizer, skill evolution LLM), save.
3. Confirm the UI shows success / restart overlay as designed; confirm logs show `SIGUSR1` / config hot-reload and updated providers.
4. Trigger an operation that uses the new embedding or summarizer (e.g. ingest / recall / skill path) and confirm behavior matches the new config without killing the process manually.

- [ ] Unit Test
- [x] Test Script Or Test Steps (please provide) — steps above
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
