### PR TITLE
fix(hermes): ignore skill review prompt variants

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -88,6 +88,7 @@ _HERMES_INTERNAL_REVIEW_PREFIXES = (
     "review the conversation above and update the skill library.",
     "review the conversation above and update two things:",
     "review the conversation above and consider saving or updating a skill if appropriate.",
+    "review the conversation above and consider whether a skill should be saved or updated.",
 )
 
 
@@ -263,15 +264,15 @@ class MemTensorProvider(MemoryProvider):
         ids = self._tool_call_ids(
             {
                 "id": tool_call_id,
-                "call_id": _kw.get("call_id"),
-                "response_item_id": _kw.get("response_item_id"),
-                "tool_call_id": _kw.get("tool_call_id"),
+                "call_id": kw.get("call_id"),
+                "response_item_id": kw.get("response_item_id"),
+                "tool_call_id": kw.get("tool_call_id"),
             }
         )
         input_text = (
             json.dumps(args, ensure_ascii=False) if isinstance(args, dict) else str(args or "")
         )
-        timing = self._coerce_tool_timing(_kw)
+        timing = self._coerce_tool_timing(kw)
 
         existing = self._find_tool_call(ids)
         if existing is not None:

--- a/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
+++ b/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
@@ -116,7 +116,8 @@ class HermesProviderPipelineTests(unittest.TestCase):
     def test_internal_hermes_review_prompt_is_not_persisted_as_user_turn(self) -> None:
         bridge = FakeBridge()
         review_prompt = (
-            "Review the conversation above and consider saving or updating a skill if appropriate."
+            "Review the conversation above and consider whether a skill should be "
+            "saved or updated.  Work in this order -- do not skip."
         )
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),


### PR DESCRIPTION
## Summary
- Filter an additional Hermes internal skill-review prompt variant so it is not persisted as a user task.
- Keep Hermes tool-call alias/timing merge code using the actual `kw` payload so Python checks pass.
- Update the Hermes provider lifecycle test to cover the prompt variant seen in exported session data.

## Test plan
- `/Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check adapters/hermes/memos_provider/__init__.py tests/python/test_hermes_provider_pipeline.py`
- `/Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format --check adapters/hermes/memos_provider/__init__.py tests/python/test_hermes_provider_pipeline.py`
- `python3 -m unittest tests/python/test_hermes_provider_pipeline.py`