### PR TITLE
fix: repair skill zip download and YAML frontmatter

### DIFF
--- a/apps/memos-local-plugin/core/util/tiny-zip.ts
+++ b/apps/memos-local-plugin/core/util/tiny-zip.ts
@@ -5,31 +5,26 @@
  * a single `SKILL.md` file. Pulling in `adm-zip` / `archiver` for that
  * is overkill, so we hand-roll the minimal PKZIP layout: one local
  * file header, one central directory record, one end-of-central-
- * directory record. CRC32 + DEFLATE-compressed payload.
+ * directory record. CRC32 + STORE (no compression) payload.
  *
  * Reference: PKZIP APPNOTE.TXT §4 / 4.3 / 4.4.
  *
  * Limitations (intentional):
  *   - Only one entry per archive.
  *   - No ZIP64 — file size capped at 2 GiB.
- *   - No timestamp metadata — we always record 1980-01-01 00:00 UTC,
- *     which most extractors render as a placeholder. This keeps the
- *     output deterministic for tests.
  */
 
-import { deflateRawSync } from "node:zlib";
 import { Buffer } from "node:buffer";
 
 const SIG_LOCAL_FILE = 0x04034b50;
 const SIG_CENTRAL_DIR = 0x02014b50;
 const SIG_END_OF_CENTRAL_DIR = 0x06054b50;
 
-const VERSION_NEEDED = 20; // 2.0 — DEFLATE.
-const COMPRESSION_DEFLATE = 8;
-const FLAGS = 0;
-
-const DOS_DATE = 0x21; // 1980-01-01
-const DOS_TIME = 0x00; // 00:00:00
+const VERSION_NEEDED = 10; // 1.0 — STORE.
+const VERSION_MADE_BY = (3 << 8) | VERSION_NEEDED; // Unix host, PKZIP 1.0.
+const COMPRESSION_STORE = 0;
+const FLAGS = 0x0800; // UTF-8 filenames/comments.
+const UNIX_REGULAR_FILE_0644 = (0o100644 << 16) >>> 0;
 
 export function buildSingleFileZip(
   filename: string,
@@ -37,36 +32,36 @@ export function buildSingleFileZip(
 ): Buffer {
   const nameBuf = Buffer.from(filename, "utf8");
   const raw = typeof contents === "string" ? Buffer.from(contents, "utf8") : Buffer.from(contents);
-  const compressed = deflateRawSync(raw);
   const crc32 = computeCrc32(raw);
   const uncompressedSize = raw.length;
-  const compressedSize = compressed.length;
+  const compressedSize = raw.length;
+  const { date, time } = dosTimestamp(new Date());
 
   // ── Local file header (30 bytes + name + extra) + payload ─────────
   const local = Buffer.alloc(30);
   local.writeUInt32LE(SIG_LOCAL_FILE, 0);
   local.writeUInt16LE(VERSION_NEEDED, 4);
   local.writeUInt16LE(FLAGS, 6);
-  local.writeUInt16LE(COMPRESSION_DEFLATE, 8);
-  local.writeUInt16LE(DOS_TIME, 10);
-  local.writeUInt16LE(DOS_DATE, 12);
+  local.writeUInt16LE(COMPRESSION_STORE, 8);
+  local.writeUInt16LE(time, 10);
+  local.writeUInt16LE(date, 12);
   local.writeUInt32LE(crc32, 14);
   local.writeUInt32LE(compressedSize, 18);
   local.writeUInt32LE(uncompressedSize, 22);
   local.writeUInt16LE(nameBuf.length, 26);
   local.writeUInt16LE(0, 28); // extra length
 
-  const localFileSection = Buffer.concat([local, nameBuf, compressed]);
+  const localFileSection = Buffer.concat([local, nameBuf, raw]);
 
   // ── Central directory header (46 bytes + name) ────────────────────
   const central = Buffer.alloc(46);
   central.writeUInt32LE(SIG_CENTRAL_DIR, 0);
-  central.writeUInt16LE(VERSION_NEEDED, 4); // version made by
+  central.writeUInt16LE(VERSION_MADE_BY, 4); // version made by
   central.writeUInt16LE(VERSION_NEEDED, 6); // version needed
   central.writeUInt16LE(FLAGS, 8);
-  central.writeUInt16LE(COMPRESSION_DEFLATE, 10);
-  central.writeUInt16LE(DOS_TIME, 12);
-  central.writeUInt16LE(DOS_DATE, 14);
+  central.writeUInt16LE(COMPRESSION_STORE, 10);
+  central.writeUInt16LE(time, 12);
+  central.writeUInt16LE(date, 14);
   central.writeUInt32LE(crc32, 16);
   central.writeUInt32LE(compressedSize, 20);
   central.writeUInt32LE(uncompressedSize, 24);
@@ -75,7 +70,7 @@ export function buildSingleFileZip(
   central.writeUInt16LE(0, 32); // comment length
   central.writeUInt16LE(0, 34); // disk #
   central.writeUInt16LE(0, 36); // internal attrs
-  central.writeUInt32LE(0, 38); // external attrs
+  central.writeUInt32LE(UNIX_REGULAR_FILE_0644, 38); // external attrs
   central.writeUInt32LE(0, 42); // local header offset
 
   const centralSection = Buffer.concat([central, nameBuf]);
@@ -92,6 +87,19 @@ export function buildSingleFileZip(
   eocd.writeUInt16LE(0, 20); // comment length
 
   return Buffer.concat([localFileSection, centralSection, eocd]);
+}
+
+function dosTimestamp(d: Date): { date: number; time: number } {
+  const year = Math.max(1980, Math.min(2107, d.getFullYear()));
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  const hours = d.getHours();
+  const minutes = d.getMinutes();
+  const seconds = Math.floor(d.getSeconds() / 2);
+  return {
+    date: ((year - 1980) << 9) | (month << 5) | day,
+    time: (hours << 11) | (minutes << 5) | seconds,
+  };
 }
 
 // ─── CRC32 (IEEE 802.3 polynomial, 0xEDB88320) ───────────────────────────

--- a/apps/memos-local-plugin/server/routes/skill.ts
+++ b/apps/memos-local-plugin/server/routes/skill.ts
@@ -260,8 +260,9 @@ export function registerSkillRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const md = renderSkillMarkdown(skill);
-    const buf = buildSingleFileZip("SKILL.md", md);
-    const filename = sanitizeFilename(skill.name || skill.id) + ".zip";
+    const packageName = sanitizeFilename(skill.name || skill.id);
+    const buf = buildSingleFileZip(`${packageName}/SKILL.md`, md);
+    const filename = packageName + ".zip";
     ctx.res.writeHead(200, {
       "content-type": "application/zip",
       "content-length": String(buf.length),
@@ -272,10 +273,32 @@ export function registerSkillRoutes(routes: Routes, deps: ServerDeps): void {
 }
 
 function renderSkillMarkdown(skill: SkillDTO): string {
-  const head = `# ${skill.name || skill.id}\n\n`;
+  const name = skill.name || skill.id;
+  const description = skillDescription(skill.invocationGuide, name);
+  const frontmatter =
+    `---\n` +
+    `name: ${yamlString(name)}\n` +
+    `description: ${yamlString(description)}\n` +
+    `---\n\n`;
+  const head = `# ${name}\n\n`;
   const meta = `> id: ${skill.id}\n> status: ${skill.status}\n> version: ${skill.version}\n\n`;
   const guide = skill.invocationGuide?.trim() || "(no invocation guide)";
-  return head + meta + guide + "\n";
+  return frontmatter + head + meta + guide + "\n";
+}
+
+function skillDescription(invocationGuide: string | undefined, name: string): string {
+  const fallback = `Use ${name} when this learned skill matches the current task.`;
+  const lines = (invocationGuide ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const firstBodyLine =
+    lines.find((line) => !line.startsWith("#") && !line.startsWith(">")) ?? fallback;
+  return firstBodyLine.replace(/\s+/g, " ").slice(0, 240);
+}
+
+function yamlString(raw: string): string {
+  return JSON.stringify(raw.replace(/\s+/g, " ").trim());
 }
 
 function sanitizeFilename(raw: string): string {

--- a/apps/memos-local-plugin/tests/unit/server/http.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/http.test.ts
@@ -94,6 +94,7 @@ function stubCore(): MemoryCore {
         rTask: null,
       },
     ]),
+    countEpisodes: vi.fn(async () => 2),
     timeline: vi.fn(async () => [{ id: "t1", step: 0, ts: 0 } as any]),
     listTraces: vi.fn(async () => [
       {
@@ -110,8 +111,10 @@ function stubCore(): MemoryCore {
         priority: 0.5,
       },
     ] as any),
+    countTraces: vi.fn(async () => 1),
     listApiLogs: vi.fn(async () => ({ logs: [], total: 0 })),
     listSkills: vi.fn(async () => []),
+    countSkills: vi.fn(async () => 0),
     getSkill: vi.fn(async (id) => ({
       id,
       name: "test-skill",
@@ -276,6 +279,7 @@ describe("HTTP server — REST routes", () => {
       offset: 0,
       sessionId: undefined,
       q: "hi",
+      groupByTurn: false,
     });
   });
 

--- a/apps/memos-local-plugin/tests/unit/server/http.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/http.test.ts
@@ -559,6 +559,14 @@ describe("HTTP server — REST routes", () => {
     const buf = Buffer.from(await r.arrayBuffer());
     // PKZIP local-file-header magic.
     expect(buf.slice(0, 4).toString("hex")).toBe("504b0304");
+    const nameLen = buf.readUInt16LE(26);
+    const extraLen = buf.readUInt16LE(28);
+    const fileSize = buf.readUInt32LE(22);
+    const name = buf.subarray(30, 30 + nameLen).toString("utf8");
+    const start = 30 + nameLen + extraLen;
+    const md = buf.subarray(start, start + fileSize).toString("utf8");
+    expect(name).toBe("test-skill/SKILL.md");
+    expect(md).toMatch(/^---\nname: "test-skill"\ndescription: "use this when X"\n---\n/);
   });
 
   it("PATCH /api/v1/policies/:id accepts a status-only body (back-compat)", async () => {

--- a/apps/memos-local-plugin/tests/unit/storage/tiny-zip.test.ts
+++ b/apps/memos-local-plugin/tests/unit/storage/tiny-zip.test.ts
@@ -3,13 +3,12 @@
  *
  * The skill download endpoint hands out a one-file ZIP built by
  * `core/util/tiny-zip.ts`. We don't pull in adm-zip just to verify
- * the bytes; instead we re-deflate-raw the embedded payload and
- * compare against the original input. That's enough to catch the
- * "we shipped a corrupt ZIP" failure mode without depending on a
+ * the bytes; instead we parse the local-file header and compare the
+ * embedded payload against the original input. That's enough to catch
+ * the "we shipped a corrupt ZIP" failure mode without depending on a
  * specific ZIP reader.
  */
 
-import { inflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 
 import { buildSingleFileZip, computeCrc32 } from "../../../core/util/tiny-zip.js";
@@ -20,7 +19,7 @@ describe("core/util/tiny-zip", () => {
     expect(buf.subarray(0, 4).toString("hex")).toBe("504b0304");
   });
 
-  it("embeds the same content we put in (after re-inflating the deflate stream)", () => {
+  it("embeds the same content we put in", () => {
     const payload = "# my skill\n\nuse this when foo bar baz\n";
     const buf = buildSingleFileZip("SKILL.md", payload);
 
@@ -28,12 +27,11 @@ describe("core/util/tiny-zip", () => {
     // extra=0, name="SKILL.md" (8 bytes), so payload starts at 38.
     const nameLen = buf.readUInt16LE(26);
     const extraLen = buf.readUInt16LE(28);
-    const compressedSize = buf.readUInt32LE(18);
+    const storedSize = buf.readUInt32LE(18);
     const start = 30 + nameLen + extraLen;
-    const compressed = buf.subarray(start, start + compressedSize);
+    const stored = buf.subarray(start, start + storedSize);
 
-    const inflated = inflateRawSync(compressed).toString("utf8");
-    expect(inflated).toBe(payload);
+    expect(stored.toString("utf8")).toBe(payload);
   });
 
   it("crc32 matches the well-known value for an empty input", () => {

--- a/apps/memos-local-plugin/web/src/views/SkillsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SkillsView.tsx
@@ -9,7 +9,7 @@
  *   - Archive
  */
 import { useEffect, useState } from "preact/hooks";
-import { api, withAgentPrefix } from "../api/client";
+import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
 import { route } from "../stores/router";
@@ -434,16 +434,23 @@ function SkillDrawer({
     }
   };
 
-  const downloadZip = () => {
-    const url = withAgentPrefix(
-      `/api/v1/skills/${encodeURIComponent(skill.id)}/download`,
-    );
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${skill.name.replace(/[^\w.-]+/g, "_") || "skill"}.zip`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+  const downloadZip = async () => {
+    setBusy(true);
+    try {
+      const blob = await api.blob(
+        `/api/v1/skills/${encodeURIComponent(skill.id)}/download`,
+      );
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${skill.name.replace(/[^\w.-]+/g, "_") || "skill"}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- Download skill ZIPs through the authenticated API client so browser downloads include the required API key.
- Emit ZIP archives with stored payloads, current timestamps, Unix file attrs, and a package folder containing `SKILL.md` for more reliable decompression.
- Render downloaded `SKILL.md` files with YAML frontmatter (`name`, `description`) for external agent compatibility.

## Test plan
- `npm test -- --run tests/unit/storage/tiny-zip.test.ts tests/unit/server/http.test.ts`


Made with [Cursor](https://cursor.com)