### PR TITLE
fix: align sharing visibility tags

### DIFF
--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -733,10 +733,10 @@ CFGEOF
       # The process stays alive to serve the Memory Viewer.
       ( cd "${prefix}" && nohup "${node_bin}" "${tsx_bin}" "${bridge_cts}" --agent=hermes --daemon >"${daemon_log}" 2>&1 & )
 
-      if wait_for_viewer "${HERMES_PORT}"; then
+      if wait_for_viewer "${HERMES_PORT}" 120; then
         success "Memory Viewer daemon running"
       else
-        error "Memory Viewer did not respond within 30s."
+        error "Memory Viewer did not respond within 120s."
         warn "Re-install dependencies and re-run: cd ${prefix} && npm install"
         return 1
       fi

--- a/apps/memos-local-plugin/tests/unit/web/share.test.ts
+++ b/apps/memos-local-plugin/tests/unit/web/share.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { effectiveShareScope } from "../../../web/src/utils/share";
+
+describe("effectiveShareScope", () => {
+  it("shows private when the global sharing switch is off", () => {
+    expect(effectiveShareScope("hub", false)).toBe("private");
+    expect(effectiveShareScope("public", false)).toBe("private");
+    expect(effectiveShareScope("private", false)).toBe("private");
+    expect(effectiveShareScope(null, false)).toBe("private");
+  });
+
+  it("preserves the user's per-item sharing intent when sharing is on", () => {
+    expect(effectiveShareScope("hub", true)).toBe("hub");
+    expect(effectiveShareScope("public", true)).toBe("public");
+    expect(effectiveShareScope("private", true)).toBe("private");
+    expect(effectiveShareScope(undefined, true)).toBe("private");
+  });
+});

--- a/apps/memos-local-plugin/web/src/components/ShareScopePill.tsx
+++ b/apps/memos-local-plugin/web/src/components/ShareScopePill.tsx
@@ -1,0 +1,11 @@
+import { t } from "../stores/i18n";
+import { effectiveShareScope, type ShareScope } from "../utils/share";
+
+export function ShareScopePill({ scope }: { scope?: ShareScope | null }) {
+  const effectiveScope = effectiveShareScope(scope);
+  return (
+    <span class={`pill pill--share-${effectiveScope}`}>
+      {t(`memories.share.scope.${effectiveScope}` as never)}
+    </span>
+  );
+}

--- a/apps/memos-local-plugin/web/src/utils/share.ts
+++ b/apps/memos-local-plugin/web/src/utils/share.ts
@@ -1,0 +1,52 @@
+import { signal } from "@preact/signals";
+import { api } from "../api/client";
+
+export type ShareScope = "private" | "public" | "hub";
+
+interface SharingConfig {
+  hub?: {
+    enabled?: boolean;
+  };
+}
+
+export const hubSharingEnabled = signal(false);
+
+let pendingConfigLoad: Promise<void> | null = null;
+
+/**
+ * The persisted per-item share scope records the user's intent. The
+ * effective scope is what the viewer may show right now under the
+ * global team-sharing switch.
+ */
+export function effectiveShareScope(
+  scope: ShareScope | null | undefined,
+  sharingEnabled = hubSharingEnabled.value,
+): ShareScope {
+  const intendedScope = scope ?? "private";
+  return sharingEnabled ? intendedScope : "private";
+}
+
+export async function loadHubSharingEnabled({
+  force = false,
+  signal,
+}: {
+  force?: boolean;
+  signal?: AbortSignal;
+} = {}): Promise<void> {
+  if (pendingConfigLoad && !force) return pendingConfigLoad;
+
+  pendingConfigLoad = api
+    .get<SharingConfig>("/api/v1/config", { signal })
+    .then((config) => {
+      hubSharingEnabled.value = !!config.hub?.enabled;
+    })
+    .catch((err) => {
+      if ((err as Error).name === "AbortError") return;
+      hubSharingEnabled.value = false;
+    })
+    .finally(() => {
+      pendingConfigLoad = null;
+    });
+
+  return pendingConfigLoad;
+}

--- a/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
@@ -52,10 +52,12 @@ import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
 import { Pager } from "../components/Pager";
+import { ShareScopePill } from "../components/ShareScopePill";
 import { route } from "../stores/router";
 import { clearEntryId } from "../stores/cross-link";
 import type { TraceDTO } from "../api/types";
 import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
+import { loadHubSharingEnabled } from "../utils/share";
 
 type RoleFilter = "" | "user" | "assistant" | "tool";
 
@@ -112,6 +114,12 @@ export function MemoriesView() {
     setToast({ msg, kind });
     setTimeout(() => setToast(null), 2400);
   };
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadHubSharingEnabled({ force: true, signal: ctrl.signal });
+    return () => ctrl.abort();
+  }, []);
 
   const loadPage = async (opts: { q: string; page: number }) => {
     setLoading(true);
@@ -524,7 +532,6 @@ export function MemoriesView() {
           {groups.map((g) => {
             const isSel = isGroupSelected(g);
             const line = pickSummary(g.head);
-            const scope = g.scope;
             const stepLabel =
               g.traces.length > 1
                 ? t("memories.card.steps", { n: g.traces.length })
@@ -558,9 +565,7 @@ export function MemoriesView() {
                 <div class="mem-card__body">
                   <div class="mem-card__title">{line}</div>
                   <div class="mem-card__meta">
-                    <span class={`pill pill--share-${scope}`}>
-                      {t(`memories.share.scope.${scope}` as never).split(" (")[0]}
-                    </span>
+                    <ShareScopePill scope={g.scope} />
                     <span>{formatTs(g.ts)}</span>
                     <span class="mono">{groupScoreLabel(g)}</span>
                     {g.toolCount > 0 && (
@@ -1109,7 +1114,7 @@ function TraceDrawer({
                   <dd>{head.priority.toFixed(3)}</dd>
                   <dt class="muted">{t("memories.field.share")}</dt>
                   <dd>
-                    <span class={`pill pill--share-${group.scope}`}>{group.scope}</span>
+                    <ShareScopePill scope={group.scope} />
                   </dd>
                   {head.tags && head.tags.length > 0 && (
                     <>

--- a/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
@@ -15,10 +15,12 @@ import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
 import { Pager } from "../components/Pager";
+import { ShareScopePill } from "../components/ShareScopePill";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { PolicyDTO } from "../api/types";
 import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
+import { loadHubSharingEnabled } from "../utils/share";
 
 interface PolicyUsage {
   skills: Array<{ id: string; name: string; status: string; eta: number }>;
@@ -58,6 +60,12 @@ export function PoliciesView() {
       return n;
     });
   };
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadHubSharingEnabled({ force: true, signal: ctrl.signal });
+    return () => ctrl.abort();
+  }, []);
 
   const load = async (opts: { q: string; status: StatusFilter; page: number }) => {
     setLoading(true);
@@ -246,6 +254,7 @@ export function PoliciesView() {
               <div class="mem-card__body">
                 <div class="mem-card__title">{p.title || "(untitled)"}</div>
                 <div class="mem-card__meta">
+                  <ShareScopePill scope={p.share?.scope} />
                   <span class={`pill pill--${p.status}`}>{t(`status.${p.status}` as never)}</span>
                   <span>support {p.support}</span>
                   <span>gain {p.gain.toFixed(2)}</span>
@@ -303,7 +312,10 @@ export function PoliciesView() {
             setDetail(null);
             clearEntryId();
           }}
-          onUpdated={(updated) => setDetail(updated)}
+          onUpdated={(updated) => {
+            setRows((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+            setDetail(updated);
+          }}
           onStatusChange={async (p, next) => {
             await setPolicyStatus(p, next);
             // refresh the drawer with the new status.
@@ -463,6 +475,7 @@ function PolicyDrawer({
             <h3 class="card__title" style="font-size:var(--fs-md)">{t("tasks.detail.meta")}</h3>
             <dl style="display:grid;grid-template-columns:120px 1fr;gap:6px 16px;margin:0;font-size:var(--fs-sm)">
               <dt class="muted">{t("memories.field.status")}</dt><dd><span class={`pill pill--${policy.status}`}>{t(`status.${policy.status}` as never)}</span></dd>
+              <dt class="muted">{t("memories.field.share")}</dt><dd><ShareScopePill scope={policy.share?.scope} /></dd>
               <dt class="muted">{t("memories.field.support")}</dt><dd>{policy.support}</dd>
               <dt class="muted">{t("memories.field.gain")}</dt><dd>{policy.gain.toFixed(3)}</dd>
               <dt class="muted">{t("memories.field.createdAt")}</dt><dd>{new Date(policy.createdAt).toLocaleString()}</dd>

--- a/apps/memos-local-plugin/web/src/views/SkillsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SkillsView.tsx
@@ -15,10 +15,12 @@ import { openSse } from "../api/sse";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
 import { Pager } from "../components/Pager";
+import { ShareScopePill } from "../components/ShareScopePill";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { CoreEvent, SkillDTO } from "../api/types";
 import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
+import { loadHubSharingEnabled } from "../utils/share";
 
 interface SkillUsage {
   sourcePolicies: Array<{
@@ -73,6 +75,12 @@ export function SkillsView() {
       return n;
     });
   };
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadHubSharingEnabled({ force: true, signal: ctrl.signal });
+    return () => ctrl.abort();
+  }, []);
 
   const load = async (nextPage: number = 0) => {
     setLoading(true);
@@ -270,6 +278,7 @@ export function SkillsView() {
                 <div class="mem-card__body">
                   <div class="mem-card__title">{s.name}</div>
                   <div class="mem-card__meta">
+                    <ShareScopePill scope={s.share?.scope} />
                     <span class={`pill pill--${s.status}`}>
                       {t(`status.${s.status}` as "status.active")}
                     </span>
@@ -614,6 +623,8 @@ function SkillDrawer({
                   {t(`status.${skill.status}` as "status.active")}
                 </span>
               </dd>
+              <dt class="muted">{t("memories.field.share")}</dt>
+              <dd><ShareScopePill scope={skill.share?.scope} /></dd>
               <dt class="muted">{t("skills.detail.version")}</dt>
               <dd>v{skill.version ?? 1}</dd>
               <dt class="muted">{t("memories.field.eta")}</dt>

--- a/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
@@ -15,10 +15,12 @@ import { api } from "../api/client";
 import { t } from "../stores/i18n";
 import { Icon } from "../components/Icon";
 import { Pager } from "../components/Pager";
+import { ShareScopePill } from "../components/ShareScopePill";
 import { route } from "../stores/router";
 import { clearEntryId, linkTo } from "../stores/cross-link";
 import type { WorldModelDTO } from "../api/types";
 import { areAllIdsSelected, toggleIdsInSelection } from "../utils/selection";
+import { loadHubSharingEnabled } from "../utils/share";
 
 interface WorldModelUsage {
   policies: Array<{
@@ -58,6 +60,12 @@ export function WorldModelsView() {
       return n;
     });
   };
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void loadHubSharingEnabled({ force: true, signal: ctrl.signal });
+    return () => ctrl.abort();
+  }, []);
 
   const load = async (opts: { q: string; page: number }) => {
     setLoading(true);
@@ -199,6 +207,7 @@ export function WorldModelsView() {
                 <div class="mem-card__body">
                   <div class="mem-card__title">{m.title || "(untitled)"}</div>
                   <div class="mem-card__meta">
+                    <ShareScopePill scope={m.share?.scope} />
                     <span class="pill pill--info" title={t("worldModels.version.title")}>
                       v{m.version ?? 1}
                     </span>
@@ -432,6 +441,8 @@ function WorldModelDrawer({
                   {t(`status.${worldModel.status}` as "status.active")}
                 </span>
               </dd>
+              <dt class="muted">{t("memories.field.share")}</dt>
+              <dd><ShareScopePill scope={worldModel.share?.scope} /></dd>
               <dt class="muted">{t("memories.field.createdAt")}</dt>
               <dd>{new Date(worldModel.createdAt).toLocaleString()}</dd>
               <dt class="muted">{t("memories.field.updatedAt")}</dt>


### PR DESCRIPTION
## Summary
- Add a shared visibility pill so memories, experiences, world models, and skills render the same privacy/team-sharing labels.
- Preserve per-item share intent while showing private labels whenever global Hub sharing is disabled.
- Include the current plugin-scoped install timeout adjustment from dev per repository rules.

## Test plan
- npm run lint
- npx vitest run tests/unit/web/share.test.ts
- npm run build:web