### PR TITLE
fix: align Hermes restart UX

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -83,6 +83,21 @@ logger = logging.getLogger(__name__)
 PLUGIN_ID = "memos-local-hermes"
 PLUGIN_VERSION = "2.0.0-beta.1"
 
+_HERMES_INTERNAL_REVIEW_PREFIXES = (
+    "review the conversation above and consider saving to memory if appropriate.",
+    "review the conversation above and update the skill library.",
+    "review the conversation above and update two things:",
+    "review the conversation above and consider saving or updating a skill if appropriate.",
+)
+
+
+def _is_hermes_internal_review_prompt(message: str) -> bool:
+    """Return True for Hermes' own background memory/skill review turns."""
+    normalized = " ".join((message or "").strip().lower().split())
+    if not normalized:
+        return False
+    return any(normalized.startswith(prefix) for prefix in _HERMES_INTERNAL_REVIEW_PREFIXES)
+
 
 class MemTensorProvider(MemoryProvider):
     """MemOS Reflect2Evolve memory for hermes-agent.
@@ -119,6 +134,10 @@ class MemTensorProvider(MemoryProvider):
         # show the model's thinking like OpenClaw does.
         self._turn_thinking: str = ""
         self._hook_registered = False
+        # Hermes runs background memory/skill reviewers by forking an agent and
+        # appending a synthetic user turn. That turn is instruction plumbing,
+        # not a human utterance, so it must not become a MemOS trace.
+        self._skip_current_turn = False
 
     # ─── Identity ─────────────────────────────────────────────────────────
 
@@ -385,7 +404,8 @@ class MemTensorProvider(MemoryProvider):
 
     def on_turn_start(self, turn_number: int, message: str, **_kwargs: Any) -> None:  # type: ignore[override]
         self._turn_number = int(turn_number or 0)
-        self._last_user_text = (message or "").strip()
+        self._skip_current_turn = _is_hermes_internal_review_prompt(message)
+        self._last_user_text = "" if self._skip_current_turn else (message or "").strip()
         # Reset per-turn buffers so reasoning / tool calls captured here
         # belong only to this turn.
         self._turn_thinking = ""
@@ -403,6 +423,9 @@ class MemTensorProvider(MemoryProvider):
         with self._prefetch_lock:
             cached = self._prefetch_result
             self._prefetch_result = ""
+        if self._skip_current_turn or _is_hermes_internal_review_prompt(query):
+            self._skip_current_turn = True
+            return ""
         if cached:
             return cached
         if not self._bridge:
@@ -448,6 +471,10 @@ class MemTensorProvider(MemoryProvider):
         thinking = self._turn_thinking
         self._tool_calls = []
         self._turn_thinking = ""
+        if self._skip_current_turn or _is_hermes_internal_review_prompt(user):
+            self._skip_current_turn = False
+            self._last_user_text = ""
+            return
         logger.info(
             "MemOS: sync_turn user=%d assistant=%d tools=%d thinking=%d",
             len(user),
@@ -895,8 +922,9 @@ class MemTensorProvider(MemoryProvider):
             return
         # `sync_turn` already flushed the turn data synchronously.
         # Just close the episode and session.
-        with contextlib.suppress(Exception):
-            self._bridge.request("episode.close", {"episodeId": self._episode_id})
+        if self._episode_id:
+            with contextlib.suppress(Exception):
+                self._bridge.request("episode.close", {"episodeId": self._episode_id})
         with contextlib.suppress(Exception):
             self._bridge.request("session.close", {"sessionId": self._session_id})
 

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -12,10 +12,11 @@
  *       Agent-aware restart. For OpenClaw the plugin lives inside the
  *       gateway process, which is managed by macOS launchd — calling
  *       `process.exit(0)` causes launchd to respawn it automatically.
- *       For Hermes: spawn a new bridge in --daemon mode, then exit the
- *       current process. The new daemon takes over the viewer port so
- *       the Memory Viewer stays available without user intervention.
+ *       For Hermes the HTTP viewer is the long-lived smoke/daemon bridge.
+ *       Do NOT restart this process; terminate the active `hermes chat`
+ *       process so the user can relaunch it and reconnect to this viewer.
  */
+import { spawn } from "node:child_process";
 import type { ServerDeps, ServerOptions } from "../types.js";
 import type { Routes } from "./registry.js";
 
@@ -60,31 +61,40 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
-    // Hermes (and others): exit first (releasing the port), then a
-    // small wrapper script spawns the new daemon. We use a shell
-    // one-liner that sleeps briefly (for port release) then starts
-    // the new daemon.
-    const nodePath = await import("node:path");
-    const { fileURLToPath } = await import("node:url");
-    const { spawn } = await import("node:child_process");
-    const thisFile = fileURLToPath(import.meta.url);
-    const pluginRoot = nodePath.resolve(nodePath.dirname(thisFile), "../..");
-    const tsxBin = nodePath.join(pluginRoot, "node_modules/.bin/tsx");
-    const bridgeScript = nodePath.join(pluginRoot, "bridge.cts");
 
-    // 3s sleep gives the OS time to release the viewer port (TCP
-    // TIME_WAIT lingers for ~1s on macOS/Linux even after the
-    // previous bridge fully exited). Bumped from 1s after operators
-    // hit "重启超时" because the new daemon kept losing the port-
-    // bind race against its predecessor.
-    const cmd = `sleep 3 && "${tsxBin}" "${bridgeScript}" --agent=${agent} --daemon`;
-    const child = spawn("bash", ["-c", cmd], {
-      detached: true,
-      stdio: "ignore",
-      cwd: pluginRoot,
-    });
-    child.unref();
-    setTimeout(() => process.exit(0), 200);
-    return { ok: true, restarting: true };
+    if (agent === "hermes") {
+      const killed = await terminateHermesChat();
+      return { ok: true, restarting: false, killed };
+    }
+
+    return { ok: false, error: `restart unsupported for agent: ${agent}` };
+  });
+}
+
+async function terminateHermesChat(): Promise<boolean> {
+  // Match the Hermes CLI wrapper used by install.sh without touching
+  // `bridge.cts --daemon`, which owns the Memory Viewer port.
+  const patterns = ["/bin/hermes", "hermes chat"];
+  let signalled = false;
+
+  for (const pattern of patterns) {
+    const ok = await runQuiet("pkill", ["-TERM", "-f", pattern]);
+    signalled ||= ok;
+  }
+
+  if (!signalled) return false;
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+
+  for (const pattern of patterns) {
+    await runQuiet("pkill", ["-KILL", "-f", pattern]);
+  }
+  return true;
+}
+
+function runQuiet(command: string, args: readonly string[]): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn(command, [...args], { stdio: "ignore" });
+    child.on("error", () => resolve(false));
+    child.on("exit", (code) => resolve(code === 0));
   });
 }

--- a/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
+++ b/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
@@ -27,6 +27,10 @@ class FakeBridge:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
         self.closed = False
+        self.host_handlers: dict[str, object] = {}
+
+    def register_host_handler(self, method: str, handler: object) -> None:
+        self.host_handlers[method] = handler
 
     def request(self, method: str, params: dict | None = None) -> dict:
         payload = params or {}
@@ -54,8 +58,9 @@ class FakeBridge:
 class HermesProviderPipelineTests(unittest.TestCase):
     def test_lifecycle_persists_turn_and_closes_real_episode(self) -> None:
         bridge = FakeBridge()
-        with patch("memos_provider.ensure_bridge_running", return_value=True), patch(
-            "memos_provider.MemosBridgeClient", return_value=bridge
+        with (
+            patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
             provider.initialize(
@@ -104,16 +109,43 @@ class HermesProviderPipelineTests(unittest.TestCase):
         self.assertEqual(turn_end["toolCalls"][0]["name"], "terminal")
         self.assertIn("npm test", turn_end["toolCalls"][0]["input"])
 
-        episode_close = next(
-            params for method, params in bridge.calls if method == "episode.close"
-        )
+        episode_close = next(params for method, params in bridge.calls if method == "episode.close")
         self.assertEqual(episode_close["episodeId"], "episode-from-turn-start")
         self.assertTrue(bridge.closed)
 
+    def test_internal_hermes_review_prompt_is_not_persisted_as_user_turn(self) -> None:
+        bridge = FakeBridge()
+        review_prompt = (
+            "Review the conversation above and consider saving or updating a skill if appropriate."
+        )
+        with (
+            patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.MemosBridgeClient", return_value=bridge),
+        ):
+            provider = memos_provider.MemTensorProvider()
+            provider.initialize("host-session")
+
+            provider.on_turn_start(10, review_prompt)
+            self.assertEqual(provider.prefetch(review_prompt), "")
+            provider._on_post_tool_call(
+                tool_name="memory_search",
+                args={"query": "conversation"},
+                result="[]",
+                tool_call_id="tool-1",
+            )
+            provider.sync_turn(review_prompt, "Nothing to save.")
+            provider.on_session_end([])
+
+        methods = [method for method, _params in bridge.calls]
+        self.assertEqual(methods, ["session.open", "session.close"])
+        self.assertFalse(any(method == "turn.start" for method, _ in bridge.calls))
+        self.assertFalse(any(method == "turn.end" for method, _ in bridge.calls))
+
     def test_on_pre_compress_reuses_last_user_text_for_snapshot(self) -> None:
         bridge = FakeBridge()
-        with patch("memos_provider.ensure_bridge_running", return_value=True), patch(
-            "memos_provider.MemosBridgeClient", return_value=bridge
+        with (
+            patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
             provider.initialize("compress-session")

--- a/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
+++ b/apps/memos-local-plugin/web/src/components/RestartOverlay.tsx
@@ -1,12 +1,11 @@
 /**
- * Restart overlay — two UX modes:
+ * Restart overlay.
  *
- *   - **OpenClaw** (auto-restart): full-screen spinner overlay styled after
- *     the legacy `memos-local-openclaw` viewer. The gateway is being
- *     restarted; we poll health and reload automatically.
- *
- *   - **Hermes / generic** (manual restart): bottom-of-screen toast that
- *     tells the user to restart the agent process themselves.
+ * IMPORTANT: config saves must never fall back to a "settings saved"
+ * toast/card. OpenClaw restarts the gateway; Hermes terminates the
+ * active `hermes chat` process while keeping the Memory Viewer daemon
+ * online. Both flows use this full-screen overlay so the user sees the
+ * same blocking restart affordance instead of a passive success card.
  */
 import { restartState, dismissRestartBanner } from "../stores/restart";
 import { health } from "../stores/health";
@@ -15,15 +14,17 @@ import { Icon } from "./Icon";
 
 function FullScreenSpinner() {
   const s = restartState.value;
+  const agentType = health.value?.agent === "openclaw" ? "openclaw" : "hermes";
 
   const message =
     s.phase === "restartFailed"
       ? t("restart.failed")
       : s.phase === "waitingUp"
         ? t("restart.waitingUp")
-        : t("restart.restarting");
+        : agentType === "hermes"
+          ? t("restart.restarting.hermes")
+          : t("restart.restarting");
 
-  const agentType = health.value?.agent === "openclaw" ? "openclaw" : "hermes";
   const hint =
     s.phase === "restartFailed"
       ? t(`restart.failedHint.${agentType}` as any)
@@ -76,68 +77,8 @@ function FullScreenSpinner() {
   );
 }
 
-function Toast() {
-  const s = restartState.value;
-  const agent = health.value?.agent ?? "agent";
-  const restartHint =
-    agent === "hermes"
-      ? t("restart.hint.hermes")
-      : t("restart.hint.generic");
-
-  const title =
-    s.phase === "cleared" ? t("restart.cleared") : t("restart.saved");
-
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      style={`
-        position:fixed;left:50%;bottom:24px;transform:translateX(-50%);
-        z-index:1000;max-width:520px;width:calc(100% - 32px);
-      `}
-    >
-      <div
-        class="card"
-        style={`
-          padding:14px 18px;display:flex;align-items:flex-start;gap:12px;
-          box-shadow:0 12px 32px -12px rgba(0,0,0,0.32);
-        `}
-      >
-        <div style="flex-shrink:0;display:flex;align-items:center;color:var(--success)">
-          <Icon name="circle-check" size={20} />
-        </div>
-        <div style="flex:1;min-width:0">
-          <div style="font-weight:var(--fw-semi);font-size:var(--fs-md)">
-            {title}
-          </div>
-          <div class="muted" style="font-size:var(--fs-sm);margin-top:2px">
-            {restartHint}
-          </div>
-        </div>
-        <button
-          class="btn btn--ghost btn--sm"
-          aria-label={t("common.close")}
-          onClick={dismissRestartBanner}
-          style="flex-shrink:0;padding:4px"
-        >
-          <Icon name="x" size={14} />
-        </button>
-      </div>
-    </div>
-  );
-}
-
 export function RestartOverlay() {
   const s = restartState.value;
   if (s.phase === "idle") return null;
-
-  if (
-    s.phase === "restarting" ||
-    s.phase === "waitingUp" ||
-    s.phase === "restartFailed"
-  ) {
-    return <FullScreenSpinner />;
-  }
-
-  return <Toast />;
+  return <FullScreenSpinner />;
 }

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -163,22 +163,16 @@ const en = {
   "analytics.tools.subtitle":
     "Per-tool response time and failure counts over the selected time range.",
 
-  "restart.saved": "Settings saved",
-  "restart.cleared": "All data cleared",
-  "restart.hint.openclaw":
-    "Restart OpenClaw to apply: openclaw gateway stop && openclaw gateway start",
-  "restart.hint.hermes":
-    "Restart Hermes to apply: stop and rerun `hermes chat`",
-  "restart.hint.generic":
-    "Restart this agent's process to load the new configuration.",
   "restart.restarting": "Configuration saved. Service is restarting…",
+  "restart.restarting.hermes":
+    "Configuration saved. Closing the current Hermes session…",
   "restart.waitingUp": "Waiting for the service to come back online…",
   "restart.autoRefresh": "The page will refresh automatically once the service is ready.",
   "restart.failed": "Restart didn't complete — the service didn't come back in time.",
   "restart.failedHint.openclaw":
     "Try manually: openclaw gateway stop && openclaw gateway start",
   "restart.failedHint.hermes":
-    "Try manually: pkill -f bridge.cts && hermes chat",
+    "Try manually: stop the current Hermes session and rerun `hermes chat`",
   "common.selectAll": "Select all",
   "common.deleteSelected": "Delete selected",
 
@@ -826,21 +820,15 @@ const zh: Record<TranslationKey, string> = {
   "analytics.tools.title": "工具响应耗时",
   "analytics.tools.subtitle": "所选时间窗口内，各工具的延迟和失败次数。来源：最近的记忆行。",
 
-  "restart.saved": "设置已保存",
-  "restart.cleared": "所有数据已清空",
-  "restart.hint.openclaw":
-    "请重启 OpenClaw 后生效：openclaw gateway stop && openclaw gateway start",
-  "restart.hint.hermes":
-    "请重启 Hermes 后生效：停止后重新执行 `hermes chat`",
-  "restart.hint.generic": "请重启该 agent 进程以加载新配置。",
   "restart.restarting": "配置已保存，服务正在重启…",
+  "restart.restarting.hermes": "配置已保存，正在关闭当前 Hermes 会话…",
   "restart.waitingUp": "正在等待服务重新上线…",
   "restart.autoRefresh": "服务就绪后页面将自动刷新。",
   "restart.failed": "重启超时 — 服务未能在预期时间内恢复。",
   "restart.failedHint.openclaw":
     "请手动重启：openclaw gateway stop && openclaw gateway start",
   "restart.failedHint.hermes":
-    "请手动重启：pkill -f bridge.cts && hermes chat",
+    "请手动重启：停止当前 Hermes 会话后重新执行 `hermes chat`",
   "common.selectAll": "全选",
   "common.deleteSelected": "删除所选",
 

--- a/apps/memos-local-plugin/web/src/stores/restart.ts
+++ b/apps/memos-local-plugin/web/src/stores/restart.ts
@@ -1,13 +1,13 @@
 /**
  * Config-save restart state manager.
  *
- * Unified flow for all agents: POST `/api/v1/admin/restart` triggers
- * the backend to spawn a fresh daemon bridge and exit. The frontend
- * polls `/api/v1/health` until the new process is live, then reloads.
+ * OpenClaw can be restarted from the viewer because the plugin lives
+ * inside the gateway process and launchd brings it back.
  *
- *   - OpenClaw: launchd respawns the gateway — may take a few seconds.
- *   - Hermes: the restart endpoint spawns `bridge.cts --daemon` before
- *     exiting, so the viewer comes back almost immediately.
+ * Hermes is different: the viewer daemon is intentionally long-lived,
+ * so restart means "terminate the active `hermes chat` process" while
+ * keeping this Memory Viewer online. The user can relaunch Hermes and
+ * it will reconnect to the existing viewer service.
  */
 import { signal } from "@preact/signals";
 import { api } from "../api/client";
@@ -15,8 +15,6 @@ import { health } from "./health";
 
 export type RestartPhase =
   | "idle"
-  | "saved"
-  | "cleared"
   | "restarting"
   | "waitingUp"
   | "restartFailed";
@@ -24,10 +22,6 @@ export type RestartPhase =
 export const restartState = signal<{ phase: RestartPhase; message?: string }>({
   phase: "idle",
 });
-
-export interface TriggerRestartOptions {
-  kick?: "restart-endpoint" | "skip";
-}
 
 function isOpenClaw(): boolean {
   return health.value?.agent === "openclaw";
@@ -63,16 +57,9 @@ async function pollHealthUntilUp(maxAttempts = 60): Promise<boolean> {
 }
 
 /**
- * Quick health check — verify the server responds again.
- *
- * Hermes' restart flow spawns the new daemon AFTER `sleep 3`
- * (admin.ts) so the old bridge can fully release the viewer port,
- * then `tsx` cold-compiles + bootstrap (DB migrations, embedder /
- * LLM clients, host-bridge registration) takes another few seconds
- * before the port is bound. Total worst-case wall time is ~10–15 s
- * on slower machines. We poll every 1 s for up to 30 attempts (30 s
- * total) so even a sluggish cold start succeeds without the user
- * hitting the "重启超时" toast prematurely.
+ * Quick health check for destructive clear-data only.
+ * Do not use this for Hermes config saves: those must keep the current
+ * viewer daemon online and terminate only the active `hermes chat`.
  */
 async function quickPollUp(maxAttempts = 30): Promise<boolean> {
   for (let i = 0; i < maxAttempts; i++) {
@@ -88,40 +75,40 @@ async function quickPollUp(maxAttempts = 30): Promise<boolean> {
 }
 
 /**
- * Config saved. Trigger a restart for any agent. The backend spawns a
- * fresh daemon bridge before exiting, so the viewer port comes back up
- * automatically for both OpenClaw (launchd) and Hermes (self-respawn).
+ * Config saved. OpenClaw gets an in-place gateway restart. Hermes keeps
+ * the viewer online and asks the backend to terminate the active chat
+ * process; once that request returns, reload the same viewer page.
+ *
+ * Do not add a passive "settings saved" toast/card here. The restart
+ * affordance is intentionally blocking for both agents so the operator
+ * sees Hermes' active chat window being closed before the viewer returns.
  */
-export async function triggerRestart(
-  _opts: TriggerRestartOptions = {},
-): Promise<void> {
+export async function triggerRestart(): Promise<void> {
   restartState.value = { phase: "restarting" };
+  if (!isOpenClaw()) {
+    try {
+      await api.post("/api/v1/admin/restart");
+      await new Promise((r) => setTimeout(r, 500));
+      window.location.href =
+        window.location.pathname + "?_t=" + Date.now();
+    } catch {
+      restartState.value = { phase: "restartFailed" };
+    }
+    return;
+  }
+
   try {
     await api.post("/api/v1/admin/restart");
   } catch {
     // Server might already be going down
   }
 
-  if (isOpenClaw()) {
-    const ok = await pollHealthUntilUp(60);
-    if (ok) {
-      window.location.href =
-        window.location.pathname + "?_t=" + Date.now();
-    } else {
-      restartState.value = { phase: "restartFailed" };
-    }
+  const ok = await pollHealthUntilUp(60);
+  if (ok) {
+    window.location.href =
+      window.location.pathname + "?_t=" + Date.now();
   } else {
-    // Hermes: new daemon spawns after `sleep 3` (admin.ts) so the
-    // old bridge can fully release the port; cold-start of tsx +
-    // bootstrap may take another few seconds. Use the default
-    // `quickPollUp` attempts (30s total).
-    const ok = await quickPollUp();
-    if (ok) {
-      window.location.href =
-        window.location.pathname + "?_t=" + Date.now();
-    } else {
-      restartState.value = { phase: "restartFailed" };
-    }
+    restartState.value = { phase: "restartFailed" };
   }
 }
 


### PR DESCRIPTION
## Summary
- Keep the Hermes Memory Viewer daemon alive during config-save restart and terminate only the active `hermes chat` process.
- Remove the passive settings-saved restart card path so config saves always show the blocking full-screen restart overlay.
- Filter Hermes internal memory/skill review prompts so they are not persisted as user turns.

## Test plan
- `/Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py`
- `/Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format --check apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py`
- `/Users/jiang/MyProject/MemOS-jiang/.venv/bin/python -m unittest apps.memos-local-plugin.tests.python.test_hermes_provider_pipeline`
- `npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck server/routes/admin.ts`
- `npm run build:web`