### PR TITLE
fix(hermes): fix memory persistence and viewer bugs

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -62,7 +62,7 @@ _PLUGIN_DIR = Path(__file__).resolve().parent
 if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
-from bridge_client import MemosBridgeClient  # noqa: E402
+from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
 from daemon_manager import ensure_bridge_running  # noqa: E402
 
 
@@ -149,19 +149,7 @@ class MemTensorProvider(MemoryProvider):
             return
         try:
             self._bridge = MemosBridgeClient()
-            resp = self._bridge.request(
-                "session.open",
-                {
-                    "agent": "hermes",
-                    "sessionId": session_id or "",
-                    "meta": {
-                        "hermesHome": self._hermes_home,
-                        "platform": self._platform,
-                        "agentIdentity": self._agent_identity,
-                    },
-                },
-            )
-            self._session_id = resp.get("sessionId") or session_id
+            self._open_session(session_id)
             logger.info(
                 "MemOS: bridge ready session=%s platform=%s (episode deferred)",
                 self._session_id,
@@ -223,18 +211,86 @@ class MemTensorProvider(MemoryProvider):
         args: dict | None = None,
         result: str = "",
         tool_call_id: str = "",
-        **_kw: Any,
+        **kw: Any,
     ) -> None:
         """Accumulate a tool call record for the current turn."""
+        timing = self._coerce_tool_timing(kw)
+        call = {
+            "name": tool_name,
+            "input": json.dumps(args, ensure_ascii=False)
+            if isinstance(args, dict)
+            else str(args or ""),
+            "output": (result or "")[:4000],
+        }
+        if timing:
+            call.update(timing)
         self._tool_calls.append(
-            {
-                "name": tool_name,
-                "input": json.dumps(args, ensure_ascii=False)
-                if isinstance(args, dict)
-                else str(args or ""),
-                "output": (result or "")[:4000],
-            }
+            call
         )
+
+    def _coerce_tool_timing(self, payload: dict[str, Any]) -> dict[str, int] | None:
+        """Preserve real tool timing if Hermes exposes it in hook kwargs."""
+        started = self._coerce_epoch_ms(
+            payload.get("startedAt")
+            or payload.get("started_at")
+            or payload.get("startTime")
+            or payload.get("start_time")
+        )
+        ended = self._coerce_epoch_ms(
+            payload.get("endedAt")
+            or payload.get("ended_at")
+            or payload.get("endTime")
+            or payload.get("end_time")
+        )
+        if started is not None and ended is not None and ended > started:
+            return {"startedAt": started, "endedAt": ended}
+
+        duration = self._coerce_duration_ms(
+            payload.get("durationMs")
+            or payload.get("duration_ms")
+            or payload.get("elapsedMs")
+            or payload.get("elapsed_ms")
+            or payload.get("latencyMs")
+            or payload.get("latency_ms")
+        )
+        if duration is not None and duration > 0:
+            end_ms = int(time.time() * 1000)
+            return {"startedAt": end_ms - duration, "endedAt": end_ms}
+
+        return None
+
+    @staticmethod
+    def _coerce_epoch_ms(value: Any) -> int | None:
+        if isinstance(value, (int, float)):
+            numeric = float(value)
+        elif isinstance(value, str):
+            try:
+                numeric = float(value)
+            except ValueError:
+                return None
+        else:
+            return None
+        if numeric <= 0:
+            return None
+        # Accept seconds or milliseconds.
+        if numeric < 10_000_000_000:
+            numeric *= 1000
+        return int(numeric)
+
+    @staticmethod
+    def _coerce_duration_ms(value: Any) -> int | None:
+        if isinstance(value, (int, float)):
+            numeric = float(value)
+        elif isinstance(value, str):
+            try:
+                numeric = float(value)
+            except ValueError:
+                return None
+        else:
+            return None
+        if numeric <= 0:
+            return None
+        return int(numeric)
 
     # ─── Turn-level hooks ─────────────────────────────────────────────────
 
@@ -303,10 +359,28 @@ class MemTensorProvider(MemoryProvider):
             len(assistant),
             len(tool_calls),
         )
+        ts_ms = int(time.time() * 1000)
         try:
-            self._turn_end(user, assistant, tool_calls, int(time.time() * 1000))
+            self._turn_end(user, assistant, tool_calls, ts_ms)
         except Exception as err:
-            logger.warning("MemOS: sync_turn turn.end failed — %s", err)
+            if not self._is_transport_closed(err):
+                logger.warning("MemOS: sync_turn turn.end failed — %s", err)
+            else:
+                logger.warning(
+                    "MemOS: bridge transport closed during sync_turn; "
+                    "reconnecting and retrying once — %s",
+                    err,
+                )
+                try:
+                    self._reconnect_bridge(session_id or self._session_id)
+                    if user:
+                        self._turn_start(user, session_id=session_id or self._session_id)
+                    self._turn_end(user, assistant, tool_calls, ts_ms)
+                except Exception:
+                    logger.exception(
+                        "MemOS: sync_turn failed after bridge reconnect; "
+                        "memory turn was not persisted"
+                    )
         if user_content:
             self._last_user_text = user_content
 
@@ -523,6 +597,42 @@ class MemTensorProvider(MemoryProvider):
         # remains accessible between `hermes chat` sessions.
 
     # ─── Internals ────────────────────────────────────────────────────────
+
+    def _open_session(self, session_id: str = "") -> None:
+        assert self._bridge is not None
+        requested_session = session_id or self._session_id or ""
+        resp = self._bridge.request(
+            "session.open",
+            {
+                "agent": "hermes",
+                "sessionId": requested_session,
+                "meta": {
+                    "hermesHome": self._hermes_home,
+                    "platform": self._platform,
+                    "agentIdentity": self._agent_identity,
+                },
+            },
+        )
+        self._session_id = resp.get("sessionId") or requested_session
+
+    def _is_transport_closed(self, err: Exception) -> bool:
+        if isinstance(err, BridgeError) and err.code == "transport_closed":
+            return True
+        msg = str(err).lower()
+        return (
+            "broken pipe" in msg
+            or "bridge closed" in msg
+            or "transport_closed" in msg
+        )
+
+    def _reconnect_bridge(self, session_id: str = "") -> None:
+        old_bridge = self._bridge
+        if old_bridge:
+            with contextlib.suppress(Exception):
+                old_bridge.close()
+        ensure_bridge_running()
+        self._bridge = MemosBridgeClient()
+        self._open_session(session_id)
 
     def _turn_start(self, query: str, *, session_id: str = "") -> str:
         assert self._bridge is not None

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -254,6 +254,10 @@ export function createMemoryCore(
   let shutDown = false;
   /** Per-episode monotonic step counter for tool outcomes. */
   const toolStepByEpisode = new Map<string, number>();
+  const skillStartedAtByPolicy = new Map<string, number>();
+  const skillRunDurationBySkill = new Map<string, number>();
+  const l2StartedAtByEpisode = new Map<string, number>();
+  let l3StartedAt: number | null = null;
 
   function ensureLive(): void {
     if (shutDown) {
@@ -437,25 +441,41 @@ export function createMemoryCore(
     handle.buses.skill.onAny((evt) => {
       const k = evt.kind;
       if (k === "skill.crystallization.started") {
-        writeApiLog(handle, log, "skill_generate", {
-          phase: "started",
-          policyId: evt.policyId,
-        }, evt, 0, true);
+        skillStartedAtByPolicy.set(evt.policyId, eventTime(evt));
       } else if (k === "skill.crystallized") {
+        const durationMs = durationSince(
+          skillStartedAtByPolicy.get(evt.policyId),
+          eventTime(evt),
+          1,
+        );
+        skillStartedAtByPolicy.delete(evt.policyId);
+        skillRunDurationBySkill.set(evt.skillId, durationMs);
         writeApiLog(handle, log, "skill_generate", {
           phase: "done",
           skillId: evt.skillId,
-        }, evt, 0, true);
+        }, evt, durationMs, true);
       } else if (k === "skill.rebuilt" || k === "skill.eta.updated" || k === "skill.archived") {
+        const skillId = (evt as { skillId?: string }).skillId;
+        const durationMs =
+          (skillId ? skillRunDurationBySkill.get(skillId) : undefined) ??
+          durationSince(eventTime(evt) - 1, eventTime(evt), 1);
+        if (k === "skill.rebuilt" && skillId) skillRunDurationBySkill.delete(skillId);
         writeApiLog(handle, log, "skill_evolve", {
           kind: k,
-          skillId: (evt as { skillId?: string }).skillId,
-        }, evt, 0, true);
+          skillId,
+        }, evt, durationMs, true);
       } else if (k === "skill.verification.failed" || k === "skill.failed") {
+        const policyId = (evt as { policyId?: string }).policyId;
+        const durationMs = durationSince(
+          policyId ? skillStartedAtByPolicy.get(policyId) : undefined,
+          eventTime(evt),
+          policyId ? 1 : 0,
+        );
+        if (policyId) skillStartedAtByPolicy.delete(policyId);
         writeApiLog(handle, log, "skill_generate", {
           phase: "failed",
           kind: k,
-        }, evt, 0, false);
+        }, evt, durationMs, false);
       }
     });
 
@@ -463,45 +483,51 @@ export function createMemoryCore(
     handle.buses.l2.onAny((evt) => {
       const k = evt.kind;
       if (k === "l2.policy.induced") {
+        const durationMs = durationSince(l2StartedAtByEpisode.get(evt.episodeId), Date.now(), 1);
         writeApiLog(handle, log, "policy_generate", {
           phase: "induced",
           policyId: evt.policyId,
           title: evt.title,
-        }, evt, 0, true);
+        }, evt, durationMs, true);
       } else if (k === "l2.policy.updated") {
+        const durationMs = durationSince(l2StartedAtByEpisode.get(evt.episodeId), Date.now(), 1);
         writeApiLog(handle, log, "policy_evolve", {
           policyId: evt.policyId,
           status: evt.status,
-        }, evt, 0, true);
+        }, evt, durationMs, true);
       } else if (k === "l2.failed") {
+        const durationMs = durationSince(l2StartedAtByEpisode.get(evt.episodeId), Date.now(), 1);
+        l2StartedAtByEpisode.delete(evt.episodeId);
         writeApiLog(handle, log, "policy_generate", {
           phase: "failed",
-        }, evt, 0, false);
+        }, evt, durationMs, false);
       }
     });
 
     // ─── L3 (领域认知) lifecycle → api_logs(world_model_*) ────────────
     handle.buses.l3.onAny((evt) => {
       const k = evt.kind;
-      if (k === "l3.world-model.created") {
+      if (k === "l3.abstraction.started") {
+        l3StartedAt = Date.now();
+      } else if (k === "l3.world-model.created") {
         writeApiLog(handle, log, "world_model_generate", {
           phase: "created",
           worldModelId: evt.worldModelId,
           title: evt.title,
-        }, evt, 0, true);
+        }, evt, durationSince(l3StartedAt, Date.now(), 1), true);
       } else if (k === "l3.world-model.updated") {
         writeApiLog(handle, log, "world_model_evolve", {
           worldModelId: evt.worldModelId,
           title: evt.title,
-        }, evt, 0, true);
+        }, evt, durationSince(l3StartedAt, Date.now(), 1), true);
       } else if (k === "l3.confidence.adjusted") {
         writeApiLog(handle, log, "world_model_evolve", {
           kind: "confidence.adjusted",
-        }, evt, 0, true);
+        }, evt, durationSince(l3StartedAt, Date.now(), 1), true);
       } else if (k === "l3.failed") {
         writeApiLog(handle, log, "world_model_generate", {
           phase: "failed",
-        }, evt, 0, false);
+        }, evt, durationSince(l3StartedAt, Date.now(), 1), false);
       }
     });
 
@@ -510,15 +536,18 @@ export function createMemoryCore(
     // what makes a task "completed" (R ≥ 0) or "failed" (R < 0) in the
     // viewer's Tasks panel.
     handle.buses.reward.onAny((evt) => {
-      if (evt.kind === "reward.scored") {
-        const ok = evt.rHuman >= 0;
+      if (evt.kind === "reward.updated") {
+        const result = evt.result;
+        const ok = result.rHuman >= 0;
+        l2StartedAtByEpisode.set(result.episodeId, Date.now());
         writeApiLog(handle, log, ok ? "task_done" : "task_failed", {
-          episodeId: evt.episodeId,
-          sessionId: evt.sessionId,
+          episodeId: result.episodeId,
+          sessionId: result.sessionId,
         }, {
-          rHuman: evt.rHuman,
-          source: evt.source,
-        }, 0, ok);
+          rHuman: result.rHuman,
+          source: result.source,
+          timings: result.timings,
+        }, durationSince(result.startedAt, result.completedAt), ok);
       }
     });
   }
@@ -745,17 +774,13 @@ export function createMemoryCore(
   ): Promise<{ traceId: string; episodeId: EpisodeId }> {
     ensureLive();
     const outcome = await handle.onTurnEnd(result);
-    // Capture is asynchronous — when the caller wants a `traceId` we
-    // deterministically allocate one upstream, but the V1 contract just
-    // returns the latest snapshot ids. We return the final trace id the
-    // episode snapshot reports (or a synthetic turn id if nothing yet).
-    const snap = outcome.episode;
-    const turnCount = snap?.turnCount ?? 0;
-    const traceIds = snap?.traceIds ?? [];
-    const lastTraceId =
-      traceIds.length > 0
-        ? traceIds[traceIds.length - 1]!
-        : `trace-${outcome.episodeId}-${turnCount}`;
+    // Return the real row id produced by the synchronous lite capture.
+    // Feedback submits this id as a FK, so a synthetic placeholder would
+    // cause SQLite "FOREIGN KEY constraint failed" later.
+    const traceIds = outcome.traceIds.length > 0
+      ? outcome.traceIds
+      : outcome.episode?.traceIds ?? [];
+    const lastTraceId = traceIds[traceIds.length - 1] ?? "";
     return {
       traceId: lastTraceId,
       episodeId: outcome.episodeId,
@@ -766,6 +791,13 @@ export function createMemoryCore(
     feedback: Omit<FeedbackDTO, "id" | "ts"> & { ts?: number },
   ): Promise<FeedbackDTO> {
     ensureLive();
+    if (feedback.traceId && !handle.repos.traces.getById(feedback.traceId as TraceId)) {
+      throw new MemosError(
+        "trace_not_found",
+        `trace not found: ${feedback.traceId}`,
+        { traceId: feedback.traceId },
+      );
+    }
     const ts = feedback.ts ?? Date.now();
     const id = randomUUID();
     const row: FeedbackRow = {
@@ -2292,6 +2324,27 @@ export function inferTier(
   if (kind === "skill") return 1;
   if (kind === "world-model") return 3;
   return 2;
+}
+
+function eventTime(evt: unknown): number {
+  const at = (evt as { at?: unknown } | null)?.at;
+  return typeof at === "number" && Number.isFinite(at) ? at : Date.now();
+}
+
+function durationSince(
+  startedAt: number | undefined | null,
+  endedAt = Date.now(),
+  fallbackMs = 0,
+): number {
+  if (
+    typeof startedAt !== "number" ||
+    !Number.isFinite(startedAt) ||
+    !Number.isFinite(endedAt) ||
+    endedAt <= startedAt
+  ) {
+    return fallbackMs;
+  }
+  return Math.max(fallbackMs, Math.round(endedAt - startedAt));
 }
 
 /**

--- a/apps/memos-local-plugin/core/pipeline/orchestrator.ts
+++ b/apps/memos-local-plugin/core/pipeline/orchestrator.ts
@@ -258,6 +258,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
   ): Promise<{ episode: EpisodeSnapshot; sessionId: SessionId; relation?: string }> {
     const mergeMode = algorithm.session.followUpMode === "merge_follow_ups";
     const mergeCapMs = algorithm.session.mergeMaxGapMs;
+    const turnTs = timestampFromMeta(meta, "startedAtTurnTs");
 
     // ─── Case 1: there is a currently open episode ──────────────────
     const currentEpId = openEpisodeBySession.get(sessionId);
@@ -271,7 +272,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
         // tail.
         const ctx = buildClassifierContext(open.turns);
         const lastTurnTs = open.turns[open.turns.length - 1]?.ts ?? open.startedAt;
-        const gapMs = Math.max(0, now() - lastTurnTs);
+        const gapMs = Math.max(0, (turnTs ?? now()) - lastTurnTs);
 
         const decision = await session.relation.classify({
           prevUserText: ctx.prevUserText,
@@ -313,6 +314,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
           session.sessionManager.addTurn(currentEpId, {
             role: "user",
             content: userText,
+            ts: turnTs,
             meta: {
               source: "follow_up",
               classifiedRelation: decision.relation,
@@ -359,6 +361,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
           const snap = await session.sessionManager.startEpisode({
             sessionId,
             userMessage: userText,
+            ts: turnTs,
             meta: { ...meta, relation: "new_task" },
           });
           openEpisodeBySession.set(sessionId, snap.id as EpisodeId);
@@ -377,6 +380,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
         const fresh = await session.sessionManager.startEpisode({
           sessionId,
           userMessage: userText,
+          ts: turnTs,
           meta: { ...meta, relation: decision.relation, gapMs },
         });
         openEpisodeBySession.set(sessionId, fresh.id as EpisodeId);
@@ -394,13 +398,14 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       const snap = await session.sessionManager.startEpisode({
         sessionId,
         userMessage: userText,
+        ts: turnTs,
         meta,
       });
       openEpisodeBySession.set(sessionId, snap.id as EpisodeId);
       return { episode: snap, sessionId, relation: "bootstrap" };
     }
 
-    const gapMs = now() - prev.endedAt;
+    const gapMs = Math.max(0, (turnTs ?? now()) - prev.endedAt);
     const decision = await session.relation.classify({
       prevUserText: prev.userText,
       prevAssistantText: prev.assistantText,
@@ -439,6 +444,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       session.sessionManager.addTurn(prev.episodeId, {
         role: "user",
         content: userText,
+        ts: turnTs,
         meta: {
           source: reopenReason,
           classifiedRelation: decision.relation,
@@ -468,6 +474,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       const snap = await session.sessionManager.startEpisode({
         sessionId,
         userMessage: userText,
+        ts: turnTs,
         meta: { ...meta, relation: "new_task" },
       });
       openEpisodeBySession.set(sessionId, snap.id as EpisodeId);
@@ -477,6 +484,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
     const snap = await session.sessionManager.startEpisode({
       sessionId,
       userMessage: userText,
+      ts: turnTs,
       meta: { ...meta, relation: decision.relation },
     });
     openEpisodeBySession.set(sessionId, snap.id as EpisodeId);
@@ -680,6 +688,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
           : tc.output != null
             ? JSON.stringify(tc.output).slice(0, 2000)
             : "",
+        ts: Number.isFinite(tc.endedAt) ? tc.endedAt : result.ts,
         meta: {
           tool: tc.name,
           name: tc.name,
@@ -699,6 +708,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
     session.sessionManager.addTurn(episodeId, {
       role: "assistant",
       content: result.agentText,
+      ts: result.ts,
       meta: {
         toolCalls: result.toolCalls,
         // V7 §0.1 split:
@@ -721,9 +731,11 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
     // (next turn classified as `new_task`, idle timeout, session_end,
     // or shutdown).
     const liveEpisode = session.sessionManager.getEpisode(episodeId);
+    let liteTraceIds: string[] = [];
     if (liveEpisode) {
       try {
-        await subs.captureRunner.runLite({ episode: liveEpisode });
+        const lite = await subs.captureRunner.runLite({ episode: liveEpisode });
+        liteTraceIds = lite.traceIds;
       } catch (err) {
         log.warn("turn.lite_capture.failed", {
           episodeId,
@@ -755,7 +767,8 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
     // The episode stays OPEN — finalize is deferred to topic end.
     return {
-      traceCount: liveEpisode?.turnCount ?? 0,
+      traceCount: liteTraceIds.length,
+      traceIds: liteTraceIds,
       episodeId: episodeId as EpisodeId,
       episode: liveEpisode ?? null,
       episodeFinalized: false,
@@ -845,6 +858,11 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   function now(): number {
     return (deps.now ?? Date.now)();
+  }
+
+  function timestampFromMeta(meta: Record<string, unknown>, key: string): number | undefined {
+    const ts = meta[key];
+    return typeof ts === "number" && Number.isFinite(ts) ? ts : undefined;
   }
 
   /**

--- a/apps/memos-local-plugin/core/pipeline/types.ts
+++ b/apps/memos-local-plugin/core/pipeline/types.ts
@@ -236,6 +236,8 @@ export interface RecordToolOutcomeInput {
 
 export interface TurnEndResult {
   traceCount: number;
+  /** Trace ids actually persisted by the per-turn lite capture pass. */
+  traceIds: string[];
   /** The episode we wrote this turn into. */
   episodeId: EpisodeId;
   /**

--- a/apps/memos-local-plugin/core/session/episode-manager.ts
+++ b/apps/memos-local-plugin/core/session/episode-manager.ts
@@ -29,6 +29,7 @@ import type {
   EpisodeSnapshot,
   EpisodeStartInput,
   EpisodeTurn,
+  EpisodeTurnInput,
   IntentDecision,
   SessionEventBus,
 } from "./types.js";
@@ -42,7 +43,7 @@ export interface EpisodeManagerDeps {
 
 export interface EpisodeManager {
   start(input: EpisodeStartInput, intent: IntentDecision): EpisodeSnapshot;
-  addTurn(id: EpisodeId, turn: Omit<EpisodeTurn, "id" | "ts">): EpisodeTurn;
+  addTurn(id: EpisodeId, turn: EpisodeTurnInput): EpisodeTurn;
   finalize(id: EpisodeId, input?: EpisodeFinalizeInput): EpisodeSnapshot;
   abandon(id: EpisodeId, reason: string): EpisodeSnapshot;
   attachTraceIds(id: EpisodeId, traceIds: string[]): void;
@@ -97,7 +98,7 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
           "episode.start requires an initial user turn with non-empty content",
         );
       }
-      const startedAt = now();
+      const startedAt = input.initialTurn.ts ?? now();
       const id = (input.id ?? ids.episode()) as EpisodeId;
       const firstTurn: EpisodeTurn = {
         ...input.initialTurn,
@@ -142,7 +143,7 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
 
     addTurn(id, turn) {
       const snap = assertOpen(get(id), id);
-      const full: EpisodeTurn = { ...turn, id: ids.span(), ts: now() };
+      const full: EpisodeTurn = { ...turn, id: ids.span(), ts: turn.ts ?? now() };
       snap.turns.push(full);
       snap.turnCount++;
       deps.sessionsRepo.touchLastSeen(snap.sessionId, full.ts);

--- a/apps/memos-local-plugin/core/session/manager.ts
+++ b/apps/memos-local-plugin/core/session/manager.ts
@@ -29,6 +29,7 @@ import type {
   EpisodeSnapshot,
   EpisodeStartInput,
   EpisodeTurn,
+  EpisodeTurnInput,
   IntentDecision,
   SessionEventBus,
   SessionOpenInput,
@@ -54,6 +55,8 @@ export interface StartEpisodeInput {
   id?: EpisodeId;
   /** First user message. Required. */
   userMessage: string;
+  /** Adapter-provided event time for the first user turn. */
+  ts?: EpochMs;
   meta?: Record<string, unknown>;
 }
 
@@ -67,7 +70,7 @@ export interface SessionManager {
   pruneIdle(now?: EpochMs): SessionId[];
 
   startEpisode(input: StartEpisodeInput): Promise<EpisodeSnapshot>;
-  addTurn(episodeId: EpisodeId, turn: Omit<EpisodeTurn, "id" | "ts">): EpisodeTurn;
+  addTurn(episodeId: EpisodeId, turn: EpisodeTurnInput): EpisodeTurn;
   finalizeEpisode(episodeId: EpisodeId, input?: EpisodeFinalizeInput): EpisodeSnapshot;
   abandonEpisode(episodeId: EpisodeId, reason: string): EpisodeSnapshot;
   /** V7 §0.1 "revision" path — reopen a previously-closed episode. */
@@ -218,7 +221,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         const startInput: EpisodeStartInput = {
           sessionId: input.sessionId,
           id: episodeId,
-          initialTurn: { role: "user", content: input.userMessage, meta: input.meta },
+          initialTurn: { role: "user", content: input.userMessage, ts: input.ts, meta: input.meta },
           meta: input.meta,
         };
         const snap = epm.start(startInput, intent);

--- a/apps/memos-local-plugin/core/session/types.ts
+++ b/apps/memos-local-plugin/core/session/types.ts
@@ -57,12 +57,17 @@ export interface EpisodeTurn {
   meta?: Record<string, unknown>;
 }
 
+export type EpisodeTurnInput = Omit<EpisodeTurn, "id" | "ts"> & {
+  /** Adapter-provided event time. Defaults to the server receive time. */
+  ts?: EpochMs;
+};
+
 export interface EpisodeStartInput {
   sessionId: SessionId;
   /** Pre-minted id (adapters sometimes pre-allocate). */
   id?: EpisodeId;
   /** The initial user query. Required — empty episodes are a programming error. */
-  initialTurn: Omit<EpisodeTurn, "id" | "ts">;
+  initialTurn: EpisodeTurnInput;
   /** Optional adapter-provided hints (e.g. sub-agent depth, tool allowlist). */
   meta?: Record<string, unknown>;
 }

--- a/apps/memos-local-plugin/server/routes/feedback.ts
+++ b/apps/memos-local-plugin/server/routes/feedback.ts
@@ -21,6 +21,13 @@ export function registerFeedbackRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "polarity is required");
       return;
     }
+    if (fb.traceId) {
+      const trace = await deps.core.getTrace(fb.traceId);
+      if (!trace) {
+        writeError(ctx, 404, "trace_not_found", `trace not found: ${fb.traceId}`);
+        return;
+      }
+    }
     const out = await deps.core.submitFeedback({
       channel: fb.channel,
       polarity: fb.polarity,

--- a/apps/memos-local-plugin/server/routes/metrics.ts
+++ b/apps/memos-local-plugin/server/routes/metrics.ts
@@ -30,6 +30,13 @@ interface ToolStat {
   lastTs: number;
 }
 
+interface UnavailableToolStat {
+  name: string;
+  calls: number;
+  errors: number;
+  lastTs: number;
+}
+
 export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
   routes.set("GET /api/v1/metrics", async (ctx) => {
     const raw = ctx.url.searchParams.get("days");
@@ -56,6 +63,9 @@ export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
     const buckets = new Map<string, number[]>();
     const errors = new Map<string, number>();
     const lastTs = new Map<string, number>();
+    const unavailableCalls = new Map<string, number>();
+    const unavailableErrors = new Map<string, number>();
+    const unavailableLastTs = new Map<string, number>();
     // Per-minute time series keyed by "YYYY-MM-DDTHH:MM" → { [tool]: ms[] }
     const minuteBuckets = new Map<string, Map<string, number[]>>();
 
@@ -72,6 +82,12 @@ export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
         if (!mb.has(name)) mb.set(name, []);
         mb.get(name)!.push(Math.max(0, durMs));
       }
+    };
+
+    const bumpUnavailable = (name: string, ok: boolean, ts: number): void => {
+      unavailableCalls.set(name, (unavailableCalls.get(name) ?? 0) + 1);
+      if (!ok) unavailableErrors.set(name, (unavailableErrors.get(name) ?? 0) + 1);
+      unavailableLastTs.set(name, Math.max(unavailableLastTs.get(name) ?? 0, ts));
     };
 
     // 1. Plugin internal operations — from api_logs. We only surface
@@ -101,7 +117,15 @@ export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
       if (tr.ts < sinceMs) continue;
       for (const tc of tr.toolCalls ?? []) {
         const name = tc.name ?? "unknown";
-        const dur = Math.max(0, (tc.endedAt ?? tr.ts) - (tc.startedAt ?? tr.ts));
+        if (
+          !Number.isFinite(tc.startedAt) ||
+          !Number.isFinite(tc.endedAt) ||
+          tc.endedAt <= tc.startedAt
+        ) {
+          bumpUnavailable(name, !tc.errorCode, tr.ts);
+          continue;
+        }
+        const dur = tc.endedAt - tc.startedAt;
         bump(name, dur, !tc.errorCode, tc.endedAt ?? tr.ts);
       }
     }
@@ -126,6 +150,15 @@ export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
     tools.sort((a, b) => b.calls - a.calls);
     const toolNames = tools.map((t) => t.name);
 
+    const unavailableTools: UnavailableToolStat[] = [...unavailableCalls.entries()]
+      .map(([name, calls]) => ({
+        name,
+        calls,
+        errors: unavailableErrors.get(name) ?? 0,
+        lastTs: unavailableLastTs.get(name) ?? 0,
+      }))
+      .sort((a, b) => b.calls - a.calls || b.lastTs - a.lastTs);
+
     let series: Array<Record<string, unknown>> | undefined;
     if (wantSeries && minuteBuckets.size > 0) {
       const sorted = [...minuteBuckets.keys()].sort();
@@ -145,6 +178,7 @@ export function registerMetricsRoutes(routes: Routes, deps: ServerDeps): void {
     return {
       tools,
       toolNames,
+      unavailableTools,
       series,
       windowMinutes,
       windowDays: Math.round(windowMinutes / 1440) || 1,

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -255,6 +255,107 @@ class MemTensorProviderTests(unittest.TestCase):
         p.on_turn_start(1, "earlier user text")
         self.assertEqual(p.on_pre_compress([{"role": "user", "content": "x"}]), "")
 
+    def test_sync_turn_transport_closed_logs_error_if_retry_fails(self) -> None:
+        """Retry failures are surfaced explicitly instead of silent loss."""
+
+        class BrokenBridge:
+            def close(self):
+                pass
+
+            def request(self, method, params=None):
+                if method == "turn.end":
+                    raise BridgeError("transport_closed", "[Errno 32] Broken pipe")
+                return {}
+
+        class RetryFailBridge:
+            def request(self, method, params=None):
+                if method == "session.open":
+                    return {"sessionId": (params or {}).get("sessionId", "sess")}
+                if method == "turn.start":
+                    return {"query": {"episodeId": "ep_after_reconnect"}}
+                if method == "turn.end":
+                    raise BridgeError("internal", "still down")
+                return {}
+
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = BrokenBridge()
+        p._session_id = "sess_tui_long_running"
+        p._episode_id = "ep_tui_long_running"
+
+        with patch("memos_provider.MemosBridgeClient", return_value=RetryFailBridge()):
+            with self.assertLogs("memos_provider", level="ERROR") as logs:
+                p.sync_turn(
+                    "帮我检索一下最近关于中东的事件，以及分析下局势",
+                    "最近有关中东的事件和局势如下...",
+                )
+
+        joined = "\n".join(logs.output)
+        self.assertIn("failed after bridge reconnect", joined)
+        self.assertIn("memory turn was not persisted", joined)
+
+    def test_sync_turn_reconnects_and_retries_after_transport_closed(self) -> None:
+        """Reconnect and retry once after a stale bridge pipe."""
+
+        class BrokenBridge:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+            def request(self, method, params=None):
+                if method == "turn.end":
+                    raise BridgeError("transport_closed", "[Errno 32] Broken pipe")
+                return {}
+
+        class HealthyBridge:
+            def __init__(self):
+                self.calls = []
+
+            def request(self, method, params=None):
+                self.calls.append((method, params or {}))
+                if method == "session.open":
+                    return {"sessionId": (params or {}).get("sessionId", "sess")}
+                if method == "turn.start":
+                    return {"query": {"episodeId": "ep_after_reconnect"}}
+                if method == "turn.end":
+                    return {"traceId": "tr_after_reconnect"}
+                return {}
+
+        broken = BrokenBridge()
+        replacement = HealthyBridge()
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = broken
+        p._session_id = "sess_tui_long_running"
+        p._episode_id = "ep_tui_long_running"
+        p._hermes_home = "/tmp/hermes-home"
+        p._platform = "tui"
+        p._agent_identity = "hermes-test"
+        p._tool_calls = [{"name": "search_files", "input": "{}", "output": "ok"}]
+
+        with patch("memos_provider.MemosBridgeClient", return_value=replacement):
+            p.sync_turn(
+                "帮我检索一下最近关于中东的事件，以及分析下局势",
+                "最近有关中东的事件和局势如下...",
+            )
+
+        methods = [method for method, _params in replacement.calls]
+        self.assertEqual(methods, ["session.open", "turn.start", "turn.end"])
+        self.assertTrue(broken.closed)
+        self.assertEqual(p._episode_id, "ep_after_reconnect")
+
+        session_params = replacement.calls[0][1]
+        self.assertEqual(session_params["sessionId"], "sess_tui_long_running")
+        self.assertEqual(session_params["meta"]["platform"], "tui")
+        self.assertEqual(session_params["meta"]["agentIdentity"], "hermes-test")
+
+        retry_payload = replacement.calls[-1][1]
+        self.assertEqual(retry_payload["sessionId"], "sess_tui_long_running")
+        self.assertEqual(retry_payload["episodeId"], "ep_after_reconnect")
+        self.assertIn("中东", retry_payload["userText"])
+        self.assertIn("局势", retry_payload["agentText"])
+        self.assertEqual(retry_payload["toolCalls"][0]["name"], "search_files")
+
     def test_get_config_schema_describes_known_fields(self) -> None:
         p = self._provider_mod.MemTensorProvider()
         schema = p.get_config_schema()

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -22,6 +22,7 @@ import { resolveHome } from "../../../core/config/paths.js";
 import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
 import { makeTmpHome, type TmpHomeContext } from "../../helpers/tmp-home.js";
 import { fakeEmbedder } from "../../helpers/fake-embedder.js";
+import type { MemosError } from "../../../agent-contract/errors.js";
 
 let db: TmpDbHandle | null = null;
 let pipeline: PipelineHandle | null = null;
@@ -138,6 +139,63 @@ describe("MemoryCore façade", () => {
 
     // Verify it's actually in the repo.
     expect(db!.repos.feedback.getById(fb.id)).not.toBeNull();
+  });
+
+  it("onTurnEnd returns a real persisted trace id that feedback accepts", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+
+    const start = await core.onTurnStart({
+      agent: "openclaw",
+      sessionId: "s-feedback",
+      userText: "remember that I prefer short status updates",
+      ts: 1_700_000_000_000,
+    });
+    const end = await core.onTurnEnd({
+      agent: "openclaw",
+      sessionId: start.query.sessionId,
+      episodeId: start.query.episodeId,
+      agentText: "Got it.",
+      toolCalls: [],
+      ts: 1_700_000_000_500,
+    });
+
+    expect(end.traceId).toMatch(/^tr_/);
+    expect(db!.repos.traces.getById(end.traceId as never)).not.toBeNull();
+
+    const fb = await core.submitFeedback({
+      channel: "explicit",
+      polarity: "positive",
+      magnitude: 1,
+      traceId: end.traceId,
+      episodeId: end.episodeId,
+    });
+    expect(fb.traceId).toBe(end.traceId);
+  });
+
+  it("submitFeedback rejects unknown trace ids before SQLite FK failure", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+
+    await expect(core.submitFeedback({
+      channel: "explicit",
+      polarity: "negative",
+      magnitude: 1,
+      traceId: "trace-not-in-db",
+    })).rejects.toMatchObject({
+      name: "MemosError",
+      code: "trace_not_found",
+    } satisfies Partial<MemosError>);
   });
 
   it("listEpisodes + timeline return empty arrays when nothing has happened", async () => {

--- a/apps/memos-local-plugin/tests/unit/pipeline/orchestrator.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/orchestrator.test.ts
@@ -95,10 +95,38 @@ describe("pipeline/orchestrator", () => {
     expect(end.episodeFinalized).toBe(false);
     expect(end.asyncWorkScheduled).toBe(true);
     expect(end.episode?.status).toBe("open");
+    expect(end.traceIds).toHaveLength(1);
+    expect(dbHandle!.repos.traces.getById(end.traceIds[0]!)).not.toBeNull();
 
     // Flush still drains any in-flight lite capture work; reflect
     // won't fire until the next turn closes this topic.
     await pipeline.flush();
+  });
+
+  it("preserves adapter-provided turn timestamps on captured traces", async () => {
+    pipeline = createPipeline(buildDeps(dbHandle!));
+    const historicalStartTs = 1_700_000_000_000 - 90 * 24 * 60 * 60 * 1000;
+    const historicalEndTs = historicalStartTs + 500;
+
+    const packet = await pipeline.onTurnStart({
+      agent: "openclaw",
+      sessionId: "s-historical",
+      userText: "90 days ago I decided Monday mornings are for project review",
+      ts: historicalStartTs,
+    });
+    await pipeline.onTurnEnd({
+      agent: "openclaw",
+      sessionId: "s-historical",
+      episodeId: packet.episodeId ?? "ep-ignored",
+      agentText: "Got it, I will remember that weekly review habit.",
+      toolCalls: [],
+      ts: historicalEndTs,
+    });
+    await pipeline.flush();
+
+    const traces = dbHandle!.repos.traces.list({ sessionId: "s-historical" });
+    expect(traces).toHaveLength(1);
+    expect(traces[0]!.ts).toBe(historicalEndTs);
   });
 
   it("emits a unified CoreEvent stream", async () => {

--- a/apps/memos-local-plugin/tests/unit/server/http.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/http.test.ts
@@ -73,6 +73,7 @@ function stubCore(): MemoryCore {
     updateWorldModel: vi.fn(async (id, patch) => ({ id, status: "active", ...patch } as any)),
     archiveWorldModel: vi.fn(async (id) => ({ id, status: "archived" } as any)),
     unarchiveWorldModel: vi.fn(async (id) => ({ id, status: "active" } as any)),
+    countEpisodes: vi.fn(async () => 2),
     listEpisodes: vi.fn(async () => ["e1", "e2"]),
     listEpisodeRows: vi.fn(async () => [
       {
@@ -110,7 +111,9 @@ function stubCore(): MemoryCore {
         priority: 0.5,
       },
     ] as any),
+    countTraces: vi.fn(async () => 1),
     listApiLogs: vi.fn(async () => ({ logs: [], total: 0 })),
+    countSkills: vi.fn(async () => 0),
     listSkills: vi.fn(async () => []),
     getSkill: vi.fn(async (id) => ({
       id,
@@ -255,6 +258,24 @@ describe("HTTP server — REST routes", () => {
       polarity: "positive",
       magnitude: 0.7,
     });
+  });
+
+  it("POST /api/v1/feedback returns trace_not_found for stale trace ids", async () => {
+    (core.getTrace as any).mockResolvedValueOnce(null);
+    const r = await fetch(`${handle.url}/api/v1/feedback`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        channel: "explicit",
+        polarity: "negative",
+        magnitude: 1,
+        traceId: "trace-not-real",
+      }),
+    });
+    expect(r.status).toBe(404);
+    const body = (await r.json()) as any;
+    expect(body.error.code).toBe("trace_not_found");
+    expect(core.submitFeedback).not.toHaveBeenCalled();
   });
 
   it("GET /api/v1/traces lists newest-first traces (used by Memories panel)", async () => {

--- a/apps/memos-local-plugin/web/src/components/ModelSetupBanner.tsx
+++ b/apps/memos-local-plugin/web/src/components/ModelSetupBanner.tsx
@@ -1,18 +1,29 @@
 /**
  * ModelSetupBanner — sticky amber strip just under the topbar.
  *
- * A simple "please configure your models" reminder. Always shown until
- * the operator clicks `✕`; the dismissal is persisted to localStorage
- * so it survives page reloads. We intentionally do NOT inspect health
- * to decide whether to hide it — the banner is a one-time onboarding
- * nudge, not a live status indicator.
+ * Shows up when at least one of the three model slots
+ * (`embedder`, `llm`, `skillEvolver`) is not usable. Hides itself
+ * automatically as soon as the bridge reports all three as
+ * `available=true` — the same flag `stores/health.ts` advertises as
+ * "the viewer's setup banner uses this flag". The user can also
+ * dismiss it manually with `✕`; that dismissal is persisted to
+ * localStorage so a half-configured user doesn't get nagged forever.
+ *
+ * Display rules, in order:
+ *   1. User clicked `✕` before          → hidden permanently.
+ *   2. `health` hasn't loaded yet       → hidden (avoids flashing a red
+ *                                          bar on first paint before we
+ *                                          know whether anything's wrong).
+ *   3. All three slots `available=true` → hidden (setup is complete).
+ *   4. Otherwise                        → shown.
  *
  * Mounted as the second row of `.shell` (see `styles/layout.css`); the
- * row collapses to zero height when the banner is dismissed.
+ * row collapses to zero height when the banner is hidden.
  */
 import { useState } from "preact/hooks";
 import { t } from "../stores/i18n";
 import { navigate } from "../stores/router";
+import { health } from "../stores/health";
 import { Icon } from "./Icon";
 
 const STORAGE_KEY = "memos.banner.modelSetup.dismissed";
@@ -37,6 +48,18 @@ export function ModelSetupBanner() {
   const [dismissed, setDismissed] = useState<boolean>(() => isDismissed());
 
   if (dismissed) return null;
+
+  // Reading `health.value` here subscribes the component to the signal,
+  // so the banner re-evaluates every time `/api/v1/health` polls (15s).
+  // If the user later misconfigures (e.g. clears apiKey in Settings),
+  // the bridge will report `available=false` and the banner reappears
+  // without needing a page reload.
+  const h = health.value;
+  if (h === null) return null; // first paint, status unknown
+  const allConfigured = Boolean(
+    h.embedder?.available && h.llm?.available && h.skillEvolver?.available,
+  );
+  if (allConfigured) return null;
 
   const handleDismiss = () => {
     persistDismissed();

--- a/apps/memos-local-plugin/web/src/components/Pager.tsx
+++ b/apps/memos-local-plugin/web/src/components/Pager.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "preact/hooks";
+import { t } from "../stores/i18n";
+import { Icon } from "./Icon";
+
+interface PagerProps {
+  page: number;
+  totalItems: number;
+  pageSize: number;
+  pageSizeOptions?: number[];
+  onPageSizeChange?: (pageSize: number) => void;
+  hasMore?: boolean;
+  loading?: boolean;
+  onPageChange: (page: number) => void;
+}
+
+export function Pager({
+  page,
+  totalItems,
+  pageSize,
+  pageSizeOptions = [10, 20, 25, 50],
+  onPageSizeChange,
+  hasMore,
+  loading = false,
+  onPageChange,
+}: PagerProps) {
+  const totalPages = Math.max(
+    1,
+    Math.ceil(totalItems / pageSize),
+    page + 1 + (hasMore ? 1 : 0),
+  );
+  const canGoNext = page + 1 < totalPages;
+  const [draft, setDraft] = useState(String(page + 1));
+  const pageItems = buildPageItems(page + 1, totalPages);
+
+  useEffect(() => {
+    setDraft(String(page + 1));
+  }, [page]);
+
+  const goTo = (nextPage: number) => {
+    const clamped = Math.min(totalPages - 1, Math.max(0, nextPage));
+    if (clamped !== page) onPageChange(clamped);
+  };
+
+  const submitJump = (event: Event) => {
+    event.preventDefault();
+    const pageNumber = Number.parseInt(draft, 10);
+    if (Number.isFinite(pageNumber)) goTo(pageNumber - 1);
+    else setDraft(String(page + 1));
+  };
+
+  return (
+    <div class="pager">
+      <button
+        class="pager__nav"
+        disabled={page === 0 || loading}
+        onClick={() => goTo(page - 1)}
+        aria-label={t("common.prev")}
+        title={t("common.prev")}
+      >
+        <Icon name="chevron-left" size={14} />
+      </button>
+
+      <div class="pager__pages" aria-label={t("pager.pageOfTotal", { n: page + 1, total: totalPages })}>
+        {pageItems.map((item, index) =>
+          item === "ellipsis" ? (
+            <span class="pager__ellipsis" key={`ellipsis-${index}`}>...</span>
+          ) : (
+            <button
+              class="pager__page-btn"
+              key={item}
+              type="button"
+              disabled={loading}
+              aria-current={item === page + 1 ? "page" : undefined}
+              onClick={() => goTo(item - 1)}
+            >
+              {item}
+            </button>
+          )
+        )}
+      </div>
+
+      <button
+        class="pager__nav"
+        disabled={!canGoNext || loading}
+        onClick={() => goTo(page + 1)}
+        aria-label={t("common.next")}
+        title={t("common.next")}
+      >
+        <Icon name="chevron-right" size={14} />
+      </button>
+
+      <div class="pager__spacer" />
+
+      <label class="pager__page-size">
+        <select
+          class="select pager__page-size-select"
+          value={pageSize}
+          disabled={loading || !onPageSizeChange}
+          onChange={(event) => {
+            const nextSize = Number.parseInt((event.target as HTMLSelectElement).value, 10);
+            if (Number.isFinite(nextSize) && nextSize !== pageSize) onPageSizeChange?.(nextSize);
+          }}
+          aria-label={t("pager.pageSize.label")}
+        >
+          {Array.from(new Set([...pageSizeOptions, pageSize])).sort((a, b) => a - b).map((option) => (
+            <option key={option} value={option}>
+              {t("pager.pageSize.option", { pageSize: option })}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <form class="pager__jump" onSubmit={submitJump}>
+        <span class="pager__jump-label">
+          {t("pager.jump.label")}
+        </span>
+        <input
+          class="input pager__jump-input"
+          type="number"
+          min={1}
+          max={totalPages}
+          value={draft}
+          disabled={loading}
+          onInput={(event) => setDraft((event.target as HTMLInputElement).value)}
+          aria-label={t("pager.jump.label")}
+        />
+        <button
+          class="sr-only"
+          type="submit"
+          disabled={loading}
+          aria-label={t("pager.jump.go")}
+          title={t("pager.jump.go")}
+        >
+          {t("pager.jump.go")}
+        </button>
+        <span class="pager__jump-label">
+          {t("pager.jump.pageUnit")}
+        </span>
+      </form>
+    </div>
+  );
+}
+
+type PageItem = number | "ellipsis";
+
+function buildPageItems(currentPage: number, totalPages: number): PageItem[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, "ellipsis", totalPages];
+  }
+
+  if (currentPage >= totalPages - 3) {
+    return [1, "ellipsis", totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
+  }
+
+  return [1, "ellipsis", currentPage - 1, currentPage, currentPage + 1, "ellipsis", totalPages];
+}

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -83,12 +83,23 @@ const en = {
   "common.loadMore": "Load more",
   "common.selected": "{n} selected",
   "common.selectPage": "Select page",
+  "common.deselectPage": "Deselect page",
   "common.deselect": "Deselect",
   "common.bulkDelete": "Delete selected",
   "common.bulkDelete.confirm": "Delete {n} selected items? This cannot be undone.",
   "pager.page": "Page {n}",
   "pager.pageOfAtLeast": "Page {n} / {total}+",
   "pager.pageOfTotal": "Page {n} / {total}",
+  "pager.totalPerPage": "Total {total} items, {pageSize} per page",
+  "pager.totalCompact": "{total} items · {pageSize}/page",
+  "pager.pageSize.label": "Items per page",
+  "pager.pageSize.option": "{pageSize} / page",
+  "pager.jump.label": "Go to",
+  "pager.jump.short": "Jump",
+  "pager.jump.to": "Go to",
+  "pager.jump.pageUnit": "page",
+  "pager.jump.go": "Go",
+  "pager.jump.goShort": "Go",
 
   // Settings extensions.
   "settings.test": "Test",
@@ -472,6 +483,10 @@ const en = {
   "analytics.chart.skillEvolutions": "Skill crystallizations per day",
   "analytics.chart.skillEvolutions.empty":
     "No skills crystallized yet — keep the plugin running to collect evidence.",
+  "analytics.axis.date": "Date",
+  "analytics.axis.time": "Time",
+  "analytics.axis.count": "Count",
+  "analytics.axis.latencyMs": "Latency (ms)",
   "analytics.kpi.evolutionRate": "Skill evolution rate",
   "analytics.kpi.evolutionRate.hint": "tasks → skills conversion",
   "analytics.kpi.policyCoverage": "Policy activation rate",
@@ -502,6 +517,9 @@ const en = {
   "analytics.tools.chart.insufficient":
     "Not enough data points in this window to draw a trend chart.",
   "analytics.tools.legend.showAll": "Show all",
+  "analytics.tools.unavailable.title": "Calls without latency data",
+  "analytics.tools.unavailable.subtitle":
+    "These tools were recorded, but their start/end timestamps were missing or identical, so they are not plotted as response-time data.",
 
   // Logs.
   "logs.title": "Logs",
@@ -698,12 +716,23 @@ const zh: Record<TranslationKey, string> = {
   "common.loadMore": "加载更多",
   "common.selected": "已选 {n} 项",
   "common.selectPage": "全选当前页",
+  "common.deselectPage": "取消当前页选择",
   "common.deselect": "取消选择",
   "common.bulkDelete": "批量删除",
   "common.bulkDelete.confirm": "确认删除 {n} 项？此操作不可撤销。",
   "pager.page": "第 {n} 页",
   "pager.pageOfAtLeast": "第 {n} 页 / 共 {total}+ 页",
   "pager.pageOfTotal": "第 {n} 页 / 共 {total} 页",
+  "pager.totalPerPage": "共 {total} 条，每页 {pageSize} 条",
+  "pager.totalCompact": "{total} 条 · {pageSize}/页",
+  "pager.pageSize.label": "每页条数",
+  "pager.pageSize.option": "{pageSize} 条/页",
+  "pager.jump.label": "跳至",
+  "pager.jump.short": "跳页",
+  "pager.jump.to": "到",
+  "pager.jump.pageUnit": "页",
+  "pager.jump.go": "跳转",
+  "pager.jump.goShort": "跳",
 
   "settings.test": "测试",
   "settings.hub.admin": "团队成员",
@@ -1052,6 +1081,10 @@ const zh: Record<TranslationKey, string> = {
   "analytics.chart.skillEvolutions": "每日技能进化次数",
   "analytics.chart.skillEvolutions.empty":
     "暂无技能结晶 — 让插件继续运行，等证据累积到门槛即可。",
+  "analytics.axis.date": "日期",
+  "analytics.axis.time": "时间",
+  "analytics.axis.count": "数量",
+  "analytics.axis.latencyMs": "耗时（ms）",
   "analytics.kpi.evolutionRate": "技能进化率",
   "analytics.kpi.evolutionRate.hint": "任务 → 技能 转化比例",
   "analytics.kpi.policyCoverage": "规则覆盖率",
@@ -1082,6 +1115,9 @@ const zh: Record<TranslationKey, string> = {
   "analytics.tools.chart.insufficient":
     "当前时间范围内数据点不足，无法绘制趋势图。",
   "analytics.tools.legend.showAll": "显示全部",
+  "analytics.tools.unavailable.title": "有调用但缺少耗时数据",
+  "analytics.tools.unavailable.subtitle":
+    "这些工具调用已被记录，但开始/结束时间缺失或相同，因此不会进入响应耗时图。",
 
   "logs.title": "日志",
   "logs.subtitle": "记忆检索和写入的结构化轨迹：召回候选、Hub 候选、LLM 筛选后保留的记忆。",

--- a/apps/memos-local-plugin/web/src/styles/components.css
+++ b/apps/memos-local-plugin/web/src/styles/components.css
@@ -628,11 +628,88 @@
   gap: var(--sp-2);
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   margin-top: var(--sp-5);
 }
-.pager__info {
+.pager__pages {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+.pager__nav,
+.pager__page-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 var(--sp-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--fg-muted);
-  font-size: var(--fs-xs);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: all var(--dur-xs);
+}
+.pager__nav:hover,
+.pager__page-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+.pager__nav:disabled,
+.pager__page-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.pager__page-btn[aria-current="page"] {
+  border-color: var(--accent);
+  background: var(--bg-elev-1);
+  color: var(--accent);
+  font-weight: var(--fw-semi);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.pager__ellipsis {
+  min-width: 32px;
+  color: var(--fg-dim);
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+.pager__spacer {
+  width: var(--sp-4);
+}
+.pager__page-size-select {
+  width: auto;
+  min-width: 112px;
+  height: 36px;
+  padding-right: var(--sp-6);
+  font-size: var(--fs-sm);
+}
+.pager__jump {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.pager__jump-label {
+  color: var(--fg);
+  font-size: var(--fs-sm);
+}
+.pager__jump-input {
+  width: 74px;
+  height: 36px;
+  text-align: center;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ── Event / log stream (monospace) ────────────────────────────── */

--- a/apps/memos-local-plugin/web/src/utils/selection.ts
+++ b/apps/memos-local-plugin/web/src/utils/selection.ts
@@ -1,0 +1,23 @@
+export function areAllIdsSelected(
+  selected: ReadonlySet<string>,
+  ids: Iterable<string>,
+): boolean {
+  const pageIds = Array.from(new Set(ids));
+  return pageIds.length > 0 && pageIds.every((id) => selected.has(id));
+}
+
+export function toggleIdsInSelection(
+  selected: ReadonlySet<string>,
+  ids: Iterable<string>,
+): Set<string> {
+  const pageIds = Array.from(new Set(ids));
+  const next = new Set(selected);
+  const shouldDeselect = areAllIdsSelected(selected, pageIds);
+
+  for (const id of pageIds) {
+    if (shouldDeselect) next.delete(id);
+    else next.add(id);
+  }
+
+  return next;
+}

--- a/apps/memos-local-plugin/web/src/views/AnalyticsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/AnalyticsView.tsx
@@ -260,8 +260,16 @@ interface ToolStat {
 
 interface ToolMetricsResponse {
   tools: ToolStat[];
+  unavailableTools?: ToolCallCount[];
   toolNames?: string[];
   series?: Array<Record<string, unknown>>;
+}
+
+interface ToolCallCount {
+  name: string;
+  calls: number;
+  errors: number;
+  lastTs: number;
 }
 
 const TOOL_COLORS = [
@@ -274,6 +282,7 @@ function ToolLatencyCard() {
   const [rows, setRows] = useState<ToolStat[]>([]);
   const [toolNames, setToolNames] = useState<string[]>([]);
   const [series, setSeries] = useState<Array<Record<string, unknown>>>([]);
+  const [unavailableTools, setUnavailableTools] = useState<ToolCallCount[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -281,11 +290,24 @@ function ToolLatencyCard() {
     api
       .get<ToolMetricsResponse>(`/api/v1/metrics/tools?minutes=${minutes}&series=true`)
       .then((r) => {
-        setRows(r.tools ?? []);
-        setToolNames(r.toolNames ?? (r.tools ?? []).map((t) => t.name));
-        setSeries(r.series ?? []);
+        const nextRows = r.tools ?? [];
+        const nextSeries = r.series ?? [];
+        const names = r.toolNames ?? nextRows.map((tool) => tool.name);
+        const namesWithLatency = names.filter((name) => {
+          const row = nextRows.find((tool) => tool.name === name);
+          return (
+            nextSeries.some((point) => getSeriesValue(point, name) > 0) ||
+            Boolean(row && (row.avgMs > 0 || row.p50Ms > 0 || row.p95Ms > 0))
+          );
+        });
+        setRows(
+          nextRows.filter((row) => namesWithLatency.includes(row.name)),
+        );
+        setToolNames(namesWithLatency);
+        setSeries(nextSeries);
+        setUnavailableTools(r.unavailableTools ?? []);
       })
-      .catch(() => { setRows([]); setToolNames([]); setSeries([]); })
+      .catch(() => { setRows([]); setToolNames([]); setSeries([]); setUnavailableTools([]); })
       .finally(() => setLoading(false));
   }, [minutes]);
 
@@ -315,29 +337,82 @@ function ToolLatencyCard() {
       </div>
       {loading ? (
         <div class="skeleton" style="height:280px" />
-      ) : rows.length === 0 ? (
+      ) : rows.length === 0 && unavailableTools.length === 0 ? (
         <div class="empty" style="padding:var(--sp-5) 0">
           <div class="empty__hint">{t("analytics.tools.empty")}</div>
         </div>
       ) : (
         <>
-          {series.length >= 2 ? (
+          {rows.length > 0 && series.length >= 2 ? (
             <ToolLineChart series={series} toolNames={toolNames} />
-          ) : (
+          ) : rows.length > 0 ? (
             <div
               class="muted"
               style="font-size:var(--fs-xs);padding:var(--sp-3) 0;text-align:center"
             >
               {t("analytics.tools.chart.insufficient")}
             </div>
+          ) : null}
+          {rows.length > 0 && (
+            <div style="margin-top:var(--sp-4)">
+              <ToolAggTable rows={rows} maxAvg={maxAvg} />
+            </div>
           )}
-          <div style="margin-top:var(--sp-4)">
-            <ToolAggTable rows={rows} maxAvg={maxAvg} />
-          </div>
+          {unavailableTools.length > 0 && (
+            <UnavailableToolList tools={unavailableTools} />
+          )}
         </>
       )}
     </section>
   );
+}
+
+function UnavailableToolList({ tools }: { tools: ToolCallCount[] }) {
+  return (
+    <div
+      class="card card--flat"
+      style="margin-top:var(--sp-4);padding:var(--sp-3);background:var(--bg-canvas)"
+    >
+      <div class="hstack" style="justify-content:space-between;gap:var(--sp-3);margin-bottom:var(--sp-2)">
+        <div>
+          <div style="font-weight:var(--fw-semi);font-size:var(--fs-sm)">
+            {t("analytics.tools.unavailable.title")}
+          </div>
+          <div class="muted" style="font-size:var(--fs-xs)">
+            {t("analytics.tools.unavailable.subtitle")}
+          </div>
+        </div>
+      </div>
+      <div style="display:flex;gap:var(--sp-2);flex-wrap:wrap">
+        {tools.slice(0, 12).map((tool) => (
+          <span
+            key={tool.name}
+            class="pill pill--info"
+            title={`${tool.name}: ${tool.calls} calls`}
+          >
+            {tool.name} · {tool.calls}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getSeriesValue(point: Record<string, unknown>, toolName: string): number {
+  const raw = point[toolName];
+  if (typeof raw === "number" && Number.isFinite(raw)) return Math.max(0, raw);
+  if (typeof raw === "string") {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+  }
+  return 0;
+}
+
+function formatMinuteLabel(raw: unknown, includeDate = false): string {
+  const minute = String(raw ?? "");
+  if (!minute) return "";
+  const label = minute.replace("T", " ");
+  return includeDate || label.length <= 11 ? label : label.slice(11);
 }
 
 function ToolLineChart({
@@ -347,11 +422,19 @@ function ToolLineChart({
   series: Array<Record<string, unknown>>;
   toolNames: string[];
 }) {
+  const [hover, setHover] = useState<{
+    x: number;
+    y: number;
+    toolName: string;
+    minute: string;
+    value: number;
+  } | null>(null);
   // Track which tools are currently visible. Empty set = all visible.
   // Clicking a legend entry toggles the filter: first click narrows to
   // a single tool, further clicks add/remove more tools.
   const [visible, setVisible] = useState<Set<string>>(new Set());
   const isVisible = (tn: string) => visible.size === 0 || visible.has(tn);
+  const visibleTools = toolNames.filter(isVisible);
   const toggleTool = (tn: string) => {
     setVisible((prev) => {
       const next = new Set(prev);
@@ -374,7 +457,7 @@ function ToolLineChart({
   // being clipped by the container's `overflow:hidden`.
   const W = 1200;
   const H = 280;
-  const pad = { t: 16, r: 16, b: 32, l: 72 };
+  const pad = { t: 16, r: 18, b: 46, l: 78 };
   const cw = W - pad.l - pad.r;
   const ch = H - pad.t - pad.b;
 
@@ -382,9 +465,8 @@ function ToolLineChart({
   // zooms in when the user filters down.
   let maxVal = 0;
   for (const s of series) {
-    for (const tn of toolNames) {
-      if (!isVisible(tn)) continue;
-      const v = Number(s[tn]) || 0;
+    for (const tn of visibleTools) {
+      const v = getSeriesValue(s, tn);
       if (v > maxVal) maxVal = v;
     }
   }
@@ -397,6 +479,8 @@ function ToolLineChart({
 
   const toY = (v: number) => pad.t + ch - (v / maxVal) * ch;
   const toX = (i: number) => pad.l + i * step;
+  const tooltipX = hover ? Math.min(W - 214, Math.max(pad.l + 8, hover.x + 10)) : 0;
+  const tooltipY = hover ? Math.max(pad.t + 8, hover.y - 48) : 0;
 
   return (
     <div style="width:100%;border-radius:12px;position:relative">
@@ -404,6 +488,7 @@ function ToolLineChart({
         viewBox={`0 0 ${W} ${H}`}
         preserveAspectRatio="xMidYMid meet"
         style="width:100%;height:auto;display:block"
+        onMouseLeave={() => setHover(null)}
       >
         {Array.from({ length: gridLines + 1 }).map((_, i) => {
           const y = toY((maxVal / gridLines) * i);
@@ -415,12 +500,26 @@ function ToolLineChart({
             </g>
           );
         })}
+        <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + ch} stroke="var(--fg-dim)" stroke-width="0.8" />
+        <line x1={pad.l} y1={pad.t + ch} x2={W - pad.r} y2={pad.t + ch} stroke="var(--fg-dim)" stroke-width="0.8" />
+        <text
+          x={16}
+          y={pad.t + ch / 2}
+          transform={`rotate(-90 16 ${pad.t + ch / 2})`}
+          text-anchor="middle"
+          fill="var(--fg-dim)"
+          font-size="12"
+        >
+          {t("analytics.axis.latencyMs")}
+        </text>
+        <text x={pad.l + cw / 2} y={H - 6} text-anchor="middle" fill="var(--fg-dim)" font-size="12">
+          {t("analytics.axis.time")}
+        </text>
         {series.map((s, i) => {
           if (i % labelEvery !== 0 && i !== series.length - 1) return null;
-          const minute = String(s.minute ?? "");
-          const time = minute.length > 11 ? minute.slice(11) : minute;
+          const time = formatMinuteLabel(s.minute);
           return (
-            <text key={`xl-${i}`} x={toX(i)} y={H - 6} text-anchor="middle" fill="var(--fg-dim)" font-size="11">
+            <text key={`xl-${i}`} x={toX(i)} y={pad.t + ch + 16} text-anchor="middle" fill="var(--fg-dim)" font-size="11">
               {time}
             </text>
           );
@@ -430,7 +529,8 @@ function ToolLineChart({
           const color = TOOL_COLORS[ti % TOOL_COLORS.length];
           const pts = series.map((s, i) => ({
             x: toX(i),
-            y: toY(Number(s[tn]) || 0),
+            y: toY(getSeriesValue(s, tn)),
+            value: getSeriesValue(s, tn),
           }));
           if (pts.length === 0) return null;
           let d = `M${pts[0].x.toFixed(1)} ${pts[0].y.toFixed(1)}`;
@@ -443,13 +543,49 @@ function ToolLineChart({
               <path d={areaD} fill={color} opacity="0.08" />
               <path d={d} fill="none" stroke={color} stroke-width="1.5" />
               {pts.map((p, i) => (
-                <circle key={`c-${i}`} cx={p.x} cy={p.y} r="2" fill={color}>
-                  <title>{`${String(series[i].minute)}: ${tn} ${Number(series[i][tn]) || 0}ms`}</title>
-                </circle>
+                <g key={`c-${i}`}>
+                  <circle cx={p.x} cy={p.y} r="2.4" fill={color} />
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r="9"
+                    fill="transparent"
+                    onMouseEnter={() =>
+                      setHover({
+                        x: p.x,
+                        y: p.y,
+                        toolName: tn,
+                        minute: formatMinuteLabel(series[i].minute, true),
+                        value: p.value,
+                      })
+                    }
+                    onMouseMove={() =>
+                      setHover({
+                        x: p.x,
+                        y: p.y,
+                        toolName: tn,
+                        minute: formatMinuteLabel(series[i].minute, true),
+                        value: p.value,
+                      })
+                    }
+                  />
+                </g>
               ))}
             </g>
           );
         })}
+        {hover && (
+          <g pointer-events="none">
+            <line x1={hover.x} y1={pad.t} x2={hover.x} y2={pad.t + ch} stroke="var(--fg-dim)" stroke-width="0.8" stroke-dasharray="4 4" opacity="0.45" />
+            <rect x={tooltipX} y={tooltipY} width="204" height="42" rx="8" fill="var(--bg-elev-1)" stroke="var(--border)" />
+            <text x={tooltipX + 10} y={tooltipY + 16} fill="var(--fg-dim)" font-size="11">
+              {hover.minute}
+            </text>
+            <text x={tooltipX + 10} y={tooltipY + 32} fill="var(--fg)" font-size="12" font-weight="600">
+              {hover.toolName}: {hover.value}ms
+            </text>
+          </g>
+        )}
       </svg>
       <div style="display:flex;gap:var(--sp-2);flex-wrap:wrap;margin-top:var(--sp-2);padding:0 4px">
         {toolNames.map((tn, ti) => {
@@ -618,51 +754,115 @@ function BarChart({
   }
 
   const hovered = hoverIdx != null ? data[hoverIdx] : null;
+  const W = 640;
+  const H = 220;
+  const pad = { t: 16, r: 16, b: 42, l: 48 };
+  const cw = W - pad.l - pad.r;
+  const ch = H - pad.t - pad.b;
+  const gridLines = 4;
+  const barGap = 3;
+  const barSlot = cw / Math.max(1, data.length);
+  const barWidth = Math.max(3, barSlot - barGap);
+  const labelEvery = Math.max(1, Math.floor(data.length / 6));
+  const toY = (value: number) => pad.t + ch - (value / max) * ch;
+  const tooltipX = hoverIdx == null
+    ? 0
+    : Math.min(
+        W - 156,
+        Math.max(pad.l + 4, pad.l + hoverIdx * barSlot + barSlot / 2 + 8),
+      );
+  const tooltipY = hovered ? Math.max(pad.t + 4, toY(hovered.count) - 46) : 0;
 
   return (
-    <div style="display:flex;flex-direction:column;gap:0;position:relative">
-      {/* Hover tooltip — the only place we show the date + count. */}
-      {hovered && (
-        <div
-          style={`
-            position:absolute;top:-4px;left:50%;transform:translateX(-50%);
-            background:var(--bg-elev-1);border:1px solid var(--border);
-            border-radius:var(--radius-sm);padding:4px 8px;
-            font-size:var(--fs-xs);color:var(--fg);white-space:nowrap;
-            box-shadow:var(--shadow-sm);z-index:2;pointer-events:none
-          `}
-        >
-          <span class="mono" style="color:var(--fg-dim);margin-right:6px">
-            {hovered.date}
-          </span>
-          <span style="font-weight:600">{hovered.count}</span>
-        </div>
-      )}
-
-      <div
-        style="display:grid;grid-auto-flow:column;gap:2px;align-items:end;height:180px;padding-top:12px"
-        onMouseLeave={() => setHoverIdx(null)}
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style="width:100%;height:220px;display:block"
+      onMouseLeave={() => setHoverIdx(null)}
+    >
+      {Array.from({ length: gridLines + 1 }).map((_, i) => {
+        const value = Math.round((max / gridLines) * i);
+        const y = toY(value);
+        return (
+          <g key={`bar-grid-${i}`}>
+            <line x1={pad.l} y1={y} x2={W - pad.r} y2={y} stroke="var(--border)" stroke-width="0.6" />
+            <text x={pad.l - 8} y={y + 4} text-anchor="end" fill="var(--fg-dim)" font-size="11">
+              {value}
+            </text>
+          </g>
+        );
+      })}
+      <line x1={pad.l} y1={pad.t} x2={pad.l} y2={pad.t + ch} stroke="var(--fg-dim)" stroke-width="0.8" />
+      <line x1={pad.l} y1={pad.t + ch} x2={W - pad.r} y2={pad.t + ch} stroke="var(--fg-dim)" stroke-width="0.8" />
+      <text
+        x={14}
+        y={pad.t + ch / 2}
+        transform={`rotate(-90 14 ${pad.t + ch / 2})`}
+        text-anchor="middle"
+        fill="var(--fg-dim)"
+        font-size="12"
       >
-        {data.map((d, i) => {
-          const pct = (d.count / max) * 100;
-          const isHover = hoverIdx === i;
-          return (
-            <div
-              key={d.date}
-              onMouseEnter={() => setHoverIdx(i)}
-              style={`
-                height:${Math.max(2, pct)}%;
-                background:linear-gradient(180deg, ${isHover ? "var(--accent-strong, var(--accent))" : "var(--accent)"}, color-mix(in srgb, var(--accent) 40%, transparent));
-                border-radius:var(--radius-sm);
-                min-width:6px;
-                transition:height var(--dur-md) var(--ease-out), background var(--dur-xs);
-                cursor:pointer;
-                opacity:${hoverIdx !== null && !isHover ? "0.6" : "1"};
-              `}
-            />
-          );
-        })}
-      </div>
-    </div>
+        {t("analytics.axis.count")}
+      </text>
+      <text x={pad.l + cw / 2} y={H - 6} text-anchor="middle" fill="var(--fg-dim)" font-size="12">
+        {t("analytics.axis.date")}
+      </text>
+      {data.map((d, i) => {
+        if (i % labelEvery !== 0 && i !== data.length - 1) return null;
+        return (
+          <text
+            key={`bar-x-${d.date}`}
+            x={pad.l + i * barSlot + barSlot / 2}
+            y={pad.t + ch + 16}
+            text-anchor="middle"
+            fill="var(--fg-dim)"
+            font-size="10"
+          >
+            {d.date.slice(5)}
+          </text>
+        );
+      })}
+      {data.map((d, i) => {
+        const x = pad.l + i * barSlot + (barSlot - barWidth) / 2;
+        const y = toY(d.count);
+        const h = pad.t + ch - y;
+        const isHover = hoverIdx === i;
+        return (
+          <rect
+            key={d.date}
+            x={x}
+            y={y}
+            width={barWidth}
+            height={Math.max(2, h)}
+            rx="3"
+            fill="var(--accent)"
+            opacity={hoverIdx !== null && !isHover ? "0.55" : "1"}
+            onMouseEnter={() => setHoverIdx(i)}
+            onMouseMove={() => setHoverIdx(i)}
+          />
+        );
+      })}
+      {hovered && hoverIdx != null && (
+        <g pointer-events="none">
+          <line
+            x1={pad.l + hoverIdx * barSlot + barSlot / 2}
+            y1={pad.t}
+            x2={pad.l + hoverIdx * barSlot + barSlot / 2}
+            y2={pad.t + ch}
+            stroke="var(--fg-dim)"
+            stroke-width="0.8"
+            stroke-dasharray="4 4"
+            opacity="0.45"
+          />
+          <rect x={tooltipX} y={tooltipY} width="148" height="40" rx="8" fill="var(--bg-elev-1)" stroke="var(--border)" />
+          <text x={tooltipX + 10} y={tooltipY + 16} fill="var(--fg-dim)" font-size="11">
+            {hovered.date}
+          </text>
+          <text x={tooltipX + 10} y={tooltipY + 32} fill="var(--fg)" font-size="12" font-weight="600">
+            {t("analytics.axis.count")}: {hovered.count}
+          </text>
+        </g>
+      )}
+    </svg>
   );
 }

--- a/apps/memos-local-plugin/web/src/views/LogsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/LogsView.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from "preact/hooks";
 import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import type { ApiLogDTO } from "../api/types";
 
 type ToolFilter =
@@ -84,7 +85,7 @@ interface ApiLogsResponse {
   nextOffset?: number;
 }
 
-const PAGE_SIZE = 25;
+const DEFAULT_PAGE_SIZE = 25;
 
 export function LogsView() {
   const [tag, setTag] = useState<LogTag>("");
@@ -92,6 +93,7 @@ export function LogsView() {
   const [logs, setLogs] = useState<ApiLogDTO[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
@@ -112,8 +114,8 @@ export function LogsView() {
       // result locally.
       const allowed = ALLOWED_TOOLS[opts.tag];
       const needsClient = allowed.length > 1 || opts.query.trim().length > 0;
-      qs.set("limit", String(needsClient ? 500 : PAGE_SIZE));
-      qs.set("offset", String(needsClient ? 0 : opts.page * PAGE_SIZE));
+      qs.set("limit", String(needsClient ? 500 : pageSize));
+      qs.set("offset", String(needsClient ? 0 : opts.page * pageSize));
       if (allowed.length === 1) qs.set("tool", allowed[0]!);
       const res = await api.get<ApiLogsResponse>(`/api/v1/api-logs?${qs.toString()}`);
       setLogs(res.logs);
@@ -130,7 +132,7 @@ export function LogsView() {
   useEffect(() => {
     void load({ tag, page: 0, query });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tag]);
+  }, [tag, pageSize]);
 
   // Debounced client-side refresh when the search query changes.
   useEffect(() => {
@@ -139,7 +141,7 @@ export function LogsView() {
     }, 200);
     return () => clearTimeout(h);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [query, pageSize]);
 
   const toggleExpand = (id: number) => {
     setExpanded((prev) => {
@@ -161,10 +163,9 @@ export function LogsView() {
       })
     : logs;
   const pagedRows = clientFilterActive
-    ? filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+    ? filtered.slice(page * pageSize, (page + 1) * pageSize)
     : filtered;
   const displayTotal = clientFilterActive ? filtered.length : total;
-  const totalPages = Math.max(1, Math.ceil(displayTotal / PAGE_SIZE));
 
   return (
     <>
@@ -254,34 +255,18 @@ export function LogsView() {
         </div>
       )}
 
-      {displayTotal > PAGE_SIZE && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => {
-              if (clientFilterActive) setPage(page - 1);
-              else void load({ tag, page: page - 1, query });
-            }}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageN", { n: page + 1, total: totalPages })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page + 1 >= totalPages || loading}
-            onClick={() => {
-              if (clientFilterActive) setPage(page + 1);
-              else void load({ tag, page: page + 1, query });
-            }}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+      {displayTotal > pageSize && (
+        <Pager
+          page={page}
+          totalItems={displayTotal}
+          pageSize={pageSize}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            if (clientFilterActive) setPage(nextPage);
+            else void load({ tag, page: nextPage, query });
+          }}
+        />
       )}
     </>
   );
@@ -312,7 +297,7 @@ function LogCard({
         </span>
         <span class="log-card__summary">{buildSummary(log, input, output)}</span>
         <span class="muted mono" style="font-size:var(--fs-xs)">
-          {log.durationMs}ms
+          {formatLogDuration(log)}
         </span>
         <span class="muted" style="font-size:var(--fs-xs)">
           {formatTs(log.calledAt)}
@@ -803,6 +788,21 @@ function GenericDetail({
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────
+
+function formatLogDuration(log: ApiLogDTO): string {
+  if (log.durationMs > 0) return `${log.durationMs}ms`;
+  if (isLifecycleTool(log.toolName)) return "—";
+  return "<1ms";
+}
+
+function isLifecycleTool(toolName: string): boolean {
+  return (
+    toolName.startsWith("skill_") ||
+    toolName.startsWith("policy_") ||
+    toolName.startsWith("world_model_") ||
+    toolName.startsWith("task_")
+  );
+}
 
 function parseJson(s: string): unknown {
   if (!s) return null;

--- a/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
@@ -51,8 +51,11 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import { route } from "../stores/router";
+import { clearEntryId } from "../stores/cross-link";
 import type { TraceDTO } from "../api/types";
+import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
 
 type RoleFilter = "" | "user" | "assistant" | "tool";
 
@@ -87,7 +90,8 @@ interface MemoryGroup {
   shared: boolean;
 }
 
-const PAGE_SIZE = 25;
+const DEFAULT_PAGE_SIZE = 25;
+const ROLE_FILTER_FETCH_LIMIT = 5000;
 
 export function MemoriesView() {
   // Pre-fill from URL `?q=` so the global search box in Header can
@@ -95,6 +99,7 @@ export function MemoriesView() {
   const [query, setQuery] = useState(() => route.value.params.q ?? "");
   const [role, setRole] = useState<RoleFilter>("");
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [loading, setLoading] = useState(false);
   const [traces, setTraces] = useState<TraceDTO[]>([]);
   const [hasMore, setHasMore] = useState(false);
@@ -112,12 +117,13 @@ export function MemoriesView() {
     setLoading(true);
     try {
       const qs = new URLSearchParams();
-      qs.set("limit", String(PAGE_SIZE));
-      qs.set("offset", String(opts.page * PAGE_SIZE));
+      const roleFilterActive = role !== "";
+      qs.set("limit", String(roleFilterActive ? ROLE_FILTER_FETCH_LIMIT : pageSize));
+      qs.set("offset", String(roleFilterActive ? 0 : opts.page * pageSize));
       if (opts.q) qs.set("q", opts.q);
       const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`);
       setTraces(res.traces);
-      setHasMore(res.nextOffset != null);
+      setHasMore(roleFilterActive ? false : res.nextOffset != null);
       setTotal(res.total ?? 0);
       setPage(opts.page);
     } catch {
@@ -129,14 +135,58 @@ export function MemoriesView() {
     }
   };
 
-  // Debounced filter — reset to page 0 on query change.
+  // Debounced filter — reset to page 0 on query or tab change.
   useEffect(() => {
+    if (route.value.params.id) return;
     const h = setTimeout(() => {
       void loadPage({ q: query.trim(), page: 0 });
     }, 200);
     return () => clearTimeout(h);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [query, pageSize, role, route.value.params.id]);
+
+  useEffect(() => {
+    const id = route.value.params.id;
+    if (!id) return;
+    const ctrl = new AbortController();
+    void openLinkedMemory(id, ctrl.signal);
+    return () => ctrl.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route.value.params.id, pageSize]);
+
+  const openLinkedMemory = async (id: string, signal: AbortSignal) => {
+    setQuery("");
+    setRole("");
+    setLoading(true);
+    try {
+      const targetTrace = await api.get<TraceDTO>(
+        `/api/v1/traces/${encodeURIComponent(id)}`,
+        { signal },
+      );
+      const targetPage = await findTracePage(id, pageSize, signal);
+      const qs = new URLSearchParams();
+      qs.set("limit", String(pageSize));
+      qs.set("offset", String(targetPage * pageSize));
+      const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`, {
+        signal,
+      });
+      const nextTraces = res.traces ?? [];
+      const targetKey = groupKey(targetTrace);
+      const targetGroup =
+        buildGroups(nextTraces).find((g) => g.ids.includes(id) || g.turnKey === targetKey) ??
+        buildGroups([targetTrace])[0] ??
+        null;
+      setTraces(nextTraces);
+      setHasMore(res.nextOffset != null);
+      setTotal(res.total ?? 0);
+      setPage(targetPage);
+      if (targetGroup) setDetail(targetGroup);
+    } catch {
+      // Missing or aborted deep links should not break the list.
+    } finally {
+      if (!signal.aborted) setLoading(false);
+    }
+  };
 
   // Sync with URL `?q=` when the route changes (e.g. the Header's
   // global search bar navigates here while this view is already open).
@@ -153,11 +203,17 @@ export function MemoriesView() {
    * message + every sub-step it produced" collapses into one card.
    * Then drop groups whose role doesn't match the chip filter.
    */
-  const groups = useMemo<MemoryGroup[]>(() => {
+  const allGroups = useMemo<MemoryGroup[]>(() => {
     const all = buildGroups(traces);
     if (!role) return all;
     return all.filter((g) => detectGroupRole(g) === role);
   }, [traces, role]);
+  const displayTotal = role ? allGroups.length : total;
+  const groups = role
+    ? allGroups.slice(page * pageSize, (page + 1) * pageSize)
+    : allGroups;
+  const pageIds = groups.flatMap((g) => g.ids);
+  const isPageSelected = areAllIdsSelected(selected, pageIds);
 
   /**
    * A card is "selected" when every member trace id is in the
@@ -178,8 +234,8 @@ export function MemoriesView() {
       return next;
     });
   };
-  const selectPage = () =>
-    setSelected(new Set(groups.flatMap((g) => g.ids)));
+  const togglePageSelection = () =>
+    setSelected((prev) => toggleIdsInSelection(prev, pageIds));
   const deselectAll = () => setSelected(new Set());
 
   const bulkDelete = async () => {
@@ -406,9 +462,11 @@ export function MemoriesView() {
           <span class="batch-bar__count">
             {t("common.selected", { n: selected.size })}
           </span>
-          <button class="btn btn--sm" onClick={selectPage}>
+          <button class="btn btn--sm" onClick={togglePageSelection}>
             <Icon name="check-square" size={14} />
-            {t("memories.bulk.selectPage")}
+            {isPageSelected
+              ? t("common.deselectPage")
+              : t("memories.bulk.selectPage")}
           </button>
           <button class="btn btn--sm" onClick={() => bulkShare("public")}>
             <Icon name="share" size={14} />
@@ -533,37 +591,28 @@ export function MemoriesView() {
       )}
 
       {/* Pager */}
-      {(page > 0 || hasMore) && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => void loadPage({ q: query.trim(), page: page - 1 })}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageOfTotal", {
-              n: page + 1,
-              total: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-            })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={!hasMore || loading}
-            onClick={() => void loadPage({ q: query.trim(), page: page + 1 })}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+      {(displayTotal > pageSize || page > 0 || hasMore) && (
+        <Pager
+          page={page}
+          totalItems={displayTotal}
+          pageSize={pageSize}
+          hasMore={role ? false : hasMore}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            if (role) setPage(nextPage);
+            else void loadPage({ q: query.trim(), page: nextPage });
+          }}
+        />
       )}
 
       {detail && (
         <TraceDrawer
           group={detail}
-          onClose={() => setDetail(null)}
+          onClose={() => {
+            setDetail(null);
+            clearEntryId();
+          }}
           onSave={saveEdit}
           onShare={(scope) => applyShareGroup(detail, scope)}
           onDelete={() => deleteGroup(detail)}
@@ -589,6 +638,27 @@ function pickSummary(trace: TraceDTO): string {
   const a = (trace.agentText ?? "").replace(/\s+/g, " ").trim();
   if (a) return a.length > 180 ? a.slice(0, 177) + "…" : a;
   return "(empty trace)";
+}
+
+async function findTracePage(
+  id: string,
+  pageSize: number,
+  signal: AbortSignal,
+): Promise<number> {
+  const scanLimit = 500;
+  let offset = 0;
+  while (true) {
+    const qs = new URLSearchParams();
+    qs.set("limit", String(scanLimit));
+    qs.set("offset", String(offset));
+    const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`, {
+      signal,
+    });
+    const index = (res.traces ?? []).findIndex((trace) => trace.id === id);
+    if (index >= 0) return Math.floor((offset + index) / pageSize);
+    if (res.nextOffset == null) return 0;
+    offset = res.nextOffset;
+  }
 }
 
 /**

--- a/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
@@ -14,9 +14,11 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { PolicyDTO } from "../api/types";
+import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
 
 interface PolicyUsage {
   skills: Array<{ id: string; name: string; status: string; eta: number }>;
@@ -24,7 +26,7 @@ interface PolicyUsage {
   sourceEpisodes: string[];
 }
 
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
 
 type StatusFilter = "" | "candidate" | "active" | "archived";
 
@@ -42,6 +44,7 @@ export function PoliciesView() {
   const [rows, setRows] = useState<PolicyDTO[]>([]);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
   const [detail, setDetail] = useState<PolicyDTO | null>(null);
@@ -60,8 +63,8 @@ export function PoliciesView() {
     setLoading(true);
     try {
       const qs = new URLSearchParams();
-      qs.set("limit", String(PAGE_SIZE));
-      qs.set("offset", String(opts.page * PAGE_SIZE));
+      qs.set("limit", String(pageSize));
+      qs.set("offset", String(opts.page * pageSize));
       if (opts.q) qs.set("q", opts.q);
       if (opts.status) qs.set("status", opts.status);
       const res = await api.get<ListResponse>(`/api/v1/policies?${qs.toString()}`);
@@ -84,7 +87,7 @@ export function PoliciesView() {
     }, 200);
     return () => clearTimeout(h);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, status]);
+  }, [query, status, pageSize]);
 
   // Deep-link: `#/policies?id=po_xxx` auto-opens the row's drawer.
   // Lets other views (Skills / WorldModels / Tasks) link straight
@@ -107,6 +110,8 @@ export function PoliciesView() {
     setToast(msg);
     setTimeout(() => setToast(null), 2200);
   };
+  const pageIds = rows.map((p) => p.id);
+  const isPageSelected = areAllIdsSelected(selected, pageIds);
 
   const setPolicyStatus = async (p: PolicyDTO, next: PolicyDTO["status"]) => {
     try {
@@ -278,30 +283,17 @@ export function PoliciesView() {
       )}
 
       {(page > 0 || hasMore) && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => void load({ q: query.trim(), status, page: page - 1 })}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageOfTotal", {
-              n: page + 1,
-              total: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-            })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={!hasMore || loading}
-            onClick={() => void load({ q: query.trim(), status, page: page + 1 })}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+        <Pager
+          page={page}
+          totalItems={total}
+          pageSize={pageSize}
+          hasMore={hasMore}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            void load({ q: query.trim(), status, page: nextPage });
+          }}
+        />
       )}
 
       {detail && (
@@ -328,10 +320,10 @@ export function PoliciesView() {
           </span>
           <button
             class="btn btn--sm"
-            onClick={() => setSelected(new Set(rows.map((p) => p.id)))}
+            onClick={() => setSelected((prev) => toggleIdsInSelection(prev, pageIds))}
           >
             <Icon name="check-square" size={14} />
-            {t("common.selectPage")}
+            {isPageSelected ? t("common.deselectPage") : t("common.selectPage")}
           </button>
           <button
             class="btn btn--danger btn--sm"

--- a/apps/memos-local-plugin/web/src/views/SkillsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SkillsView.tsx
@@ -12,9 +12,11 @@ import { useEffect, useState } from "preact/hooks";
 import { api, withAgentPrefix } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { SkillDTO } from "../api/types";
+import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
 
 interface SkillUsage {
   sourcePolicies: Array<{
@@ -28,7 +30,7 @@ interface SkillUsage {
 
 type StatusFilter = "" | "active" | "candidate" | "archived";
 
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
 
 export function SkillsView() {
   const [query, setQuery] = useState("");
@@ -37,6 +39,7 @@ export function SkillsView() {
   const [detail, setDetail] = useState<SkillDTO | null>(null);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -53,8 +56,8 @@ export function SkillsView() {
     setLoading(true);
     try {
       const qs = new URLSearchParams();
-      qs.set("limit", String(PAGE_SIZE));
-      qs.set("offset", String(nextPage * PAGE_SIZE));
+      qs.set("limit", String(pageSize));
+      qs.set("offset", String(nextPage * pageSize));
       if (status) qs.set("status", status);
       const r = await api.get<{ skills: SkillDTO[]; nextOffset?: number; total?: number }>(
         `/api/v1/skills?${qs.toString()}`,
@@ -73,7 +76,7 @@ export function SkillsView() {
   };
   useEffect(() => {
     void load(0);
-  }, [status]);
+  }, [status, pageSize]);
 
   // Deep-link: `#/skills?id=sk_xxx` auto-opens the drawer.
   useEffect(() => {
@@ -101,6 +104,8 @@ export function SkillsView() {
       s.invocationGuide.toLowerCase().includes(q)
     );
   });
+  const pageIds = filtered.map((s) => s.id);
+  const isPageSelected = areAllIdsSelected(selected, pageIds);
 
   return (
     <>
@@ -236,30 +241,17 @@ export function SkillsView() {
       )}
 
       {(page > 0 || hasMore) && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => void load(page - 1)}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageOfTotal", {
-              n: page + 1,
-              total: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-            })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={!hasMore || loading}
-            onClick={() => void load(page + 1)}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+        <Pager
+          page={page}
+          totalItems={total}
+          pageSize={pageSize}
+          hasMore={hasMore}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            void load(nextPage);
+          }}
+        />
       )}
 
       {detail && (
@@ -284,10 +276,10 @@ export function SkillsView() {
           </span>
           <button
             class="btn btn--sm"
-            onClick={() => setSelected(new Set(filtered.map((s) => s.id)))}
+            onClick={() => setSelected((prev) => toggleIdsInSelection(prev, pageIds))}
           >
             <Icon name="check-square" size={14} />
-            {t("common.selectPage")}
+            {isPageSelected ? t("common.deselectPage") : t("common.selectPage")}
           </button>
           <button
             class="btn btn--danger btn--sm"

--- a/apps/memos-local-plugin/web/src/views/TasksView.tsx
+++ b/apps/memos-local-plugin/web/src/views/TasksView.tsx
@@ -11,9 +11,11 @@ import { useEffect, useState } from "preact/hooks";
 import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import { ChatLog, flattenChat, type TimelineTrace } from "./tasks-chat";
+import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
 
 type TaskStatus = "" | "active" | "completed" | "skipped" | "failed";
 
@@ -46,7 +48,13 @@ interface Timeline {
   traces: TimelineTrace[];
 }
 
-const PAGE_SIZE = 20;
+interface EpisodeListResponse {
+  episodes: EpisodeRow[];
+  nextOffset?: number;
+  total?: number;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
 
 export function TasksView() {
   const [query, setQuery] = useState("");
@@ -54,6 +62,7 @@ export function TasksView() {
   const [rows, setRows] = useState<EpisodeRow[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
   const [detail, setDetail] = useState<EpisodeRow | null>(null);
@@ -72,10 +81,10 @@ export function TasksView() {
     const ctrl = new AbortController();
     setLoading(true);
     const qs = new URLSearchParams();
-    qs.set("limit", String(PAGE_SIZE));
-    qs.set("offset", String(nextPage * PAGE_SIZE));
+    qs.set("limit", String(pageSize));
+    qs.set("offset", String(nextPage * pageSize));
     api
-      .get<{ episodes: EpisodeRow[]; nextOffset?: number; total?: number }>(
+      .get<EpisodeListResponse>(
         `/api/v1/episodes?${qs.toString()}`,
         { signal: ctrl.signal },
       )
@@ -95,10 +104,48 @@ export function TasksView() {
   };
 
   useEffect(() => {
+    if (route.value.params.id) return;
     const ctrl = loadPage(0);
     return () => ctrl.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pageSize, route.value.params.id]);
+
+  useEffect(() => {
+    const id = route.value.params.id;
+    if (!id) return;
+    const ctrl = new AbortController();
+    void openLinkedEpisode(id, ctrl.signal);
+    return () => ctrl.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [route.value.params.id, pageSize]);
+
+  const openLinkedEpisode = async (id: string, signal: AbortSignal) => {
+    setQuery("");
+    setStatus("");
+    setLoading(true);
+    try {
+      const pageSizeForLookup = pageSize;
+      const targetPage = await findEpisodePage(id, pageSizeForLookup, signal);
+      const qs = new URLSearchParams();
+      qs.set("limit", String(pageSizeForLookup));
+      qs.set("offset", String(targetPage * pageSizeForLookup));
+      const res = await api.get<EpisodeListResponse>(
+        `/api/v1/episodes?${qs.toString()}`,
+        { signal },
+      );
+      const nextRows = res.episodes ?? [];
+      setRows(nextRows);
+      setHasMore(res.nextOffset != null);
+      setTotal(res.total ?? 0);
+      setPage(targetPage);
+      const match = nextRows.find((r) => r.id === id);
+      if (match) setDetail(match);
+    } catch {
+      // Ignore aborted or stale deep links; the list stays as-is.
+    } finally {
+      if (!signal.aborted) setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!detail) {
@@ -127,9 +174,11 @@ export function TasksView() {
     }
     return true;
   });
+  const pageIds = filtered.map((r) => r.id);
+  const isPageSelected = areAllIdsSelected(selected, pageIds);
 
-  const selectPage = () => {
-    setSelected(new Set(filtered.map((r) => r.id)));
+  const togglePageSelection = () => {
+    setSelected((prev) => toggleIdsInSelection(prev, pageIds));
   };
   const deselectAll = () => setSelected(new Set());
   const bulkDelete = async () => {
@@ -302,37 +351,27 @@ export function TasksView() {
       )}
 
       {(page > 0 || hasMore) && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => loadPage(page - 1)}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageOfTotal", {
-              n: page + 1,
-              total: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-            })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={!hasMore || loading}
-            onClick={() => loadPage(page + 1)}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+        <Pager
+          page={page}
+          totalItems={total}
+          pageSize={pageSize}
+          hasMore={hasMore}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            loadPage(nextPage);
+          }}
+        />
       )}
 
       {detail && (
         <TaskDrawer
           episode={detail}
           timeline={timeline}
-          onClose={() => setDetail(null)}
+          onClose={() => {
+            setDetail(null);
+            clearEntryId();
+          }}
         />
       )}
 
@@ -341,9 +380,9 @@ export function TasksView() {
           <span class="batch-bar__count">
             {t("common.selected", { n: selected.size })}
           </span>
-          <button class="btn btn--sm" onClick={selectPage}>
+          <button class="btn btn--sm" onClick={togglePageSelection}>
             <Icon name="check-square" size={14} />
-            {t("common.selectPage")}
+            {isPageSelected ? t("common.deselectPage") : t("common.selectPage")}
           </button>
           <button class="btn btn--danger btn--sm" onClick={bulkDelete}>
             <Icon name="trash-2" size={14} />
@@ -357,6 +396,29 @@ export function TasksView() {
       )}
     </>
   );
+}
+
+async function findEpisodePage(
+  id: string,
+  pageSize: number,
+  signal: AbortSignal,
+): Promise<number> {
+  const scanLimit = 5_000;
+  let offset = 0;
+  while (true) {
+    const qs = new URLSearchParams();
+    qs.set("shape", "ids");
+    qs.set("limit", String(scanLimit));
+    qs.set("offset", String(offset));
+    const res = await api.get<{
+      episodeIds: string[];
+      nextOffset?: number;
+    }>(`/api/v1/episodes?${qs.toString()}`, { signal });
+    const index = (res.episodeIds ?? []).indexOf(id);
+    if (index >= 0) return Math.floor((offset + index) / pageSize);
+    if (res.nextOffset == null) return 0;
+    offset = res.nextOffset;
+  }
 }
 
 // Keep this in lockstep with `core/pipeline/memory-core.ts::deriveSkillStatus`:

--- a/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
@@ -14,9 +14,11 @@ import { useEffect, useState } from "preact/hooks";
 import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
+import { Pager } from "../components/Pager";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { WorldModelDTO } from "../api/types";
+import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
 
 interface WorldModelUsage {
   policies: Array<{
@@ -27,7 +29,7 @@ interface WorldModelUsage {
   }>;
 }
 
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
 
 interface ListResponse {
   worldModels: WorldModelDTO[];
@@ -42,6 +44,7 @@ export function WorldModelsView() {
   const [rows, setRows] = useState<WorldModelDTO[]>([]);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
   const [detail, setDetail] = useState<WorldModelDTO | null>(null);
@@ -60,8 +63,8 @@ export function WorldModelsView() {
     setLoading(true);
     try {
       const qs = new URLSearchParams();
-      qs.set("limit", String(PAGE_SIZE));
-      qs.set("offset", String(opts.page * PAGE_SIZE));
+      qs.set("limit", String(pageSize));
+      qs.set("offset", String(opts.page * pageSize));
       if (opts.q) qs.set("q", opts.q);
       const res = await api.get<ListResponse>(`/api/v1/world-models?${qs.toString()}`);
       setRows(res.worldModels);
@@ -83,7 +86,7 @@ export function WorldModelsView() {
     }, 200);
     return () => clearTimeout(h);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [query, pageSize]);
 
   // Deep-link: `#/world-models?id=wm_xxx` auto-opens the drawer.
   useEffect(() => {
@@ -113,6 +116,8 @@ export function WorldModelsView() {
       setTimeout(() => setToast(null), 2200);
     }
   };
+  const pageIds = rows.map((m) => m.id);
+  const isPageSelected = areAllIdsSelected(selected, pageIds);
 
   return (
     <>
@@ -217,30 +222,17 @@ export function WorldModelsView() {
       )}
 
       {(page > 0 || hasMore) && (
-        <div class="pager">
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={page === 0 || loading}
-            onClick={() => void load({ q: query.trim(), page: page - 1 })}
-          >
-            <Icon name="chevron-left" size={14} />
-            {t("common.prev")}
-          </button>
-          <span class="pager__info">
-            {t("pager.pageOfTotal", {
-              n: page + 1,
-              total: Math.max(1, Math.ceil(total / PAGE_SIZE)),
-            })}
-          </span>
-          <button
-            class="btn btn--ghost btn--sm"
-            disabled={!hasMore || loading}
-            onClick={() => void load({ q: query.trim(), page: page + 1 })}
-          >
-            {t("common.next")}
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
+        <Pager
+          page={page}
+          totalItems={total}
+          pageSize={pageSize}
+          hasMore={hasMore}
+          loading={loading}
+          onPageSizeChange={setPageSize}
+          onPageChange={(nextPage) => {
+            void load({ q: query.trim(), page: nextPage });
+          }}
+        />
       )}
 
       {detail && (
@@ -266,10 +258,10 @@ export function WorldModelsView() {
           </span>
           <button
             class="btn btn--sm"
-            onClick={() => setSelected(new Set(rows.map((m) => m.id)))}
+            onClick={() => setSelected((prev) => toggleIdsInSelection(prev, pageIds))}
           >
             <Icon name="check-square" size={14} />
-            {t("common.selectPage")}
+            {isPageSelected ? t("common.deselectPage") : t("common.selectPage")}
           </button>
           <button
             class="btn btn--danger btn--sm"


### PR DESCRIPTION
## Description

This PR fixes multiple Hermes local plugin bugs around memory persistence, feedback stability, analytics, pagination, and viewer navigation.

Main changes:
- Reconnect and retry the Hermes provider bridge when stdio transport closes during `sync_turn`, preventing silent memory loss.
- Preserve historical `ts` values passed through `turn.start` / `turn.end` instead of overwriting them with current DB time.
- Return real persisted trace IDs from `turn.end` and validate feedback trace IDs to avoid SQLite foreign key 500 errors.
- Improve viewer pagination, current-page select/deselect, total/page-size display, page jump, and cross-page deep links for tasks and memories.
- Improve analytics tool latency charts, hover values, unavailable tool reporting, log duration display, and model setup banner UX.

Dependencies required: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script Or Test Steps (please provide)

Tested with:

```bash
npm run build:web
npx vitest run tests/unit/pipeline/orchestrator.test.ts tests/unit/pipeline/memory-core.test.ts tests/unit/server/http.test.ts
python3 -m unittest tests.python.test_bridge_client tests.python.test_hermes_provider_pipeline