### PR TITLE
feat: isolate MemOS memory by agent namespace

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -255,6 +255,21 @@ class MemTensorProvider(MemoryProvider):
         """Return True when a global Hermes hook belongs to this provider."""
         return not session_id or not self._session_id or session_id == self._session_id
 
+    def _runtime_namespace(self) -> dict[str, Any]:
+        profile_id = (self._agent_identity or "").strip() or "default"
+        normalized_home = self._hermes_home.replace("\\", "/").rstrip("/")
+        if normalized_home:
+            marker = "/profiles/"
+            if marker in normalized_home:
+                profile_id = normalized_home.rsplit(marker, 1)[-1].split("/", 1)[0] or profile_id
+            elif normalized_home.endswith("/.hermes") and profile_id in ("", "hermes"):
+                profile_id = "default"
+        return {
+            "agentKind": "hermes",
+            "profileId": profile_id,
+            "profileLabel": profile_id,
+        }
+
     def _register_tool_call_hook(self) -> None:
         if self._hook_registered:
             return
@@ -999,6 +1014,7 @@ class MemTensorProvider(MemoryProvider):
                 max_results = self._int_arg(args, "maxResults", 10, 1, 50)
                 params: dict[str, Any] = {
                     "agent": "hermes",
+                    "namespace": self._runtime_namespace(),
                     "query": query,
                     "topK": {
                         "tier1": max_results,
@@ -1026,7 +1042,9 @@ class MemTensorProvider(MemoryProvider):
                 method = methods.get(kind)
                 if method is None:
                     return json.dumps({"error": f"unknown memory kind: {kind}"})
-                item = self._bridge.request(method, {"id": item_id})
+                item = self._bridge.request(
+                    method, {"id": item_id, "namespace": self._runtime_namespace()}
+                )
                 if not item:
                     return json.dumps({"found": False, "kind": kind, "id": item_id})
                 if kind == "trace":
@@ -1071,14 +1089,17 @@ class MemTensorProvider(MemoryProvider):
             if tool_name == "memory_timeline":
                 resp = self._bridge.request(
                     "memory.timeline",
-                    {"episodeId": args.get("episodeId", self._episode_id)},
+                    {
+                        "episodeId": args.get("episodeId", self._episode_id),
+                        "namespace": self._runtime_namespace(),
+                    },
                 )
                 limit = self._int_arg(args, "limit", 20, 1, 100)
                 traces = resp.get("traces", [])[:limit]
                 return json.dumps({"traces": traces})
             if tool_name == "skill_list":
                 limit = self._int_arg(args, "limit", 10, 1, 50)
-                params = {"limit": limit}
+                params = {"limit": limit, "namespace": self._runtime_namespace()}
                 if args.get("status"):
                     params["status"] = args["status"]
                 return json.dumps(self._bridge.request("skill.list", params))
@@ -1088,7 +1109,7 @@ class MemTensorProvider(MemoryProvider):
                 if not query:
                     resp = self._bridge.request(
                         "memory.list_world_models",
-                        {"limit": limit, "offset": 0},
+                        {"limit": limit, "offset": 0, "namespace": self._runtime_namespace()},
                     )
                     return json.dumps(
                         {
@@ -1106,6 +1127,7 @@ class MemTensorProvider(MemoryProvider):
                     "memory.search",
                     {
                         "agent": "hermes",
+                        "namespace": self._runtime_namespace(),
                         "query": query,
                         "topK": {"tier1": 0, "tier2": 0, "tier3": limit},
                     },
@@ -1138,6 +1160,7 @@ class MemTensorProvider(MemoryProvider):
                     "skill.get",
                     {
                         "id": skill_id,
+                        "namespace": self._runtime_namespace(),
                         "recordTrial": True,
                         "sessionId": self._session_id,
                         "episodeId": self._episode_id or None,
@@ -1423,10 +1446,13 @@ class MemTensorProvider(MemoryProvider):
             {
                 "agent": "hermes",
                 "sessionId": requested_session,
+                "namespace": self._runtime_namespace(),
                 "meta": {
                     "hermesHome": self._hermes_home,
                     "platform": self._platform,
                     "agentIdentity": self._agent_identity,
+                    "profileId": self._runtime_namespace()["profileId"],
+                    "namespace": self._runtime_namespace(),
                     **host_runtime,
                 },
             },
@@ -1503,10 +1529,12 @@ class MemTensorProvider(MemoryProvider):
             "turn.start",
             {
                 "agent": "hermes",
+                "namespace": self._runtime_namespace(),
                 "sessionId": session_id or self._session_id,
                 "userText": query,
                 "contextHints": {
                     "agentIdentity": self._agent_identity,
+                    "namespace": self._runtime_namespace(),
                     **host_runtime,
                 },
                 "ts": int(time.time() * 1000),
@@ -1542,6 +1570,7 @@ class MemTensorProvider(MemoryProvider):
         ]
         payload: dict[str, Any] = {
             "agent": "hermes",
+            "namespace": self._runtime_namespace(),
             "sessionId": self._session_id,
             "episodeId": self._episode_id,
             "agentText": assistant_content,
@@ -1549,6 +1578,7 @@ class MemTensorProvider(MemoryProvider):
             "toolCalls": clean_tool_calls,
             "contextHints": {
                 "agentIdentity": self._agent_identity,
+                "namespace": self._runtime_namespace(),
                 **self._host_runtime_context(),
             },
             "ts": ts_ms,

--- a/apps/memos-local-plugin/adapters/openclaw/bridge.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/bridge.ts
@@ -23,6 +23,7 @@ import type {
   AgentKind,
   EpisodeId,
   RetrievalResultDTO,
+  RuntimeNamespace,
   SessionId,
   ToolCallDTO,
   TurnInputDTO,
@@ -623,6 +624,23 @@ export function bridgeSessionId(agentId: string, sessionKey: string): SessionId 
   return `openclaw::${agentId}::${sessionKey}`;
 }
 
+function namespaceFromAgentCtx(ctx: {
+  agentId?: string;
+  sessionKey?: string;
+  workspaceDir?: string;
+  agentDir?: string;
+}): RuntimeNamespace {
+  const profileId = (ctx.agentId || "main").trim() || "main";
+  const workspacePath = ctx.workspaceDir || ctx.agentDir || undefined;
+  return {
+    agentKind: "openclaw",
+    profileId,
+    profileLabel: profileId,
+    workspacePath,
+    sessionKey: ctx.sessionKey,
+  };
+}
+
 /**
  * Ephemeral OpenClaw sub-agents (slug generator, boot-check probes,
  * approval prompts, …) open their own run inside the same plugin host
@@ -766,11 +784,17 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
   async function ensureSession(
     agentId: string | undefined,
     sessionKey: string | undefined,
+    namespace?: RuntimeNamespace,
   ): Promise<SessionId> {
     const effectiveAgent = agentId ?? "main";
     const effectiveKey = sessionKey ?? "default";
     const sid = bridgeSessionId(effectiveAgent, effectiveKey);
-    await opts.core.openSession({ agent: opts.agent, sessionId: sid });
+    await opts.core.openSession({
+      agent: opts.agent,
+      sessionId: sid,
+      namespace,
+      meta: namespace ? { namespace } : undefined,
+    });
     return sid;
   }
 
@@ -818,16 +842,19 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
       const prompt = stripOpenClawUserEnvelope(rawPrompt);
       if (!prompt) return;
 
-      const sessionId = await ensureSession(ctx.agentId, ctx.sessionKey);
+      const namespace = namespaceFromAgentCtx(ctx);
+      const sessionId = await ensureSession(ctx.agentId, ctx.sessionKey, namespace);
       lastUserTextBySession.set(sessionId, prompt);
 
       const turn: TurnInputDTO = {
         agent: opts.agent,
+        namespace,
         sessionId,
         userText: prompt,
         ts: now(),
         contextHints: {
           agentId: ctx.agentId,
+          namespace,
           sessionKey: ctx.sessionKey,
           sessionId: ctx.sessionId,
           runId: ctx.runId,
@@ -876,6 +903,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
       // trace / episode, so there's nothing to persist here either.
       return;
     }
+    const namespace = namespaceFromAgentCtx(ctx);
     const sessionId = bridgeSessionId(ctx.agentId ?? "main", ctx.sessionKey ?? "default");
     const allMessages = Array.isArray(event.messages) ? event.messages : [];
 
@@ -964,7 +992,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
           });
           return;
         }
-        await opts.core.openSession({ agent: opts.agent, sessionId });
+        await opts.core.openSession({ agent: opts.agent, sessionId, namespace, meta: { namespace } });
         episodeId = await opts.core.openEpisode({
           sessionId,
           userMessage: turn.userText,
@@ -974,12 +1002,14 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
 
       const turnResult: TurnResultDTO = {
         agent: opts.agent,
+        namespace,
         sessionId,
         episodeId,
         agentText: turn.agentText,
         agentThinking: turn.agentThinking,
         toolCalls: turn.toolCalls,
         reflection: turn.reflection,
+        contextHints: { namespace },
         ts: now(),
       };
 
@@ -1068,7 +1098,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
   ): Promise<void> {
     if (isEphemeralSessionKey(ctx.sessionKey)) return;
     try {
-      await ensureSession(ctx.agentId, ctx.sessionKey);
+      await ensureSession(ctx.agentId, ctx.sessionKey, namespaceFromAgentCtx(ctx));
       opts.log.debug("memos.session.started", {
         sessionId: event.sessionId,
         sessionKey: ctx.sessionKey,

--- a/apps/memos-local-plugin/adapters/openclaw/index.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/index.ts
@@ -84,6 +84,7 @@ async function createRuntime(api: OpenClawPluginApi): Promise<PluginRuntime> {
   // viewer port to bind.
   const { core, config, home } = await bootstrapMemoryCoreFull({
     agent: "openclaw",
+    namespace: { agentKind: "openclaw", profileId: "main" },
     pkgVersion: PLUGIN_VERSION,
   });
   await core.init();

--- a/apps/memos-local-plugin/adapters/openclaw/tools.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/tools.ts
@@ -16,7 +16,7 @@
  */
 import { Type, type Static } from "@sinclair/typebox";
 
-import type { AgentKind, SkillId, TraceId } from "../../agent-contract/dto.js";
+import type { AgentKind, RuntimeNamespace, SkillId, TraceId } from "../../agent-contract/dto.js";
 import type { MemoryCore } from "../../agent-contract/memory-core.js";
 
 import { bridgeSessionId } from "./bridge.js";
@@ -109,6 +109,17 @@ function sessionFromCtx(ctx: OpenClawPluginToolContext | undefined): string | un
   return bridgeSessionId(agentId, sessionKey);
 }
 
+function namespaceFromCtx(ctx: OpenClawPluginToolContext | undefined): RuntimeNamespace {
+  const profileId = (ctx?.agentId || "main").trim() || "main";
+  return {
+    agentKind: "openclaw",
+    profileId,
+    profileLabel: profileId,
+    workspacePath: ctx?.workspaceDir || ctx?.agentDir,
+    sessionKey: ctx?.sessionKey,
+  };
+}
+
 async function resolveCore(opts: ToolsOptions): Promise<MemoryCore> {
   const core = opts.core ?? (await opts.getCore?.());
   if (!core) {
@@ -138,6 +149,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const sessionId = params.sessionScope ? sessionFromCtx(ctx) : undefined;
         const result = await core.searchMemory({
           agent: opts.agent,
+          namespace: namespaceFromCtx(ctx),
           sessionId: sessionId as never,
           query: params.query,
           topK: {
@@ -163,7 +175,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
 
   // ── memory_get ──
   api.registerTool(
-    (_ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof MemoryGetParams> => ({
+    (ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof MemoryGetParams> => ({
       name: "memory_get",
       label: "Memory Get",
       description:
@@ -174,7 +186,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const core = await resolveCore(opts);
         const kind = params.kind ?? "trace";
         if (kind === "trace") {
-          const trace = await core.getTrace(params.id as TraceId);
+          const trace = await core.getTrace(params.id as TraceId, namespaceFromCtx(ctx));
           if (!trace) return { found: false, kind, id: params.id, body: "", meta: {} };
           return {
             found: true,
@@ -196,7 +208,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           };
         }
         if (kind === "policy") {
-          const policy = await core.getPolicy(params.id);
+          const policy = await core.getPolicy(params.id, namespaceFromCtx(ctx));
           if (!policy) return { found: false, kind, id: params.id, body: "", meta: {} };
           return {
             found: true,
@@ -213,7 +225,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
             },
           };
         }
-        const wm = await core.getWorldModel(params.id);
+        const wm = await core.getWorldModel(params.id, namespaceFromCtx(ctx));
         if (!wm) return { found: false, kind, id: params.id, body: "", meta: {} };
         return {
           found: true,
@@ -229,7 +241,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
 
   // ── memory_timeline ──
   api.registerTool(
-    (_ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof MemoryTimelineParams> => ({
+    (ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof MemoryTimelineParams> => ({
       name: "memory_timeline",
       label: "Memory Timeline",
       description:
@@ -238,7 +250,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
       parameters: MemoryTimelineParams,
       async execute(_toolCallId: string, params: MemoryTimelineParamsT) {
         const core = await resolveCore(opts);
-        const traces = await core.timeline({ episodeId: params.episodeId as never });
+        const traces = await core.timeline({ episodeId: params.episodeId as never, namespace: namespaceFromCtx(ctx) });
         const limited = traces.slice(0, params.limit ?? 20);
         return {
           episodeId: params.episodeId,
@@ -258,7 +270,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
 
   // ── skill_list ──
   api.registerTool(
-    (_ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof SkillListParams> => ({
+    (ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof SkillListParams> => ({
       name: "skill_list",
       label: "Skill List",
       description:
@@ -269,6 +281,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const skills = await core.listSkills({
           status: params.status,
           limit: params.limit,
+          namespace: namespaceFromCtx(ctx),
         });
         return {
           skills: skills.map((s) => ({
@@ -296,7 +309,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
   // only the world-model snippets so the agent can inject domain
   // knowledge on demand.
   api.registerTool(
-    (_ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof EnvironmentQueryParams> => ({
+    (ctx: OpenClawPluginToolContext): AgentToolDescriptor<typeof EnvironmentQueryParams> => ({
       name: "memory_environment",
       label: "Environment Knowledge",
       description:
@@ -314,7 +327,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         // dump.
         const core = await resolveCore(opts);
         if (!query) {
-          const rows = await core.listWorldModels({ limit: cap, offset: 0 });
+          const rows = await core.listWorldModels({ limit: cap, offset: 0, namespace: namespaceFromCtx(ctx) });
           return {
             worldModels: rows.map((w) => ({
               id: w.id,
@@ -330,6 +343,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         // cosine ranking apply, then keep only the tier-3 hits.
         const res = await core.searchMemory({
           agent: opts.agent,
+          namespace: namespaceFromCtx(ctx),
           query,
           topK: { tier1: 0, tier2: 0, tier3: cap },
         });
@@ -362,6 +376,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           recordUse: true,
           recordTrial: true,
           sessionId: sessionFromCtx(ctx) as never,
+          namespace: namespaceFromCtx(ctx),
           toolCallId,
         });
         if (!skill) return { found: false, skill: null };

--- a/apps/memos-local-plugin/agent-contract/dto.ts
+++ b/apps/memos-local-plugin/agent-contract/dto.ts
@@ -9,6 +9,23 @@
 
 export type AgentKind = "openclaw" | "hermes" | string;
 
+export type ShareScope = "private" | "local" | "public" | "hub";
+
+export interface RuntimeNamespace {
+  agentKind: AgentKind;
+  profileId: string;
+  profileLabel?: string;
+  workspaceId?: string;
+  workspacePath?: string;
+  sessionKey?: string;
+}
+
+export interface OwnershipDTO {
+  ownerAgentKind?: AgentKind;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
+}
+
 export type SessionId = string;
 export type EpisodeId = string;
 export type TraceId = string;
@@ -71,6 +88,7 @@ export interface ToolCallDTO {
 export interface TurnInputDTO {
   agent: AgentKind;
   sessionId: SessionId;
+  namespace?: RuntimeNamespace;
   /** Optional pre-existing episodeId (for continued tasks). */
   episodeId?: EpisodeId;
   /** Free-form text the user said this turn. */
@@ -85,6 +103,7 @@ export interface TurnResultDTO {
   agent: AgentKind;
   sessionId: SessionId;
   episodeId: EpisodeId;
+  namespace?: RuntimeNamespace;
   /** Free-form text the agent emitted. */
   agentText: string;
   /**
@@ -122,6 +141,7 @@ export type SubagentOutcome =
 
 export interface SubagentOutcomeDTO {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   /** Parent session that requested the delegation. */
   sessionId: SessionId;
   /** Parent episode to append the delegation result to, when known. */
@@ -142,7 +162,7 @@ export interface SubagentOutcomeDTO {
 
 // ─── Memory items ─────────────────────────────────────────────────────────────
 
-export interface TraceDTO {
+export interface TraceDTO extends OwnershipDTO {
   id: TraceId;
   episodeId: EpisodeId;
   sessionId: SessionId;
@@ -164,7 +184,7 @@ export interface TraceDTO {
    * "共享 / 取消共享" button label.
    */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -226,7 +246,7 @@ export interface ApiLogDTO {
   calledAt: EpochMs;
 }
 
-export interface PolicyDTO {
+export interface PolicyDTO extends OwnershipDTO {
   id: PolicyId;
   title: string;
   trigger: string;
@@ -246,7 +266,7 @@ export interface PolicyDTO {
    * shape as {@link TraceDTO.share}.
    */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -293,7 +313,7 @@ export interface WorldModelStructureEntryDTO {
   evidenceIds?: string[];
 }
 
-export interface WorldModelDTO {
+export interface WorldModelDTO extends OwnershipDTO {
   id: WorldModelId;
   title: string;
   /** Free-form prose summarizing structure/patterns/constraints. */
@@ -333,7 +353,7 @@ export interface WorldModelDTO {
   status: "active" | "archived";
   /** Sharing state (migration 009). `null` = private/not shared. */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -341,7 +361,7 @@ export interface WorldModelDTO {
   editedAt?: EpochMs;
 }
 
-export interface SkillDTO {
+export interface SkillDTO extends OwnershipDTO {
   id: SkillId;
   name: string;
   /** "candidate" while still on trial, then "active", then "archived". */
@@ -389,7 +409,7 @@ export interface SkillDTO {
   version: number;
   /** Sharing state (migration 009). `null` = private/not shared. */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -401,7 +421,7 @@ export interface SkillDTO {
   lastUsedAt?: EpochMs | null;
 }
 
-export interface EpisodeDTO {
+export interface EpisodeDTO extends OwnershipDTO {
   id: EpisodeId;
   sessionId: SessionId;
   startedAt: EpochMs;
@@ -419,6 +439,9 @@ export interface EpisodeDTO {
 export interface EpisodeListItemDTO {
   id: EpisodeId;
   sessionId: SessionId;
+  ownerAgentKind?: AgentKind;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
   startedAt: EpochMs;
   endedAt?: EpochMs;
   status: "open" | "closed";
@@ -506,6 +529,7 @@ export interface FeedbackDTO {
 
 export interface RetrievalQueryDTO {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId?: SessionId;
   episodeId?: EpisodeId;
   query: string;
@@ -522,6 +546,10 @@ export interface RetrievalHitDTO {
   refKind: "skill" | "trace" | "episode" | "world-model";
   score: number;
   snippet: string;
+  ownerAgentKind?: AgentKind;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
+  shareScope?: ShareScope;
 }
 
 export interface RetrievalResultDTO {
@@ -545,6 +573,7 @@ export type RetrievalReason =
 
 export interface TurnStartCtx {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId: SessionId;
   episodeId?: EpisodeId;
   userText: string;
@@ -555,6 +584,7 @@ export interface TurnStartCtx {
 
 export interface ToolDrivenCtx {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId: SessionId;
   episodeId?: EpisodeId;
   /** Which memory tool was called (memory_search / memory_timeline / …). */
@@ -566,6 +596,7 @@ export interface ToolDrivenCtx {
 
 export interface RepairCtx {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId: SessionId;
   episodeId?: EpisodeId;
   /** Which tool has been failing. */

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -28,6 +28,7 @@ import type {
   TurnInputDTO,
   TurnResultDTO,
   WorldModelDTO,
+  RuntimeNamespace,
 } from "./dto.js";
 import type { CoreEvent } from "./events.js";
 import type { LogRecord } from "./log-record.js";
@@ -39,6 +40,7 @@ export interface CoreHealth {
   version: string;
   uptimeMs: number;
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   paths: {
     home: string;
     config: string;
@@ -129,6 +131,7 @@ export interface MemoryCore {
     agent: AgentKind;
     sessionId?: SessionId;
     meta?: Record<string, unknown>;
+    namespace?: RuntimeNamespace;
   }): Promise<SessionId>;
   closeSession(sessionId: SessionId): Promise<void>;
   openEpisode(input: {
@@ -163,7 +166,7 @@ export interface MemoryCore {
 
   // ── memory queries ──
   searchMemory(query: RetrievalQueryDTO): Promise<RetrievalResultDTO>;
-  getTrace(id: string): Promise<TraceDTO | null>;
+  getTrace(id: string, namespace?: RuntimeNamespace): Promise<TraceDTO | null>;
   /**
    * Mutate a single trace's user-facing fields (role / summary /
    * body). Never touches algorithmic signals. Returns the updated
@@ -194,13 +197,13 @@ export interface MemoryCore {
   shareTrace(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
   ): Promise<TraceDTO | null>;
-  getPolicy(id: string): Promise<PolicyDTO | null>;
-  getWorldModel(id: string): Promise<WorldModelDTO | null>;
+  getPolicy(id: string, namespace?: RuntimeNamespace): Promise<PolicyDTO | null>;
+  getWorldModel(id: string, namespace?: RuntimeNamespace): Promise<WorldModelDTO | null>;
   /**
    * List L2 policies ("经验") — newest-first. The viewer uses this
    * for the Experiences panel.
@@ -223,6 +226,7 @@ export interface MemoryCore {
     limit?: number;
     offset?: number;
     q?: string;
+    namespace?: RuntimeNamespace;
   }): Promise<WorldModelDTO[]>;
   /** Total world-model rows matching the same filter. */
   countWorldModels(input?: { q?: string }): Promise<number>;
@@ -256,7 +260,7 @@ export interface MemoryCore {
   sharePolicy(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
@@ -268,7 +272,7 @@ export interface MemoryCore {
   shareWorldModel(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
@@ -313,7 +317,7 @@ export interface MemoryCore {
   }): Promise<EpisodeListItemDTO[]>;
   /** Total episode rows matching the same filter (no limit/offset). */
   countEpisodes(input?: { sessionId?: SessionId }): Promise<number>;
-  timeline(input: { episodeId: EpisodeId }): Promise<TraceDTO[]>;
+  timeline(input: { episodeId: EpisodeId; namespace?: RuntimeNamespace }): Promise<TraceDTO[]>;
   /**
    * Reverse-chronological trace listing for the Memories viewer.
    *
@@ -356,7 +360,7 @@ export interface MemoryCore {
   }): Promise<{ logs: ApiLogDTO[]; total: number }>;
 
   // ── skills ──
-  listSkills(input?: { status?: SkillDTO["status"]; limit?: number }): Promise<SkillDTO[]>;
+  listSkills(input?: { status?: SkillDTO["status"]; limit?: number; namespace?: RuntimeNamespace }): Promise<SkillDTO[]>;
   /** Total skill rows matching the same filter (no limit). */
   countSkills(input?: { status?: SkillDTO["status"] }): Promise<number>;
   getSkill(id: SkillId, opts?: {
@@ -367,6 +371,7 @@ export interface MemoryCore {
     traceId?: string;
     turnId?: EpochMs;
     toolCallId?: string;
+    namespace?: RuntimeNamespace;
   }): Promise<SkillDTO | null>;
   archiveSkill(id: SkillId, reason?: string): Promise<void>;
   /**
@@ -391,7 +396,7 @@ export interface MemoryCore {
   shareSkill(
     id: SkillId,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -142,6 +142,7 @@ async function main(): Promise<void> {
 
   const { core, config, home } = await bootstrapMemoryCoreFull({
     agent: args.agent,
+    namespace: { agentKind: args.agent, profileId: "default" },
     pkgVersion,
     // Skip in daemon mode — daemon has no stdio, so reverse RPC
     // can't ever fire and registering would just hide the "no

--- a/apps/memos-local-plugin/bridge/methods.ts
+++ b/apps/memos-local-plugin/bridge/methods.ts
@@ -30,6 +30,7 @@ import type {
   ToolOutcomeDTO,
   TurnInputDTO,
   TurnResultDTO,
+  RuntimeNamespace,
 } from "../agent-contract/dto.js";
 
 export interface DispatcherOptions {
@@ -63,6 +64,10 @@ function asRecord(p: unknown, method: RpcMethodName): Record<string, unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function namespaceParam(p: Record<string, unknown>): RuntimeNamespace | undefined {
+  return isRecord(p.namespace) ? (p.namespace as unknown as RuntimeNamespace) : undefined;
 }
 
 function requireString(
@@ -119,7 +124,7 @@ export function makeDispatcher(
             ? (p.sessionId as SessionId)
             : undefined;
         const meta = isRecord(p.meta) ? p.meta : undefined;
-        const out = await core.openSession({ agent, sessionId, meta });
+        const out = await core.openSession({ agent, sessionId, meta, namespace: namespaceParam(p) });
         return { sessionId: out };
       }
       case RPC_METHODS.SESSION_CLOSE: {
@@ -174,6 +179,7 @@ export function makeDispatcher(
         const p = asRecord(params, method);
         const q: RetrievalQueryDTO = {
           agent: (typeof p.agent === "string" ? p.agent : "openclaw") as AgentKind,
+          namespace: namespaceParam(p),
           sessionId: (p.sessionId as SessionId | undefined) ?? undefined,
           episodeId: (p.episodeId as EpisodeId | undefined) ?? undefined,
           query: requireString(p, "query", method),
@@ -184,15 +190,21 @@ export function makeDispatcher(
       }
       case RPC_METHODS.MEMORY_GET_TRACE: {
         const p = asRecord(params, method);
-        return await core.getTrace(requireString(p, "id", method));
+        const id = requireString(p, "id", method);
+        const ns = namespaceParam(p);
+        return ns ? await core.getTrace(id, ns) : await core.getTrace(id);
       }
       case RPC_METHODS.MEMORY_GET_POLICY: {
         const p = asRecord(params, method);
-        return await core.getPolicy(requireString(p, "id", method));
+        const id = requireString(p, "id", method);
+        const ns = namespaceParam(p);
+        return ns ? await core.getPolicy(id, ns) : await core.getPolicy(id);
       }
       case RPC_METHODS.MEMORY_GET_WORLD: {
         const p = asRecord(params, method);
-        return await core.getWorldModel(requireString(p, "id", method));
+        const id = requireString(p, "id", method);
+        const ns = namespaceParam(p);
+        return ns ? await core.getWorldModel(id, ns) : await core.getWorldModel(id);
       }
       case RPC_METHODS.MEMORY_LIST_EPISODES: {
         const p = asRecord(params, method);
@@ -207,6 +219,7 @@ export function makeDispatcher(
         const p = asRecord(params, method);
         const out = await core.timeline({
           episodeId: requireString(p, "episodeId", method) as EpisodeId,
+          namespace: namespaceParam(p),
         });
         return { traces: out };
       }
@@ -222,33 +235,53 @@ export function makeDispatcher(
       }
       case RPC_METHODS.MEMORY_LIST_WORLDS: {
         const p = asRecord(params, method);
-        const out = await core.listWorldModels({
+        const input: Parameters<MemoryCore["listWorldModels"]>[0] = {
           limit: typeof p.limit === "number" ? p.limit : undefined,
           offset: typeof p.offset === "number" ? p.offset : undefined,
           q: typeof p.q === "string" ? p.q : undefined,
-        });
+        };
+        const ns = namespaceParam(p);
+        if (ns) input!.namespace = ns;
+        const out = await core.listWorldModels(input);
         return { worldModels: out };
       }
 
       // ── skills ──
       case RPC_METHODS.SKILL_LIST: {
         const p = asRecord(params, method);
-        const out = await core.listSkills({
+        const input: Parameters<MemoryCore["listSkills"]>[0] = {
           status: (p.status as SkillDTO["status"] | undefined) ?? undefined,
           limit: typeof p.limit === "number" ? p.limit : undefined,
-        });
+        };
+        const ns = namespaceParam(p);
+        if (ns) input!.namespace = ns;
+        const out = await core.listSkills(input);
         return { skills: out };
       }
       case RPC_METHODS.SKILL_GET: {
         const p = asRecord(params, method);
-        const opts: Parameters<MemoryCore["getSkill"]>[1] = { recordUse: true };
-        opts.recordTrial = p.recordTrial !== false;
+        const opts: Parameters<MemoryCore["getSkill"]>[1] = {};
+        const hasOptions =
+          p.recordTrial !== undefined ||
+          p.sessionId !== undefined ||
+          p.episodeId !== undefined ||
+          p.traceId !== undefined ||
+          p.turnId !== undefined ||
+          p.toolCallId !== undefined ||
+          p.namespace !== undefined;
+        if (hasOptions) {
+          opts.recordUse = true;
+          opts.recordTrial = p.recordTrial !== false;
+        }
         if (typeof p.sessionId === "string") opts.sessionId = p.sessionId as SessionId;
         if (typeof p.episodeId === "string") opts.episodeId = p.episodeId as EpisodeId;
         if (typeof p.traceId === "string") opts.traceId = p.traceId;
         if (typeof p.turnId === "number") opts.turnId = p.turnId;
         if (typeof p.toolCallId === "string") opts.toolCallId = p.toolCallId;
-        return await core.getSkill(requireString(p, "id", method) as SkillId, opts);
+        const ns = namespaceParam(p);
+        if (ns) opts.namespace = ns;
+        const id = requireString(p, "id", method) as SkillId;
+        return hasOptions ? await core.getSkill(id, opts) : await core.getSkill(id);
       }
       case RPC_METHODS.SKILL_ARCHIVE: {
         const p = asRecord(params, method);

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -506,6 +506,7 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     vecs: VecPair[],
     episode: CaptureInput["episode"],
   ): TraceRow[] {
+    const owner = ownerFromEpisode(episode);
     const traces: TraceCandidate[] = scored.map((s, i) => ({
       ...s,
       traceId: ids.trace() as TraceId,
@@ -517,6 +518,7 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
       id: t.traceId,
       episodeId: episode.id,
       sessionId: episode.sessionId,
+      ...owner,
       ts: t.ts,
       userText: t.userText,
       agentText: t.agentText,
@@ -549,6 +551,19 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
       turnId: pickTurnId(t.meta, t.ts),
       schemaVersion: 1,
     }));
+  }
+
+  function ownerFromEpisode(episode: CaptureInput["episode"]) {
+    const meta = episode.meta ?? {};
+    const contextHints =
+      meta.contextHints && typeof meta.contextHints === "object"
+        ? (meta.contextHints as Record<string, unknown>)
+        : {};
+    return {
+      ownerAgentKind: stringMeta(meta, "ownerAgentKind") ?? stringMeta(contextHints, "ownerAgentKind") ?? "unknown",
+      ownerProfileId: stringMeta(meta, "ownerProfileId") ?? stringMeta(contextHints, "ownerProfileId") ?? "default",
+      ownerWorkspaceId: stringMeta(meta, "ownerWorkspaceId") ?? stringMeta(contextHints, "ownerWorkspaceId") ?? null,
+    };
   }
 
   function buildTraceCandidates(
@@ -1001,6 +1016,11 @@ function traceActionText(row: Pick<TraceRow, "agentText" | "toolCalls">): string
     .map((t) => `${t.name}(${safeStringify(t.input).slice(0, 300)})`)
     .join("; ");
   return [row.agentText.trim(), toolSig].filter((s) => s.length > 0).join("\n---\n") || "(empty)";
+}
+
+function stringMeta(meta: Record<string, unknown>, key: string): string | undefined {
+  const value = meta[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function safeStringify(v: unknown): string {

--- a/apps/memos-local-plugin/core/feedback/feedback.ts
+++ b/apps/memos-local-plugin/core/feedback/feedback.ts
@@ -279,8 +279,10 @@ function persistRepair(
   draft: DecisionRepairDraft,
   ts: EpochMs,
 ): DecisionRepairRow {
+  const owner = ownerFromRepairEvidence(repos, draft);
   const row: DecisionRepairRow = {
     id: ids.decisionRepair(),
+    ...owner,
     ts,
     contextHash: draft.contextHash,
     preference: draft.preference,
@@ -291,6 +293,19 @@ function persistRepair(
   };
   repos.decisionRepairs.insert(row);
   return row;
+}
+
+function ownerFromRepairEvidence(
+  repos: Repos,
+  draft: DecisionRepairDraft,
+): { ownerAgentKind: string; ownerProfileId: string; ownerWorkspaceId: string | null } {
+  const traceId = draft.highValueTraceIds[0] ?? draft.lowValueTraceIds[0];
+  const trace = traceId ? repos.traces.getById(traceId) : null;
+  return {
+    ownerAgentKind: trace?.ownerAgentKind ?? "unknown",
+    ownerProfileId: trace?.ownerProfileId ?? "default",
+    ownerWorkspaceId: trace?.ownerWorkspaceId ?? null,
+  };
 }
 
 function skip(

--- a/apps/memos-local-plugin/core/memory/l2/candidate-pool.ts
+++ b/apps/memos-local-plugin/core/memory/l2/candidate-pool.ts
@@ -70,6 +70,9 @@ export function makeCandidatePool(deps: CandidatePoolDeps) {
       // Refresh TTL + similarity (in case reward changed V).
       repos.candidatePool.upsert({
         id,
+        ownerAgentKind: input.trace.ownerAgentKind,
+        ownerProfileId: input.trace.ownerProfileId,
+        ownerWorkspaceId: input.trace.ownerWorkspaceId,
         policyId: existing.policyId,
         evidenceTraceIds: unique([...existing.evidenceTraceIds, input.trace.id]),
         signature,
@@ -81,6 +84,9 @@ export function makeCandidatePool(deps: CandidatePoolDeps) {
 
     repos.candidatePool.insert({
       id,
+      ownerAgentKind: input.trace.ownerAgentKind,
+      ownerProfileId: input.trace.ownerProfileId,
+      ownerWorkspaceId: input.trace.ownerWorkspaceId,
       policyId: null,
       evidenceTraceIds: [input.trace.id],
       signature,

--- a/apps/memos-local-plugin/core/memory/l2/l2.ts
+++ b/apps/memos-local-plugin/core/memory/l2/l2.ts
@@ -227,6 +227,10 @@ export async function runL2(
         inducedBy: `${L2_INDUCTION_PROMPT.id}.v${L2_INDUCTION_PROMPT.version}`,
         now: input.now ?? Date.now(),
       });
+      const owner = ownerFromTraces(traces);
+      policy.ownerAgentKind = owner.ownerAgentKind;
+      policy.ownerProfileId = owner.ownerProfileId;
+      policy.ownerWorkspaceId = owner.ownerWorkspaceId;
       try {
         repos.policies.insert(policy);
         if (!policy.vec) {
@@ -378,6 +382,19 @@ export async function runL2(
     timings,
     startedAt,
     completedAt,
+  };
+}
+
+function ownerFromTraces(traces: readonly TraceRow[]): {
+  ownerAgentKind: string;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+} {
+  const first = traces[0];
+  return {
+    ownerAgentKind: first?.ownerAgentKind ?? "unknown",
+    ownerProfileId: first?.ownerProfileId ?? "default",
+    ownerWorkspaceId: first?.ownerWorkspaceId ?? null,
   };
 }
 

--- a/apps/memos-local-plugin/core/memory/l3/l3.ts
+++ b/apps/memos-local-plugin/core/memory/l3/l3.ts
@@ -270,6 +270,10 @@ export async function runL3(
         inducedBy: `${L3_ABSTRACTION_PROMPT.id}.v${L3_ABSTRACTION_PROMPT.version}`,
         now,
       });
+      const owner = ownerFromPolicies(cluster.policies);
+      wm.ownerAgentKind = owner.ownerAgentKind;
+      wm.ownerProfileId = owner.ownerProfileId;
+      wm.ownerWorkspaceId = owner.ownerWorkspaceId;
       try {
         repos.worldModel.insert(wm);
         if (!wm.vec) {
@@ -332,6 +336,19 @@ export async function runL3(
     timings,
     startedAt,
     completedAt,
+  };
+}
+
+function ownerFromPolicies(policies: readonly { ownerAgentKind?: string; ownerProfileId?: string; ownerWorkspaceId?: string | null }[]): {
+  ownerAgentKind: string;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+} {
+  const first = policies[0];
+  return {
+    ownerAgentKind: first?.ownerAgentKind ?? "unknown",
+    ownerProfileId: first?.ownerProfileId ?? "default",
+    ownerWorkspaceId: first?.ownerWorkspaceId ?? null,
   };
 }
 

--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -347,7 +347,7 @@ export function buildRetrievalDeps(
 ): RetrievalDeps {
   const embedder = deps.embedder;
   return {
-    repos: wrapRetrievalRepos(deps.repos),
+    repos: wrapRetrievalRepos(deps.repos, deps.namespace),
     embedder: embedder
       ? {
           embed: (text, role) =>
@@ -360,6 +360,7 @@ export function buildRetrievalDeps(
             new Float32Array(0) as unknown as import("../types.js").EmbeddingVector,
         },
     config: algorithm.retrieval,
+    namespace: deps.namespace,
     now: deps.now ?? Date.now,
     llm: deps.llm,
   };

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -42,6 +42,7 @@ import type {
   SubagentOutcomeDTO,
   TraceDTO,
   WorldModelDTO,
+  RuntimeNamespace,
 } from "../../agent-contract/dto.js";
 import type { CoreEvent } from "../../agent-contract/events.js";
 import type { LogRecord } from "../../agent-contract/log-record.js";
@@ -83,12 +84,21 @@ import {
 } from "../llm/host-bridge.js";
 
 import { createPipeline } from "./orchestrator.js";
+import { wrapRetrievalRepos } from "./retrieval-repos.js";
 import type { PipelineDeps, PipelineHandle } from "./types.js";
+import {
+  namespaceFromHints,
+  namespaceMeta,
+  normalizeNamespace,
+  ownerFromNamespace,
+  isVisibleTo,
+} from "../runtime/namespace.js";
 
 // ─── Public bootstrap helpers ───────────────────────────────────────────────
 
 export interface BootstrapOptions {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   /** Optional pre-resolved home. If omitted, derived from `resolveHome`. */
   home?: ResolvedHome;
   /** Optional pre-resolved config. If omitted, we load from disk. */
@@ -152,6 +162,7 @@ export async function bootstrapMemoryCoreFull(
     channel: "core.pipeline.bootstrap",
     ctx: { agent: options.agent },
   });
+  const namespace = normalizeNamespace(options.namespace, options.agent);
 
   // 1. Storage.
   const db = openDb({ filepath: home.dbFile, agent: options.agent });
@@ -392,6 +403,7 @@ export async function bootstrapMemoryCoreFull(
     reflectLlm: reflectLlm ?? llm,
     embedder,
     log,
+    namespace,
     now: options.now,
   };
   const handle = createPipeline(deps);
@@ -442,6 +454,7 @@ export function createMemoryCore(
   const skillRunDurationBySkill = new Map<string, number>();
   const l2StartedAtByEpisode = new Map<string, number>();
   let l3StartedAt: number | null = null;
+  let activeNamespace = handle.namespace;
   // Most recent episode that triggered an L3 abstraction run. Set by
   // the L2 → L3 hop on `l2.policy.induced` / `l2.policy.updated`,
   // consumed by L3 lifecycle writers below. The L3 subscriber is
@@ -457,6 +470,37 @@ export function createMemoryCore(
         "memory-core is shut down",
       );
     }
+  }
+
+  function namespaceFor(
+    agent: AgentKind,
+    input?: { namespace?: RuntimeNamespace; contextHints?: Record<string, unknown>; meta?: Record<string, unknown> },
+  ): RuntimeNamespace {
+    return namespaceFromHints(agent, input?.contextHints ?? input?.meta, input?.namespace ?? activeNamespace);
+  }
+
+  function withNamespaceMeta(
+    agent: AgentKind,
+    meta?: Record<string, unknown>,
+    namespace?: RuntimeNamespace,
+  ): { meta: Record<string, unknown>; namespace: RuntimeNamespace } {
+    const ns = namespaceFromHints(agent, meta, namespace ?? handle.namespace);
+    return { namespace: ns, meta: { ...(meta ?? {}), ...namespaceMeta(ns) } };
+  }
+
+  function visibleToCurrent(row: {
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    share?: { scope?: string | null } | null;
+  }, ns: RuntimeNamespace = activeNamespace): boolean {
+    return isVisibleTo(row, ns);
+  }
+
+  function ownedByCurrent(row: {
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+  }, ns: RuntimeNamespace = activeNamespace): boolean {
+    return row.ownerAgentKind === ns.agentKind && row.ownerProfileId === ns.profileId;
   }
 
   // ─── Stale topic auto-finalize ──
@@ -1092,6 +1136,7 @@ export function createMemoryCore(
       version: pkgVersion,
       uptimeMs: Date.now() - bootAt,
       agent: handle.agent,
+      namespace: activeNamespace,
       paths: {
         home: home.root,
         config: home.configFile,
@@ -1120,12 +1165,15 @@ export function createMemoryCore(
     agent: AgentKind;
     sessionId?: SessionId;
     meta?: Record<string, unknown>;
+    namespace?: RuntimeNamespace;
   }): Promise<SessionId> {
     ensureLive();
+    const { meta } = withNamespaceMeta(input.agent, input.meta, input.namespace);
+    activeNamespace = namespaceFromHints(input.agent, meta, input.namespace ?? activeNamespace);
     const snap = handle.sessionManager.openSession({
       id: input.sessionId,
       agent: input.agent,
-      meta: input.meta ?? {},
+      meta,
     });
     return snap.id as SessionId;
   }
@@ -1208,8 +1256,18 @@ export function createMemoryCore(
     const startedAt = Date.now();
     let ok = true;
     let packet: Awaited<ReturnType<typeof handle.onTurnStart>> | null = null;
+    const ns = namespaceFor(turn.agent, turn);
+    activeNamespace = ns;
+    const namespacedTurn = {
+      ...turn,
+      namespace: ns,
+      contextHints: {
+        ...(turn.contextHints ?? {}),
+        ...namespaceMeta(ns),
+      },
+    };
     try {
-      packet = await handle.onTurnStart(turn);
+      packet = await handle.onTurnStart(namespacedTurn);
 
       // The orchestrator stamps the *routed* session / episode id onto the
       // packet (V7 §0.1 may create, reopen, or migrate to a new session),
@@ -1218,6 +1276,7 @@ export function createMemoryCore(
       // `query.episodeId`, instead of having to keep their own cache.
       const query: RetrievalQueryDTO = {
         agent: turn.agent,
+        namespace: ns,
         sessionId: packet.sessionId,
         episodeId: packet.episodeId,
         query: turn.userText,
@@ -1298,7 +1357,16 @@ export function createMemoryCore(
     result: Parameters<MemoryCore["onTurnEnd"]>[0],
   ): Promise<{ traceId: string; episodeId: EpisodeId }> {
     ensureLive();
-    const outcome = await handle.onTurnEnd(result);
+      const ns = namespaceFor(result.agent, result);
+      activeNamespace = ns;
+      const outcome = await handle.onTurnEnd({
+        ...result,
+        namespace: ns,
+        contextHints: {
+          ...(result.contextHints ?? {}),
+          ...namespaceMeta(ns),
+        },
+      });
     // Return the real row id produced by the synchronous lite capture.
     // Feedback submits this id as a FK, so a synthetic placeholder would
     // cause SQLite "FOREIGN KEY constraint failed" later.
@@ -1327,6 +1395,7 @@ export function createMemoryCore(
     const id = randomUUID();
     const row: FeedbackRow = {
       id,
+      ...ownerFromNamespace(handle.namespace),
       ts,
       episodeId: feedback.episodeId ?? null,
       traceId: feedback.traceId ?? null,
@@ -1386,9 +1455,11 @@ export function createMemoryCore(
     const normalizedOutcome = outcome.outcome ?? (outcome.error ? "error" : "unknown");
     const childToolCalls = outcome.toolCalls ?? [];
 
-    await openSession({ agent: outcome.agent, sessionId: outcome.sessionId });
+    const ns = namespaceFor(outcome.agent, outcome);
+    await openSession({ agent: outcome.agent, sessionId: outcome.sessionId, namespace: ns });
     const recorded = await onTurnEnd({
       agent: outcome.agent,
+      namespace: ns,
       sessionId: outcome.sessionId,
       episodeId: outcome.episodeId ?? ("" as EpisodeId),
       agentText: `Subagent task: ${task}\n\nSubagent result: ${result}`,
@@ -1666,7 +1737,13 @@ export function createMemoryCore(
     query: RetrievalQueryDTO,
   ): Promise<RetrievalResultDTO> {
     ensureLive();
-    const deps = handle.retrievalDeps();
+    const ns = query.namespace ?? activeNamespace;
+    activeNamespace = ns;
+    const deps = {
+      ...handle.retrievalDeps(),
+      namespace: ns,
+      repos: wrapRetrievalRepos(handle.repos, ns),
+    };
     const { turnStartRetrieve } = await import("../retrieval/retrieve.js");
     const sessionId =
       query.sessionId ??
@@ -1709,6 +1786,7 @@ export function createMemoryCore(
       const result = await turnStartRetrieve(deps, {
         reason: "turn_start",
         agent: query.agent,
+        namespace: ns,
         sessionId,
         episodeId: query.episodeId,
         userText: query.query,
@@ -1803,10 +1881,11 @@ export function createMemoryCore(
     }
   }
 
-  async function getTrace(id: string): Promise<TraceDTO | null> {
+  async function getTrace(id: string, namespace?: RuntimeNamespace): Promise<TraceDTO | null> {
     ensureLive();
+    if (namespace) activeNamespace = namespace;
     const row = handle.repos.traces.getById(id);
-    return row ? traceRowToDTO(row, handle.repos.episodes.getById(row.episodeId)) : null;
+    return row && visibleToCurrent(row) ? traceRowToDTO(row, handle.repos.episodes.getById(row.episodeId)) : null;
   }
 
   async function updateTrace(
@@ -1820,7 +1899,7 @@ export function createMemoryCore(
   ): Promise<TraceDTO | null> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.traces.updateBody(id, patch);
     const updated = handle.repos.traces.getById(id);
     return updated
@@ -1831,7 +1910,7 @@ export function createMemoryCore(
   async function deleteTrace(id: string): Promise<{ deleted: boolean }> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing) return { deleted: false };
+    if (!existing || !ownedByCurrent(existing)) return { deleted: false };
     handle.repos.traces.deleteById(id);
     return { deleted: true };
   }
@@ -1843,7 +1922,7 @@ export function createMemoryCore(
     // The viewer's bulk delete is low-frequency (dozens at a time).
     for (const id of ids) {
       const existing = handle.repos.traces.getById(id);
-      if (!existing) continue;
+      if (!existing || !ownedByCurrent(existing)) continue;
       handle.repos.traces.deleteById(id);
       deleted++;
     }
@@ -1853,14 +1932,14 @@ export function createMemoryCore(
   async function shareTrace(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
   ): Promise<TraceDTO | null> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.traces.updateShare(id, share);
     const updated = handle.repos.traces.getById(id);
     return updated
@@ -1868,10 +1947,11 @@ export function createMemoryCore(
       : null;
   }
 
-  async function getPolicy(id: string): Promise<PolicyDTO | null> {
+  async function getPolicy(id: string, namespace?: RuntimeNamespace): Promise<PolicyDTO | null> {
     ensureLive();
+    if (namespace) activeNamespace = namespace;
     const row = handle.repos.policies.getById(id);
-    return row ? policyRowToDTO(row) : null;
+    return row && visibleToCurrent(row) ? policyRowToDTO(row) : null;
   }
 
   async function listPolicies(input?: {
@@ -1889,13 +1969,14 @@ export function createMemoryCore(
       limit: limit + offset + (needle ? 200 : 0),
       offset: 0,
     });
+    const visibleRows = rows.filter((r) => visibleToCurrent(r));
     const filtered = needle
-      ? rows.filter((r) =>
+      ? visibleRows.filter((r) =>
           (r.title + "\n" + r.trigger + "\n" + r.procedure)
             .toLowerCase()
             .includes(needle),
         )
-      : rows;
+      : visibleRows;
     return filtered.slice(offset, offset + limit).map(policyRowToDTO);
   }
 
@@ -1906,12 +1987,12 @@ export function createMemoryCore(
     ensureLive();
     const needle = (input?.q ?? "").trim().toLowerCase();
     if (!needle) {
-      return handle.repos.policies.count({ status: input?.status });
+      return handle.repos.policies.list({ status: input?.status, limit: 100_000 }).filter((r) => visibleToCurrent(r)).length;
     }
     // q is a client-side substring match; mirror `listPolicies` and
     // walk the full filtered result. Caller passes no limit/offset
     // so the natural list pages through everything.
-    const rows = handle.repos.policies.list({ status: input?.status });
+    const rows = handle.repos.policies.list({ status: input?.status }).filter((r) => visibleToCurrent(r));
     return rows.filter((r) =>
       (r.title + "\n" + r.trigger + "\n" + r.procedure)
         .toLowerCase()
@@ -1925,7 +2006,7 @@ export function createMemoryCore(
   ): Promise<PolicyDTO | null> {
     ensureLive();
     const existing = handle.repos.policies.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.policies.upsert({ ...existing, status, updatedAt: Date.now() });
     const updated = handle.repos.policies.getById(id);
     return updated ? policyRowToDTO(updated) : null;
@@ -1934,7 +2015,7 @@ export function createMemoryCore(
   async function deletePolicy(id: string): Promise<{ deleted: boolean }> {
     ensureLive();
     const existing = handle.repos.policies.getById(id);
-    if (!existing) return { deleted: false };
+    if (!existing || !ownedByCurrent(existing)) return { deleted: false };
     handle.repos.policies.deleteById(id);
     return { deleted: true };
   }
@@ -1945,7 +2026,7 @@ export function createMemoryCore(
   ): Promise<PolicyDTO | null> {
     ensureLive();
     const existing = handle.repos.policies.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     const current = existing.decisionGuidance;
     const nextPref = dedupeStrings([
       ...current.preference,
@@ -1970,17 +2051,18 @@ export function createMemoryCore(
     return updated ? policyRowToDTO(updated) : null;
   }
 
-  async function getWorldModel(id: string): Promise<WorldModelDTO | null> {
+  async function getWorldModel(id: string, namespace?: RuntimeNamespace): Promise<WorldModelDTO | null> {
     ensureLive();
+    if (namespace) activeNamespace = namespace;
     const row = handle.repos.worldModel.getById(id);
-    return row ? worldModelRowToDTO(row) : null;
+    return row && visibleToCurrent(row) ? worldModelRowToDTO(row) : null;
   }
 
   async function countWorldModels(input?: { q?: string }): Promise<number> {
     ensureLive();
     const needle = (input?.q ?? "").trim().toLowerCase();
-    if (!needle) return handle.repos.worldModel.count();
-    const rows = handle.repos.worldModel.list({});
+    const rows = handle.repos.worldModel.list({ limit: 100_000 }).filter((r) => visibleToCurrent(r));
+    if (!needle) return rows.length;
     return rows.filter((r) =>
       (r.title + "\n" + r.body).toLowerCase().includes(needle),
     ).length;
@@ -1990,8 +2072,10 @@ export function createMemoryCore(
     limit?: number;
     offset?: number;
     q?: string;
+    namespace?: RuntimeNamespace;
   }): Promise<WorldModelDTO[]> {
     ensureLive();
+    if (input?.namespace) activeNamespace = input.namespace;
     const limit = Math.max(1, Math.min(500, input?.limit ?? 50));
     const offset = Math.max(0, input?.offset ?? 0);
     const needle = (input?.q ?? "").trim().toLowerCase();
@@ -1999,18 +2083,19 @@ export function createMemoryCore(
       limit: limit + offset + (needle ? 200 : 0),
       offset: 0,
     });
+    const visibleRows = rows.filter((r) => visibleToCurrent(r));
     const filtered = needle
-      ? rows.filter((r) =>
+      ? visibleRows.filter((r) =>
           (r.title + "\n" + r.body).toLowerCase().includes(needle),
         )
-      : rows;
+      : visibleRows;
     return filtered.slice(offset, offset + limit).map(worldModelRowToDTO);
   }
 
   async function deleteWorldModel(id: string): Promise<{ deleted: boolean }> {
     ensureLive();
     const existing = handle.repos.worldModel.getById(id);
-    if (!existing) return { deleted: false };
+    if (!existing || !ownedByCurrent(existing)) return { deleted: false };
     handle.repos.worldModel.deleteById(id);
     return { deleted: true };
   }
@@ -2018,14 +2103,14 @@ export function createMemoryCore(
   async function sharePolicy(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
   ): Promise<PolicyDTO | null> {
     ensureLive();
     const existing = handle.repos.policies.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.policies.updateShare(id, share);
     const updated = handle.repos.policies.getById(id);
     return updated ? policyRowToDTO(updated) : null;
@@ -2034,14 +2119,14 @@ export function createMemoryCore(
   async function shareWorldModel(
     id: string,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
   ): Promise<WorldModelDTO | null> {
     ensureLive();
     const existing = handle.repos.worldModel.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.worldModel.updateShare(id, share);
     const updated = handle.repos.worldModel.getById(id);
     return updated ? worldModelRowToDTO(updated) : null;
@@ -2059,7 +2144,7 @@ export function createMemoryCore(
   ): Promise<PolicyDTO | null> {
     ensureLive();
     const existing = handle.repos.policies.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.policies.updateContent(id, patch);
     const updated = handle.repos.policies.getById(id);
     return updated ? policyRowToDTO(updated) : null;
@@ -2071,7 +2156,7 @@ export function createMemoryCore(
   ): Promise<WorldModelDTO | null> {
     ensureLive();
     const existing = handle.repos.worldModel.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     if (patch.title !== undefined || patch.body !== undefined) {
       handle.repos.worldModel.updateContent(id, {
         title: patch.title,
@@ -2088,7 +2173,7 @@ export function createMemoryCore(
   async function archiveWorldModel(id: string): Promise<WorldModelDTO | null> {
     ensureLive();
     const existing = handle.repos.worldModel.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     if (existing.status !== "archived") {
       handle.repos.worldModel.setStatus(id, "archived", Date.now());
     }
@@ -2099,7 +2184,7 @@ export function createMemoryCore(
   async function unarchiveWorldModel(id: string): Promise<WorldModelDTO | null> {
     ensureLive();
     const existing = handle.repos.worldModel.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     if (existing.status === "archived") {
       handle.repos.worldModel.setStatus(id, "active", Date.now());
     }
@@ -2118,14 +2203,14 @@ export function createMemoryCore(
       limit: input.limit ?? 50,
       offset: input.offset ?? 0,
     });
-    return rows.map((r: EpisodeRow) => r.id as EpisodeId);
+    return rows.filter((r: EpisodeRow) => visibleToCurrent(r)).map((r: EpisodeRow) => r.id as EpisodeId);
   }
 
   async function countEpisodes(input?: {
     sessionId?: SessionId;
   }): Promise<number> {
     ensureLive();
-    return handle.repos.episodes.count({ sessionId: input?.sessionId });
+    return handle.repos.episodes.list({ sessionId: input?.sessionId, limit: 100_000 }).filter((r) => visibleToCurrent(r)).length;
   }
 
   async function listEpisodeRows(input?: {
@@ -2145,7 +2230,7 @@ export function createMemoryCore(
       sessionId: input?.sessionId,
       limit: input?.limit ?? 50,
       offset: input?.offset ?? 0,
-    });
+    }).filter((r) => visibleToCurrent(r));
 
     // Build reverse indexes for the skill-status derivation. Rebuilt
     // per call rather than cached because the base table volumes are
@@ -2254,6 +2339,9 @@ export function createMemoryCore(
       return {
         id: r.id,
         sessionId: r.sessionId,
+        ownerAgentKind: r.ownerAgentKind,
+        ownerProfileId: r.ownerProfileId,
+        ownerWorkspaceId: r.ownerWorkspaceId ?? null,
         startedAt: r.startedAt,
         endedAt: r.endedAt ?? undefined,
         status: r.status,
@@ -2280,14 +2368,17 @@ export function createMemoryCore(
 
   async function timeline(input: {
     episodeId: EpisodeId;
+    namespace?: RuntimeNamespace;
   }): Promise<TraceDTO[]> {
     ensureLive();
+    if (input.namespace) activeNamespace = input.namespace;
     const episode = handle.repos.episodes.getById(input.episodeId);
+    if (episode && !visibleToCurrent(episode)) return [];
     const rows = handle.repos.traces.list({
       episodeId: input.episodeId,
       limit: 500,
       newestFirst: false,
-    });
+    }).filter((r) => visibleToCurrent(r));
     return orderTraceRowsForEpisode(rows, episode?.traceIds ?? []).map((row) =>
       traceRowToDTO(row, episode),
     );
@@ -2328,14 +2419,17 @@ export function createMemoryCore(
   }): Promise<number> {
     ensureLive();
     const needle = (input?.q ?? "").trim().toLowerCase();
+    const visible = (r: TraceRow) => visibleToCurrent(r);
     if (!needle) {
-      return input?.groupByTurn
-        ? handle.repos.traces.countTurns({ sessionId: input?.sessionId })
-        : handle.repos.traces.count({ sessionId: input?.sessionId });
+      const rows = handle.repos.traces.list({ sessionId: input?.sessionId, limit: 100_000 }).filter(visible);
+      if (!input?.groupByTurn) return rows.length;
+      const turnKeys = new Set<string>();
+      for (const r of rows) turnKeys.add(`${r.episodeId ?? "_"}:${r.turnId}`);
+      return turnKeys.size;
     }
     // q substring scan — mirror `listTraces`. Walk all matching
     // traces from the repo (no limit) and apply the same filter.
-    const rows = handle.repos.traces.list({ sessionId: input?.sessionId });
+    const rows = handle.repos.traces.list({ sessionId: input?.sessionId }).filter(visible);
     const matched = rows.filter((r) => {
       return traceSearchHaystack(r).includes(needle);
     });
@@ -2367,6 +2461,7 @@ export function createMemoryCore(
           offset,
         });
         const rows = handle.repos.traces.listByTurnKeys(turnKeys);
+        const visibleRows = rows.filter((r) => visibleToCurrent(r));
         // The frontend's `buildGroups` preserves first-encounter order
         // when bucketing traces by turnKey. We need newest turn first
         // (matching `listTurnKeys` DESC order), with the episode's
@@ -2375,8 +2470,8 @@ export function createMemoryCore(
         turnKeys.forEach((k, i) =>
           turnOrder.set(`${k.episodeId ?? "_"}:${k.turnId}`, i),
         );
-        const traceOrder = traceOrderLookup(rows);
-        rows.sort((a, b) => {
+        const traceOrder = traceOrderLookup(visibleRows);
+        visibleRows.sort((a, b) => {
           const ka = `${a.episodeId ?? "_"}:${a.turnId}`;
           const kb = `${b.episodeId ?? "_"}:${b.turnId}`;
           const ia = turnOrder.get(ka) ?? 0;
@@ -2384,10 +2479,10 @@ export function createMemoryCore(
           if (ia !== ib) return ia - ib;
           return compareTraceRowsForEpisodeOrder(a, b, traceOrder);
         });
-        return traceRowsToDTOs(rows);
+        return traceRowsToDTOs(visibleRows);
       }
       // Search + group: scan, filter, then paginate by distinct turn key.
-      const allRows = handle.repos.traces.list({ sessionId: input?.sessionId });
+      const allRows = handle.repos.traces.list({ sessionId: input?.sessionId }).filter((r) => visibleToCurrent(r));
       const matched = allRows.filter((r) => {
         return traceSearchHaystack(r).includes(needle);
       });
@@ -2408,7 +2503,7 @@ export function createMemoryCore(
       );
       // Once a turn matches the search, return the whole turn so the
       // Memories card uses the same step list as the Tasks timeline.
-      const rows = handle.repos.traces.listByTurnKeys(orderedKeys);
+      const rows = handle.repos.traces.listByTurnKeys(orderedKeys).filter((r) => visibleToCurrent(r));
       const traceOrder = traceOrderLookup(rows);
       const traces = rows
         .sort((a, b) => {
@@ -2425,10 +2520,10 @@ export function createMemoryCore(
     if (!needle) {
       const rows = handle.repos.traces.list({
         sessionId: input?.sessionId,
-        limit,
-        offset,
-      });
-      return traceRowsToDTOs(rows);
+        limit: limit + offset + 500,
+        offset: 0,
+      }).filter((r) => visibleToCurrent(r));
+      return traceRowsToDTOs(rows.slice(offset, offset + limit));
     }
     // Substring search: SQLite LIKE would need an index. For the
     // viewer's interactive filter the current volumes (low thousands
@@ -2440,6 +2535,7 @@ export function createMemoryCore(
       offset: 0,
     });
     const filtered = rows.filter((r) => {
+      if (!visibleToCurrent(r)) return false;
       return traceSearchHaystack(r).includes(needle);
     });
     return traceRowsToDTOs(filtered.slice(offset, offset + limit));
@@ -2486,21 +2582,22 @@ export function createMemoryCore(
 
   // ─── Skills ──
   async function listSkills(
-    input?: { status?: SkillDTO["status"]; limit?: number },
+    input?: { status?: SkillDTO["status"]; limit?: number; namespace?: RuntimeNamespace },
   ): Promise<SkillDTO[]> {
     ensureLive();
+    if (input?.namespace) activeNamespace = input.namespace;
     const rows = handle.repos.skills.list({
       status: input?.status,
-      limit: input?.limit ?? 50,
+      limit: 5_000,
     });
-    return rows.map(skillRowToDTO);
+    return rows.filter((r) => visibleToCurrent(r)).slice(0, input?.limit ?? 50).map(skillRowToDTO);
   }
 
   async function countSkills(input?: {
     status?: SkillDTO["status"];
   }): Promise<number> {
     ensureLive();
-    return handle.repos.skills.count({ status: input?.status });
+    return handle.repos.skills.list({ status: input?.status, limit: 5_000 }).filter((r) => visibleToCurrent(r)).length;
   }
 
   async function getSkill(
@@ -2513,11 +2610,13 @@ export function createMemoryCore(
       traceId?: string;
       turnId?: number;
       toolCallId?: string;
+      namespace?: RuntimeNamespace;
     },
   ): Promise<SkillDTO | null> {
     ensureLive();
+    if (opts?.namespace) activeNamespace = opts.namespace;
     const row = handle.repos.skills.getById(id);
-    if (!row) return null;
+    if (!row || !visibleToCurrent(row)) return null;
     if (opts?.recordUse) {
       handle.repos.skills.recordUse(id, Date.now());
       if (opts.recordTrial) {
@@ -2555,6 +2654,9 @@ export function createMemoryCore(
     }
     handle.repos.skillTrials.createPending({
       id: `st_${randomUUID()}`,
+      ownerAgentKind: episode.ownerAgentKind,
+      ownerProfileId: episode.ownerProfileId,
+      ownerWorkspaceId: episode.ownerWorkspaceId,
       skillId,
       sessionId: opts.sessionId ?? episode.sessionId ?? null,
       episodeId: episode.id,
@@ -3007,6 +3109,7 @@ export function createMemoryCore(
     if (!existing) {
       throw new MemosError("skill_not_found", `skill not found: ${id}`);
     }
+    if (!ownedByCurrent(existing)) return;
     const now = Date.now();
     handle.repos.skills.setStatus(id, "archived", now);
     handle.buses.skill.emit({
@@ -3034,7 +3137,7 @@ export function createMemoryCore(
   async function deleteSkill(id: SkillId): Promise<{ deleted: boolean }> {
     ensureLive();
     const existing = handle.repos.skills.getById(id);
-    if (!existing) return { deleted: false };
+    if (!existing || !ownedByCurrent(existing)) return { deleted: false };
     handle.repos.skills.deleteById(id);
     return { deleted: true };
   }
@@ -3042,7 +3145,7 @@ export function createMemoryCore(
   async function reactivateSkill(id: SkillId): Promise<SkillDTO | null> {
     ensureLive();
     const existing = handle.repos.skills.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     const now = Date.now();
     handle.repos.skills.setStatus(id, "active", now);
     if (existing.status !== "active") {
@@ -3067,7 +3170,7 @@ export function createMemoryCore(
   ): Promise<SkillDTO | null> {
     ensureLive();
     const existing = handle.repos.skills.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.skills.updateContent(id, patch);
     const updated = handle.repos.skills.getById(id);
     return updated ? skillRowToDTO(updated) : null;
@@ -3076,14 +3179,14 @@ export function createMemoryCore(
   async function shareSkill(
     id: SkillId,
     share: {
-      scope: "private" | "public" | "hub" | null;
+      scope: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
       sharedAt?: number | null;
     },
   ): Promise<SkillDTO | null> {
     ensureLive();
     const existing = handle.repos.skills.getById(id);
-    if (!existing) return null;
+    if (!existing || !ownedByCurrent(existing)) return null;
     handle.repos.skills.updateShare(id, share);
     const updated = handle.repos.skills.getById(id);
     return updated ? skillRowToDTO(updated) : null;
@@ -3456,6 +3559,9 @@ function compareTraceRowsForEpisodeOrder(
 export function traceRowToDTO(row: TraceRow, episode?: EpisodeRow | null): TraceDTO {
   return {
     id: row.id,
+    ownerAgentKind: row.ownerAgentKind,
+    ownerProfileId: row.ownerProfileId,
+    ownerWorkspaceId: row.ownerWorkspaceId ?? null,
     episodeId: row.episodeId,
     sessionId: row.sessionId,
     ts: row.ts,
@@ -3487,6 +3593,9 @@ function episodeRewardSkipped(episode?: EpisodeRow | null): boolean {
 export function policyRowToDTO(row: PolicyRow): PolicyDTO {
   return {
     id: row.id,
+    ownerAgentKind: row.ownerAgentKind,
+    ownerProfileId: row.ownerProfileId,
+    ownerWorkspaceId: row.ownerWorkspaceId ?? null,
     title: row.title,
     trigger: row.trigger,
     procedure: row.procedure,
@@ -3531,6 +3640,9 @@ export function worldModelRowToDTO(row: WorldModelRow): WorldModelDTO {
   const s = row.structure;
   return {
     id: row.id,
+    ownerAgentKind: row.ownerAgentKind,
+    ownerProfileId: row.ownerProfileId,
+    ownerWorkspaceId: row.ownerWorkspaceId ?? null,
     title: row.title,
     body: row.body,
     structure: {
@@ -3570,6 +3682,9 @@ export function skillRowToDTO(row: SkillRow): SkillDTO {
   };
   return {
     id: row.id,
+    ownerAgentKind: row.ownerAgentKind,
+    ownerProfileId: row.ownerProfileId,
+    ownerWorkspaceId: row.ownerWorkspaceId ?? null,
     name: row.name,
     status: row.status,
     invocationGuide: row.invocationGuide,

--- a/apps/memos-local-plugin/core/pipeline/orchestrator.ts
+++ b/apps/memos-local-plugin/core/pipeline/orchestrator.ts
@@ -49,6 +49,7 @@ import {
   extractAlgorithmConfig,
   pipelineLogger,
 } from "./deps.js";
+import { wrapRetrievalRepos } from "./retrieval-repos.js";
 import type {
   PipelineAlgorithmConfig,
   PipelineBuses,
@@ -839,6 +840,14 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
   const retrievalDeps = buildRetrievalDeps(deps, algorithm);
   const turnStartRetrievalStats = new Map<string, RetrievalResult["stats"]>();
 
+  function retrievalDepsFor(namespace = deps.namespace): typeof retrievalDeps {
+    return {
+      ...retrievalDeps,
+      namespace,
+      repos: wrapRetrievalRepos(deps.repos, namespace),
+    };
+  }
+
   async function retrieveTurnStart(input: TurnInputDTO): Promise<InjectionPacket> {
     const ctx = {
       reason: "turn_start" as const,
@@ -850,7 +859,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       ts: input.ts,
     };
     const result: RetrievalResult = await turnStartRetrieve(
-      retrievalDeps,
+      retrievalDepsFor(input.namespace),
       ctx,
       { events: buses.retrieval },
     );
@@ -866,7 +875,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   async function retrieveToolDriven(ctx: ToolDrivenCtx): Promise<InjectionPacket> {
     const result = await toolDrivenRetrieve(
-      retrievalDeps,
+      retrievalDepsFor(ctx.namespace),
       { reason: "tool_driven", ...ctx },
       { events: buses.retrieval },
     );
@@ -875,7 +884,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   async function retrieveSkillInvoke(ctx: SkillInvokeCtx): Promise<InjectionPacket> {
     const result = await skillInvokeRetrieve(
-      retrievalDeps,
+      retrievalDepsFor(ctx.namespace),
       { reason: "skill_invoke", ...ctx },
       { events: buses.retrieval },
     );
@@ -884,7 +893,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   async function retrieveSubAgent(ctx: SubAgentCtx): Promise<InjectionPacket> {
     const result = await subAgentRetrieve(
-      retrievalDeps,
+      retrievalDepsFor(ctx.namespace),
       { reason: "sub_agent", ...ctx },
       { events: buses.retrieval },
     );
@@ -893,7 +902,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
 
   async function retrieveRepair(ctx: RepairCtx): Promise<InjectionPacket | null> {
     const result = await repairRetrieve(
-      retrievalDeps,
+      retrievalDepsFor(ctx.namespace),
       { reason: "decision_repair", ...ctx },
       { events: buses.retrieval },
     );
@@ -914,6 +923,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
       initialSessionId,
       input.userText,
       {
+        ...(input.contextHints ?? {}),
         contextHints: input.contextHints ?? {},
         agent: input.agent,
         startedAtTurnTs: input.ts,
@@ -1289,6 +1299,7 @@ export function createPipeline(deps: PipelineDeps): PipelineHandle {
     home: deps.home,
     config: deps.config,
     algorithm,
+    namespace: deps.namespace,
     db: deps.db,
     repos: deps.repos,
     llm: deps.llm,

--- a/apps/memos-local-plugin/core/pipeline/retrieval-repos.ts
+++ b/apps/memos-local-plugin/core/pipeline/retrieval-repos.ts
@@ -9,9 +9,10 @@
 
 import type { RetrievalRepos } from "../retrieval/types.js";
 import type { Repos } from "../storage/repos/index.js";
-import type { TraceId } from "../../agent-contract/dto.js";
+import type { RuntimeNamespace, TraceId } from "../../agent-contract/dto.js";
+import { isVisibleTo } from "../runtime/namespace.js";
 
-export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
+export function wrapRetrievalRepos(repos: Repos, namespace: RuntimeNamespace): RetrievalRepos {
   return {
     skills: {
       searchByVector(query, k, opts) {
@@ -19,7 +20,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
       },
       getById(id) {
         const row = repos.skills.getById(id);
-        if (!row) return null;
+        if (!row || !isVisibleTo(row, namespace)) return null;
         return {
           id: row.id,
           name: row.name,
@@ -36,7 +37,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
       },
       getManyByIds(ids) {
         const rows = repos.traces.getManyByIds(ids as readonly TraceId[]);
-        return rows.map((r) => ({
+        return rows.filter((r) => isVisibleTo(r, namespace)).map((r) => ({
           id: r.id,
           episodeId: r.episodeId,
           sessionId: r.sessionId,
@@ -53,7 +54,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
       },
       searchByErrorSignature(fragments, limit, opts) {
         const rows = repos.traces.searchByErrorSignature(fragments, limit, opts);
-        return rows.map((r) => ({
+        return rows.filter((r) => isVisibleTo(r, namespace)).map((r) => ({
           id: r.id,
           episodeId: r.episodeId,
           sessionId: r.sessionId,
@@ -75,7 +76,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
       },
       getById(id) {
         const row = repos.worldModel.getById(id);
-        if (!row) return null;
+        if (!row || !isVisibleTo(row, namespace)) return null;
         return {
           id: row.id,
           title: row.title,
@@ -93,7 +94,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
         const rows = repos.policies.list(
           filter && filter.status ? { status: filter.status } : {},
         );
-        return rows.map((r) => ({
+        return rows.filter((r) => isVisibleTo(r, namespace)).map((r) => ({
           id: r.id,
           title: r.title,
           sourceEpisodeIds: r.sourceEpisodeIds,
@@ -102,7 +103,7 @@ export function wrapRetrievalRepos(repos: Repos): RetrievalRepos {
       },
       getById(id) {
         const row = repos.policies.getById(id);
-        if (!row) return null;
+        if (!row || !isVisibleTo(row, namespace)) return null;
         return {
           id: row.id,
           title: row.title,

--- a/apps/memos-local-plugin/core/pipeline/types.ts
+++ b/apps/memos-local-plugin/core/pipeline/types.ts
@@ -64,6 +64,7 @@ import type {
   TurnInputDTO,
   TurnResultDTO,
   TurnStartCtx,
+  RuntimeNamespace,
 } from "../../agent-contract/dto.js";
 import type {
   SkillInvokeCtx,
@@ -134,6 +135,7 @@ export interface PipelineDeps {
   reflectLlm: LlmClient | null;
   embedder: Embedder | null;
   log: Logger;
+  namespace: RuntimeNamespace;
   /** Injection hook so tests can provide a fake clock. */
   now?: () => number;
 }
@@ -147,6 +149,7 @@ export interface PipelineHandle {
   readonly home: ResolvedHome;
   readonly config: ResolvedConfig;
   readonly algorithm: PipelineAlgorithmConfig;
+  readonly namespace: RuntimeNamespace;
 
   // Infrastructure (adapters that want direct access).
   readonly db: StorageDb;

--- a/apps/memos-local-plugin/core/retrieval/types.ts
+++ b/apps/memos-local-plugin/core/retrieval/types.ts
@@ -17,6 +17,7 @@ import type {
   ToolDrivenCtx,
   TurnStartCtx,
   EpochMs,
+  RuntimeNamespace,
 } from "../../agent-contract/dto.js";
 
 import type {
@@ -536,6 +537,7 @@ export interface RetrievalDeps {
   repos: RetrievalRepos;
   embedder: RetrievalEmbedder;
   config: RetrievalConfig;
+  namespace: RuntimeNamespace;
   now: () => EpochMs;
   /**
    * Optional LLM used by the post-rank relevance filter
@@ -630,6 +632,7 @@ export type RetrievalCtx =
 /** Called when the host model decides to invoke a specific Skill. */
 export interface SkillInvokeCtx {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId: SessionId;
   episodeId?: EpisodeId;
   /** Skill id we're about to run (or a free-form query if id unknown). */
@@ -642,6 +645,7 @@ export interface SkillInvokeCtx {
 /** Called when a sub-agent is spawned with a mission query. */
 export interface SubAgentCtx {
   agent: AgentKind;
+  namespace?: RuntimeNamespace;
   sessionId: SessionId;
   episodeId?: EpisodeId;
   /** The sub-agent mission / system prompt head. */

--- a/apps/memos-local-plugin/core/runtime/namespace.ts
+++ b/apps/memos-local-plugin/core/runtime/namespace.ts
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto";
+import type {
+  AgentKind,
+  RuntimeNamespace,
+  ShareScope,
+} from "../../agent-contract/dto.js";
+
+export const DEFAULT_PROFILE_ID = "default";
+
+export interface OwnerFields {
+  ownerAgentKind: AgentKind;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+}
+
+export interface VisibilityWhere {
+  sql: string;
+  params: Record<string, unknown>;
+}
+
+export function normalizeNamespace(
+  input: Partial<RuntimeNamespace> | null | undefined,
+  fallbackAgent: AgentKind = "unknown",
+): RuntimeNamespace {
+  const agentKind = cleanId(input?.agentKind) || String(fallbackAgent || "unknown");
+  const profileId = cleanId(input?.profileId) || DEFAULT_PROFILE_ID;
+  const workspacePath = cleanPath(input?.workspacePath);
+  const workspaceId =
+    cleanId(input?.workspaceId) || (workspacePath ? hashWorkspace(workspacePath) : undefined);
+  const sessionKey = cleanText(input?.sessionKey);
+  const profileLabel = cleanText(input?.profileLabel);
+  return {
+    agentKind,
+    profileId,
+    ...(profileLabel ? { profileLabel } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(workspacePath ? { workspacePath } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+}
+
+export function namespaceFromHints(
+  agent: AgentKind,
+  hints?: Record<string, unknown> | null,
+  fallback?: RuntimeNamespace,
+): RuntimeNamespace {
+  const embedded = asNamespace(hints?.namespace);
+  const agentIdentity = cleanId(hints?.agentIdentity);
+  const profileId =
+    embedded?.profileId ||
+    agentIdentity ||
+    deriveHermesProfileId(cleanText(hints?.hermesHome)) ||
+    cleanId(hints?.profileId) ||
+    fallback?.profileId;
+  return normalizeNamespace(
+    {
+      agentKind: embedded?.agentKind || cleanId(hints?.agentKind) || fallback?.agentKind || agent,
+      profileId,
+      profileLabel:
+        embedded?.profileLabel ||
+        cleanText(hints?.profileLabel) ||
+        cleanText(hints?.agentIdentity) ||
+        fallback?.profileLabel,
+      workspaceId: embedded?.workspaceId || cleanId(hints?.workspaceId) || fallback?.workspaceId,
+      workspacePath:
+        embedded?.workspacePath ||
+        cleanPath(hints?.workspaceDir) ||
+        cleanPath(hints?.agentDir) ||
+        cleanPath(hints?.workspacePath) ||
+        fallback?.workspacePath,
+      sessionKey: embedded?.sessionKey || cleanText(hints?.sessionKey) || fallback?.sessionKey,
+    },
+    agent,
+  );
+}
+
+export function ownerFromNamespace(ns: RuntimeNamespace): OwnerFields {
+  const normalized = normalizeNamespace(ns, ns.agentKind);
+  return {
+    ownerAgentKind: normalized.agentKind,
+    ownerProfileId: normalized.profileId,
+    ownerWorkspaceId: normalized.workspaceId ?? null,
+  };
+}
+
+export function ownerParams(ns: RuntimeNamespace, prefix = "owner"): Record<string, unknown> {
+  const owner = ownerFromNamespace(ns);
+  return {
+    [`${prefix}_agent_kind`]: owner.ownerAgentKind,
+    [`${prefix}_profile_id`]: owner.ownerProfileId,
+    [`${prefix}_workspace_id`]: owner.ownerWorkspaceId,
+  };
+}
+
+export function normalizeShareScope(scope: unknown): ShareScope {
+  if (scope === "local" || scope === "public" || scope === "hub") return scope;
+  return "private";
+}
+
+export function visibilityWhere(
+  ns: RuntimeNamespace | null | undefined,
+  alias = "",
+): VisibilityWhere {
+  const col = (name: string) => `${alias ? `${alias}.` : ""}${name}`;
+  const normalized = normalizeNamespace(ns, ns?.agentKind ?? "unknown");
+  return {
+    sql:
+      `((` +
+      `${col("owner_agent_kind")} = @vis_owner_agent_kind AND ` +
+      `${col("owner_profile_id")} = @vis_owner_profile_id` +
+      `) OR COALESCE(${col("share_scope")}, 'private') IN ('local', 'public', 'hub'))`,
+    params: {
+      vis_owner_agent_kind: normalized.agentKind,
+      vis_owner_profile_id: normalized.profileId,
+    },
+  };
+}
+
+export function ownerWhere(
+  ns: RuntimeNamespace | null | undefined,
+  alias = "",
+): VisibilityWhere {
+  const col = (name: string) => `${alias ? `${alias}.` : ""}${name}`;
+  const normalized = normalizeNamespace(ns, ns?.agentKind ?? "unknown");
+  return {
+    sql:
+      `${col("owner_agent_kind")} = @owner_agent_kind AND ` +
+      `${col("owner_profile_id")} = @owner_profile_id`,
+    params: {
+      owner_agent_kind: normalized.agentKind,
+      owner_profile_id: normalized.profileId,
+    },
+  };
+}
+
+export function isVisibleTo(
+  row: {
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    share?: { scope?: ShareScope | string | null } | null;
+  },
+  ns: RuntimeNamespace,
+): boolean {
+  const scope = normalizeShareScope(row.share?.scope);
+  if (scope === "local" || scope === "public" || scope === "hub") return true;
+  if (
+    (!row.ownerAgentKind || row.ownerAgentKind === "unknown") &&
+    (!row.ownerProfileId || row.ownerProfileId === DEFAULT_PROFILE_ID)
+  ) {
+    return true;
+  }
+  const normalized = normalizeNamespace(ns, ns.agentKind);
+  return (
+    row.ownerAgentKind === normalized.agentKind &&
+    row.ownerProfileId === normalized.profileId
+  );
+}
+
+export function namespaceMeta(ns: RuntimeNamespace): Record<string, unknown> {
+  const normalized = normalizeNamespace(ns, ns.agentKind);
+  return {
+    namespace: normalized,
+    ownerAgentKind: normalized.agentKind,
+    ownerProfileId: normalized.profileId,
+    ownerWorkspaceId: normalized.workspaceId ?? null,
+  };
+}
+
+function asNamespace(value: unknown): RuntimeNamespace | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const agentKind = cleanId(record.agentKind);
+  const profileId = cleanId(record.profileId);
+  if (!agentKind && !profileId) return null;
+  return normalizeNamespace({
+    agentKind: agentKind || "unknown",
+    profileId: profileId || DEFAULT_PROFILE_ID,
+    profileLabel: cleanText(record.profileLabel),
+    workspaceId: cleanId(record.workspaceId),
+    workspacePath: cleanPath(record.workspacePath),
+    sessionKey: cleanText(record.sessionKey),
+  });
+}
+
+function deriveHermesProfileId(hermesHome: string | undefined): string | undefined {
+  if (!hermesHome) return undefined;
+  const normalized = hermesHome.replace(/\\/g, "/").replace(/\/+$/, "");
+  const match = /\/profiles\/([^/]+)$/.exec(normalized);
+  if (match?.[1]) return cleanId(match[1]);
+  if (normalized.endsWith("/.hermes")) return DEFAULT_PROFILE_ID;
+  return undefined;
+}
+
+function cleanText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function cleanPath(value: unknown): string | undefined {
+  return cleanText(value);
+}
+
+function cleanId(value: unknown): string | undefined {
+  const trimmed = cleanText(value);
+  if (!trimmed) return undefined;
+  return trimmed.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || undefined;
+}
+
+function hashWorkspace(workspacePath: string): string {
+  return createHash("sha256").update(workspacePath).digest("hex").slice(0, 16);
+}

--- a/apps/memos-local-plugin/core/session/episode-manager.ts
+++ b/apps/memos-local-plugin/core/session/episode-manager.ts
@@ -130,6 +130,9 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
       deps.episodesRepo.insert({
         id,
         sessionId: input.sessionId,
+        ownerAgentKind: stringMeta(snap.meta, "ownerAgentKind") ?? "unknown",
+        ownerProfileId: stringMeta(snap.meta, "ownerProfileId") ?? "default",
+        ownerWorkspaceId: stringMeta(snap.meta, "ownerWorkspaceId") ?? null,
         startedAt,
         endedAt: null,
         traceIds: [],
@@ -348,6 +351,11 @@ export function createEpisodeManager(deps: EpisodeManagerDeps): EpisodeManager {
       return out;
     },
   };
+}
+
+function stringMeta(meta: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = meta?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function rewardScoredAt(meta: Record<string, unknown>): unknown {

--- a/apps/memos-local-plugin/core/session/manager.ts
+++ b/apps/memos-local-plugin/core/session/manager.ts
@@ -122,6 +122,9 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     deps.sessionsRepo.upsertIfMissing({
       id,
       agent: input.agent,
+      ownerAgentKind: stringMeta(input.meta, "ownerAgentKind") ?? input.agent,
+      ownerProfileId: stringMeta(input.meta, "ownerProfileId") ?? "default",
+      ownerWorkspaceId: stringMeta(input.meta, "ownerWorkspaceId") ?? null,
       startedAt: ts,
       lastSeenAt: ts,
       meta: input.meta ?? {},
@@ -379,6 +382,11 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
 
     shutdown,
   };
+}
+
+function stringMeta(meta: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = meta?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 // Re-export helpers tests will want to use.

--- a/apps/memos-local-plugin/core/session/persistence.ts
+++ b/apps/memos-local-plugin/core/session/persistence.ts
@@ -17,6 +17,9 @@ export interface SessionRepo {
   upsertIfMissing(row: {
     id: SessionId;
     agent: AgentKind;
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    ownerWorkspaceId?: string | null;
     startedAt: EpochMs;
     lastSeenAt: EpochMs;
     meta: Record<string, unknown>;
@@ -25,6 +28,9 @@ export interface SessionRepo {
   getById(id: SessionId): {
     id: SessionId;
     agent: AgentKind;
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    ownerWorkspaceId?: string | null;
     startedAt: EpochMs;
     lastSeenAt: EpochMs;
     meta: Record<string, unknown>;
@@ -32,6 +38,9 @@ export interface SessionRepo {
   listRecent(limit?: number): Array<{
     id: SessionId;
     agent: AgentKind;
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    ownerWorkspaceId?: string | null;
     startedAt: EpochMs;
     lastSeenAt: EpochMs;
     meta: Record<string, unknown>;
@@ -43,6 +52,9 @@ export interface EpisodesRepo {
   insert(row: {
     id: EpisodeId;
     sessionId: SessionId;
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    ownerWorkspaceId?: string | null;
     startedAt: EpochMs;
     endedAt: EpochMs | null;
     traceIds: string[];
@@ -75,6 +87,9 @@ export function adaptSessionsRepo(sqlite: SqliteSessions): SessionRepo {
       sqlite.upsert({
         id: row.id,
         agent: row.agent as AgentKind,
+        ownerAgentKind: row.ownerAgentKind,
+        ownerProfileId: row.ownerProfileId,
+        ownerWorkspaceId: row.ownerWorkspaceId,
         startedAt: row.startedAt,
         lastSeenAt: row.lastSeenAt,
         meta: row.meta,
@@ -91,6 +106,9 @@ export function adaptSessionsRepo(sqlite: SqliteSessions): SessionRepo {
       return {
         id: r.id,
         agent: r.agent,
+        ownerAgentKind: r.ownerAgentKind,
+        ownerProfileId: r.ownerProfileId,
+        ownerWorkspaceId: r.ownerWorkspaceId,
         startedAt: r.startedAt,
         lastSeenAt: r.lastSeenAt,
         meta: r.meta,
@@ -100,6 +118,9 @@ export function adaptSessionsRepo(sqlite: SqliteSessions): SessionRepo {
       return sqlite.listRecent(limit).map((r) => ({
         id: r.id,
         agent: r.agent,
+        ownerAgentKind: r.ownerAgentKind,
+        ownerProfileId: r.ownerProfileId,
+        ownerWorkspaceId: r.ownerWorkspaceId,
         startedAt: r.startedAt,
         lastSeenAt: r.lastSeenAt,
         meta: r.meta,
@@ -115,6 +136,9 @@ export function adaptEpisodesRepo(sqlite: SqliteEpisodes): EpisodesRepo {
       sqlite.insert({
         id: row.id,
         sessionId: row.sessionId,
+        ownerAgentKind: row.ownerAgentKind,
+        ownerProfileId: row.ownerProfileId,
+        ownerWorkspaceId: row.ownerWorkspaceId,
         startedAt: row.startedAt,
         endedAt: row.endedAt,
         traceIds: row.traceIds,

--- a/apps/memos-local-plugin/core/skill/packager.ts
+++ b/apps/memos-local-plugin/core/skill/packager.ts
@@ -99,6 +99,9 @@ export async function buildSkillRow(
 
   const row: SkillRow = {
     id,
+    ownerAgentKind: existing?.ownerAgentKind ?? policy.ownerAgentKind,
+    ownerProfileId: existing?.ownerProfileId ?? policy.ownerProfileId,
+    ownerWorkspaceId: existing?.ownerWorkspaceId ?? policy.ownerWorkspaceId,
     name: draft.name,
     status: "candidate",
     invocationGuide,

--- a/apps/memos-local-plugin/core/storage/migrations/001-initial.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/001-initial.sql
@@ -30,16 +30,24 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 CREATE TABLE IF NOT EXISTS sessions (
   id            TEXT    PRIMARY KEY,
   agent         TEXT    NOT NULL,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
   started_at    INTEGER NOT NULL,
   last_seen_at  INTEGER NOT NULL,
   meta_json     TEXT    NOT NULL DEFAULT '{}' CHECK (json_valid(meta_json))
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_sessions_owner ON sessions(owner_agent_kind, owner_profile_id, last_seen_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_last_seen ON sessions(last_seen_at DESC);
 
 CREATE TABLE IF NOT EXISTS episodes (
   id            TEXT    PRIMARY KEY,
   session_id    TEXT    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
+  share_scope   TEXT    DEFAULT 'private',
   started_at    INTEGER NOT NULL,
   ended_at      INTEGER,
   trace_ids_json TEXT   NOT NULL DEFAULT '[]' CHECK (json_valid(trace_ids_json)),
@@ -48,6 +56,8 @@ CREATE TABLE IF NOT EXISTS episodes (
   meta_json     TEXT    NOT NULL DEFAULT '{}' CHECK (json_valid(meta_json))
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_episodes_owner ON episodes(owner_agent_kind, owner_profile_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_episodes_share ON episodes(share_scope, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_episodes_session ON episodes(session_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_episodes_status ON episodes(status, started_at DESC);
 
@@ -65,6 +75,9 @@ CREATE TABLE IF NOT EXISTS traces (
   id                    TEXT    PRIMARY KEY,
   episode_id            TEXT    NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
   session_id            TEXT    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  owner_agent_kind      TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id      TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id    TEXT,
   ts                    INTEGER NOT NULL,
   user_text             TEXT    NOT NULL,
   agent_text            TEXT    NOT NULL,
@@ -80,13 +93,15 @@ CREATE TABLE IF NOT EXISTS traces (
   error_signatures_json TEXT    NOT NULL DEFAULT '[]' CHECK (json_valid(error_signatures_json)),
   vec_summary           BLOB,
   vec_action            BLOB,
-  share_scope           TEXT,
+  share_scope           TEXT    DEFAULT 'private',
   share_target          TEXT,
   shared_at             INTEGER,
   turn_id               INTEGER NOT NULL,
   schema_version        INTEGER NOT NULL DEFAULT 1
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_traces_owner        ON traces(owner_agent_kind, owner_profile_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_traces_share        ON traces(share_scope, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_traces_episode_ts   ON traces(episode_id, ts);
 CREATE INDEX IF NOT EXISTS idx_traces_session_ts   ON traces(session_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_traces_priority     ON traces(priority DESC);
@@ -104,6 +119,9 @@ CREATE INDEX IF NOT EXISTS idx_traces_episode_turn ON traces(episode_id, turn_id
 -- without a null branch.
 CREATE TABLE IF NOT EXISTS policies (
   id                       TEXT    PRIMARY KEY,
+  owner_agent_kind         TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id         TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id       TEXT,
   title                    TEXT    NOT NULL,
   trigger                  TEXT    NOT NULL,
   procedure                TEXT    NOT NULL,
@@ -119,18 +137,23 @@ CREATE TABLE IF NOT EXISTS policies (
   vec                      BLOB,
   created_at               INTEGER NOT NULL,
   updated_at               INTEGER NOT NULL,
-  share_scope              TEXT,
+  share_scope              TEXT    DEFAULT 'private',
   share_target             TEXT,
   shared_at                INTEGER,
   edited_at                INTEGER
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_policies_owner   ON policies(owner_agent_kind, owner_profile_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_policies_share   ON policies(share_scope, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_policies_status  ON policies(status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_policies_support ON policies(support DESC, gain DESC);
 
 -- Candidate pool for incremental L2 induction (V7 §2.4.1 step 3).
 CREATE TABLE IF NOT EXISTS l2_candidate_pool (
   id                      TEXT    PRIMARY KEY,
+  owner_agent_kind        TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id        TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id      TEXT,
   policy_id               TEXT REFERENCES policies(id) ON DELETE SET NULL,
   evidence_trace_ids_json TEXT    NOT NULL DEFAULT '[]' CHECK (json_valid(evidence_trace_ids_json)),
   signature               TEXT    NOT NULL,
@@ -139,6 +162,7 @@ CREATE TABLE IF NOT EXISTS l2_candidate_pool (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_l2_candidate_sig     ON l2_candidate_pool(signature);
+CREATE INDEX IF NOT EXISTS idx_l2_candidate_owner   ON l2_candidate_pool(owner_agent_kind, owner_profile_id, expires_at);
 CREATE INDEX IF NOT EXISTS idx_l2_candidate_expires ON l2_candidate_pool(expires_at);
 
 -- ─── L3 World-model ─────────────────────────────────────────────────────────
@@ -147,6 +171,9 @@ CREATE INDEX IF NOT EXISTS idx_l2_candidate_expires ON l2_candidate_pool(expires
 -- 012 squashed in.
 CREATE TABLE IF NOT EXISTS world_model (
   id                   TEXT    PRIMARY KEY,
+  owner_agent_kind     TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id     TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id   TEXT,
   title                TEXT    NOT NULL,
   body                 TEXT    NOT NULL,
   policy_ids_json      TEXT    NOT NULL DEFAULT '[]' CHECK (json_valid(policy_ids_json)),
@@ -160,7 +187,7 @@ CREATE TABLE IF NOT EXISTS world_model (
   vec                  BLOB,
   created_at           INTEGER NOT NULL,
   updated_at           INTEGER NOT NULL,
-  share_scope          TEXT,
+  share_scope          TEXT    DEFAULT 'private',
   share_target         TEXT,
   shared_at            INTEGER,
   edited_at            INTEGER,
@@ -168,6 +195,8 @@ CREATE TABLE IF NOT EXISTS world_model (
   archived_at          INTEGER
 ) STRICT;
 
+CREATE INDEX IF NOT EXISTS idx_world_owner      ON world_model(owner_agent_kind, owner_profile_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_world_share      ON world_model(share_scope, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_world_updated    ON world_model(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_world_confidence ON world_model(confidence DESC);
 
@@ -177,6 +206,9 @@ CREATE INDEX IF NOT EXISTS idx_world_confidence ON world_model(confidence DESC);
 -- (014) are all baked in.
 CREATE TABLE IF NOT EXISTS skills (
   id                    TEXT    PRIMARY KEY,
+  owner_agent_kind      TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id      TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id    TEXT,
   name                  TEXT    NOT NULL,
   status                TEXT    NOT NULL CHECK (status IN ('candidate','active','archived')) DEFAULT 'candidate',
   invocation_guide      TEXT    NOT NULL,
@@ -193,18 +225,23 @@ CREATE TABLE IF NOT EXISTS skills (
   created_at            INTEGER NOT NULL,
   updated_at            INTEGER NOT NULL,
   version               INTEGER NOT NULL DEFAULT 1,
-  share_scope           TEXT,
+  share_scope           TEXT    DEFAULT 'private',
   share_target          TEXT,
   shared_at             INTEGER,
   edited_at             INTEGER
 ) STRICT;
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_skills_name ON skills(name);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_skills_owner_name ON skills(owner_agent_kind, owner_profile_id, name);
+CREATE INDEX IF NOT EXISTS idx_skills_owner ON skills(owner_agent_kind, owner_profile_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_skills_share ON skills(share_scope, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status, eta DESC);
 
 -- ─── Feedback ───────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS feedback (
   id          TEXT    PRIMARY KEY,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
   ts          INTEGER NOT NULL,
   episode_id  TEXT REFERENCES episodes(id) ON DELETE SET NULL,
   trace_id    TEXT REFERENCES traces(id)   ON DELETE SET NULL,
@@ -216,12 +253,16 @@ CREATE TABLE IF NOT EXISTS feedback (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_feedback_ts      ON feedback(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_feedback_owner   ON feedback(owner_agent_kind, owner_profile_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_feedback_trace   ON feedback(trace_id);
 CREATE INDEX IF NOT EXISTS idx_feedback_episode ON feedback(episode_id);
 
 -- ─── Decision repair history ────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS decision_repairs (
   id                     TEXT    PRIMARY KEY,
+  owner_agent_kind       TEXT    NOT NULL DEFAULT 'unknown',
+  owner_profile_id       TEXT    NOT NULL DEFAULT 'default',
+  owner_workspace_id     TEXT,
   ts                     INTEGER NOT NULL,
   context_hash           TEXT    NOT NULL,
   preference             TEXT    NOT NULL,
@@ -232,11 +273,15 @@ CREATE TABLE IF NOT EXISTS decision_repairs (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_repairs_ts      ON decision_repairs(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_repairs_owner   ON decision_repairs(owner_agent_kind, owner_profile_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_repairs_context ON decision_repairs(context_hash);
 
 -- ─── Audit log (database-side). The file-based audit.log is separate. ──────
 CREATE TABLE IF NOT EXISTS audit_events (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
   ts          INTEGER NOT NULL,
   actor       TEXT    NOT NULL,          -- "user" | "system" | "hub:<user>"
   kind        TEXT    NOT NULL,          -- "config.update" | "skill.retire" | ...
@@ -245,6 +290,7 @@ CREATE TABLE IF NOT EXISTS audit_events (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_audit_ts   ON audit_events(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_owner ON audit_events(owner_agent_kind, owner_profile_id, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_kind ON audit_events(kind, ts DESC);
 
 -- ─── API call log (was migration 007) ───────────────────────────────────────
@@ -252,6 +298,9 @@ CREATE INDEX IF NOT EXISTS idx_audit_kind ON audit_events(kind, ts DESC);
 -- higher level if the volume grows big.
 CREATE TABLE IF NOT EXISTS api_logs (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
   tool_name    TEXT    NOT NULL,
   input_json   TEXT    NOT NULL DEFAULT '{}',
   output_json  TEXT    NOT NULL DEFAULT '',
@@ -261,6 +310,7 @@ CREATE TABLE IF NOT EXISTS api_logs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_api_logs_called_at ON api_logs(called_at DESC);
+CREATE INDEX IF NOT EXISTS idx_api_logs_owner ON api_logs(owner_agent_kind, owner_profile_id, called_at DESC);
 CREATE INDEX IF NOT EXISTS idx_api_logs_tool_time ON api_logs(tool_name, called_at DESC);
 
 -- ─── Generic key-value store ───────────────────────────────────────────────

--- a/apps/memos-local-plugin/core/storage/migrations/005-skill-trials.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/005-skill-trials.sql
@@ -1,5 +1,8 @@
 CREATE TABLE IF NOT EXISTS skill_trials (
   id            TEXT    PRIMARY KEY,
+  owner_agent_kind TEXT NOT NULL DEFAULT 'unknown',
+  owner_profile_id TEXT NOT NULL DEFAULT 'default',
+  owner_workspace_id TEXT,
   skill_id      TEXT    NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
   session_id    TEXT    REFERENCES sessions(id) ON DELETE SET NULL,
   episode_id    TEXT    NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
@@ -13,8 +16,11 @@ CREATE TABLE IF NOT EXISTS skill_trials (
 ) STRICT;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_skill_trials_pending_episode_skill
-  ON skill_trials(skill_id, episode_id)
+  ON skill_trials(owner_agent_kind, owner_profile_id, skill_id, episode_id)
   WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_skill_trials_owner
+  ON skill_trials(owner_agent_kind, owner_profile_id, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_skill_trials_episode_status
   ON skill_trials(episode_id, status, created_at DESC);

--- a/apps/memos-local-plugin/core/storage/migrations/007-namespace-visibility.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/007-namespace-visibility.sql
@@ -1,0 +1,2 @@
+-- Namespace + visibility migration is implemented idempotently in migrator.ts
+-- because fresh installs may already get these columns from 001-initial.sql.

--- a/apps/memos-local-plugin/core/storage/migrator.ts
+++ b/apps/memos-local-plugin/core/storage/migrator.ts
@@ -157,6 +157,16 @@ function applyMigration(db: StorageDb, file: MigrationFile): void {
     ensureSkillUsageColumns(db);
     return;
   }
+  if (file.version === 6 && file.name === "world-model-version") {
+    if (tableExists(db, "world_model")) {
+      ensureColumn(db, "world_model", "version", "INTEGER NOT NULL DEFAULT 1");
+    }
+    return;
+  }
+  if (file.version === 7 && file.name === "namespace-visibility") {
+    ensureNamespaceVisibilityColumns(db);
+    return;
+  }
   db.exec(fs.readFileSync(file.fullPath, "utf8"));
 }
 
@@ -191,6 +201,77 @@ function ensureSkillUsageColumns(db: StorageDb): void {
   }
   if (!columns.has("last_used_at")) {
     db.exec(`ALTER TABLE skills ADD COLUMN last_used_at INTEGER`);
+  }
+}
+
+function ensureNamespaceVisibilityColumns(db: StorageDb): void {
+  const ownerTables = [
+    "sessions",
+    "episodes",
+    "traces",
+    "policies",
+    "world_model",
+    "skills",
+    "feedback",
+    "decision_repairs",
+    "l2_candidate_pool",
+    "skill_trials",
+    "api_logs",
+    "audit_events",
+  ];
+  for (const table of ownerTables) {
+    if (!tableExists(db, table)) continue;
+    ensureColumn(db, table, "owner_agent_kind", "TEXT NOT NULL DEFAULT 'unknown'");
+    ensureColumn(db, table, "owner_profile_id", "TEXT NOT NULL DEFAULT 'default'");
+    ensureColumn(db, table, "owner_workspace_id", "TEXT");
+  }
+  for (const table of ["episodes", "traces", "policies", "world_model", "skills"]) {
+    if (!tableExists(db, table)) continue;
+    ensureColumn(db, table, "share_scope", "TEXT DEFAULT 'private'");
+    db.exec(`UPDATE ${table} SET share_scope='private' WHERE share_scope IS NULL`);
+  }
+
+  execIfTable(db, "skills", `DROP INDEX IF EXISTS uq_skills_name`);
+  execIfTable(db, "sessions", `CREATE INDEX IF NOT EXISTS idx_sessions_owner ON sessions(owner_agent_kind, owner_profile_id, last_seen_at DESC)`);
+  execIfTable(db, "episodes", `CREATE INDEX IF NOT EXISTS idx_episodes_owner ON episodes(owner_agent_kind, owner_profile_id, started_at DESC)`);
+  execIfTable(db, "episodes", `CREATE INDEX IF NOT EXISTS idx_episodes_share ON episodes(share_scope, started_at DESC)`);
+  execIfTable(db, "traces", `CREATE INDEX IF NOT EXISTS idx_traces_owner ON traces(owner_agent_kind, owner_profile_id, ts DESC)`);
+  execIfTable(db, "traces", `CREATE INDEX IF NOT EXISTS idx_traces_share ON traces(share_scope, ts DESC)`);
+  execIfTable(db, "policies", `CREATE INDEX IF NOT EXISTS idx_policies_owner ON policies(owner_agent_kind, owner_profile_id, updated_at DESC)`);
+  execIfTable(db, "policies", `CREATE INDEX IF NOT EXISTS idx_policies_share ON policies(share_scope, updated_at DESC)`);
+  execIfTable(db, "world_model", `CREATE INDEX IF NOT EXISTS idx_world_owner ON world_model(owner_agent_kind, owner_profile_id, updated_at DESC)`);
+  execIfTable(db, "world_model", `CREATE INDEX IF NOT EXISTS idx_world_share ON world_model(share_scope, updated_at DESC)`);
+  execIfTable(db, "skills", `CREATE UNIQUE INDEX IF NOT EXISTS uq_skills_owner_name ON skills(owner_agent_kind, owner_profile_id, name)`);
+  execIfTable(db, "skills", `CREATE INDEX IF NOT EXISTS idx_skills_owner ON skills(owner_agent_kind, owner_profile_id, updated_at DESC)`);
+  execIfTable(db, "skills", `CREATE INDEX IF NOT EXISTS idx_skills_share ON skills(share_scope, updated_at DESC)`);
+  execIfTable(db, "feedback", `CREATE INDEX IF NOT EXISTS idx_feedback_owner ON feedback(owner_agent_kind, owner_profile_id, ts DESC)`);
+  execIfTable(db, "decision_repairs", `CREATE INDEX IF NOT EXISTS idx_repairs_owner ON decision_repairs(owner_agent_kind, owner_profile_id, ts DESC)`);
+  execIfTable(db, "l2_candidate_pool", `CREATE INDEX IF NOT EXISTS idx_l2_candidate_owner ON l2_candidate_pool(owner_agent_kind, owner_profile_id, expires_at)`);
+  execIfTable(db, "skill_trials", `CREATE INDEX IF NOT EXISTS idx_skill_trials_owner ON skill_trials(owner_agent_kind, owner_profile_id, created_at DESC)`);
+  execIfTable(db, "api_logs", `CREATE INDEX IF NOT EXISTS idx_api_logs_owner ON api_logs(owner_agent_kind, owner_profile_id, called_at DESC)`);
+  execIfTable(db, "audit_events", `CREATE INDEX IF NOT EXISTS idx_audit_owner ON audit_events(owner_agent_kind, owner_profile_id, ts DESC)`);
+}
+
+function execIfTable(db: StorageDb, table: string, sql: string): void {
+  if (tableExists(db, table)) db.exec(sql);
+}
+
+function tableExists(db: StorageDb, table: string): boolean {
+  return Boolean(
+    db.prepare<{ name: string }, { name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name=@name`,
+    ).get({ name: table }),
+  );
+}
+
+function ensureColumn(db: StorageDb, table: string, column: string, definition: string): void {
+  const columns = new Set(
+    db.prepare<unknown, { name: string }>(`PRAGMA table_info(${table})`)
+      .all()
+      .map((row) => row.name),
+  );
+  if (!columns.has(column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
   }
 }
 

--- a/apps/memos-local-plugin/core/storage/repos/_helpers.ts
+++ b/apps/memos-local-plugin/core/storage/repos/_helpers.ts
@@ -7,6 +7,12 @@
 import { rootLogger } from "../../logger/index.js";
 import { decodeVector, encodeVector } from "../vector.js";
 import type { EmbeddingVector } from "../../types.js";
+import type { RuntimeNamespace } from "../../../agent-contract/dto.js";
+import {
+  normalizeShareScope,
+  ownerFromNamespace,
+  visibilityWhere as runtimeVisibilityWhere,
+} from "../../runtime/namespace.js";
 import type { PageOptions, RawRow, TimeRange } from "../types.js";
 
 export const repoLog = rootLogger.child({ channel: "storage.repos" });
@@ -75,6 +81,61 @@ export function joinWhere(fragments: Array<string | undefined>): string {
   const parts = fragments.filter((p): p is string => Boolean(p && p.trim()));
   if (parts.length === 0) return "";
   return `WHERE ${parts.join(" AND ")}`;
+}
+
+export function ownerColumns(): string[] {
+  return ["owner_agent_kind", "owner_profile_id", "owner_workspace_id"];
+}
+
+export function ownerParamsFromRow(row: {
+  ownerAgentKind?: string;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
+}): Record<string, unknown> {
+  return {
+    owner_agent_kind: row.ownerAgentKind ?? "unknown",
+    owner_profile_id: row.ownerProfileId ?? "default",
+    owner_workspace_id: row.ownerWorkspaceId ?? null,
+  };
+}
+
+export function ownerFieldsFromRaw(r: {
+  owner_agent_kind?: string | null;
+  owner_profile_id?: string | null;
+  owner_workspace_id?: string | null;
+}): {
+  ownerAgentKind: string;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+} {
+  return {
+    ownerAgentKind: r.owner_agent_kind || "unknown",
+    ownerProfileId: r.owner_profile_id || "default",
+    ownerWorkspaceId: r.owner_workspace_id ?? null,
+  };
+}
+
+export function defaultOwnerFields(ns?: RuntimeNamespace | null): {
+  ownerAgentKind: string;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+} {
+  return ns ? ownerFromNamespace(ns) : {
+    ownerAgentKind: "unknown",
+    ownerProfileId: "default",
+    ownerWorkspaceId: null,
+  };
+}
+
+export function visibilityWhere(ns: RuntimeNamespace, alias = ""): {
+  sql: string;
+  params: Record<string, unknown>;
+} {
+  return runtimeVisibilityWhere(ns, alias);
+}
+
+export function normalizeShareForStorage(scope: unknown): string {
+  return normalizeShareScope(scope);
 }
 
 export function rowOr<T>(row: RawRow | undefined, map: (r: RawRow) => T): T | null {

--- a/apps/memos-local-plugin/core/storage/repos/candidate_pool.ts
+++ b/apps/memos-local-plugin/core/storage/repos/candidate_pool.ts
@@ -1,10 +1,13 @@
 import type { CandidatePoolRow, PolicyId } from "../../types.js";
 import type { PageOptions, StorageDb } from "../types.js";
 import { buildInsert, buildUpdate } from "../tx.js";
-import { buildPageClauses, fromJsonText, toJsonText } from "./_helpers.js";
+import { buildPageClauses, fromJsonText, ownerFieldsFromRaw, ownerParamsFromRow, toJsonText } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "policy_id",
   "evidence_trace_ids_json",
   "signature",
@@ -40,6 +43,7 @@ export function makeCandidatePoolRepo(db: StorageDb) {
     insert(row: CandidatePoolRow): void {
       insert.run({
         id: row.id,
+        ...ownerParamsFromRow(row),
         policy_id: row.policyId,
         evidence_trace_ids_json: toJsonText(row.evidenceTraceIds),
         signature: row.signature,
@@ -98,6 +102,9 @@ export function makeCandidatePoolRepo(db: StorageDb) {
 
 interface RawCandidateRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   policy_id: string | null;
   evidence_trace_ids_json: string;
   signature: string;
@@ -108,6 +115,7 @@ interface RawCandidateRow {
 function mapRow(r: RawCandidateRow): CandidatePoolRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     policyId: r.policy_id,
     evidenceTraceIds: fromJsonText(r.evidence_trace_ids_json, []),
     signature: r.signature,

--- a/apps/memos-local-plugin/core/storage/repos/decision_repairs.ts
+++ b/apps/memos-local-plugin/core/storage/repos/decision_repairs.ts
@@ -5,11 +5,16 @@ import {
   buildPageClauses,
   fromJsonText,
   joinWhere,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   toJsonText,
 } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "ts",
   "context_hash",
   "preference",
@@ -35,6 +40,7 @@ export function makeDecisionRepairsRepo(db: StorageDb) {
     insert(row: DecisionRepairRow): void {
       insert.run({
         id: row.id,
+        ...ownerParamsFromRow(row),
         ts: row.ts,
         context_hash: row.contextHash,
         preference: row.preference,
@@ -69,6 +75,9 @@ export function makeDecisionRepairsRepo(db: StorageDb) {
 
 interface RawRepairRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   ts: number;
   context_hash: string;
   preference: string;
@@ -81,6 +90,7 @@ interface RawRepairRow {
 function mapRow(r: RawRepairRow): DecisionRepairRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     ts: r.ts,
     contextHash: r.context_hash,
     preference: r.preference,

--- a/apps/memos-local-plugin/core/storage/repos/episodes.ts
+++ b/apps/memos-local-plugin/core/storage/repos/episodes.ts
@@ -5,6 +5,9 @@ import {
   buildPageClauses,
   fromJsonText,
   joinWhere,
+  normalizeShareForStorage,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   timeRangeWhere,
   toJsonText,
 } from "./_helpers.js";
@@ -12,6 +15,10 @@ import {
 const COLUMNS = [
   "id",
   "session_id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
+  "share_scope",
   "started_at",
   "ended_at",
   "trace_ids_json",
@@ -47,6 +54,8 @@ export function makeEpisodesRepo(db: StorageDb) {
       insert.run({
         id: row.id,
         session_id: row.sessionId,
+        ...ownerParamsFromRow(row),
+        share_scope: normalizeShareForStorage(row.share?.scope),
         started_at: row.startedAt,
         ended_at: row.endedAt ?? null,
         trace_ids_json: toJsonText(row.traceIds),
@@ -60,6 +69,8 @@ export function makeEpisodesRepo(db: StorageDb) {
       replace.run({
         id: row.id,
         session_id: row.sessionId,
+        ...ownerParamsFromRow(row),
+        share_scope: normalizeShareForStorage(row.share?.scope),
         started_at: row.startedAt,
         ended_at: row.endedAt ?? null,
         trace_ids_json: toJsonText(row.traceIds),
@@ -164,6 +175,10 @@ export function makeEpisodesRepo(db: StorageDb) {
 interface RawEpisodeRow {
   id: string;
   session_id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
+  share_scope: string;
   started_at: number;
   ended_at: number | null;
   trace_ids_json: string;
@@ -176,6 +191,8 @@ function mapRow(r: RawEpisodeRow): EpisodeRow & EpisodeMetaRow {
   return {
     id: r.id,
     sessionId: r.session_id,
+    ...ownerFieldsFromRaw(r),
+    share: { scope: normalizeShareForStorage(r.share_scope) as "private" | "local" | "public" | "hub" },
     startedAt: r.started_at,
     endedAt: r.ended_at,
     traceIds: fromJsonText<string[]>(r.trace_ids_json, []),

--- a/apps/memos-local-plugin/core/storage/repos/feedback.ts
+++ b/apps/memos-local-plugin/core/storage/repos/feedback.ts
@@ -5,12 +5,17 @@ import {
   buildPageClauses,
   fromJsonText,
   joinWhere,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   timeRangeWhere,
   toJsonText,
 } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "ts",
   "episode_id",
   "trace_id",
@@ -37,6 +42,7 @@ export function makeFeedbackRepo(db: StorageDb) {
     insert(row: FeedbackRow): void {
       insert.run({
         id: row.id,
+        ...ownerParamsFromRow(row),
         ts: row.ts,
         episode_id: row.episodeId ?? null,
         trace_id: row.traceId ?? null,
@@ -88,6 +94,9 @@ export function makeFeedbackRepo(db: StorageDb) {
 
 interface RawFeedbackRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   ts: number;
   episode_id: string | null;
   trace_id: string | null;
@@ -101,6 +110,7 @@ interface RawFeedbackRow {
 function mapRow(r: RawFeedbackRow): FeedbackRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     ts: r.ts,
     episodeId: r.episode_id,
     traceId: r.trace_id,

--- a/apps/memos-local-plugin/core/storage/repos/policies.ts
+++ b/apps/memos-local-plugin/core/storage/repos/policies.ts
@@ -7,6 +7,9 @@ import {
   fromBlob,
   fromJsonText,
   joinWhere,
+  normalizeShareForStorage,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   timeRangeWhere,
   toBlob,
   toJsonText,
@@ -14,6 +17,9 @@ import {
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "title",
   "trigger",
   "procedure",
@@ -39,6 +45,9 @@ export interface PolicySearchMeta {
   status: "candidate" | "active" | "archived";
   support: number;
   gain: number;
+  owner_agent_kind?: string;
+  owner_profile_id?: string;
+  owner_workspace_id?: string | null;
 }
 
 export function makePoliciesRepo(db: StorageDb) {
@@ -144,7 +153,7 @@ export function makePoliciesRepo(db: StorageDb) {
       return scanAndTopK<PolicySearchMeta>(
         db,
         "policies",
-        ["title", "status", "support", "gain"],
+        ["title", "status", "support", "gain", "owner_agent_kind", "owner_profile_id", "owner_workspace_id"],
         query,
         k,
         {
@@ -167,7 +176,7 @@ export function makePoliciesRepo(db: StorageDb) {
     updateShare(
       id: PolicyId,
       share: {
-        scope: "private" | "public" | "hub" | null;
+        scope: "private" | "local" | "public" | "hub" | null;
         target?: string | null;
         sharedAt?: number | null;
       },
@@ -181,7 +190,7 @@ export function makePoliciesRepo(db: StorageDb) {
         `UPDATE policies SET share_scope=@share_scope, share_target=@share_target, shared_at=@shared_at WHERE id=@id`,
       ).run({
         id,
-        share_scope: share.scope,
+        share_scope: normalizeShareForStorage(share.scope),
         share_target: share.target ?? null,
         shared_at: share.sharedAt ?? null,
       });
@@ -243,6 +252,9 @@ export function makePoliciesRepo(db: StorageDb) {
 
 interface RawPolicyRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   title: string;
   trigger: string;
   procedure: string;
@@ -271,6 +283,7 @@ const EMPTY_GUIDANCE: PolicyRow["decisionGuidance"] = Object.freeze({
 function rowToParams(row: PolicyRow): Record<string, unknown> {
   return {
     id: row.id,
+    ...ownerParamsFromRow(row),
     title: row.title,
     trigger: row.trigger,
     procedure: row.procedure,
@@ -288,7 +301,7 @@ function rowToParams(row: PolicyRow): Record<string, unknown> {
     vec: toBlob(row.vec),
     created_at: row.createdAt,
     updated_at: row.updatedAt,
-    share_scope: row.share?.scope ?? null,
+    share_scope: normalizeShareForStorage(row.share?.scope),
     share_target: row.share?.target ?? null,
     shared_at: row.share?.sharedAt ?? null,
     edited_at: row.editedAt ?? null,
@@ -298,6 +311,7 @@ function rowToParams(row: PolicyRow): Record<string, unknown> {
 function mapRow(r: RawPolicyRow): PolicyRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     title: r.title,
     trigger: r.trigger,
     procedure: r.procedure,
@@ -315,7 +329,7 @@ function mapRow(r: RawPolicyRow): PolicyRow {
     share:
       r.share_scope != null
         ? {
-            scope: r.share_scope as "private" | "public" | "hub",
+            scope: normalizeShareForStorage(r.share_scope) as "private" | "local" | "public" | "hub",
             target: r.share_target,
             sharedAt: r.shared_at,
           }

--- a/apps/memos-local-plugin/core/storage/repos/sessions.ts
+++ b/apps/memos-local-plugin/core/storage/repos/sessions.ts
@@ -6,17 +6,29 @@
 import type { AgentKind, SessionId } from "../../types.js";
 import type { StorageDb } from "../types.js";
 import { buildInsert, buildUpdate } from "../tx.js";
-import { fromJsonText, toJsonText } from "./_helpers.js";
+import { fromJsonText, ownerFieldsFromRaw, ownerParamsFromRow, toJsonText } from "./_helpers.js";
 
 export interface SessionRow {
   id: SessionId;
   agent: AgentKind;
+  ownerAgentKind?: AgentKind;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
   startedAt: number;
   lastSeenAt: number;
   meta: Record<string, unknown>;
 }
 
-const COLUMNS = ["id", "agent", "started_at", "last_seen_at", "meta_json"];
+const COLUMNS = [
+  "id",
+  "agent",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
+  "started_at",
+  "last_seen_at",
+  "meta_json",
+];
 
 export function makeSessionsRepo(db: StorageDb) {
   const insert = db.prepare(
@@ -26,10 +38,10 @@ export function makeSessionsRepo(db: StorageDb) {
     buildUpdate({ table: "sessions", columns: ["id", "last_seen_at", "meta_json"] }),
   );
   const selectById = db.prepare<{ id: string }, RawSessionRow>(
-    `SELECT id, agent, started_at, last_seen_at, meta_json FROM sessions WHERE id=@id`,
+    `SELECT ${COLUMNS.join(", ")} FROM sessions WHERE id=@id`,
   );
   const selectRecent = db.prepare<{ limit: number }, RawSessionRow>(
-    `SELECT id, agent, started_at, last_seen_at, meta_json FROM sessions ORDER BY last_seen_at DESC LIMIT @limit`,
+    `SELECT ${COLUMNS.join(", ")} FROM sessions ORDER BY last_seen_at DESC LIMIT @limit`,
   );
   const deleteOlderThan = db.prepare<{ cutoff: number }>(
     `DELETE FROM sessions WHERE last_seen_at < @cutoff`,
@@ -40,6 +52,7 @@ export function makeSessionsRepo(db: StorageDb) {
       insert.run({
         id: row.id,
         agent: row.agent,
+        ...ownerParamsFromRow(row),
         started_at: row.startedAt,
         last_seen_at: row.lastSeenAt,
         meta_json: toJsonText(row.meta ?? {}),
@@ -76,6 +89,9 @@ export function makeSessionsRepo(db: StorageDb) {
 interface RawSessionRow {
   id: string;
   agent: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   started_at: number;
   last_seen_at: number;
   meta_json: string;
@@ -85,6 +101,7 @@ function mapRow(r: RawSessionRow): SessionRow {
   return {
     id: r.id,
     agent: r.agent,
+    ...ownerFieldsFromRaw(r),
     startedAt: r.started_at,
     lastSeenAt: r.last_seen_at,
     meta: fromJsonText<Record<string, unknown>>(r.meta_json, {}),

--- a/apps/memos-local-plugin/core/storage/repos/skill_trials.ts
+++ b/apps/memos-local-plugin/core/storage/repos/skill_trials.ts
@@ -1,10 +1,13 @@
 import type { EpisodeId, SkillId, SkillTrialRow } from "../../types.js";
 import type { StorageDb } from "../types.js";
 import { buildInsert } from "../tx.js";
-import { fromJsonText, toJsonText } from "./_helpers.js";
+import { fromJsonText, ownerFieldsFromRaw, ownerParamsFromRow, toJsonText } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "skill_id",
   "session_id",
   "episode_id",
@@ -83,6 +86,9 @@ export function makeSkillTrialsRepo(db: StorageDb) {
 
 interface RawSkillTrialRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   skill_id: string;
   session_id: string | null;
   episode_id: string;
@@ -98,6 +104,7 @@ interface RawSkillTrialRow {
 function rowToParams(row: SkillTrialRow): Record<string, unknown> {
   return {
     id: row.id,
+    ...ownerParamsFromRow(row),
     skill_id: row.skillId,
     session_id: row.sessionId,
     episode_id: row.episodeId,
@@ -114,6 +121,7 @@ function rowToParams(row: SkillTrialRow): Record<string, unknown> {
 function mapRow(row: RawSkillTrialRow): SkillTrialRow {
   return {
     id: row.id,
+    ...ownerFieldsFromRaw(row),
     skillId: row.skill_id as SkillId,
     sessionId: row.session_id,
     episodeId: row.episode_id as EpisodeId,

--- a/apps/memos-local-plugin/core/storage/repos/skills.ts
+++ b/apps/memos-local-plugin/core/storage/repos/skills.ts
@@ -7,12 +7,18 @@ import {
   fromBlob,
   fromJsonText,
   joinWhere,
+  normalizeShareForStorage,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   toBlob,
   toJsonText,
 } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "name",
   "status",
   "invocation_guide",
@@ -42,6 +48,9 @@ export interface SkillSearchMeta {
   status: SkillRow["status"];
   eta: number;
   gain: number;
+  owner_agent_kind?: string;
+  owner_profile_id?: string;
+  owner_workspace_id?: string | null;
 }
 
 export function makeSkillsRepo(db: StorageDb) {
@@ -165,7 +174,7 @@ export function makeSkillsRepo(db: StorageDb) {
       return scanAndTopK<SkillSearchMeta>(
         db,
         "skills",
-        ["name", "status", "eta", "gain"],
+        ["name", "status", "eta", "gain", "owner_agent_kind", "owner_profile_id", "owner_workspace_id"],
         query,
         k,
         {
@@ -207,19 +216,22 @@ export function makeSkillsRepo(db: StorageDb) {
                s.name AS name,
                s.status AS status,
                s.eta  AS eta,
-               s.gain AS gain
+               s.gain AS gain,
+               s.owner_agent_kind AS owner_agent_kind,
+               s.owner_profile_id AS owner_profile_id,
+               s.owner_workspace_id AS owner_workspace_id
           FROM skills_fts f
           JOIN skills      s ON s.id = f.skill_id
          WHERE skills_fts MATCH @match${extra}
          ORDER BY rank
          LIMIT @k`;
       const rows = db
-        .prepare<typeof params, { id: string; name: string; status: SkillRow["status"]; eta: number; gain: number }>(sql)
+        .prepare<typeof params, { id: string; name: string; status: SkillRow["status"]; eta: number; gain: number; owner_agent_kind: string; owner_profile_id: string; owner_workspace_id: string | null }>(sql)
         .all(params);
       return rows.map((r, idx) => ({
         id: r.id,
         score: 1 / (idx + 1),
-        meta: { name: r.name, status: r.status, eta: r.eta, gain: r.gain },
+        meta: { name: r.name, status: r.status, eta: r.eta, gain: r.gain, owner_agent_kind: r.owner_agent_kind, owner_profile_id: r.owner_profile_id, owner_workspace_id: r.owner_workspace_id },
       }));
     },
 
@@ -256,18 +268,18 @@ export function makeSkillsRepo(db: StorageDb) {
         });
       }
       const sql = `
-        SELECT id, name, status, eta, gain
+        SELECT id, name, status, eta, gain, owner_agent_kind, owner_profile_id, owner_workspace_id
           FROM skills
          WHERE ${whereParts.join(" AND ")}
          ORDER BY updated_at DESC
          LIMIT @k`;
       const rows = db
-        .prepare<typeof params, { id: string; name: string; status: SkillRow["status"]; eta: number; gain: number }>(sql)
+        .prepare<typeof params, { id: string; name: string; status: SkillRow["status"]; eta: number; gain: number; owner_agent_kind: string; owner_profile_id: string; owner_workspace_id: string | null }>(sql)
         .all(params);
       return rows.map((r, idx) => ({
         id: r.id,
         score: 1 / (idx + 1),
-        meta: { name: r.name, status: r.status, eta: r.eta, gain: r.gain },
+        meta: { name: r.name, status: r.status, eta: r.eta, gain: r.gain, owner_agent_kind: r.owner_agent_kind, owner_profile_id: r.owner_profile_id, owner_workspace_id: r.owner_workspace_id },
       }));
     },
 
@@ -282,7 +294,7 @@ export function makeSkillsRepo(db: StorageDb) {
     updateShare(
       id: SkillId,
       share: {
-        scope: "private" | "public" | "hub" | null;
+        scope: "private" | "local" | "public" | "hub" | null;
         target?: string | null;
         sharedAt?: number | null;
       },
@@ -296,7 +308,7 @@ export function makeSkillsRepo(db: StorageDb) {
         `UPDATE skills SET share_scope=@share_scope, share_target=@share_target, shared_at=@shared_at WHERE id=@id`,
       ).run({
         id,
-        share_scope: share.scope,
+        share_scope: normalizeShareForStorage(share.scope),
         share_target: share.target ?? null,
         shared_at: share.sharedAt ?? null,
       });
@@ -364,6 +376,9 @@ function trialEtaWithPrior(
 
 interface RawSkillRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   name: string;
   status: SkillRow["status"];
   invocation_guide: string;
@@ -391,6 +406,7 @@ interface RawSkillRow {
 function rowToParams(row: SkillRow): Record<string, unknown> {
   return {
     id: row.id,
+    ...ownerParamsFromRow(row),
     name: row.name,
     status: row.status,
     invocation_guide: row.invocationGuide,
@@ -406,7 +422,7 @@ function rowToParams(row: SkillRow): Record<string, unknown> {
     created_at: row.createdAt,
     updated_at: row.updatedAt,
     version: row.version ?? 1,
-    share_scope: row.share?.scope ?? null,
+    share_scope: normalizeShareForStorage(row.share?.scope),
     share_target: row.share?.target ?? null,
     shared_at: row.share?.sharedAt ?? null,
     edited_at: row.editedAt ?? null,
@@ -426,6 +442,7 @@ function clamp01(n: number): number {
 function mapRow(r: RawSkillRow): SkillRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     name: r.name,
     status: r.status,
     invocationGuide: r.invocation_guide,
@@ -445,7 +462,7 @@ function mapRow(r: RawSkillRow): SkillRow {
     share:
       r.share_scope != null
         ? {
-            scope: r.share_scope as "private" | "public" | "hub",
+            scope: normalizeShareForStorage(r.share_scope) as "private" | "local" | "public" | "hub",
             target: r.share_target,
             sharedAt: r.shared_at,
           }

--- a/apps/memos-local-plugin/core/storage/repos/traces.ts
+++ b/apps/memos-local-plugin/core/storage/repos/traces.ts
@@ -7,7 +7,10 @@ import {
   fromBlob,
   fromJsonText,
   joinWhere,
+  normalizeShareForStorage,
   nullable,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   timeRangeWhere,
   toBlob,
   toJsonText,
@@ -17,6 +20,9 @@ const COLUMNS = [
   "id",
   "episode_id",
   "session_id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "ts",
   "user_text",
   "agent_text",
@@ -45,6 +51,9 @@ export type TraceSearchMeta = {
   value: number;
   episode_id: EpisodeId;
   session_id: SessionId;
+  owner_agent_kind?: string;
+  owner_profile_id?: string;
+  owner_workspace_id?: string | null;
   tags_json?: string;
   error_signatures_json?: string;
 };
@@ -259,7 +268,17 @@ export function makeTracesRepo(db: StorageDb) {
       return scanAndTopK<TraceSearchMeta>(
         db,
         "traces",
-        ["ts", "priority", "value", "episode_id", "session_id", "tags_json"],
+        [
+          "ts",
+          "priority",
+          "value",
+          "episode_id",
+          "session_id",
+          "owner_agent_kind",
+          "owner_profile_id",
+          "owner_workspace_id",
+          "tags_json",
+        ],
         query,
         k,
         {
@@ -314,6 +333,9 @@ export function makeTracesRepo(db: StorageDb) {
                t.value       AS value,
                t.episode_id  AS episode_id,
                t.session_id  AS session_id,
+               t.owner_agent_kind AS owner_agent_kind,
+               t.owner_profile_id AS owner_profile_id,
+               t.owner_workspace_id AS owner_workspace_id,
                t.tags_json   AS tags_json,
                t.error_signatures_json AS error_signatures_json
           FROM traces_fts f
@@ -337,6 +359,9 @@ export function makeTracesRepo(db: StorageDb) {
           value: r.value,
           episode_id: r.episode_id as EpisodeId,
           session_id: r.session_id as SessionId,
+          owner_agent_kind: r.owner_agent_kind,
+          owner_profile_id: r.owner_profile_id,
+          owner_workspace_id: r.owner_workspace_id,
           tags_json: r.tags_json,
           error_signatures_json: r.error_signatures_json,
         },
@@ -383,6 +408,7 @@ export function makeTracesRepo(db: StorageDb) {
       const extra = opts.where ? ` AND (${opts.where})` : "";
       const sql = `
         SELECT id, ts, priority, value, episode_id, session_id, tags_json,
+               owner_agent_kind, owner_profile_id, owner_workspace_id,
                error_signatures_json
           FROM traces
          WHERE (${ors.join(" OR ")})${extra}
@@ -398,6 +424,9 @@ export function makeTracesRepo(db: StorageDb) {
           value: r.value,
           episode_id: r.episode_id as EpisodeId,
           session_id: r.session_id as SessionId,
+          owner_agent_kind: r.owner_agent_kind,
+          owner_profile_id: r.owner_profile_id,
+          owner_workspace_id: r.owner_workspace_id,
           tags_json: r.tags_json,
           error_signatures_json: r.error_signatures_json,
         },
@@ -532,7 +561,7 @@ export function makeTracesRepo(db: StorageDb) {
     updateShare(
       id: TraceId,
       share: {
-        scope: "private" | "public" | "hub" | null;
+        scope: "private" | "local" | "public" | "hub" | null;
         target?: string | null;
         sharedAt?: number | null;
       },
@@ -546,7 +575,7 @@ export function makeTracesRepo(db: StorageDb) {
         `UPDATE traces SET share_scope=@share_scope, share_target=@share_target, shared_at=@shared_at WHERE id=@id`,
       ).run({
         id,
-        share_scope: share.scope,
+        share_scope: normalizeShareForStorage(share.scope),
         share_target: share.target ?? null,
         shared_at: share.sharedAt ?? null,
       });
@@ -561,6 +590,9 @@ interface RawHit {
   value: number;
   episode_id: string;
   session_id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   tags_json: string;
   error_signatures_json: string;
 }
@@ -569,6 +601,9 @@ interface RawTraceRow {
   id: string;
   episode_id: string;
   session_id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   ts: number;
   user_text: string;
   agent_text: string;
@@ -619,6 +654,7 @@ function rowToParams(row: TraceRow): Record<string, unknown> {
     id: row.id,
     episode_id: row.episodeId,
     session_id: row.sessionId,
+    ...ownerParamsFromRow(row),
     ts: row.ts,
     user_text: row.userText,
     agent_text: row.agentText,
@@ -634,7 +670,7 @@ function rowToParams(row: TraceRow): Record<string, unknown> {
     error_signatures_json: toJsonText(normalizeSignatures(row.errorSignatures)),
     vec_summary: toBlob(row.vecSummary),
     vec_action: toBlob(row.vecAction),
-    share_scope: row.share?.scope ?? null,
+    share_scope: normalizeShareForStorage(row.share?.scope),
     share_target: row.share?.target ?? null,
     shared_at: row.share?.sharedAt ?? null,
     turn_id: row.turnId ?? null,
@@ -647,6 +683,7 @@ function mapRow(r: RawTraceRow): TraceRow {
     id: r.id,
     episodeId: r.episode_id,
     sessionId: r.session_id,
+    ...ownerFieldsFromRaw(r),
     ts: r.ts,
     userText: r.user_text,
     agentText: r.agent_text,
@@ -665,7 +702,7 @@ function mapRow(r: RawTraceRow): TraceRow {
     share:
       r.share_scope != null
         ? {
-            scope: r.share_scope as "private" | "public" | "hub",
+            scope: normalizeShareForStorage(r.share_scope) as "private" | "local" | "public" | "hub",
             target: r.share_target,
             sharedAt: r.shared_at,
           }

--- a/apps/memos-local-plugin/core/storage/repos/world_model.ts
+++ b/apps/memos-local-plugin/core/storage/repos/world_model.ts
@@ -11,12 +11,18 @@ import {
   buildPageClauses,
   fromBlob,
   fromJsonText,
+  normalizeShareForStorage,
+  ownerFieldsFromRaw,
+  ownerParamsFromRow,
   toBlob,
   toJsonText,
 } from "./_helpers.js";
 
 const COLUMNS = [
   "id",
+  "owner_agent_kind",
+  "owner_profile_id",
+  "owner_workspace_id",
   "title",
   "body",
   "policy_ids_json",
@@ -39,6 +45,9 @@ const COLUMNS = [
 
 export interface WorldSearchMeta {
   title: string;
+  owner_agent_kind?: string;
+  owner_profile_id?: string;
+  owner_workspace_id?: string | null;
 }
 
 export function makeWorldModelRepo(db: StorageDb) {
@@ -158,7 +167,7 @@ export function makeWorldModelRepo(db: StorageDb) {
       const where = opts.minConfidence !== undefined
         ? `vec IS NOT NULL AND confidence >= ${Number(opts.minConfidence)}`
         : "vec IS NOT NULL";
-      return scanAndTopK<WorldSearchMeta>(db, "world_model", ["title"], query, k, {
+      return scanAndTopK<WorldSearchMeta>(db, "world_model", ["title", "owner_agent_kind", "owner_profile_id", "owner_workspace_id"], query, k, {
         vecColumn: "vec",
         where,
         hardCap: opts.hardCap,
@@ -185,19 +194,22 @@ export function makeWorldModelRepo(db: StorageDb) {
           : "";
       const sql = `
         SELECT w.id    AS id,
-               w.title AS title
+               w.title AS title,
+               w.owner_agent_kind AS owner_agent_kind,
+               w.owner_profile_id AS owner_profile_id,
+               w.owner_workspace_id AS owner_workspace_id
           FROM world_model_fts f
           JOIN world_model     w ON w.id = f.world_id
          WHERE world_model_fts MATCH @match ${conf}
          ORDER BY rank
          LIMIT @k`;
       const rows = db
-        .prepare<typeof params, { id: string; title: string }>(sql)
+        .prepare<typeof params, { id: string; title: string; owner_agent_kind: string; owner_profile_id: string; owner_workspace_id: string | null }>(sql)
         .all(params);
       return rows.map((r, idx) => ({
         id: r.id,
         score: 1 / (idx + 1),
-        meta: { title: r.title },
+        meta: { title: r.title, owner_agent_kind: r.owner_agent_kind, owner_profile_id: r.owner_profile_id, owner_workspace_id: r.owner_workspace_id },
       }));
     },
 
@@ -230,18 +242,18 @@ export function makeWorldModelRepo(db: StorageDb) {
         whereParts.push(`confidence >= ${Number(opts.minConfidence)}`);
       }
       const sql = `
-        SELECT id, title
+        SELECT id, title, owner_agent_kind, owner_profile_id, owner_workspace_id
           FROM world_model
          WHERE ${whereParts.join(" AND ")}
          ORDER BY updated_at DESC
          LIMIT @k`;
       const rows = db
-        .prepare<typeof params, { id: string; title: string }>(sql)
+        .prepare<typeof params, { id: string; title: string; owner_agent_kind: string; owner_profile_id: string; owner_workspace_id: string | null }>(sql)
         .all(params);
       return rows.map((r, idx) => ({
         id: r.id,
         score: 1 / (idx + 1),
-        meta: { title: r.title },
+        meta: { title: r.title, owner_agent_kind: r.owner_agent_kind, owner_profile_id: r.owner_profile_id, owner_workspace_id: r.owner_workspace_id },
       }));
     },
 
@@ -280,7 +292,7 @@ export function makeWorldModelRepo(db: StorageDb) {
     updateShare(
       id: WorldModelId,
       share: {
-        scope: "private" | "public" | "hub" | null;
+        scope: "private" | "local" | "public" | "hub" | null;
         target?: string | null;
         sharedAt?: number | null;
       },
@@ -294,7 +306,7 @@ export function makeWorldModelRepo(db: StorageDb) {
         `UPDATE world_model SET share_scope=@share_scope, share_target=@share_target, shared_at=@shared_at WHERE id=@id`,
       ).run({
         id,
-        share_scope: share.scope,
+        share_scope: normalizeShareForStorage(share.scope),
         share_target: share.target ?? null,
         shared_at: share.sharedAt ?? null,
       });
@@ -338,6 +350,9 @@ export function makeWorldModelRepo(db: StorageDb) {
 
 interface RawWorldRow {
   id: string;
+  owner_agent_kind: string;
+  owner_profile_id: string;
+  owner_workspace_id: string | null;
   title: string;
   body: string;
   policy_ids_json: string;
@@ -367,6 +382,7 @@ const EMPTY_STRUCTURE: WorldModelStructure = {
 function rowToParams(row: WorldModelRow): Record<string, unknown> {
   return {
     id: row.id,
+    ...ownerParamsFromRow(row),
     title: row.title,
     body: row.body,
     policy_ids_json: toJsonText(row.policyIds),
@@ -381,7 +397,7 @@ function rowToParams(row: WorldModelRow): Record<string, unknown> {
     induced_by: row.inducedBy ?? "",
     status: row.status ?? "active",
     archived_at: row.archivedAt ?? null,
-    share_scope: row.share?.scope ?? null,
+    share_scope: normalizeShareForStorage(row.share?.scope),
     share_target: row.share?.target ?? null,
     shared_at: row.share?.sharedAt ?? null,
     edited_at: row.editedAt ?? null,
@@ -391,6 +407,7 @@ function rowToParams(row: WorldModelRow): Record<string, unknown> {
 function mapRow(r: RawWorldRow): WorldModelRow {
   return {
     id: r.id,
+    ...ownerFieldsFromRaw(r),
     title: r.title,
     body: r.body,
     policyIds: fromJsonText(r.policy_ids_json, []),
@@ -408,7 +425,7 @@ function mapRow(r: RawWorldRow): WorldModelRow {
     share:
       r.share_scope != null
         ? {
-            scope: r.share_scope as "private" | "public" | "hub",
+            scope: normalizeShareForStorage(r.share_scope) as "private" | "local" | "public" | "hub",
             target: r.share_target,
             sharedAt: r.shared_at,
           }

--- a/apps/memos-local-plugin/core/types.ts
+++ b/apps/memos-local-plugin/core/types.ts
@@ -20,6 +20,7 @@ import type {
   TraceId,
   ValueScore,
   WorldModelId,
+  ShareScope,
 } from "../agent-contract/dto.js";
 
 // ─── Re-exports for convenience ──────────────────────────────────────────────
@@ -40,7 +41,15 @@ export type {
   TraceId,
   ValueScore,
   WorldModelId,
+  RuntimeNamespace,
+  ShareScope,
 } from "../agent-contract/dto.js";
+
+export interface OwnedRow {
+  ownerAgentKind?: string;
+  ownerProfileId?: string;
+  ownerWorkspaceId?: string | null;
+}
 
 // ─── Embeddings ──────────────────────────────────────────────────────────────
 
@@ -55,7 +64,7 @@ export interface Embedded<T> {
 
 // ─── Memory rows (storage-shaped, before being serialized to DTO) ────────────
 
-export interface TraceRow {
+export interface TraceRow extends OwnedRow {
   id: TraceId;
   episodeId: EpisodeId;
   sessionId: SessionId;
@@ -76,7 +85,7 @@ export interface TraceRow {
    * can annotate rows and make the Hub sync round-trippable.
    */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -134,7 +143,7 @@ export interface TraceRow {
   schemaVersion: number;
 }
 
-export interface PolicyRow {
+export interface PolicyRow extends OwnedRow {
   id: PolicyId;
   title: string;
   trigger: string;
@@ -161,7 +170,7 @@ export interface PolicyRow {
   updatedAt: EpochMs;
   /** Sharing state (migration 009). Mirrors `TraceRow.share`. */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -191,7 +200,7 @@ export interface WorldModelStructureEntry {
   evidenceIds?: string[];
 }
 
-export interface WorldModelRow {
+export interface WorldModelRow extends OwnedRow {
   id: WorldModelId;
   title: string;
   /** Rendered markdown summary, used by prompts + viewer + embedding. */
@@ -222,7 +231,7 @@ export interface WorldModelRow {
   archivedAt?: EpochMs | null;
   /** Sharing state (migration 009). */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -230,7 +239,7 @@ export interface WorldModelRow {
   editedAt?: EpochMs | null;
 }
 
-export interface SkillRow {
+export interface SkillRow extends OwnedRow {
   id: SkillId;
   name: string;
   status: "candidate" | "active" | "archived";
@@ -263,7 +272,7 @@ export interface SkillRow {
   version: number;
   /** Sharing state (migration 009). */
   share?: {
-    scope: "private" | "public" | "hub";
+    scope: ShareScope;
     target?: string | null;
     sharedAt?: EpochMs | null;
   } | null;
@@ -275,7 +284,7 @@ export interface SkillRow {
   lastUsedAt?: EpochMs | null;
 }
 
-export interface SkillTrialRow {
+export interface SkillTrialRow extends OwnedRow {
   id: string;
   skillId: SkillId;
   sessionId: SessionId | null;
@@ -289,9 +298,14 @@ export interface SkillTrialRow {
   evidence: Record<string, unknown>;
 }
 
-export interface EpisodeRow {
+export interface EpisodeRow extends OwnedRow {
   id: EpisodeId;
   sessionId: SessionId;
+  share?: {
+    scope: ShareScope;
+    target?: string | null;
+    sharedAt?: EpochMs | null;
+  } | null;
   startedAt: EpochMs;
   endedAt: EpochMs | null;
   traceIds: TraceId[];
@@ -300,7 +314,7 @@ export interface EpisodeRow {
   status: "open" | "closed";
 }
 
-export interface FeedbackRow {
+export interface FeedbackRow extends OwnedRow {
   id: FeedbackId;
   ts: EpochMs;
   episodeId: EpisodeId | null;
@@ -312,7 +326,7 @@ export interface FeedbackRow {
   raw: unknown;
 }
 
-export interface CandidatePoolRow {
+export interface CandidatePoolRow extends OwnedRow {
   id: string;
   policyId: PolicyId | null;        // null until promoted
   evidenceTraceIds: TraceId[];
@@ -321,7 +335,7 @@ export interface CandidatePoolRow {
   expiresAt: EpochMs;
 }
 
-export interface DecisionRepairRow {
+export interface DecisionRepairRow extends OwnedRow {
   id: string;
   ts: EpochMs;
   contextHash: string;

--- a/apps/memos-local-plugin/server/routes/diag.ts
+++ b/apps/memos-local-plugin/server/routes/diag.ts
@@ -55,6 +55,31 @@ export function registerDiagRoutes(routes: Routes, deps: ServerDeps): void {
     };
   });
 
+  routes.set("GET /api/v1/diag/namespace", async () => {
+    const health = await deps.core.health();
+    const [traces, episodes, policies, worldModels, skills] = await Promise.all([
+      deps.core.listTraces({ limit: 200, offset: 0 }),
+      deps.core.listEpisodeRows({ limit: 200, offset: 0 }),
+      deps.core.listPolicies({ limit: 200, offset: 0 }),
+      deps.core.listWorldModels({ limit: 200, offset: 0 }),
+      deps.core.listSkills({ limit: 200 }),
+    ]);
+    const namespaces = new Map<string, { agentKind: string; profileId: string; count: number }>();
+    for (const row of [...traces, ...episodes, ...policies, ...worldModels, ...skills]) {
+      const agentKind = row.ownerAgentKind ?? "unknown";
+      const profileId = row.ownerProfileId ?? "default";
+      const key = `${agentKind}/${profileId}`;
+      const current = namespaces.get(key) ?? { agentKind, profileId, count: 0 };
+      current.count++;
+      namespaces.set(key, current);
+    }
+    return {
+      current: health.namespace ?? { agentKind: health.agent, profileId: "default" },
+      db: health.paths.db,
+      namespaces: [...namespaces.values()].sort((a, b) => b.count - a.count),
+    };
+  });
+
   routes.set("POST /api/v1/diag/simulate-turn", async (ctx) => {
     // Safety lock: accept only when explicitly opted-in with
     // `?allow=1`. Without this header the endpoint returns 403 — we

--- a/apps/memos-local-plugin/server/routes/policies.ts
+++ b/apps/memos-local-plugin/server/routes/policies.ts
@@ -152,7 +152,7 @@ export function registerPoliciesRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const body = parseJson<{
-      scope?: "private" | "public" | "hub" | null;
+      scope?: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
     }>(ctx);
     const scope = body.scope === undefined ? "public" : body.scope;
@@ -373,7 +373,7 @@ export function registerPoliciesRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const body = parseJson<{
-      scope?: "private" | "public" | "hub" | null;
+      scope?: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
     }>(ctx);
     const scope = body.scope === undefined ? "public" : body.scope;

--- a/apps/memos-local-plugin/server/routes/skill.ts
+++ b/apps/memos-local-plugin/server/routes/skill.ts
@@ -227,7 +227,7 @@ export function registerSkillRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const body = parseJson<{
-      scope?: "private" | "public" | "hub" | null;
+      scope?: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
     }>(ctx);
     const scope = body.scope === undefined ? "public" : body.scope;

--- a/apps/memos-local-plugin/server/routes/trace.ts
+++ b/apps/memos-local-plugin/server/routes/trace.ts
@@ -147,7 +147,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       return;
     }
     const body = parseJson<{
-      scope?: "private" | "public" | "hub" | null;
+      scope?: "private" | "local" | "public" | "hub" | null;
       target?: string | null;
     }>(ctx);
     const scope = body.scope === undefined ? "public" : body.scope;

--- a/apps/memos-local-plugin/tests/unit/adapters/hermes-persistence.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/hermes-persistence.test.ts
@@ -124,6 +124,7 @@ function buildCore(root: string, version: string): {
     reflectLlm: null,
     embedder: semanticFakeEmbedder(config.embedding.dimensions),
     log: rootLogger.child({ channel: "test.adapters.hermes.persistence" }),
+    namespace: { agentKind: "hermes", profileId: "default" },
     now: () => 1_700_000_000_000,
   };
   const pipeline = createPipeline(deps);

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
@@ -59,6 +59,7 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     reflectLlm: null,
     embedder: fakeEmbedder({ dimensions: DEFAULT_CONFIG.embedding.dimensions }),
     log: rootLogger.child({ channel: "test.adapters.openclaw" }),
+    namespace: { agentKind: "openclaw", profileId: "main" },
     now: () => 1_700_000_000_000,
   };
 }

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-e2e.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-e2e.test.ts
@@ -143,6 +143,7 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     reflectLlm: null,
     embedder: semanticFakeEmbedder(DEFAULT_CONFIG.embedding.dimensions),
     log: rootLogger.child({ channel: "test.adapters.openclaw.e2e" }),
+    namespace: { agentKind: "openclaw", profileId: "main" },
     now: () => 1_700_000_000_000,
   };
 }

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -40,6 +40,7 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     reflectLlm: null,
     embedder: fakeEmbedder({ dimensions: DEFAULT_CONFIG.embedding.dimensions }),
     log: rootLogger.child({ channel: "test.memory-core" }),
+    namespace: { agentKind: "openclaw", profileId: "main" },
     now: () => 1_700_000_000_000,
   };
 }
@@ -127,6 +128,51 @@ describe("MemoryCore façade", () => {
     expect(res.tierLatencyMs).toBeDefined();
     expect(typeof res.injectedContext).toBe("string");
     expect(res.query.query).toBe("how do I build this project?");
+  });
+
+  it("isolates private traces by namespace and exposes local shared traces", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+
+    const mainNs = { agentKind: "openclaw", profileId: "main" };
+    const reviewerNs = { agentKind: "openclaw", profileId: "reviewer" };
+
+    const start = await core.onTurnStart({
+      agent: "openclaw",
+      namespace: mainNs,
+      sessionId: "s-main",
+      userText: "remember namespace private trace",
+      ts: 1_700_000_000_001,
+    });
+    await core.onTurnEnd({
+      agent: "openclaw",
+      namespace: mainNs,
+      sessionId: "s-main",
+      episodeId: start.query.episodeId!,
+      agentText: "stored only for main",
+      toolCalls: [],
+      ts: 1_700_000_000_002,
+    });
+
+    const ownerRows = await core.listTraces({ limit: 10 });
+    expect(ownerRows).toHaveLength(1);
+    expect(ownerRows[0]?.ownerProfileId).toBe("main");
+
+    await core.openSession({ agent: "openclaw", sessionId: "s-reviewer", namespace: reviewerNs });
+    expect(await core.listTraces({ limit: 10 })).toHaveLength(0);
+
+    await core.openSession({ agent: "openclaw", sessionId: "s-main", namespace: mainNs });
+    await core.shareTrace(ownerRows[0]!.id, { scope: "local" });
+
+    await core.openSession({ agent: "openclaw", sessionId: "s-reviewer", namespace: reviewerNs });
+    const sharedRows = await core.listTraces({ limit: 10 });
+    expect(sharedRows).toHaveLength(1);
+    expect(sharedRows[0]?.share?.scope).toBe("local");
   });
 
   it("records visible subagent task and result in the parent episode", async () => {

--- a/apps/memos-local-plugin/tests/unit/pipeline/orchestrator.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/orchestrator.test.ts
@@ -35,6 +35,7 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     reflectLlm: null,
     embedder: fakeEmbedder({ dimensions: DEFAULT_CONFIG.embedding.dimensions }),
     log: rootLogger.child({ channel: "test.pipeline" }),
+    namespace: { agentKind: "openclaw", profileId: "main" },
     now: () => 1_700_000_000_000,
   };
 }

--- a/apps/memos-local-plugin/web/src/utils/share.ts
+++ b/apps/memos-local-plugin/web/src/utils/share.ts
@@ -1,7 +1,7 @@
 import { signal } from "@preact/signals";
 import { api } from "../api/client";
 
-export type ShareScope = "private" | "public" | "hub";
+export type ShareScope = "private" | "local" | "public" | "hub";
 
 interface SharingConfig {
   hub?: {

--- a/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/MemoriesView.tsx
@@ -88,7 +88,7 @@ interface MemoryGroup {
   aggValue: number;
   aggAlpha: number;
   hasReflection: boolean;
-  scope: "private" | "public" | "hub";
+  scope: "private" | "local" | "public" | "hub";
   shared: boolean;
 }
 
@@ -385,7 +385,7 @@ export function MemoriesView() {
    */
   const applyShareGroup = async (
     g: MemoryGroup,
-    scope: "private" | "public" | "hub" | null,
+    scope: "private" | "local" | "public" | "hub" | null,
   ) => {
     try {
       const updates = await Promise.all(
@@ -896,7 +896,7 @@ function buildGroups(traces: readonly TraceDTO[]): MemoryGroup[] {
     const ids = bucket.map((t) => t.id);
     const sumV = bucket.reduce((acc, t) => acc + (t.value ?? 0), 0);
     const sumA = bucket.reduce((acc, t) => acc + (t.alpha ?? 0), 0);
-    const scope: "private" | "public" | "hub" = head.share?.scope ?? "private";
+    const scope: "private" | "local" | "public" | "hub" = head.share?.scope ?? "private";
     return {
       turnKey: key,
       episodeId: head.episodeId ?? null,
@@ -1028,7 +1028,7 @@ function TraceDrawer({
       tags?: string[];
     },
   ) => Promise<void> | void;
-  onShare: (scope: "private" | "public" | "hub" | null) => Promise<void> | void;
+  onShare: (scope: "private" | "local" | "public" | "hub" | null) => Promise<void> | void;
   onDelete: () => Promise<void> | void;
 }) {
   const head = group.head;
@@ -1037,7 +1037,7 @@ function TraceDrawer({
   const [userText, setUserText] = useState(head.userText ?? "");
   const [agentText, setAgentText] = useState(head.agentText ?? "");
   const [tags, setTags] = useState((head.tags ?? []).join(", "));
-  const [scope, setScope] = useState<"private" | "public" | "hub">(
+  const [scope, setScope] = useState<"private" | "local" | "public" | "hub">(
     head.share?.scope ?? "public",
   );
 
@@ -1064,7 +1064,7 @@ function TraceDrawer({
     setMode("view");
   };
 
-  const submitShare = (s: "private" | "public" | "hub" | null) => {
+  const submitShare = (s: "private" | "local" | "public" | "hub" | null) => {
     void onShare(s);
     setMode("view");
   };
@@ -1209,7 +1209,7 @@ function TraceDrawer({
               <div class="modal__field">
                 <label>{t("memories.share.scope")}</label>
                 <div class="vstack" style="gap:var(--sp-2)">
-                  {(["private", "public", "hub"] as const).map((v) => (
+                  {(["private", "local", "public", "hub"] as const).map((v) => (
                     <label
                       key={v}
                       class="hstack"

--- a/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
+++ b/apps/memos-local-plugin/web/src/views/PoliciesView.tsx
@@ -392,7 +392,7 @@ function PolicyDrawer({
   const [procedure, setProcedure] = useState(policy.procedure);
   const [verification, setVerification] = useState(policy.verification);
   const [boundary, setBoundary] = useState(policy.boundary);
-  const [scope, setScope] = useState<"private" | "public" | "hub">(
+  const [scope, setScope] = useState<"private" | "local" | "public" | "hub">(
     policy.share?.scope ?? "public",
   );
   const [busy, setBusy] = useState(false);
@@ -426,7 +426,7 @@ function PolicyDrawer({
     }
   };
 
-  const submitShare = async (s: "private" | "public" | "hub" | null) => {
+  const submitShare = async (s: "private" | "local" | "public" | "hub" | null) => {
     setBusy(true);
     try {
       const updated = await api.post<PolicyDTO>(
@@ -638,7 +638,7 @@ function PolicyDrawer({
               <div class="modal__field">
                 <label>{t("memories.share.scope")}</label>
                 <div class="vstack" style="gap:var(--sp-2)">
-                  {(["private", "public", "hub"] as const).map((v) => (
+                  {(["private", "local", "public", "hub"] as const).map((v) => (
                     <label
                       key={v}
                       class="hstack"

--- a/apps/memos-local-plugin/web/src/views/SkillsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/SkillsView.tsx
@@ -471,7 +471,7 @@ function SkillDrawer({
   const [mode, setMode] = useState<"view" | "edit" | "share">("view");
   const [name, setName] = useState(skill.name);
   const [guide, setGuide] = useState(skill.invocationGuide ?? "");
-  const [scope, setScope] = useState<"private" | "public" | "hub">(
+  const [scope, setScope] = useState<"private" | "local" | "public" | "hub">(
     skill.share?.scope ?? "public",
   );
   const [busy, setBusy] = useState(false);
@@ -555,7 +555,7 @@ function SkillDrawer({
     }
   };
 
-  const submitShare = async (s: "private" | "public" | "hub" | null) => {
+  const submitShare = async (s: "private" | "local" | "public" | "hub" | null) => {
     setBusy(true);
     try {
       await api.post(`/api/v1/skills/${encodeURIComponent(skill.id)}/share`, {
@@ -859,7 +859,7 @@ function SkillDrawer({
               <div class="modal__field">
                 <label>{t("memories.share.scope")}</label>
                 <div class="vstack" style="gap:var(--sp-2)">
-                  {(["private", "public", "hub"] as const).map((v) => (
+                  {(["private", "local", "public", "hub"] as const).map((v) => (
                     <label
                       key={v}
                       class="hstack"

--- a/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
+++ b/apps/memos-local-plugin/web/src/views/WorldModelsView.tsx
@@ -333,7 +333,7 @@ function WorldModelDrawer({
   const [mode, setMode] = useState<"view" | "edit" | "share">("view");
   const [title, setTitle] = useState(worldModel.title);
   const [body, setBody] = useState(worldModel.body ?? "");
-  const [scope, setScope] = useState<"private" | "public" | "hub">(
+  const [scope, setScope] = useState<"private" | "local" | "public" | "hub">(
     worldModel.share?.scope ?? "public",
   );
   const [busy, setBusy] = useState(false);
@@ -395,7 +395,7 @@ function WorldModelDrawer({
     }
   };
 
-  const submitShare = async (s: "private" | "public" | "hub" | null) => {
+  const submitShare = async (s: "private" | "local" | "public" | "hub" | null) => {
     setBusy(true);
     try {
       await api.post(
@@ -543,7 +543,7 @@ function WorldModelDrawer({
               <div class="modal__field">
                 <label>{t("memories.share.scope")}</label>
                 <div class="vstack" style="gap:var(--sp-2)">
-                  {(["private", "public", "hub"] as const).map((v) => (
+                  {(["private", "local", "public", "hub"] as const).map((v) => (
                     <label
                       key={v}
                       class="hstack"


### PR DESCRIPTION
## Summary
- Add namespace ownership fields for Hermes profiles and OpenClaw agents across MemOS memory rows.
- Thread runtime namespace context through Hermes/OpenClaw adapters, retrieval, tools, and viewer APIs.
- Enforce private-vs-shared visibility while preserving local/public/hub sharing flows.

## Test plan
- npm run lint
- npx vitest run tests/unit/pipeline/memory-core.test.ts tests/unit/storage/migrator.test.ts tests/unit/bridge/methods.test.ts tests/unit/adapters/hermes-protocol.test.ts tests/unit/adapters/openclaw-bridge.test.ts tests/unit/adapters/hermes-persistence.test.ts
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check apps/memos-local-plugin/adapters/hermes/memos_provider
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format --check apps/memos-local-plugin/adapters/hermes/memos_provider

Note: full npm run test:unit still has unrelated existing failures in reward.integration, reward.subscriber, and memory/l3/cluster.