### PR TITLE
fix: keep task user message before tools

### DIFF
--- a/apps/memos-local-plugin/tests/unit/web/tasks-chat.test.ts
+++ b/apps/memos-local-plugin/tests/unit/web/tasks-chat.test.ts
@@ -123,6 +123,30 @@ describe("flattenChat", () => {
     expect(user.ts).toBe(T0);
   });
 
+  it("renders the turn user message before tools even when a later trace carries userText", () => {
+    const skill = trace({
+      id: "tr_skill",
+      ts: T0 + 1_000,
+      turnId: T0,
+      toolCalls: [{ name: "skill_get", input: { id: "sk_1" } }],
+    });
+    const delegate = trace({
+      id: "tr_delegate",
+      ts: T0 + 2_000,
+      turnId: T0,
+      userText: "今年杭州五一游客多吗",
+      toolCalls: [{ name: "delegate_task", input: { goal: "查杭州五一游客数据" } }],
+    });
+
+    const msgs = flattenChat([skill, delegate]);
+
+    expect(msgs.map((m) => m.role)).toEqual(["user", "tool", "tool"]);
+    expect(msgs[0]!.text).toBe("今年杭州五一游客多吗");
+    expect(msgs[0]!.traceId).toBe("tr_delegate");
+    expect(msgs[1]!.toolName).toBe("skill_get");
+    expect(msgs[2]!.toolName).toBe("delegate_task");
+  });
+
   it("keeps tool calls without startedAt untimed", () => {
     const t = trace({
       id: "tr3",

--- a/apps/memos-local-plugin/web/src/views/tasks-chat-data.ts
+++ b/apps/memos-local-plugin/web/src/views/tasks-chat-data.ts
@@ -119,18 +119,55 @@ const TOOL_OUTPUT_PREVIEW_CHARS = 1_600;
  */
 export function flattenChat(traces: readonly TimelineTrace[]): ChatMsg[] {
   const out: ChatMsg[] = [];
-  for (const tr of traces) {
-    const u = (tr.userText ?? "").trim();
-    if (u) {
+  for (const group of groupTracesByTurn(traces)) {
+    const userTrace = group.find((tr) => (tr.userText ?? "").trim().length > 0);
+    const userText = (userTrace?.userText ?? "").trim();
+    if (userTrace && userText) {
       out.push({
         role: "user",
-        text: u,
-        ts: tr.turnId ?? tr.ts,
-        key: `${tr.id}:user`,
-        traceId: tr.id,
+        text: userText,
+        ts: userTrace.turnId ?? userTrace.ts,
+        key: `${userTrace.id}:user`,
+        traceId: userTrace.id,
       });
     }
 
+    for (const tr of group) {
+      appendTraceMessages(out, tr);
+    }
+  }
+  // Walk the flattened list in a second pass and stamp parallel-batch
+  // metadata onto runs of consecutive `tool` messages. Done after the
+  // whole list is built so the heuristic can compare each tool to its
+  // visible neighbour, regardless of which trace it came from.
+  assignParallelBatches(out);
+  return out;
+}
+
+function groupTracesByTurn(traces: readonly TimelineTrace[]): TimelineTrace[][] {
+  const groups: TimelineTrace[][] = [];
+  let current: TimelineTrace[] = [];
+  let currentTurnId: number | null = null;
+
+  for (const tr of traces) {
+    const turnId = Number.isFinite(tr.turnId) ? tr.turnId! : null;
+    if (
+      current.length === 0 ||
+      (turnId !== null && currentTurnId !== null && turnId === currentTurnId)
+    ) {
+      current.push(tr);
+      currentTurnId = turnId;
+      continue;
+    }
+    groups.push(current);
+    current = [tr];
+    currentTurnId = turnId;
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+function appendTraceMessages(out: ChatMsg[], tr: TimelineTrace): void {
     const tools = [...(tr.toolCalls ?? [])].sort((a, b) => {
       const at = a.startedAt ?? Number.POSITIVE_INFINITY;
       const bt = b.startedAt ?? Number.POSITIVE_INFINITY;
@@ -188,13 +225,6 @@ export function flattenChat(traces: readonly TimelineTrace[]): ChatMsg[] {
         traceId: tr.id,
       });
     }
-  }
-  // Walk the flattened list in a second pass and stamp parallel-batch
-  // metadata onto runs of consecutive `tool` messages. Done after the
-  // whole list is built so the heuristic can compare each tool to its
-  // visible neighbour, regardless of which trace it came from.
-  assignParallelBatches(out);
-  return out;
 }
 
 // ─── assignParallelBatches: detect parallel tool batches ────────────────


### PR DESCRIPTION
## Summary
- Render Tasks chat turns with the user message first, even when backend trace anchoring leaves tool traces earlier in the timeline payload.
- Add a regression test for the `skill_get` before user message scenario.
- Includes the existing MemOS branch updates already present on `mem-agent-0424-zgm` for trace ordering, scoring, diagnostics, and viewer behavior.

## Test plan
- `npm test -- tests/unit/web/tasks-chat.test.ts`
- `ruff check apps/memos-local-plugin/adapters/hermes/memos_provider apps/memos-local-plugin/tests/python`
- `ruff format apps/memos-local-plugin/adapters/hermes/memos_provider apps/memos-local-plugin/tests/python`
- `npm run build:all && npm pack`

Made with [Cursor](https://cursor.com)