### PR TITLE
fix(memos-local-openclaw): ship compiled JS for OpenClaw plugin loader (#1619)

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -527,7 +527,7 @@ const memosLocalPlugin = {
     // ─── Tool: memory_search ───
 
     api.registerTool(
-      (context) => ({
+      (context: any) => ({
         name: "memory_search",
         label: "Memory Search",
         description:
@@ -758,7 +758,7 @@ const memosLocalPlugin = {
     // ─── Tool: memory_timeline ───
 
     api.registerTool(
-      (context) => ({
+      (context: any) => ({
         name: "memory_timeline",
         label: "Memory Timeline",
         description:
@@ -819,7 +819,7 @@ const memosLocalPlugin = {
     // ─── Tool: memory_get ───
 
     api.registerTool(
-      (context) => ({
+      (context: any) => ({
         name: "memory_get",
         label: "Memory Get",
         description:
@@ -1124,7 +1124,7 @@ ${detail.content}`,
             };
           }
 
-          const groupNames = status.user.groups.map((group) => group.name);
+          const groupNames = (status.user.groups ?? []).map((group: { name: string }) => group.name);
           return {
             content: [{
               type: "text",
@@ -1382,7 +1382,7 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     const viewerPort = (pluginCfg as any).viewerPort ?? (gatewayPort + 10);
 
     api.registerTool(
-      (context) => ({
+      (context: any) => ({
         name: "memory_viewer",
         label: "Open Memory Viewer",
         description:
@@ -1646,7 +1646,7 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     // ─── Tool: skill_search ───
 
     api.registerTool(
-      (context) => ({
+      (context: any) => ({
         name: "skill_search",
         label: "Skill Search",
         description:

--- a/apps/memos-local-openclaw/openclaw.plugin.json
+++ b/apps/memos-local-openclaw/openclaw.plugin.json
@@ -33,5 +33,5 @@
       "If better-sqlite3 fails to build, ensure you have C++ build tools: xcode-select --install (macOS) or build-essential (Linux)"
     ]
   },
-  "extensions": ["./index.ts"]
+  "extensions": ["./dist/index.js"]
 }

--- a/apps/memos-local-openclaw/package.json
+++ b/apps/memos-local-openclaw/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.9-beta.1",
   "description": "MemOS Local memory plugin for OpenClaw — full-write, hybrid-recall, progressive retrieval",
   "type": "module",
-  "main": "index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "index.ts",
-    "src",
+    "dist",
     "skill",
     "prebuilds",
     "scripts/native-binding.cjs",
@@ -19,7 +19,7 @@
   "openclaw": {
     "id": "memos-local-openclaw-plugin",
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ],
     "skills": [
       "skill/memos-memory-guide"
@@ -27,14 +27,14 @@
     "installDependencies": true
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/fix-esm-imports.cjs",
     "dev": "tsc --watch",
     "lint": "eslint src --ext .ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:accuracy": "tsx scripts/run-accuracy-test.ts",
     "postinstall": "node scripts/postinstall.cjs",
-    "prepublishOnly": "echo 'Source-only publish — no build needed.'"
+    "prepublishOnly": "rm -rf dist && tsc && node scripts/fix-esm-imports.cjs"
   },
   "keywords": [
     "openclaw",

--- a/apps/memos-local-openclaw/scripts/fix-esm-imports.cjs
+++ b/apps/memos-local-openclaw/scripts/fix-esm-imports.cjs
@@ -15,8 +15,15 @@ const path = require("path");
 
 const DIST = path.resolve(__dirname, "..", "dist");
 
-// Matches:  import ... from "X"  |  export ... from "X"  |  import("X")
-const IMPORT_RE = /(\bfrom\s*['"]|\bimport\s*\(\s*['"])(\.[^'"]+)(['"])/g;
+// Matches relative module specifiers in:
+//   import ... from "X"   /   export ... from "X"   (static import / re-export)
+//   import("X")                                     (dynamic import)
+//   import "X"                                      (side-effect import)
+//
+// `\bimport\s+['"]` requires whitespace between the keyword and the quote so
+// it cannot collide with identifiers like `important`. Specifiers must start
+// with `.` so absolute and bare-package imports are left untouched.
+const IMPORT_RE = /(\bfrom\s*['"]|\bimport\s*\(\s*['"]|\bimport\s+['"])(\.[^'"]+)(['"])/g;
 
 function rewriteSpec(spec, fileDir) {
   if (/\.(m?js|cjs|json)$/.test(spec)) return spec;

--- a/apps/memos-local-openclaw/scripts/fix-esm-imports.cjs
+++ b/apps/memos-local-openclaw/scripts/fix-esm-imports.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Post-build: append `.js` (or `/index.js`) to every relative ESM import in dist/.
+ *
+ * Why: tsconfig uses `moduleResolution: "bundler"` so source files don't need
+ * `.js` suffixes — but Node's native ESM loader requires explicit suffixes.
+ * OpenClaw's plugin loader runs the emitted JS through the standard loader,
+ * so we rewrite the imports here instead of polluting source with `.js`.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DIST = path.resolve(__dirname, "..", "dist");
+
+// Matches:  import ... from "X"  |  export ... from "X"  |  import("X")
+const IMPORT_RE = /(\bfrom\s*['"]|\bimport\s*\(\s*['"])(\.[^'"]+)(['"])/g;
+
+function rewriteSpec(spec, fileDir) {
+  if (/\.(m?js|cjs|json)$/.test(spec)) return spec;
+  const abs = path.resolve(fileDir, spec);
+  if (fs.existsSync(abs + ".js")) return spec + ".js";
+  if (fs.existsSync(path.join(abs, "index.js"))) return spec.replace(/\/?$/, "/index.js");
+  return spec;
+}
+
+let touched = 0;
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) { walk(full); continue; }
+    if (!entry.name.endsWith(".js")) continue;
+    const src = fs.readFileSync(full, "utf8");
+    let changed = false;
+    const out = src.replace(IMPORT_RE, (m, head, spec, tail) => {
+      const next = rewriteSpec(spec, path.dirname(full));
+      if (next !== spec) { changed = true; return head + next + tail; }
+      return m;
+    });
+    if (changed) { fs.writeFileSync(full, out); touched++; }
+  }
+}
+
+if (!fs.existsSync(DIST)) {
+  console.error("[fix-esm-imports] dist/ not found — run tsc first");
+  process.exit(1);
+}
+walk(DIST);
+console.log(`[fix-esm-imports] rewrote imports in ${touched} file(s)`);

--- a/apps/memos-local-openclaw/src/openclaw-sdk.d.ts
+++ b/apps/memos-local-openclaw/src/openclaw-sdk.d.ts
@@ -1,0 +1,13 @@
+declare module "openclaw/plugin-sdk" {
+  export interface OpenClawPluginApi {
+    registerTool(...args: any[]): void;
+    registerHook(...args: any[]): void;
+    registerMemoryCapability(...args: any[]): void;
+    registerService(...args: any[]): void;
+    getConfig(): any;
+    getLogger(): any;
+    config: any;
+    logger: any;
+    [key: string]: any;
+  }
+}

--- a/apps/memos-local-openclaw/src/shared/plugin-root.ts
+++ b/apps/memos-local-openclaw/src/shared/plugin-root.ts
@@ -1,0 +1,28 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Resolve the plugin's installation root by walking up from the caller's file
+ * until a `package.json` whose name matches `memos-local-openclaw-plugin` is found.
+ *
+ * Necessary because the build emits to `dist/` with `rootDir: "."`, so
+ * compiled files live one extra level deep than their sources. Hard-coded
+ * `../../` paths break across dev (src/) vs published (dist/src/) layouts.
+ */
+export function findPluginRoot(importMetaUrl: string): string {
+  let dir = path.dirname(fileURLToPath(importMetaUrl));
+  for (let i = 0; i < 8; i++) {
+    const pkgPath = path.join(dir, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+        if (typeof pkg.name === "string" && pkg.name.includes("memos-local")) return dir;
+      } catch { /* keep walking */ }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`findPluginRoot: could not locate plugin root from ${importMetaUrl}`);
+}

--- a/apps/memos-local-openclaw/src/shared/plugin-root.ts
+++ b/apps/memos-local-openclaw/src/shared/plugin-root.ts
@@ -3,8 +3,24 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
+ * Exact package names recognized as this plugin's installation root.
+ *
+ * Kept narrow (not a substring match) so monorepo layouts — where sibling
+ * packages such as `memos-local-plugin` live next to `memos-local-openclaw` —
+ * can never accidentally lock onto the wrong root.
+ *
+ * The unscoped form covers historical / local checkouts; the scoped form is
+ * the published name on npm.
+ */
+const PLUGIN_PACKAGE_NAMES = new Set([
+  "memos-local-openclaw-plugin",
+  "@memtensor/memos-local-openclaw-plugin",
+]);
+
+/**
  * Resolve the plugin's installation root by walking up from the caller's file
- * until a `package.json` whose name matches `memos-local-openclaw-plugin` is found.
+ * until a `package.json` whose `name` matches one of {@link PLUGIN_PACKAGE_NAMES}
+ * is found.
  *
  * Necessary because the build emits to `dist/` with `rootDir: "."`, so
  * compiled files live one extra level deep than their sources. Hard-coded
@@ -17,7 +33,7 @@ export function findPluginRoot(importMetaUrl: string): string {
     if (fs.existsSync(pkgPath)) {
       try {
         const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
-        if (typeof pkg.name === "string" && pkg.name.includes("memos-local")) return dir;
+        if (typeof pkg.name === "string" && PLUGIN_PACKAGE_NAMES.has(pkg.name)) return dir;
       } catch { /* keep walking */ }
     }
     const parent = path.dirname(dir);

--- a/apps/memos-local-openclaw/src/skill/bundled-memory-guide.ts
+++ b/apps/memos-local-openclaw/src/skill/bundled-memory-guide.ts
@@ -4,6 +4,7 @@
  */
 import * as fs from "fs";
 import * as path from "path";
+import { findPluginRoot } from "../shared/plugin-root";
 
-const skillPath = path.join(__dirname, "..", "..", "skill", "memos-memory-guide", "SKILL.md");
+const skillPath = path.join(findPluginRoot(import.meta.url), "skill", "memos-memory-guide", "SKILL.md");
 export const MEMORY_GUIDE_SKILL_MD: string = fs.readFileSync(skillPath, "utf-8");

--- a/apps/memos-local-openclaw/src/storage/ensure-binding.ts
+++ b/apps/memos-local-openclaw/src/storage/ensure-binding.ts
@@ -2,6 +2,10 @@ import { existsSync, mkdirSync, copyFileSync } from "fs";
 import { execSync } from "child_process";
 import path from "path";
 import { createRequire } from "module";
+import { fileURLToPath } from "node:url";
+import { findPluginRoot } from "../shared/plugin-root";
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Ensure the better-sqlite3 native binary is available.
@@ -19,7 +23,7 @@ export function ensureSqliteBinding(log?: { info: (msg: string) => void; warn: (
   if (existsSync(bindingPath)) return;
 
   const platform = `${process.platform}-${process.arch}`;
-  const pluginRoot = path.resolve(__dirname, "..", "..");
+  const pluginRoot = findPluginRoot(import.meta.url);
   const prebuildSrc = path.join(pluginRoot, "prebuilds", platform, "better_sqlite3.node");
 
   if (existsSync(prebuildSrc)) {

--- a/apps/memos-local-openclaw/src/telemetry.ts
+++ b/apps/memos-local-openclaw/src/telemetry.ts
@@ -13,6 +13,7 @@ import * as path from "path";
 import * as os from "os";
 import { v4 as uuidv4 } from "uuid";
 import type { Logger } from "./types";
+import { findPluginRoot } from "./shared/plugin-root";
 
 export interface TelemetryConfig {
   enabled?: boolean;
@@ -27,7 +28,7 @@ function loadTelemetryCredentials(pluginDir?: string): { endpoint: string; pid: 
     };
   }
   const bases = pluginDir ? [pluginDir, path.join(pluginDir, "src")] : [];
-  if (typeof __dirname === "string") bases.push(path.resolve(__dirname, ".."), __dirname);
+  try { bases.push(findPluginRoot(import.meta.url)); } catch { /* not in a memos-local install */ }
   const candidates = bases.map(b => path.join(b, "telemetry.credentials.json"));
   for (const credPath of candidates) {
     try {

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -5,6 +5,7 @@ import { execSync, exec, execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
+import { findPluginRoot } from "../shared/plugin-root";
 import type { SqliteStore } from "../storage/sqlite";
 import type { Embedder } from "../embedding";
 import { Summarizer, modelHealth } from "../ingest/providers";
@@ -121,7 +122,7 @@ export class ViewerServer {
   private static readonly SESSION_TTL = 24 * 60 * 60 * 1000;
   private static readonly PLUGIN_VERSION: string = (() => {
     try {
-      const pkgPath = path.resolve(__dirname, "../../package.json");
+      const pkgPath = path.join(findPluginRoot(import.meta.url), "package.json");
       return JSON.parse(fs.readFileSync(pkgPath, "utf-8")).version ?? "unknown";
     } catch {
       return "unknown";
@@ -3554,18 +3555,11 @@ export class ViewerServer {
   }
 
   private findPluginPackageJson(): string | null {
-    let dir = __dirname;
-    for (let i = 0; i < 6; i++) {
-      const candidate = path.join(dir, "package.json");
-      if (fs.existsSync(candidate)) {
-        try {
-          const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-          if (pkg.name && pkg.name.includes("memos-local")) return candidate;
-        } catch { /* skip */ }
-      }
-      dir = path.dirname(dir);
+    try {
+      return path.join(findPluginRoot(import.meta.url), "package.json");
+    } catch {
+      return null;
     }
-    return null;
   }
 
   private async handleUpdateCheck(res: http.ServerResponse): Promise<void> {

--- a/apps/memos-local-openclaw/tsconfig.json
+++ b/apps/memos-local-openclaw/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "ESNext",
     "lib": ["ES2022"],
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -13,8 +13,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests", "scripts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Closes #1619.

The `@memtensor/memos-local-openclaw-plugin` npm package was publishing TypeScript source only, so OpenClaw 2026.5.4's plugin loader rejected it with `expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs`. Investigating the `apps/memos-local-openclaw/` source surfaced **three layers** of misconfiguration that all had to be fixed together — just adding a build step would not have sufficed:

1. `tsconfig.json` had `rootDir: "src"` + `include: ["src"]`, so the OpenClaw plugin entry (root `index.ts`) was never in the compile graph at all. The pre-existing `dist/index.js` from `npm run build` was actually `src/index.ts`'s output (a separate library-style entry), not the plugin entry — a silent footgun.
2. `package.json` `main` / `openclaw.extensions` pointed at `index.ts`, `prepublishOnly` was a placeholder echo, and `files` did not include `dist`.
3. The root entry uses `import.meta.url`, and several `src/*` files use bare `__dirname`. ESM-only on the entry side, CJS-only on the helper side — both had to be reconciled before any build output could actually load.

## Changes

| Layer | What | Why |
|---|---|---|
| Build config | `tsconfig.json` → `rootDir: "."`, include root `index.ts`, emit ESM (`module: ESNext`, `moduleResolution: bundler`, `target: ES2022`) | Pull the actual plugin entry into the compile graph; produce ESM since the entry uses `import.meta.url` |
| Package metadata | `main` → `dist/index.js`; `files` includes `dist`; `openclaw.extensions` → `./dist/index.js`; `prepublishOnly` → `rm -rf dist && tsc && node scripts/fix-esm-imports.cjs` | Publish the compiled artifact OpenClaw's loader expects |
| Plugin manifest | `openclaw.plugin.json` `extensions` → `./dist/index.js` | Same |
| Build post-process | New `scripts/fix-esm-imports.cjs` (~50 lines, no new deps) | `moduleResolution: bundler` emits relative imports without `.js` suffixes, but Node's native ESM loader requires them. Rewriting at build time keeps source clean |
| Core abstraction | New `src/shared/plugin-root.ts` (`findPluginRoot(import.meta.url)`) | The new `dist/src/*` layout is one level deeper than the old `dist/*`, so every hard-coded `__dirname/../..` in `bundled-memory-guide.ts`, `ensure-binding.ts`, `telemetry.ts`, and `viewer/server.ts` would have silently pointed at the wrong directory. Marker-based lookup (walks up to a `package.json` whose name starts with `memos-local`) decouples runtime path resolution from emit layout. `viewer/server.ts` already had a 6-level local version of this — now consolidated |
| Type shim | New `src/openclaw-sdk.d.ts` (`declare module "openclaw/plugin-sdk"`) | OpenClaw injects this at runtime; without a dev-time shim, strict tsc cannot compile the root entry |
| Strict-mode fixes | `index.ts` — 5× `(context: any)` annotations, 1× `?? []` null guard | The root entry had never been compiled under strict mode; minimal annotations matching the file's existing `any` style |

## Verification

```text
$ rm -rf dist && npx tsc && node scripts/fix-esm-imports.cjs
[fix-esm-imports] rewrote imports in 32 file(s)

$ node --input-type=module -e "import('./dist/index.js').then(m => console.log('OK', m.default?.id, typeof m.default?.register))"
OK memos-local-openclaw-plugin function

$ npm pack --dry-run
package size: 486.4 kB
unpacked size: 2.6 MB
total files: 229   # dist/index.js (124 kB) + dist/src/** included
```

* tsc compiles clean
* Node 25 native ESM loader resolves `dist/index.js`, exporting `{id, register, ...}` — matches the OpenClaw plugin contract
* `npm pack` now ships compiled artifacts; raw `index.ts` and `src/*.ts` no longer published
* Test suite: 213 passed / 4 failed — verified against `main` baseline (same 4 pre-existing failures in `accuracy.test.ts`, `task-processor.test.ts`, `update-install.test.ts`); **no regressions from this change**

## Test plan

- [ ] Bump version (suggest `1.0.11` or `1.0.9-beta.2`) and `npm publish`
- [ ] Run the install script from the issue: `curl -fsSL https://cdn.memtensor.com.cn/memos-local-openclaw/install.sh | bash`
- [ ] Confirm `~/.openclaw/extensions/memos-local-openclaw-plugin/dist/index.js` exists
- [ ] Restart gateway, confirm `plugins.slots.memory` resolves to `memos-local-openclaw-plugin` without the previous "plugin not found" error
- [ ] Verify `memory_search`, `memory_get`, `memory_viewer` tools register correctly