### PR TITLE
fix: stabilize MemOS trace ordering and scoring

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -136,6 +136,7 @@ class MemTensorProvider(MemoryProvider):
         self._hermes_home: str = ""
         self._agent_identity: str = "hermes"
         self._platform: str = "cli"
+        self._last_host_runtime: dict[str, str] = {}
         self._turn_number: int = 0
         # Last user turn text — used by `sync_turn` to compose `turn.end`.
         self._last_user_text: str = ""
@@ -313,6 +314,8 @@ class MemTensorProvider(MemoryProvider):
             existing["output"] = (result or "")[:4000]
             existing["_ids"] = sorted(set((existing.get("_ids") or []) + ids))
             existing["_id"] = existing.get("_id") or (ids[0] if ids else "")
+            if existing.get("_id"):
+                existing["toolCallId"] = existing["_id"]
             if timing:
                 existing.update(timing)
             return
@@ -323,6 +326,7 @@ class MemTensorProvider(MemoryProvider):
             "output": (result or "")[:4000],
             "_id": ids[0] if ids else "",
             "_ids": ids,
+            "toolCallId": ids[0] if ids else "",
         }
         if timing:
             call.update(timing)
@@ -478,6 +482,7 @@ class MemTensorProvider(MemoryProvider):
                             "assistantTextBefore": content_str or "",
                             "_id": ids[0] if ids else "",
                             "_ids": ids,
+                            "toolCallId": ids[0] if ids else "",
                         }
                         self._tool_calls.append(existing)
                     else:
@@ -492,6 +497,8 @@ class MemTensorProvider(MemoryProvider):
                         )
                         existing["_ids"] = sorted(set((existing.get("_ids") or []) + ids))
                         existing["_id"] = existing.get("_id") or (ids[0] if ids else "")
+                        if existing.get("_id"):
+                            existing["toolCallId"] = existing["_id"]
 
                     marker = id(existing)
                     if marker not in ordered_object_ids:
@@ -724,7 +731,7 @@ class MemTensorProvider(MemoryProvider):
         result: str,
         *,
         child_session_id: str = "",
-        **_kwargs: Any,
+        **kwargs: Any,
     ) -> None:  # type: ignore[override]
         """Record a subagent outcome.
 
@@ -738,6 +745,9 @@ class MemTensorProvider(MemoryProvider):
         try:
             if not self._episode_id and self._last_user_text:
                 self._turn_start(self._last_user_text, session_id=self._session_id)
+            hook_meta = {
+                "hookKwargs": kwargs,
+            }
             self._bridge.request(
                 "subagent.record",
                 {
@@ -748,6 +758,7 @@ class MemTensorProvider(MemoryProvider):
                     "result": result,
                     "toolCalls": self._extract_child_tool_calls(child_session_id),
                     "ts": int(time.time() * 1000),
+                    "meta": hook_meta,
                 },
             )
         except Exception as err:
@@ -1369,9 +1380,36 @@ class MemTensorProvider(MemoryProvider):
 
     # ─── Internals ────────────────────────────────────────────────────────
 
+    def _host_runtime_context(self) -> dict[str, str]:
+        """Best-effort snapshot of Hermes' main conversation runtime."""
+        try:
+            from hermes_cli.runtime_provider import (  # type: ignore[import-not-found]
+                resolve_runtime_provider,
+            )
+
+            runtime = resolve_runtime_provider()
+        except Exception:
+            return dict(self._last_host_runtime)
+
+        out: dict[str, str] = {}
+        if isinstance(runtime, dict):
+            for source, target in (
+                ("provider", "hostProvider"),
+                ("model", "hostModel"),
+                ("api_mode", "hostApiMode"),
+                ("base_url", "hostBaseUrl"),
+            ):
+                value = runtime.get(source)
+                if isinstance(value, str) and value.strip():
+                    out[target] = value.strip()
+        if out:
+            self._last_host_runtime = dict(out)
+        return out
+
     def _open_session(self, session_id: str = "", *, timeout: float = 30.0) -> None:
         assert self._bridge is not None
         requested_session = session_id or self._session_id or ""
+        host_runtime = self._host_runtime_context()
         resp = self._bridge.request(
             "session.open",
             {
@@ -1381,6 +1419,7 @@ class MemTensorProvider(MemoryProvider):
                     "hermesHome": self._hermes_home,
                     "platform": self._platform,
                     "agentIdentity": self._agent_identity,
+                    **host_runtime,
                 },
             },
             timeout=timeout,
@@ -1451,12 +1490,17 @@ class MemTensorProvider(MemoryProvider):
 
     def _turn_start(self, query: str, *, session_id: str = "") -> str:
         assert self._bridge is not None
+        host_runtime = self._host_runtime_context()
         resp = self._bridge.request(
             "turn.start",
             {
                 "agent": "hermes",
                 "sessionId": session_id or self._session_id,
                 "userText": query,
+                "contextHints": {
+                    "agentIdentity": self._agent_identity,
+                    **host_runtime,
+                },
                 "ts": int(time.time() * 1000),
             },
         )
@@ -1495,6 +1539,10 @@ class MemTensorProvider(MemoryProvider):
             "agentText": assistant_content,
             "userText": user_content,
             "toolCalls": clean_tool_calls,
+            "contextHints": {
+                "agentIdentity": self._agent_identity,
+                **self._host_runtime_context(),
+            },
             "ts": ts_ms,
         }
         if agent_thinking:

--- a/apps/memos-local-plugin/agent-contract/dto.ts
+++ b/apps/memos-local-plugin/agent-contract/dto.ts
@@ -38,6 +38,8 @@ export interface ToolCallDTO {
   input: unknown;
   output?: unknown;
   errorCode?: string;
+  /** Host/model tool call id, when available. Used to correlate tool results. */
+  toolCallId?: string;
   /**
    * Real tool execution timestamps when the host exposes them. Tools
    * reconstructed later from `post_llm_call` history may not have reliable
@@ -96,6 +98,8 @@ export interface TurnResultDTO {
   agentThinking?: string;
   /** Tools called this turn (in order). */
   toolCalls: ToolCallDTO[];
+  /** Optional adapter-provided host/runtime hints for scoring context. */
+  contextHints?: Record<string, unknown>;
   /**
    * Optional MemOS-produced reflection (the plugin's summary of what
    * the model did, used to compute α + backprop V). NEVER displayed
@@ -186,6 +190,16 @@ export interface TraceDTO {
   rHuman?: Reward;
   /** Cached priority used for L2 candidate selection. */
   priority: number;
+  /** Episode-level scoring state, attached for viewer display. */
+  episodeStatus?: "open" | "closed";
+  episodeRTask?: Reward | null;
+  /**
+   * True only when the reward gate explicitly stamped
+   * `meta.reward.skipped=true`. Do not infer this from `rTask=null` because a
+   * freshly-finalized episode can be closed while reward scoring is still
+   * running.
+   */
+  episodeRewardSkipped?: boolean;
   /**
    * Stable group key shared by every L1 trace produced from the same
    * user message. Equal to the user turn's `ts` (epoch ms). The

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -124,7 +124,11 @@ export interface MemoryCore {
   health(): Promise<CoreHealth>;
 
   // ── session / episode ──
-  openSession(input: { agent: AgentKind; sessionId?: SessionId }): Promise<SessionId>;
+  openSession(input: {
+    agent: AgentKind;
+    sessionId?: SessionId;
+    meta?: Record<string, unknown>;
+  }): Promise<SessionId>;
   closeSession(sessionId: SessionId): Promise<void>;
   openEpisode(input: {
     sessionId: SessionId;

--- a/apps/memos-local-plugin/bridge/methods.ts
+++ b/apps/memos-local-plugin/bridge/methods.ts
@@ -61,6 +61,10 @@ function asRecord(p: unknown, method: RpcMethodName): Record<string, unknown> {
   return p as Record<string, unknown>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function requireString(
   obj: Record<string, unknown>,
   key: string,
@@ -114,7 +118,8 @@ export function makeDispatcher(
           typeof p.sessionId === "string" && p.sessionId.length > 0
             ? (p.sessionId as SessionId)
             : undefined;
-        const out = await core.openSession({ agent, sessionId });
+        const meta = isRecord(p.meta) ? p.meta : undefined;
+        const out = await core.openSession({ agent, sessionId, meta });
         return { sessionId: out };
       }
       case RPC_METHODS.SESSION_CLOSE: {

--- a/apps/memos-local-plugin/core/capture/batch-scorer.ts
+++ b/apps/memos-local-plugin/core/capture/batch-scorer.ts
@@ -119,6 +119,7 @@ export async function batchScoreReflections(
   const fieldChars = { ...DEFAULT_FIELD_CHARS, ...(opts.perFieldChars ?? {}) };
 
   const payload = {
+    host_context: batchHostContext(inputs, llm),
     steps: inputs.map((input, i) => ({
       idx: i,
       state: clip(input.step.userText, fieldChars.state),
@@ -221,6 +222,26 @@ export async function batchScoreReflections(
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────
+
+function batchHostContext(
+  inputs: ReadonlyArray<BatchScoreInput>,
+  llm: LlmClient,
+): Record<string, string> | undefined {
+  const hints = inputs
+    .map((input) => input.step.meta.contextHints)
+    .find((value): value is Record<string, unknown> =>
+      typeof value === "object" && value !== null && !Array.isArray(value),
+    );
+  const out: Record<string, string> = {
+    reflectionProvider: llm.provider,
+    reflectionModel: llm.model,
+  };
+  for (const key of ["agentIdentity", "hostProvider", "hostModel", "hostApiMode", "hostBaseUrl"]) {
+    const value = hints?.[key];
+    if (typeof value === "string" && value.trim()) out[key] = value.trim();
+  }
+  return out;
+}
 
 function disabledScoreFor(input: BatchScoreInput): ReflectionScore {
   const text = (input.existingReflection ?? "").trim();

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -19,7 +19,7 @@ import type { Embedder } from "../embedding/index.js";
 import type { LlmClient } from "../llm/index.js";
 import { rootLogger } from "../logger/index.js";
 import { ids } from "../id.js";
-import type { TraceRow, TraceId } from "../types.js";
+import type { EpisodeRow, TraceRow, TraceId } from "../types.js";
 import type { makeEmbeddingRetryQueueRepo } from "../storage/repos/embedding_retry_queue.js";
 import type { makeTracesRepo } from "../storage/repos/traces.js";
 import type { EpisodesRepo } from "../session/persistence.js";
@@ -42,6 +42,7 @@ import type {
   NormalizedStep,
   ReflectionScore,
   ScoredStep,
+  StepCandidate,
   TraceCandidate,
 } from "./types.js";
 
@@ -551,13 +552,27 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     scored: ScoredStep[],
     rows: TraceRow[],
   ): TraceCandidate[] {
-    return scored.map((s, i) => ({
-      ...s,
-      traceId: rows[i]!.id as TraceId,
-      tags: rows[i]!.tags,
-      vecSummary: rows[i]!.vecSummary,
-      vecAction: rows[i]!.vecAction,
-    }));
+    const used = new Set<number>();
+    return rows.map((row) => {
+      const idx = scored.findIndex((s, i) => !used.has(i) && rowMatchesStep(row, s));
+      const s = scored[idx >= 0 ? idx : 0]!;
+      if (idx >= 0) used.add(idx);
+      return {
+        ...s,
+        traceId: row.id as TraceId,
+        tags: row.tags,
+        vecSummary: row.vecSummary,
+        vecAction: row.vecAction,
+      };
+    });
+  }
+
+  function rowMatchesStep(row: TraceRow, step: ScoredStep): boolean {
+    if (row.ts !== step.ts) return false;
+    const rowTool = row.toolCalls[0];
+    const stepTool = step.toolCalls[0];
+    if (rowTool || stepTool) return rowTool?.name === stepTool?.name;
+    return row.userText === step.userText && row.agentText === step.agentText;
   }
 
   async function persistRows(
@@ -565,6 +580,26 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     input: CaptureInput,
     warnings: CaptureResult["warnings"],
   ): Promise<boolean> {
+    const existingBeforeInsert = deps.tracesRepo.list({ episodeId: input.episode.id });
+    const seenSignatures = new Set(existingBeforeInsert.map(traceIdentitySignature));
+    const uniqueRows = rows.filter((row) => {
+      const signature = traceIdentitySignature(row);
+      if (seenSignatures.has(signature)) return false;
+      seenSignatures.add(signature);
+      return true;
+    });
+    if (uniqueRows.length !== rows.length) {
+      warnings.push({
+        stage: "persist",
+        message: "skipped duplicate trace rows during capture persist",
+        detail: {
+          skipped: rows.length - uniqueRows.length,
+          episodeId: input.episode.id,
+        },
+      });
+      rows.splice(0, rows.length, ...uniqueRows);
+    }
+
     try {
       for (const row of rows) deps.tracesRepo.insert(row);
       enqueueMissingTraceVectors(rows, warnings);
@@ -589,9 +624,11 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
         : new MemosError(ERROR_CODES.INTERNAL, "capture.persist failed", failure);
     }
     try {
+      const current = deps.episodesRepo.getById(input.episode.id) as EpisodeRow | null;
+      const currentTraceIds = current?.traceIds ?? input.episode.traceIds;
       deps.episodesRepo.updateTraceIds(
         input.episode.id,
-        [...input.episode.traceIds, ...rows.map((r) => r.id)],
+        reconcileTraceIds([...currentTraceIds, ...rows.map((r) => r.id)], input.episode),
       );
     } catch (err) {
       warnings.push({
@@ -601,6 +638,105 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
       });
     }
     return true;
+  }
+
+  function reconcileTraceIds(traceIds: TraceId[], episode: CaptureInput["episode"]): TraceId[] {
+    const uniqueIds = dedupeTraceIds(traceIds);
+    const rowById = new Map(deps.tracesRepo.getManyByIds(uniqueIds).map((row) => [row.id, row]));
+    const originalIndex = new Map(uniqueIds.map((id, idx) => [id, idx]));
+    const stepOrder = new Map<string, number>();
+    extractSteps(episode).forEach((step, idx) => {
+      const signature = stepIdentitySignature(step);
+      if (!stepOrder.has(signature)) stepOrder.set(signature, idx);
+    });
+    const seenSignatures = new Set<string>();
+    return uniqueIds
+      .filter((id) => rowById.has(id))
+      .sort((a, b) => {
+        const ai = stepOrder.get(traceIdentitySignature(rowById.get(a)!));
+        const bi = stepOrder.get(traceIdentitySignature(rowById.get(b)!));
+        if (ai != null && bi != null && ai !== bi) return ai - bi;
+        if (ai != null && bi == null) return -1;
+        if (ai == null && bi != null) return 1;
+        return (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0);
+      })
+      .filter((id) => {
+        const signature = traceIdentitySignature(rowById.get(id)!);
+        if (seenSignatures.has(signature)) return false;
+        seenSignatures.add(signature);
+        return true;
+      });
+  }
+
+  function dedupeTraceIds(traceIds: TraceId[]): TraceId[] {
+    const seen = new Set<TraceId>();
+    const out: TraceId[] = [];
+    for (const id of traceIds) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      out.push(id);
+    }
+    return out;
+  }
+
+  function stepIdentitySignature(step: StepCandidate): string {
+    const tool = step.toolCalls[0];
+    const turnId = pickTurnId(step.meta, step.ts);
+    if (tool) {
+      const hasRealTiming =
+        typeof tool.startedAt === "number" || typeof tool.endedAt === "number";
+      return [
+        "tool",
+        turnId,
+        tool.name,
+        hasRealTiming ? tool.startedAt ?? "" : step.ts,
+        hasRealTiming ? tool.endedAt ?? "" : "",
+        stableJson(tool.input),
+        stableJson(tool.output),
+        tool.errorCode ?? "",
+      ].join("\x1f");
+    }
+    if (step.agentText.trim()) {
+      return ["assistant", turnId, step.ts, step.agentText.trim()].join("\x1f");
+    }
+    return ["user", turnId, step.ts, step.userText.trim()].join("\x1f");
+  }
+
+  function traceIdentitySignature(row: TraceRow): string {
+    const tool = row.toolCalls[0];
+    if (tool) {
+      const hasRealTiming =
+        typeof tool.startedAt === "number" || typeof tool.endedAt === "number";
+      return [
+        "tool",
+        row.turnId,
+        tool.name,
+        hasRealTiming ? tool.startedAt ?? "" : row.ts,
+        hasRealTiming ? tool.endedAt ?? "" : "",
+        stableJson(tool.input),
+        stableJson(tool.output),
+        tool.errorCode ?? "",
+      ].join("\x1f");
+    }
+    if (row.agentText.trim()) {
+      return ["assistant", row.turnId, row.ts, row.agentText.trim()].join("\x1f");
+    }
+    return ["user", row.turnId, row.ts, row.userText.trim()].join("\x1f");
+  }
+
+  function stableJson(value: unknown): string {
+    if (value === undefined) return "";
+    return JSON.stringify(sortJson(value));
+  }
+
+  function sortJson(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(sortJson);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, val]) => [key, sortJson(val)]),
+    );
   }
 
   function enqueueMissingTraceVectors(

--- a/apps/memos-local-plugin/core/capture/step-extractor.ts
+++ b/apps/memos-local-plugin/core/capture/step-extractor.ts
@@ -264,6 +264,7 @@ function toolCallFromTurn(turn: EpisodeTurn): ToolCallDTO | null {
   const endedAt = typeof meta.endedAt === "number" ? meta.endedAt : undefined;
   const input = meta.input ?? meta.args ?? undefined;
   const errorCode = typeof meta.errorCode === "string" ? meta.errorCode : undefined;
+  const toolCallId = typeof meta.toolCallId === "string" ? meta.toolCallId : undefined;
   const thinkingBefore = typeof meta.thinkingBefore === "string" ? meta.thinkingBefore : undefined;
   const assistantTextBefore = typeof meta.assistantTextBefore === "string" ? meta.assistantTextBefore : undefined;
   return {
@@ -271,6 +272,7 @@ function toolCallFromTurn(turn: EpisodeTurn): ToolCallDTO | null {
     input,
     output: turn.content,
     errorCode,
+    toolCallId,
     startedAt,
     endedAt,
     thinkingBefore,
@@ -297,11 +299,12 @@ function coerceToolCall(raw: unknown): ToolCallDTO | null {
   const input = r.input ?? r.args ?? undefined;
   const output = r.output ?? r.result ?? undefined;
   const errorCode = typeof r.errorCode === "string" ? r.errorCode : undefined;
+  const toolCallId = typeof r.toolCallId === "string" ? r.toolCallId : undefined;
   const startedAt = typeof r.startedAt === "number" ? r.startedAt : undefined;
   const endedAt = typeof r.endedAt === "number" ? r.endedAt : undefined;
   const thinkingBefore = typeof r.thinkingBefore === "string" ? r.thinkingBefore : undefined;
   const assistantTextBefore = typeof r.assistantTextBefore === "string" ? r.assistantTextBefore : undefined;
-  return { name, input, output, errorCode, startedAt, endedAt, thinkingBefore, assistantTextBefore };
+  return { name, input, output, errorCode, toolCallId, startedAt, endedAt, thinkingBefore, assistantTextBefore };
 }
 
 function depthFromMeta(meta: Record<string, unknown>): number {

--- a/apps/memos-local-plugin/core/llm/prompts/reflection.ts
+++ b/apps/memos-local-plugin/core/llm/prompts/reflection.ts
@@ -100,6 +100,12 @@ INPUT: a JSON array under "steps". Each entry has:
   false, leave "reflection_text" empty for steps that came in with empty
   "reflection".
 
+The user payload may also include "host_context". That describes the host
+agent being reviewed and the separate reflection model doing this review.
+Do NOT project the reflection model's own identity/provider/capabilities onto
+the host agent. If hostModel/hostProvider are present, treat them as the
+authoritative runtime context unless the episode itself contains a correction.
+
 For EACH input step, return one object containing:
 - "idx": copy the input idx exactly
 - "reflection_text":

--- a/apps/memos-local-plugin/core/llm/prompts/reward.ts
+++ b/apps/memos-local-plugin/core/llm/prompts/reward.ts
@@ -73,6 +73,12 @@ Rules:
   continuation), NOT negative. Never invent anger.
 - Base scores ONLY on what TASK_SUMMARY actually describes — do not
   assume facts not shown.
+- You are grading the HOST AGENT described in HOST_AGENT_CONTEXT, not
+  yourself. Do NOT use your own model identity, provider, policies, or
+  capabilities to decide whether the host agent answered identity/model
+  questions correctly. If hostModel/hostProvider are provided, treat them
+  as the authoritative runtime context unless the conversation itself
+  contains a correction.
 - Produce one short justification.
 
 Return JSON, EXACTLY this shape (no extra keys, no commentary):

--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -218,6 +218,12 @@ export function buildPipelineSubscribers(
     llm: deps.llm,
     bus: buses.reward,
     cfg: algorithm.reward,
+    evaluator: {
+      reflectionProvider: deps.reflectLlm?.provider,
+      reflectionModel: deps.reflectLlm?.model,
+      scorerProvider: deps.llm?.provider,
+      scorerModel: deps.llm?.model,
+    },
     now: deps.now,
     // Wire the live episode snapshot so the R_human scorer sees the
     // real user / assistant turns of the episode. Without this, the

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -439,6 +439,7 @@ export function createMemoryCore(
     4 * 60 * 60 * 1000,
   );
   let lastStaleScan = 0;
+  let lastDirtyClosedScan = 0;
   async function autoFinalizeStaleTasks(): Promise<void> {
     const nowMs = Date.now();
     if (nowMs - lastStaleScan < 30_000) return;
@@ -462,6 +463,24 @@ export function createMemoryCore(
       if (stale.length > 0) await recoverOpenEpisodesAsSessionEnd(stale);
     } catch (err) {
       log.debug("stale_topic.scan_error", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function autoRescoreDirtyClosedEpisodes(): Promise<void> {
+    const nowMs = Date.now();
+    if (nowMs - lastDirtyClosedScan < 30_000) return;
+    lastDirtyClosedScan = nowMs;
+    try {
+      const dirtyClosed = handle.repos.episodes
+        .list({ status: "closed", limit: 500 })
+        .filter((ep) => episodeRewardIsDirty(ep));
+      if (dirtyClosed.length > 0) {
+        await recoverDirtyClosedEpisodes(dirtyClosed);
+      }
+    } catch (err) {
+      log.debug("dirty_closed_reward.scan_error", {
         err: err instanceof Error ? err.message : String(err),
       });
     }
@@ -502,6 +521,12 @@ export function createMemoryCore(
         if (stale.length > 0) {
           await recoverOpenEpisodesAsSessionEnd(stale);
         }
+      }
+      const dirtyClosed = handle.repos.episodes
+        .list({ status: "closed", limit: 500 })
+        .filter((ep) => episodeRewardIsDirty(ep));
+      if (dirtyClosed.length > 0) {
+        await recoverDirtyClosedEpisodes(dirtyClosed);
       }
     } catch (err) {
       log.debug("init.orphan_scan.failed", {
@@ -711,7 +736,7 @@ export function createMemoryCore(
           recoveryReason: "missed_session_end",
         });
 
-        if (ep.rTask != null) {
+        if (ep.rTask != null && !episodeRewardIsDirty(ep)) {
           log.info("init.orphan.repaired_finalized", {
             episodeId,
             sessionId: ep.sessionId,
@@ -787,9 +812,67 @@ export function createMemoryCore(
     }
   }
 
+  async function recoverDirtyClosedEpisodes(
+    episodes: Array<EpisodeRow & { meta?: Record<string, unknown> }>,
+  ): Promise<void> {
+    log.info("init.dirty_closed_episodes.rescore", { count: episodes.length });
+    for (const ep of episodes) {
+      const episodeId = ep.id as EpisodeId;
+      const endedAt = ep.endedAt ?? Date.now();
+      handle.repos.episodes.updateMeta(episodeId, {
+        closeReason: "finalized",
+        recoveredAtStartup: endedAt,
+        recoveryReason: "dirty_reward_rescore",
+      });
+      const snapshot = snapshotFromRecoveredEpisode(ep, endedAt, {
+        recoveryReason: "dirty_reward_rescore",
+      });
+      handle.buses.session.emit({
+        kind: "episode.finalized",
+        episode: snapshot,
+        closedBy: "finalized",
+      });
+    }
+    await handle.flush();
+  }
+
+  function episodeRewardIsDirty(ep: EpisodeRow & { meta?: Record<string, unknown> }): boolean {
+    const meta = ep.meta ?? {};
+    if (meta.rewardDirty && typeof meta.rewardDirty === "object") return true;
+
+    const reward = meta.reward;
+    if (reward && typeof reward === "object" && (reward as { skipped?: unknown }).skipped === true) {
+      return false;
+    }
+    if (
+      ep.rTask == null &&
+      (ep.traceIds?.length ?? 0) > 0 &&
+      (meta.closeReason === "finalized" || meta.recoveryReason === "missed_session_end")
+    ) {
+      return true;
+    }
+    if (!reward || typeof reward !== "object") return false;
+    const traceCount = (reward as { traceCount?: unknown }).traceCount;
+    if (typeof traceCount === "number") {
+      return traceCount !== (ep.traceIds?.length ?? 0);
+    }
+
+    // Backward compatibility for episodes scored before reward coverage
+    // metadata existed: if a trace was appended after the recorded reward
+    // time, the old task score no longer covers the full episode.
+    const scoredAt = (reward as { scoredAt?: unknown }).scoredAt;
+    if (typeof scoredAt !== "number") return false;
+    const traceIds = (ep.traceIds ?? []) as TraceId[];
+    if (traceIds.length === 0) return false;
+    return handle.repos.traces
+      .getManyByIds(traceIds)
+      .some((tr) => tr.ts > scoredAt);
+  }
+
   function snapshotFromRecoveredEpisode(
     ep: EpisodeRow & { meta?: Record<string, unknown> },
     endedAt: number,
+    opts: { recoveryReason?: string } = {},
   ): EpisodeSnapshot {
     const traceIds = (ep.traceIds ?? []) as TraceId[];
     const traces =
@@ -844,7 +927,7 @@ export function createMemoryCore(
         ...(ep.meta ?? {}),
         closeReason: "finalized",
         recoveredAtStartup: endedAt,
-        recoveryReason: "missed_session_end",
+        recoveryReason: opts.recoveryReason ?? "missed_session_end",
       },
       intent: normaliseRecoveredIntent(ep.meta),
     };
@@ -974,12 +1057,13 @@ export function createMemoryCore(
   async function openSession(input: {
     agent: AgentKind;
     sessionId?: SessionId;
+    meta?: Record<string, unknown>;
   }): Promise<SessionId> {
     ensureLive();
     const snap = handle.sessionManager.openSession({
       id: input.sessionId,
       agent: input.agent,
-      meta: {},
+      meta: input.meta ?? {},
     });
     return snap.id as SessionId;
   }
@@ -1270,6 +1354,14 @@ export function createMemoryCore(
       ],
       ts,
     });
+    const anchor = {
+      task,
+      result,
+      childSessionId: outcome.childSessionId ?? null,
+      traceId: recorded.traceId as TraceId,
+      meta: outcome.meta ?? {},
+    };
+    anchorSubagentTraceAfterDelegate(recorded.episodeId, anchor);
 
     let childRecorded: { traceId: string; episodeId: EpisodeId } | null = null;
     const childSessionId = outcome.childSessionId ?? null;
@@ -1308,6 +1400,7 @@ export function createMemoryCore(
         }
       }
     }
+    anchorSubagentTraceAfterDelegate(recorded.episodeId, anchor);
 
     try {
       handle.repos.apiLogs.insert({
@@ -1341,6 +1434,169 @@ export function createMemoryCore(
     }
 
     return recorded;
+  }
+
+  function anchorSubagentTraceAfterDelegate(
+    episodeId: EpisodeId,
+    anchor: {
+      task: string;
+      result: string;
+      childSessionId: SessionId | null;
+      traceId: TraceId;
+      meta: Record<string, unknown>;
+    },
+  ): void {
+    const episode = handle.repos.episodes.getById(episodeId);
+    if (!episode) return;
+    const rows = episode.traceIds.length > 0
+      ? handle.repos.traces.getManyByIds(episode.traceIds)
+      : handle.repos.traces.list({ episodeId, limit: 500, newestFirst: false });
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    const ordered = (
+      episode.traceIds.length > 0 ? episode.traceIds : rows.map((row) => row.id)
+    ).filter((id) => byId.has(id));
+    const synthetic = ordered.filter((id) =>
+      isMatchingSubagentTrace(byId.get(id)!, anchor),
+    );
+    if (synthetic.length === 0) return;
+    const delegateId = findMatchingDelegateTaskTrace(ordered.map((id) => byId.get(id)!), anchor);
+    if (!delegateId) return;
+    moveUserTextToAnchoredDelegate(byId, delegateId, synthetic);
+
+    const withoutSynthetic = ordered.filter((id) => !synthetic.includes(id));
+    const delegateIdx = withoutSynthetic.indexOf(delegateId);
+    if (delegateIdx < 0) return;
+    const next = [
+      ...withoutSynthetic.slice(0, delegateIdx + 1),
+      ...synthetic,
+      ...withoutSynthetic.slice(delegateIdx + 1),
+    ];
+    if (next.join("\0") !== episode.traceIds.join("\0")) {
+      handle.repos.episodes.appendTrace(episodeId, next);
+    }
+  }
+
+  function moveUserTextToAnchoredDelegate(
+    byId: Map<string, TraceRow>,
+    delegateId: TraceId,
+    syntheticIds: string[],
+  ): void {
+    const delegate = byId.get(delegateId);
+    if (!delegate || delegate.userText.trim()) return;
+    const source = syntheticIds
+      .map((id) => byId.get(id))
+      .find((row): row is TraceRow =>
+        Boolean(row && row.turnId === delegate.turnId && row.userText.trim()),
+      );
+    if (!source) return;
+    handle.repos.traces.updateBody(delegateId, { userText: source.userText });
+    handle.repos.traces.updateBody(source.id, { userText: "" });
+    delegate.userText = source.userText;
+    source.userText = "";
+  }
+
+  function isMatchingSubagentTrace(
+    row: TraceRow,
+    anchor: {
+      task: string;
+      result: string;
+      childSessionId: SessionId | null;
+      traceId: TraceId;
+      meta: Record<string, unknown>;
+    },
+  ): boolean {
+    if (row.id === anchor.traceId) return true;
+    if (row.agentText.includes(`Subagent task: ${anchor.task}`)) return true;
+    if (row.agentText.includes(`Subagent result: ${anchor.result}`)) return true;
+    const tool = row.toolCalls[0];
+    if (!tool || tool.name !== "subagent") return false;
+    const input = asRecord(tool.input);
+    if (!input) return false;
+    if (typeof input.task === "string" && input.task === anchor.task) return true;
+    return anchor.childSessionId != null && input.childSessionId === anchor.childSessionId;
+  }
+
+  function findMatchingDelegateTaskTrace(
+    rows: TraceRow[],
+    anchor: { task: string; meta: Record<string, unknown> },
+  ): TraceId | null {
+    const anchorToolCallId = subagentAnchorToolCallId(anchor.meta);
+    if (anchorToolCallId) {
+      const byId = rows.find((row) => delegateToolCallIdMatches(row, anchorToolCallId));
+      if (byId) return byId.id;
+    }
+
+    // Deterministic fallback for Hermes versions whose `on_delegation`
+    // hook does not expose tool_call_id: only anchor when exactly one
+    // delegate_task goal equals the subagent task.
+    const matches = rows.filter((row) => delegateTaskGoal(row) === anchor.task);
+    return matches.length === 1 ? matches[0]!.id : null;
+  }
+
+  function delegateToolCallIdMatches(row: TraceRow, anchorToolCallId: string): boolean {
+    const tool = row.toolCalls[0];
+    if (!tool || tool.name !== "delegate_task") return false;
+    if (tool.toolCallId === anchorToolCallId) return true;
+
+    const input = parseMaybeJsonObject(tool.input);
+    if (!input) return false;
+    const inputCallId = firstString(
+      input.toolCallId,
+      input.tool_call_id,
+      input.callId,
+      input.call_id,
+    );
+    return inputCallId === anchorToolCallId;
+  }
+
+  function delegateTaskGoal(row: TraceRow): string | null {
+    const tool = row.toolCalls[0];
+    if (!tool || tool.name !== "delegate_task") return null;
+    const input = parseMaybeJsonObject(tool.input);
+    if (!input) return null;
+    return firstString(input.goal);
+  }
+
+  function subagentAnchorToolCallId(meta: Record<string, unknown>): string | null {
+    const hookKwargs = asRecord(meta.hookKwargs) ?? {};
+    return firstString(
+      meta.toolCallId,
+      meta.tool_call_id,
+      meta.callId,
+      meta.call_id,
+      hookKwargs.toolCallId,
+      hookKwargs.tool_call_id,
+      hookKwargs.callId,
+      hookKwargs.call_id,
+    );
+  }
+
+  function parseMaybeJsonObject(value: unknown): Record<string, unknown> | null {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+    if (typeof value !== "string") return null;
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : null;
+  }
+
+  function firstString(...values: unknown[]): string | null {
+    for (const value of values) {
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+    return null;
   }
 
   // ─── Memory queries ──
@@ -1488,7 +1744,7 @@ export function createMemoryCore(
   async function getTrace(id: string): Promise<TraceDTO | null> {
     ensureLive();
     const row = handle.repos.traces.getById(id);
-    return row ? traceRowToDTO(row) : null;
+    return row ? traceRowToDTO(row, handle.repos.episodes.getById(row.episodeId)) : null;
   }
 
   async function updateTrace(
@@ -1505,7 +1761,9 @@ export function createMemoryCore(
     if (!existing) return null;
     handle.repos.traces.updateBody(id, patch);
     const updated = handle.repos.traces.getById(id);
-    return updated ? traceRowToDTO(updated) : null;
+    return updated
+      ? traceRowToDTO(updated, handle.repos.episodes.getById(updated.episodeId))
+      : null;
   }
 
   async function deleteTrace(id: string): Promise<{ deleted: boolean }> {
@@ -1543,7 +1801,9 @@ export function createMemoryCore(
     if (!existing) return null;
     handle.repos.traces.updateShare(id, share);
     const updated = handle.repos.traces.getById(id);
-    return updated ? traceRowToDTO(updated) : null;
+    return updated
+      ? traceRowToDTO(updated, handle.repos.episodes.getById(updated.episodeId))
+      : null;
   }
 
   async function getPolicy(id: string): Promise<PolicyDTO | null> {
@@ -1816,6 +2076,7 @@ export function createMemoryCore(
     // Auto-finalize only hard-stale open topics. Recent interrupted
     // topics stay open so the next user turn can be merged by topic.
     await autoFinalizeStaleTasks();
+    await autoRescoreDirtyClosedEpisodes();
 
     const rows = handle.repos.episodes.list({
       sessionId: input?.sessionId,
@@ -1939,7 +2200,9 @@ export function createMemoryCore(
       limit: 500,
       newestFirst: false,
     });
-    return orderTraceRowsForEpisode(rows, episode?.traceIds ?? []).map(traceRowToDTO);
+    return orderTraceRowsForEpisode(rows, episode?.traceIds ?? []).map((row) =>
+      traceRowToDTO(row, episode),
+    );
   }
 
   async function listApiLogs(input?: {
@@ -1986,8 +2249,7 @@ export function createMemoryCore(
     // traces from the repo (no limit) and apply the same filter.
     const rows = handle.repos.traces.list({ sessionId: input?.sessionId });
     const matched = rows.filter((r) => {
-      const hay = ((r.summary ?? "") + "\n" + r.userText + "\n" + r.agentText).toLowerCase();
-      return hay.includes(needle);
+      return traceSearchHaystack(r).includes(needle);
     });
     if (!input?.groupByTurn) return matched.length;
     const turnKeys = new Set<string>();
@@ -2034,13 +2296,12 @@ export function createMemoryCore(
           if (ia !== ib) return ia - ib;
           return compareTraceRowsForEpisodeOrder(a, b, traceOrder);
         });
-        return rows.map(traceRowToDTO);
+        return traceRowsToDTOs(rows);
       }
       // Search + group: scan, filter, then paginate by distinct turn key.
       const allRows = handle.repos.traces.list({ sessionId: input?.sessionId });
       const matched = allRows.filter((r) => {
-        const hay = ((r.summary ?? "") + "\n" + r.userText + "\n" + r.agentText).toLowerCase();
-        return hay.includes(needle);
+        return traceSearchHaystack(r).includes(needle);
       });
       const seen = new Map<string, { episodeId: string | null; turnId: number; maxTs: number }>();
       for (const r of matched) {
@@ -2057,9 +2318,11 @@ export function createMemoryCore(
       orderedKeys.forEach((k, i) =>
         turnOrder.set(`${k.episodeId ?? "_"}:${k.turnId}`, i),
       );
-      const traceOrder = traceOrderLookup(matched);
-      const traces = matched
-        .filter((r) => turnOrder.has(`${r.episodeId ?? "_"}:${r.turnId}`))
+      // Once a turn matches the search, return the whole turn so the
+      // Memories card uses the same step list as the Tasks timeline.
+      const rows = handle.repos.traces.listByTurnKeys(orderedKeys);
+      const traceOrder = traceOrderLookup(rows);
+      const traces = rows
         .sort((a, b) => {
           const ka = `${a.episodeId ?? "_"}:${a.turnId}`;
           const kb = `${b.episodeId ?? "_"}:${b.turnId}`;
@@ -2068,7 +2331,7 @@ export function createMemoryCore(
           if (ia !== ib) return ia - ib;
           return compareTraceRowsForEpisodeOrder(a, b, traceOrder);
         });
-      return traces.map(traceRowToDTO);
+      return traceRowsToDTOs(traces);
     }
 
     if (!needle) {
@@ -2077,7 +2340,7 @@ export function createMemoryCore(
         limit,
         offset,
       });
-      return rows.map(traceRowToDTO);
+      return traceRowsToDTOs(rows);
     }
     // Substring search: SQLite LIKE would need an index. For the
     // viewer's interactive filter the current volumes (low thousands
@@ -2089,10 +2352,30 @@ export function createMemoryCore(
       offset: 0,
     });
     const filtered = rows.filter((r) => {
-      const hay = ((r.summary ?? "") + "\n" + r.userText + "\n" + r.agentText).toLowerCase();
-      return hay.includes(needle);
+      return traceSearchHaystack(r).includes(needle);
     });
-    return filtered.slice(offset, offset + limit).map(traceRowToDTO);
+    return traceRowsToDTOs(filtered.slice(offset, offset + limit));
+  }
+
+  function traceSearchHaystack(row: TraceRow): string {
+    return [
+      row.id,
+      row.episodeId,
+      row.summary ?? "",
+      row.userText,
+      row.agentText,
+      summarizeToolCalls(row.toolCalls),
+    ].join("\n").toLowerCase();
+  }
+
+  function traceRowsToDTOs(rows: readonly TraceRow[]): TraceDTO[] {
+    const episodes = new Map<string, EpisodeRow | null>();
+    return rows.map((row) => {
+      if (!episodes.has(row.episodeId)) {
+        episodes.set(row.episodeId, handle.repos.episodes.getById(row.episodeId));
+      }
+      return traceRowToDTO(row, episodes.get(row.episodeId) ?? undefined);
+    });
   }
 
   function traceOrderLookup(
@@ -2102,9 +2385,12 @@ export function createMemoryCore(
     const episodeIds = new Set(rows.map((r) => r.episodeId).filter(Boolean));
     for (const episodeId of episodeIds) {
       const ep = handle.repos.episodes.getById(episodeId);
-      if (!ep || ep.traceIds.length === 0) continue;
+      if (!ep) continue;
       const order = new Map<string, number>();
-      ep.traceIds.forEach((id, idx) => order.set(id, idx));
+      const episodeRows = rows.filter((row) => row.episodeId === episodeId);
+      orderTraceRowsForEpisode(episodeRows, ep.traceIds).forEach((row, idx) =>
+        order.set(row.id, idx),
+      );
       out.set(episodeId, order);
     }
     return out;
@@ -2321,7 +2607,7 @@ export function createMemoryCore(
     skills: SkillDTO[];
   }> {
     ensureLive();
-    const traces = handle.repos.traces.list({ limit: 100_000 }).map(traceRowToDTO);
+    const traces = traceRowsToDTOs(handle.repos.traces.list({ limit: 100_000 }));
     const policies = handle.repos.policies.list({ limit: 5_000 }).map(policyRowToDTO);
     const worldModels = handle.repos.worldModel.list({ limit: 2_000 }).map(worldModelRowToDTO);
     const skills = handle.repos.skills.list({ limit: 5_000 }).map(skillRowToDTO);
@@ -2800,15 +3086,198 @@ function orderTraceRowsForEpisode(
   rows: readonly TraceRow[],
   traceIds: readonly TraceId[],
 ): TraceRow[] {
-  if (traceIds.length === 0) return [...rows];
+  if (traceIds.length === 0) return anchorSubagentRowsForDisplay([...rows]);
   const order = new Map<string, number>();
   traceIds.forEach((id, idx) => order.set(id, idx));
-  return [...rows].sort((a, b) => {
+  const ordered = [...rows].sort((a, b) => {
     const ai = order.get(a.id) ?? Number.POSITIVE_INFINITY;
     const bi = order.get(b.id) ?? Number.POSITIVE_INFINITY;
     if (ai !== bi) return ai - bi;
     return a.ts - b.ts;
   });
+  return anchorSubagentRowsForDisplay(ordered);
+}
+
+function anchorSubagentRowsForDisplay(rows: TraceRow[]): TraceRow[] {
+  const delegateByToolCallId = new Map<string, string>();
+  const delegateByGoal = new Map<string, string>();
+  const duplicateGoals = new Set<string>();
+  for (const row of rows) {
+    const tool = row.toolCalls[0];
+    if (tool?.name !== "delegate_task") continue;
+    if (tool.toolCallId) delegateByToolCallId.set(tool.toolCallId, row.id);
+    const goal = delegateRowGoal(row);
+    if (goal) {
+      if (delegateByGoal.has(goal)) duplicateGoals.add(goal);
+      else delegateByGoal.set(goal, row.id);
+    }
+  }
+  for (const goal of duplicateGoals) delegateByGoal.delete(goal);
+  if (delegateByToolCallId.size === 0 && delegateByGoal.size === 0) return rows;
+
+  const groups: Array<{ delegateId: string; rows: TraceRow[] }> = [];
+  const groupedIds = new Set<string>();
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    if (groupedIds.has(row.id)) continue;
+    const delegateId = subagentRowDelegateId(row, delegateByToolCallId, delegateByGoal);
+    if (!delegateId) continue;
+    const relatedTextRows: TraceRow[] = [];
+    for (let j = i - 1; j >= 0; j--) {
+      const prev = rows[j]!;
+      if (groupedIds.has(prev.id)) continue;
+      if (!isSubagentTextRow(prev)) break;
+      relatedTextRows.unshift(prev);
+    }
+    const group = [row, ...relatedTextRows];
+    groupedIds.add(row.id);
+    for (const related of relatedTextRows) groupedIds.add(related.id);
+    for (let j = i + 1; j < rows.length; j++) {
+      const next = rows[j]!;
+      if (
+        next.toolCalls.length > 0 ||
+        groupedIds.has(next.id) ||
+        !isSubagentTextRow(next)
+      ) {
+        break;
+      }
+      group.push(next);
+      groupedIds.add(next.id);
+    }
+    groups.push({ delegateId, rows: group });
+  }
+  if (groups.length === 0) return rows;
+
+  let ordered = rows.filter((row) => !groupedIds.has(row.id));
+  for (const group of groups) {
+    const delegateIdx = ordered.findIndex((row) => row.id === group.delegateId);
+    if (delegateIdx < 0) {
+      ordered.push(...group.rows);
+      continue;
+    }
+    ordered = [
+      ...ordered.slice(0, delegateIdx + 1),
+      ...group.rows,
+      ...ordered.slice(delegateIdx + 1),
+    ];
+  }
+  return moveDisplayUserTextToAnchoredDelegates(ordered);
+}
+
+function isSubagentTextRow(row: TraceRow): boolean {
+  return row.toolCalls.length === 0 &&
+    (
+      row.agentText.includes("Subagent task:") ||
+      row.agentText.includes("Subagent result:")
+    );
+}
+
+function moveDisplayUserTextToAnchoredDelegates(rows: TraceRow[]): TraceRow[] {
+  let out = rows;
+  let cloned = false;
+  const clone = (): TraceRow[] => {
+    if (!cloned) {
+      out = out.map((row) => ({ ...row }));
+      cloned = true;
+    }
+    return out;
+  };
+
+  for (let i = 0; i < out.length; i++) {
+    const delegate = out[i]!;
+    if (delegate.toolCalls[0]?.name !== "delegate_task" || delegate.userText.trim()) continue;
+    for (let j = i + 1; j < out.length; j++) {
+      const candidate = out[j]!;
+      if (candidate.turnId !== delegate.turnId) break;
+      if (candidate.toolCalls[0]?.name === "delegate_task") break;
+      if (candidate.toolCalls[0]?.name !== "subagent" || !candidate.userText.trim()) continue;
+      const next = clone();
+      next[i] = { ...next[i]!, userText: candidate.userText };
+      next[j] = { ...next[j]!, userText: "" };
+      break;
+    }
+  }
+  return out;
+}
+
+function subagentRowDelegateId(
+  row: TraceRow,
+  delegateByToolCallId: ReadonlyMap<string, string>,
+  delegateByGoal: ReadonlyMap<string, string>,
+): string | null {
+  const toolCallId = subagentRowToolCallId(row);
+  if (toolCallId) {
+    const byId = delegateByToolCallId.get(toolCallId);
+    if (byId) return byId;
+  }
+  const task = subagentRowTask(row);
+  return task ? delegateByGoal.get(task) ?? null : null;
+}
+
+function subagentRowToolCallId(row: TraceRow): string | null {
+  const tool = row.toolCalls[0];
+  if (tool?.name !== "subagent") return null;
+  const input = tool.input && typeof tool.input === "object" && !Array.isArray(tool.input)
+    ? tool.input as Record<string, unknown>
+    : null;
+  const meta = input && input.meta && typeof input.meta === "object" && !Array.isArray(input.meta)
+    ? input.meta as Record<string, unknown>
+    : {};
+  const hookKwargs = meta.hookKwargs && typeof meta.hookKwargs === "object" && !Array.isArray(meta.hookKwargs)
+    ? meta.hookKwargs as Record<string, unknown>
+    : {};
+  return firstNonEmptyString(
+    meta.toolCallId,
+    meta.tool_call_id,
+    meta.callId,
+    meta.call_id,
+    hookKwargs.toolCallId,
+    hookKwargs.tool_call_id,
+    hookKwargs.callId,
+    hookKwargs.call_id,
+  );
+}
+
+function subagentRowTask(row: TraceRow): string | null {
+  const tool = row.toolCalls[0];
+  if (tool?.name !== "subagent") return null;
+  const input = topLevelRecord(tool.input);
+  return firstNonEmptyString(input?.task);
+}
+
+function delegateRowGoal(row: TraceRow): string | null {
+  const tool = row.toolCalls[0];
+  if (tool?.name !== "delegate_task") return null;
+  const input = topLevelJsonObject(tool.input);
+  return firstNonEmptyString(input?.goal);
+}
+
+function topLevelRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function topLevelJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
 }
 
 function compareTraceRowsForEpisodeOrder(
@@ -2829,7 +3298,7 @@ function compareTraceRowsForEpisodeOrder(
 
 // ─── Row → DTO mappers ───────────────────────────────────────────────────────
 
-export function traceRowToDTO(row: TraceRow): TraceDTO {
+export function traceRowToDTO(row: TraceRow, episode?: EpisodeRow | null): TraceDTO {
   return {
     id: row.id,
     episodeId: row.episodeId,
@@ -2847,8 +3316,17 @@ export function traceRowToDTO(row: TraceRow): TraceDTO {
     alpha: row.alpha,
     rHuman: row.rHuman ?? undefined,
     priority: row.priority,
+    episodeStatus: episode?.status,
+    episodeRTask: episode?.rTask ?? null,
+    episodeRewardSkipped: episodeRewardSkipped(episode),
     turnId: row.turnId,
   };
+}
+
+function episodeRewardSkipped(episode?: EpisodeRow | null): boolean {
+  const meta = (episode as { meta?: Record<string, unknown> } | null | undefined)?.meta;
+  const reward = meta?.reward;
+  return Boolean(reward && typeof reward === "object" && (reward as { skipped?: unknown }).skipped === true);
 }
 
 export function policyRowToDTO(row: PolicyRow): PolicyDTO {

--- a/apps/memos-local-plugin/core/pipeline/orchestrator.ts
+++ b/apps/memos-local-plugin/core/pipeline/orchestrator.ts
@@ -222,14 +222,21 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   // ─── session/episode helpers ────────────────────────────────────────────
 
-  async function ensureSession(agent: AgentKind, sessionId?: SessionId): Promise<SessionId> {
+  async function ensureSession(
+    agent: AgentKind,
+    sessionId?: SessionId,
+    meta?: Record<string, unknown>,
+  ): Promise<SessionId> {
     if (sessionId && session.sessionManager.getSession(sessionId)) {
+      if (meta && Object.keys(meta).length > 0) {
+        session.sessionManager.openSession({ id: sessionId, agent, meta });
+      }
       return sessionId;
     }
     const snap = session.sessionManager.openSession({
       id: sessionId,
       agent,
-      meta: {},
+      meta: meta ?? {},
     });
     return snap.id as SessionId;
   }
@@ -835,7 +842,11 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   async function onTurnStart(input: TurnInputDTO): Promise<InjectionPacket> {
     const t0 = now();
-    const initialSessionId = await ensureSession(input.agent, input.sessionId);
+    const initialSessionId = await ensureSession(
+      input.agent,
+      input.sessionId,
+      input.contextHints,
+    );
 
     const routing = await openEpisodeIfNeeded(
       initialSessionId,
@@ -894,7 +905,11 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
   }
 
   async function onTurnEnd(result: TurnResultDTO): Promise<TurnEndResult> {
-    const sessionId = await ensureSession(result.agent, result.sessionId);
+    const sessionId = await ensureSession(
+      result.agent,
+      result.sessionId,
+      result.contextHints,
+    );
     const episodeId = openEpisodeBySession.get(sessionId) ?? result.episodeId;
     if (!episodeId) {
       throw new Error(
@@ -906,6 +921,14 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       throw new Error(
         "pipeline.onTurnEnd: episode " + episodeId + " is not open",
       );
+    }
+    if (result.contextHints && Object.keys(result.contextHints).length > 0) {
+      session.sessionManager.patchEpisodeMeta(episodeId, {
+        contextHints: {
+          ...((episode.meta.contextHints as Record<string, unknown> | undefined) ?? {}),
+          ...result.contextHints,
+        },
+      });
     }
 
     // V7 §0.1: record tool-call turns BEFORE the assistant turn so the
@@ -929,6 +952,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
           name: tc.name,
           input: tc.input,
           errorCode: tc.errorCode,
+          toolCallId: tc.toolCallId,
           startedAt: tc.startedAt,
           endedAt: tc.endedAt,
           // V7 §0.1: preserve the model's "Thought for X" narration that
@@ -955,6 +979,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
         //     reflection field on the trace row.
         agentThinking: result.agentThinking ?? null,
         reflection: result.reflection ?? null,
+        contextHints: result.contextHints ?? {},
         ts: result.ts,
       },
     });

--- a/apps/memos-local-plugin/core/reward/reward.ts
+++ b/apps/memos-local-plugin/core/reward/reward.ts
@@ -46,6 +46,12 @@ export interface RewardDeps {
   llm: LlmClient | null;
   bus: RewardEventBus;
   cfg: RewardConfig;
+  evaluator?: {
+    reflectionProvider?: string;
+    reflectionModel?: string;
+    scorerProvider?: string;
+    scorerModel?: string;
+  };
   now?: () => number;
   /**
    * Optional accessor for the episode snapshot (turns + meta). If omitted,
@@ -180,6 +186,7 @@ export function createRewardRunner(deps: RewardDeps): RewardRunner {
       episode: snapshot,
       traces,
       cfg: { summaryMaxChars: deps.cfg.summaryMaxChars },
+      evaluator: deps.evaluator,
     });
     tMetrics.summary = now() - tSumStart;
 
@@ -257,7 +264,10 @@ export function createRewardRunner(deps: RewardDeps): RewardRunner {
           reason: humanScore.reason,
           scoredAt: startedAt,
           trigger: input.trigger,
+          traceCount: bp.updates.length,
+          traceIds: bp.updates.map((u) => u.traceId),
         },
+        rewardDirty: undefined,
       });
     } catch (err) {
       warnings.push({

--- a/apps/memos-local-plugin/core/reward/task-summary.ts
+++ b/apps/memos-local-plugin/core/reward/task-summary.ts
@@ -37,6 +37,12 @@ export interface SummaryInput {
   episode: EpisodeSnapshot;
   traces: readonly TraceRow[];
   cfg: Pick<RewardConfig, "summaryMaxChars">;
+  evaluator?: {
+    reflectionProvider?: string;
+    reflectionModel?: string;
+    scorerProvider?: string;
+    scorerModel?: string;
+  };
 }
 
 export function buildTaskSummary(input: SummaryInput): TaskSummary {
@@ -66,8 +72,12 @@ export function buildTaskSummary(input: SummaryInput): TaskSummary {
     : "(no recorded exchanges)";
 
   const agentActions = traces.map(traceOneLiner).filter(Boolean).join("\n");
+  const hostContext = formatHostAgentContext(episode, input.evaluator);
 
   const body = [
+    hostContext ? `HOST_AGENT_CONTEXT:` : "",
+    hostContext,
+    hostContext ? `` : "",
     `USER_ASKS_AND_AGENT_REPLIES (${pairs.length}, in order):`,
     pairsText,
     ``,
@@ -94,12 +104,44 @@ export function buildTaskSummary(input: SummaryInput): TaskSummary {
   return {
     episodeId: episode.id,
     sessionId: episode.sessionId,
+    hostContext,
     userQuery: oneLine(userQuery, 500),
     agentActions,
     outcome: oneLine(outcome, 800),
     text,
     truncated,
   };
+}
+
+function formatHostAgentContext(
+  episode: EpisodeSnapshot,
+  evaluator?: SummaryInput["evaluator"],
+): string {
+  const meta = episode.meta ?? {};
+  const hints = isRecord(meta.contextHints) ? meta.contextHints : {};
+  const fields: Array<[string, unknown]> = [
+    ["agent", meta.agent],
+    ["agentIdentity", hints.agentIdentity ?? meta.agentIdentity],
+    ["hostProvider", hints.hostProvider ?? meta.hostProvider],
+    ["hostModel", hints.hostModel ?? meta.hostModel],
+    ["hostApiMode", hints.hostApiMode ?? meta.hostApiMode],
+    ["reflectionProvider", evaluator?.reflectionProvider],
+    ["reflectionModel", evaluator?.reflectionModel],
+    ["scorerProvider", evaluator?.scorerProvider],
+    ["scorerModel", evaluator?.scorerModel],
+  ];
+  const lines = fields
+    .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
+    .map(([key, value]) => `${key}: ${oneLine(String(value), 240)}`);
+  if (lines.length === 0) return "";
+  lines.push(
+    "gradingInstruction: Evaluate the host agent's answer in this host context; do not project the evaluator model's own identity, provider, or capabilities onto the host agent.",
+  );
+  return lines.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────

--- a/apps/memos-local-plugin/core/reward/types.ts
+++ b/apps/memos-local-plugin/core/reward/types.ts
@@ -116,6 +116,8 @@ export interface HumanScoreInput {
 export interface TaskSummary {
   episodeId: EpisodeId;
   sessionId: SessionId;
+  /** Optional host/evaluator context included in the packed summary. */
+  hostContext?: string;
   userQuery: string;
   agentActions: string;
   outcome: string;

--- a/apps/memos-local-plugin/core/session/episode-manager.ts
+++ b/apps/memos-local-plugin/core/session/episode-manager.ts
@@ -297,12 +297,28 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
       }
       snap.status = "open";
       snap.endedAt = null;
+      const previousReward = snap.rTask != null
+        ? {
+            previousRTask: snap.rTask,
+            previousScoredAt: rewardScoredAt(snap.meta),
+          }
+        : {};
       snap.meta = {
         ...snap.meta,
         closeReason: undefined,
         topicState: "active",
         reopenedAt: now(),
         reopenReason: reason,
+        ...(snap.rTask != null || snap.meta.reward
+          ? {
+              rewardDirty: {
+                reason: "episode_reopened",
+                reopenedFor: reason,
+                at: now(),
+                ...previousReward,
+              },
+            }
+          : {}),
       };
       deps.episodesRepo.reopen(id, snap.meta);
       log.info("episode.reopened", {
@@ -332,6 +348,12 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
       return out;
     },
   };
+}
+
+function rewardScoredAt(meta: Record<string, unknown>): unknown {
+  const reward = meta.reward;
+  if (!reward || typeof reward !== "object") return undefined;
+  return (reward as { scoredAt?: unknown }).scoredAt;
 }
 
 function cloneSnapshot(s: EpisodeSnapshot): EpisodeSnapshot {

--- a/apps/memos-local-plugin/core/session/manager.ts
+++ b/apps/memos-local-plugin/core/session/manager.ts
@@ -80,6 +80,7 @@ export interface SessionManager {
   ): EpisodeSnapshot;
   hydrateEpisode(snapshot: EpisodeSnapshot): EpisodeSnapshot;
   attachTraceIds(episodeId: EpisodeId, traceIds: string[]): void;
+  patchEpisodeMeta(episodeId: EpisodeId, metaPatch: Record<string, unknown>): EpisodeSnapshot;
 
   getEpisode(id: EpisodeId): EpisodeSnapshot | null;
   listEpisodes(sessionId: SessionId): EpisodeSnapshot[];
@@ -125,6 +126,9 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       lastSeenAt: ts,
       meta: input.meta ?? {},
     });
+    if (input.meta && Object.keys(input.meta).length > 0) {
+      deps.sessionsRepo.touchLastSeen(id, ts, input.meta);
+    }
     const row = deps.sessionsRepo.getById(id);
     if (!row) {
       throw new MemosError(ERROR_CODES.INTERNAL, "sessions.upsert inserted row but getById returned null", {
@@ -347,6 +351,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     reopenEpisode,
     hydrateEpisode,
     attachTraceIds: epm.attachTraceIds,
+    patchEpisodeMeta: epm.patchMeta,
 
     getEpisode: epm.get,
     listEpisodes: epm.listForSession,

--- a/apps/memos-local-plugin/tests/unit/capture/capture.test.ts
+++ b/apps/memos-local-plugin/tests/unit/capture/capture.test.ts
@@ -27,7 +27,7 @@ import type {
   EpisodeTurn,
 } from "../../../core/session/types.js";
 import { retrievalFor } from "../../../core/session/heuristics.js";
-import type { EpochMs, EpisodeId, SessionId } from "../../../core/types.js";
+import type { EpochMs, EpisodeId, SessionId, TraceId, TraceRow } from "../../../core/types.js";
 import { fakeEmbedder } from "../../helpers/fake-embedder.js";
 import { fakeLlm } from "../../helpers/fake-llm.js";
 import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
@@ -131,6 +131,37 @@ function episodeSnapshot(opts: {
   };
 }
 
+function traceRow(opts: {
+  id: string;
+  ts: number;
+  userText?: string;
+  agentText?: string;
+  toolCalls?: TraceRow["toolCalls"];
+}): TraceRow {
+  return {
+    id: opts.id as TraceId,
+    episodeId: "ep_1" as EpisodeId,
+    sessionId: "se_1" as SessionId,
+    ts: opts.ts as EpochMs,
+    userText: opts.userText ?? "",
+    agentText: opts.agentText ?? "",
+    summary: null,
+    toolCalls: opts.toolCalls ?? [],
+    reflection: null,
+    agentThinking: null,
+    value: 0,
+    alpha: 0,
+    rHuman: null,
+    priority: 0.5,
+    tags: [],
+    errorSignatures: [],
+    vecSummary: null,
+    vecAction: null,
+    turnId: 1_000 as EpochMs,
+    schemaVersion: 1,
+  };
+}
+
 describe("capture/pipeline (end-to-end)", () => {
   beforeAll(() => initTestLogger());
 
@@ -209,6 +240,117 @@ describe("capture/pipeline (end-to-end)", () => {
     expect(persisted!.priority).toBe(0.5);
     expect(persisted!.vecSummary).toBeInstanceOf(Float32Array);
     expect(persisted!.vecAction).toBeInstanceOf(Float32Array);
+  });
+
+  it("preserves existing episode trace order when tools have no reliable startedAt", async () => {
+    const runner = buildRunner({ alphaScoring: false });
+    const rows: TraceRow[] = [
+      traceRow({
+        id: "tr_web",
+        ts: 3_000,
+        userText: "look up current sales",
+        toolCalls: [{ name: "web_search", input: undefined, output: "[web_search]" }],
+      }),
+      traceRow({
+        id: "tr_terminal",
+        ts: 1_100,
+        toolCalls: [{
+          name: "terminal",
+          input: undefined,
+          output: JSON.stringify({ output: "ok" }),
+          startedAt: 1_050,
+          endedAt: 1_100,
+        }],
+      }),
+      traceRow({ id: "tr_final", ts: 4_000, agentText: "final answer" }),
+    ];
+    for (const row of rows) tmp.repos.traces.insert(row);
+    episodesRepo.updateTraceIds("ep_1" as EpisodeId, rows.map((row) => row.id));
+
+    const ep = episodeSnapshot({
+      id: "ep_1",
+      sessionId: "se_1",
+      turns: [
+        turn("user", "look up current sales", 1_000),
+        turn("tool", "[web_search]", 3_000, { tool: "web_search" }),
+        turn("tool", JSON.stringify({ output: "ok" }), 1_100, {
+          tool: "terminal",
+          startedAt: 1_050,
+          endedAt: 1_100,
+        }),
+        turn("assistant", "final answer", 4_000),
+        turn("user", "thanks", 5_000),
+        turn("assistant", "you are welcome", 5_100),
+      ],
+    });
+    ep.traceIds = rows.map((row) => row.id);
+
+    const lite = await runner.runLite({ episode: ep });
+
+    expect(lite.traceIds).toHaveLength(1);
+    const episode = tmp.repos.episodes.getById("ep_1" as EpisodeId)!;
+    expect(episode.traceIds).toEqual([...rows.map((row) => row.id), lite.traceIds[0]]);
+  });
+
+  it("places newly inserted older conversation steps before the final assistant trace", async () => {
+    const runner = buildRunner({ alphaScoring: false });
+    const finalTrace = traceRow({ id: "tr_final", ts: 2_000, agentText: "final answer" });
+    tmp.repos.traces.insert(finalTrace);
+    episodesRepo.updateTraceIds("ep_1" as EpisodeId, [finalTrace.id]);
+
+    const ep = episodeSnapshot({
+      id: "ep_1",
+      sessionId: "se_1",
+      turns: [
+        turn("user", "look up current sales", 1_000),
+        turn("tool", JSON.stringify({ success: true }), 1_100, {
+          tool: "browser_navigate",
+          input: { url: "https://example.com" },
+          output: { success: true },
+          startedAt: 1_050,
+          endedAt: 1_100,
+        }),
+        turn("assistant", "final answer", 2_000),
+      ],
+    });
+    ep.traceIds = [finalTrace.id];
+
+    const lite = await runner.runLite({ episode: ep });
+
+    expect(lite.traceIds).toHaveLength(1);
+    expect(tmp.repos.episodes.getById("ep_1" as EpisodeId)!.traceIds).toEqual([
+      lite.traceIds[0],
+      finalTrace.id,
+    ]);
+  });
+
+  it("skips duplicate tool rows with the same action signature during capture persist", async () => {
+    const runner = buildRunner({ alphaScoring: false });
+    const toolMeta = {
+      tool: "browser_navigate",
+      input: { url: "https://example.com" },
+      output: { success: true },
+      startedAt: 1_050,
+      endedAt: 1_100,
+    };
+    const ep = episodeSnapshot({
+      id: "ep_1",
+      sessionId: "se_1",
+      turns: [
+        turn("user", "look up current sales", 1_000),
+        turn("tool", JSON.stringify({ success: true }), 1_100, toolMeta),
+        turn("tool", JSON.stringify({ success: true }), 1_200, toolMeta),
+        turn("assistant", "final answer", 2_000),
+      ],
+    });
+
+    const lite = await runner.runLite({ episode: ep });
+    const rows = tmp.repos.traces.list({ episodeId: "ep_1" as EpisodeId });
+
+    expect(lite.traceIds).toHaveLength(2);
+    expect(rows.filter((row) => row.toolCalls[0]?.name === "browser_navigate")).toHaveLength(1);
+    expect(rows.filter((row) => row.agentText === "final answer")).toHaveLength(1);
+    expect(tmp.repos.episodes.getById("ep_1" as EpisodeId)!.traceIds).toEqual(lite.traceIds);
   });
 
   it("passes through adapter-provided reflection and stores α from LLM", async () => {

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -16,6 +16,7 @@ import {
   type PipelineHandle,
 } from "../../../core/pipeline/index.js";
 import type { MemoryCore } from "../../../agent-contract/memory-core.js";
+import type { TraceDTO } from "../../../agent-contract/dto.js";
 import { rootLogger } from "../../../core/logger/index.js";
 import { DEFAULT_CONFIG } from "../../../core/config/defaults.js";
 import { resolveHome } from "../../../core/config/paths.js";
@@ -41,6 +42,15 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     log: rootLogger.child({ channel: "test.memory-core" }),
     now: () => 1_700_000_000_000,
   };
+}
+
+function traceKind(trace: TraceDTO): string {
+  return trace.toolCalls[0]?.name ??
+    (trace.agentText.includes("Subagent task:")
+      ? "subagent_task_text"
+      : trace.agentText.includes("Subagent result:")
+      ? "subagent_result_text"
+      : "assistant");
 }
 
 beforeEach(() => {
@@ -133,11 +143,12 @@ describe("MemoryCore façade", () => {
       userText: "delegate package script inspection",
       ts: 1_700_000_000_000,
     });
+    const episodeId = turn.query.episodeId!;
 
     await core.recordSubagentOutcome({
       agent: "hermes",
       sessionId: "s-parent",
-      episodeId: turn.episodeId,
+      episodeId,
       childSessionId: "s-child",
       task: "check package.json scripts",
       result: "found build and test scripts",
@@ -154,7 +165,7 @@ describe("MemoryCore façade", () => {
       ts: 1_700_000_000_001,
     });
 
-    const timeline = await core.timeline({ episodeId: turn.episodeId });
+    const timeline = await core.timeline({ episodeId });
     const subagentTrace = timeline.find((trace) =>
       trace.agentText.includes("Subagent task:"),
     );
@@ -189,6 +200,190 @@ describe("MemoryCore façade", () => {
     expect(childTimeline.some((trace) =>
       trace.toolCalls.some((call) => call.name === "read_file")
     )).toBe(true);
+  });
+
+  it("anchors subagent records after the matching delegate_task tool call id", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+    const turn = await core.onTurnStart({
+      agent: "hermes",
+      sessionId: "s-parent",
+      userText: "delegate weather lookup",
+      ts: 1_700_000_000_000,
+    });
+    const episodeId = turn.query.episodeId!;
+    const delegateGoal = "check Hangzhou weather";
+    await core.onTurnEnd({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      agentText: "I will use the delegated result.",
+      toolCalls: [
+        {
+          name: "delegate_task",
+          toolCallId: "call_delegate_1",
+          input: { goal: delegateGoal, context: "weather" },
+          output: { results: [{ task_index: 0, summary: "sunny" }] },
+          startedAt: 1_700_000_000_100,
+          endedAt: 1_700_000_000_200,
+        },
+      ],
+      ts: 1_700_000_000_300,
+    });
+
+    await core.recordSubagentOutcome({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      childSessionId: "s-child",
+      task: delegateGoal,
+      result: "sunny",
+      outcome: "ok",
+      ts: 1_700_000_000_050,
+      meta: { hookKwargs: { tool_call_id: "call_delegate_1" } },
+    });
+
+    const timeline = await core.timeline({ episodeId });
+    const order = timeline.map((trace) =>
+      trace.toolCalls[0]?.name ??
+        (trace.agentText.includes("Subagent task:")
+          ? "subagent_task_text"
+          : trace.agentText.includes("Subagent result:")
+          ? "subagent_result_text"
+          : "assistant"),
+    );
+    expect(order).toEqual([
+      "delegate_task",
+      "subagent",
+      "subagent_task_text",
+      "assistant",
+    ]);
+  });
+
+  it("anchors subagent records by a unique matching delegate goal when tool call id is absent", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+    const turn = await core.onTurnStart({
+      agent: "hermes",
+      sessionId: "s-parent",
+      userText: "delegate Canada weather",
+      ts: 1_700_000_000_000,
+    });
+    const episodeId = turn.query.episodeId!;
+    const delegateGoal = "check Canada weather";
+
+    await core.recordSubagentOutcome({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      childSessionId: "s-child",
+      task: delegateGoal,
+      result: "Toronto sunny",
+      outcome: "ok",
+      ts: 1_700_000_000_050,
+      meta: { hookKwargs: {} },
+    });
+    await core.onTurnEnd({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      agentText: "Here is the delegated result.",
+      toolCalls: [
+        {
+          name: "delegate_task",
+          toolCallId: "call_delegate_late",
+          input: { goal: delegateGoal, context: "weather" },
+          output: "Toronto sunny",
+          startedAt: 1_700_000_000_100,
+          endedAt: 1_700_000_000_200,
+        },
+      ],
+      ts: 1_700_000_000_300,
+    });
+
+    const timeline = await core.timeline({ episodeId });
+    expect(timeline.map(traceKind)).toEqual([
+      "delegate_task",
+      "subagent",
+      "subagent_task_text",
+      "assistant",
+    ]);
+    const delegateTrace = timeline.find((trace) => trace.toolCalls[0]?.name === "delegate_task")!;
+    const subagentTrace = timeline.find((trace) => trace.toolCalls[0]?.name === "subagent")!;
+    expect(delegateTrace.userText).toBe("delegate Canada weather");
+    expect(subagentTrace.userText).toBe("");
+  });
+
+  it("does not anchor by goal when multiple delegate_task traces share the same goal", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+    const turn = await core.onTurnStart({
+      agent: "hermes",
+      sessionId: "s-parent",
+      userText: "delegate duplicate weather tasks",
+      ts: 1_700_000_000_000,
+    });
+    const episodeId = turn.query.episodeId!;
+    const delegateGoal = "check Canada weather";
+
+    await core.recordSubagentOutcome({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      childSessionId: "s-child",
+      task: delegateGoal,
+      result: "Toronto sunny",
+      outcome: "ok",
+      ts: 1_700_000_000_050,
+      meta: { hookKwargs: {} },
+    });
+    await core.onTurnEnd({
+      agent: "hermes",
+      sessionId: "s-parent",
+      episodeId,
+      agentText: "Here is the delegated result.",
+      toolCalls: [
+        {
+          name: "delegate_task",
+          toolCallId: "call_delegate_1",
+          input: { goal: delegateGoal, city: "Toronto" },
+          output: "Toronto sunny",
+          startedAt: 1_700_000_000_100,
+          endedAt: 1_700_000_000_200,
+        },
+        {
+          name: "delegate_task",
+          toolCallId: "call_delegate_2",
+          input: { goal: delegateGoal, city: "Vancouver" },
+          output: "Vancouver rainy",
+          startedAt: 1_700_000_000_210,
+          endedAt: 1_700_000_000_250,
+        },
+      ],
+      ts: 1_700_000_000_300,
+    });
+
+    const timeline = await core.timeline({ episodeId });
+    expect(timeline.map(traceKind).slice(0, 3)).toEqual([
+      "subagent",
+      "subagent_task_text",
+      "delegate_task",
+    ]);
   });
 
   it("submitFeedback persists and returns a DTO", async () => {
@@ -553,5 +748,188 @@ describe("bootstrapMemoryCore", () => {
     expect(row?.status).toBe("open");
     expect(row?.topicState === "active" || row?.topicState === "interrupted").toBe(true);
     expect(row?.preview).toContain("Hermes viewer");
+  });
+
+  it("rescoring closed episodes when traces were appended after the last reward", async () => {
+    home = await makeTmpHome({ agent: "openclaw" });
+
+    const seeder = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "dirty-rescore-seed",
+    });
+    await seeder.init();
+    await seeder.shutdown();
+
+    const Sqlite = (await import("better-sqlite3")).default;
+    const writeDb = new Sqlite(home.home.dbFile);
+    const ts = Date.now() - 1_000;
+    writeDb
+      .prepare(
+        `INSERT INTO sessions (id, agent, started_at, last_seen_at, meta_json) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("se_dirty", "openclaw", ts, ts, "{}");
+    writeDb
+      .prepare(
+        `INSERT INTO episodes (id, session_id, started_at, ended_at, trace_ids_json, r_task, status, meta_json) VALUES (?, ?, ?, ?, ?, ?, 'closed', ?)`,
+      )
+      .run(
+        "ep_dirty",
+        "se_dirty",
+        ts,
+        ts + 1,
+        JSON.stringify(["tr_dirty"]),
+        0.7,
+        JSON.stringify({
+          closeReason: "finalized",
+          reward: { rHuman: 0.7, scoredAt: ts - 500 },
+        }),
+      );
+    writeDb
+      .prepare(
+        `INSERT INTO traces (
+          id, episode_id, session_id, ts, user_text, agent_text, summary,
+          tool_calls_json, reflection, agent_thinking, value, alpha, r_human,
+          priority, tags_json, error_signatures_json, vec_summary, vec_action,
+          share_scope, share_target, shared_at, turn_id, schema_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        "tr_dirty",
+        "ep_dirty",
+        "se_dirty",
+        ts,
+        "请继续解释这个数据集的建模任务和目标变量，说明为什么它是回归问题。",
+        "这是一个房价预测回归任务，目标变量 SalePrice 是连续数值，需要根据房屋特征预测价格。",
+        "房价预测回归任务说明",
+        "[]",
+        null,
+        null,
+        0,
+        0,
+        null,
+        0.5,
+        "[]",
+        "[]",
+        ts,
+        1,
+      );
+    writeDb.close();
+
+    core = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "dirty-rescore-recover",
+    });
+    await core.init();
+
+    const readDb = new Sqlite(home.home.dbFile, { readonly: true });
+    const episode = readDb
+      .prepare("SELECT r_task, meta_json FROM episodes WHERE id = ?")
+      .get("ep_dirty") as { r_task: number | null; meta_json: string } | undefined;
+    readDb.close();
+
+    expect(episode).toBeDefined();
+    expect(episode!.r_task).toBe(0);
+    const meta = JSON.parse(episode!.meta_json) as {
+      rewardDirty?: unknown;
+      recoveryReason?: string;
+      reward?: { traceCount?: number; traceIds?: string[] };
+    };
+    expect(meta.rewardDirty).toBeUndefined();
+    expect(meta.recoveryReason).toBe("dirty_reward_rescore");
+    expect(meta.reward?.traceCount).toBe(1);
+    expect(meta.reward?.traceIds).toEqual(["tr_dirty"]);
+  });
+
+  it("rescoring finalized closed episodes that have traces but no reward metadata", async () => {
+    home = await makeTmpHome({ agent: "openclaw" });
+
+    const seeder = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "missing-reward-seed",
+    });
+    await seeder.init();
+    await seeder.shutdown();
+
+    const Sqlite = (await import("better-sqlite3")).default;
+    const writeDb = new Sqlite(home.home.dbFile);
+    const ts = Date.now() - 1_000;
+    writeDb
+      .prepare(
+        `INSERT INTO sessions (id, agent, started_at, last_seen_at, meta_json) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("se_missing_reward", "openclaw", ts, ts, "{}");
+    writeDb
+      .prepare(
+        `INSERT INTO episodes (id, session_id, started_at, ended_at, trace_ids_json, r_task, status, meta_json) VALUES (?, ?, ?, ?, ?, ?, 'closed', ?)`,
+      )
+      .run(
+        "ep_missing_reward",
+        "se_missing_reward",
+        ts,
+        ts + 1,
+        JSON.stringify(["tr_missing_reward"]),
+        null,
+        JSON.stringify({ closeReason: "finalized", recoveryReason: "missed_session_end" }),
+      );
+    writeDb
+      .prepare(
+        `INSERT INTO traces (
+          id, episode_id, session_id, ts, user_text, agent_text, summary,
+          tool_calls_json, reflection, agent_thinking, value, alpha, r_human,
+          priority, tags_json, error_signatures_json, vec_summary, vec_action,
+          share_scope, share_target, shared_at, turn_id, schema_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        "tr_missing_reward",
+        "ep_missing_reward",
+        "se_missing_reward",
+        ts,
+        "上海骨科医院推荐",
+        "上海六院、长征医院、华山医院等骨科较强，可按创伤、脊柱、手外科方向选择。",
+        "上海骨科医院推荐",
+        "[]",
+        null,
+        null,
+        0,
+        0,
+        null,
+        0.5,
+        "[]",
+        "[]",
+        ts,
+        1,
+      );
+    writeDb.close();
+
+    core = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "missing-reward-recover",
+    });
+    await core.init();
+
+    const readDb = new Sqlite(home.home.dbFile, { readonly: true });
+    const episode = readDb
+      .prepare("SELECT r_task, meta_json FROM episodes WHERE id = ?")
+      .get("ep_missing_reward") as { r_task: number | null; meta_json: string } | undefined;
+    readDb.close();
+
+    expect(episode).toBeDefined();
+    expect(episode!.r_task).toBe(0);
+    const meta = JSON.parse(episode!.meta_json) as {
+      recoveryReason?: string;
+      reward?: { traceCount?: number; traceIds?: string[] };
+    };
+    expect(meta.recoveryReason).toBe("dirty_reward_rescore");
+    expect(meta.reward?.traceCount).toBe(1);
+    expect(meta.reward?.traceIds).toEqual(["tr_missing_reward"]);
   });
 });

--- a/apps/memos-local-plugin/tests/unit/reward/task-summary.test.ts
+++ b/apps/memos-local-plugin/tests/unit/reward/task-summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { REWARD_R_HUMAN_PROMPT } from "../../../core/llm/prompts/reward.js";
 import { buildTaskSummary } from "../../../core/reward/task-summary.js";
 import type { EpisodeSnapshot } from "../../../core/session/types.js";
 import type { EpochMs, TraceRow } from "../../../core/types.js";
@@ -57,6 +58,12 @@ function makeTrace(i: number, opts: Partial<TraceRow> & { tool?: string; text?: 
 }
 
 describe("reward/task-summary", () => {
+  it("tells the scorer not to project its own identity onto the host agent", () => {
+    expect(REWARD_R_HUMAN_PROMPT.system).toContain("grading the HOST AGENT");
+    expect(REWARD_R_HUMAN_PROMPT.system).toContain("Do NOT use your own model identity");
+    expect(REWARD_R_HUMAN_PROMPT.system).toContain("hostModel/hostProvider");
+  });
+
   it("builds a multi-turn exchange summary with user asks, steps, and final exchange", () => {
     const ep = makeEpisode();
     const traces = [makeTrace(1, { tool: "fetch" }), makeTrace(2, { text: "parsed JSON" })];
@@ -121,5 +128,47 @@ describe("reward/task-summary", () => {
     const sum = buildTaskSummary({ episode: ep, traces, cfg: { summaryMaxChars: 1000 } });
     expect(sum.agentActions).toMatch(/web\.search/);
     expect(sum.agentActions).not.toMatch(/this text should NOT appear/);
+  });
+
+  it("includes host and evaluator model context for identity-sensitive scoring", () => {
+    const ep = makeEpisode({
+      meta: {
+        agent: "hermes",
+        contextHints: {
+          agentIdentity: "hermes",
+          hostProvider: "custom",
+          hostModel: "deepseek-v4-flash",
+        },
+      },
+      turns: [
+        { id: "u1", ts: 1 as EpochMs, role: "user", content: "现在是什么模型" },
+        {
+          id: "a1",
+          ts: 2 as EpochMs,
+          role: "assistant",
+          content: "当前模型是 deepseek-v4-flash",
+        },
+      ],
+    });
+
+    const sum = buildTaskSummary({
+      episode: ep,
+      traces: [],
+      cfg: { summaryMaxChars: 1000 },
+      evaluator: {
+        reflectionProvider: "openai_compatible",
+        reflectionModel: "claude-sonnet-4-6-20260218",
+        scorerProvider: "openai_compatible",
+        scorerModel: "claude-sonnet-4-6-20260218",
+      },
+    });
+
+    expect(sum.text).toMatch(/HOST_AGENT_CONTEXT:/);
+    expect(sum.text).toContain("agent: hermes");
+    expect(sum.text).toContain("hostProvider: custom");
+    expect(sum.text).toContain("hostModel: deepseek-v4-flash");
+    expect(sum.text).toContain("reflectionModel: claude-sonnet-4-6-20260218");
+    expect(sum.text).toContain("scorerModel: claude-sonnet-4-6-20260218");
+    expect(sum.text).toContain("do not project the evaluator model's own identity");
   });
 });

--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -292,6 +292,8 @@ const en = {
   "memories.field.episodeTimeline": "Steps in this task",
   "memories.field.steps": "Steps in this turn ({n})",
   "memories.card.steps": "{n} steps",
+  "memories.score.skipped": "Scoring skipped",
+  "memories.score.pending": "Pending score",
   // Tooltip helpers for memory metadata fields. Shown when the user
   // hovers the small "?" icon next to each label so they can find out
   // what the score means without leaving the drawer.
@@ -958,6 +960,8 @@ const zh: Record<TranslationKey, string> = {
   "memories.field.episodeTimeline": "本任务的其他步骤",
   "memories.field.steps": "本轮步骤（共 {n} 步）",
   "memories.card.steps": "{n} 步",
+  "memories.score.skipped": "跳过评分",
+  "memories.score.pending": "待评分",
   "memories.help.value":
     "记忆被捕获时的重要性评分（0–1）。值越高表示助手当时越觉得这条记忆值得保留。",
   "memories.help.alpha":

--- a/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
@@ -562,9 +562,7 @@ export function MemoriesView() {
                       {t(`memories.share.scope.${scope}` as never).split(" (")[0]}
                     </span>
                     <span>{formatTs(g.ts)}</span>
-                    <span class="mono">
-                      V {g.aggValue.toFixed(2)} · α {g.aggAlpha.toFixed(2)}
-                    </span>
+                    <span class="mono">{groupScoreLabel(g)}</span>
                     {g.toolCount > 0 && (
                       <span class="pill pill--info" title={g.toolNames.join(", ")}>
                         <Icon name="cable" size={12} />
@@ -652,6 +650,27 @@ function detectRole(trace: TraceDTO): "user" | "assistant" | "tool" | "" {
   if (trace.agentText) return "assistant";
   if (trace.userText) return "user";
   return "";
+}
+
+function episodeScoringSkipped(trace: TraceDTO): boolean {
+  return trace.episodeRewardSkipped === true;
+}
+
+function episodeScoringPending(trace: TraceDTO): boolean {
+  return trace.episodeRTask == null && !episodeScoringSkipped(trace);
+}
+
+function groupScoreLabel(group: MemoryGroup): string {
+  const scoringTrace = group.traces.find((trace) => trace.episodeRTask != null) ?? group.head;
+  if (episodeScoringSkipped(scoringTrace)) return t("memories.score.skipped");
+  if (episodeScoringPending(scoringTrace)) return t("memories.score.pending");
+  return `V ${group.aggValue.toFixed(2)} · α ${group.aggAlpha.toFixed(2)}`;
+}
+
+function traceScoreLabel(trace: TraceDTO): string {
+  if (episodeScoringSkipped(trace)) return t("memories.score.skipped");
+  if (episodeScoringPending(trace)) return t("memories.score.pending");
+  return `V ${trace.value.toFixed(2)} · α ${trace.alpha.toFixed(2)}`;
 }
 
 async function findTracePage(
@@ -1073,9 +1092,13 @@ function TraceDrawer({
                   <dt class="muted">{t("memories.field.ts")}</dt>
                   <dd>{group.ts ? new Date(group.ts).toLocaleString() : "—"}</dd>
                   <dt class="muted">{t("memories.field.value")}</dt>
-                  <dd>{group.aggValue.toFixed(3)}</dd>
-                  <dt class="muted">{t("memories.field.alpha")}</dt>
-                  <dd>{group.aggAlpha.toFixed(3)}</dd>
+                  <dd>{groupScoreLabel(group)}</dd>
+                  {!episodeScoringSkipped(head) && (
+                    <>
+                      <dt class="muted">{t("memories.field.alpha")}</dt>
+                      <dd>{group.aggAlpha.toFixed(3)}</dd>
+                    </>
+                  )}
                   {head.rHuman != null && (
                     <>
                       <dt class="muted">{t("memories.field.rHuman")}</dt>
@@ -1306,7 +1329,7 @@ function StepList({ traces }: { traces: readonly TraceDTO[] }) {
                   </span>
                 )}
                 <span class="mono muted" style="font-size:var(--fs-xs)">
-                  V {tr.value.toFixed(2)} · α {tr.alpha.toFixed(2)}
+                  {traceScoreLabel(tr)}
                 </span>
                 <span class="truncate" style="flex:1;min-width:0;font-size:var(--fs-sm)">
                   {summary}


### PR DESCRIPTION
## Summary
- Improve MemOS trace capture, ordering, and idempotency for Hermes tool/subagent flows.
- Preserve scoring recovery and reward metadata so Memories and Tasks views show consistent status and scores.
- Align viewer ordering for grouped memory traces with task timelines, including subagent/delegate anchoring.

## Test plan
- `ruff check adapters tests/python && ruff format --check adapters tests/python`
- `npm run test -- tests/unit/pipeline/memory-core.test.ts`
- `npm run lint`
- `npm run build:all && npm pack`
- Installed local tarball and restarted Hermes bridge/viewer/chat


Made with [Cursor](https://cursor.com)