### PR TITLE
fix: package memos plugin runtime assets

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
+++ b/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
@@ -39,12 +39,10 @@ else
   warn "npm not found on PATH; bridge.cts requires Node.js ≥ 20."
 fi
 
-# ── 2. viewer + site bundles ──────────────────────────────────────────────────
+# ── 2. viewer bundle ──────────────────────────────────────────────────────────
 if [[ -x "./node_modules/.bin/vite" ]]; then
   log "Building viewer bundle → web/dist/"
   ./node_modules/.bin/vite build --config vite.config.ts >/dev/null
-  log "Building site bundle → site/dist/"
-  ( cd site && ../node_modules/.bin/vite build >/dev/null )
 else
   warn "vite not found in node_modules; skipping bundle build"
 fi

--- a/apps/memos-local-plugin/adapters/openclaw/index.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/index.ts
@@ -23,6 +23,7 @@
  *   - We import **types only** from `./openclaw-api.ts`; the real SDK is
  *     injected by the host at load time.
  */
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,7 +44,7 @@ import type { ServerHandle } from "../../server/types.js";
 // ─── Plugin metadata ───────────────────────────────────────────────────────
 
 export const PLUGIN_ID = "memos-local-plugin";
-export const PLUGIN_VERSION = "2.0.0-beta.1";
+export const PLUGIN_VERSION = "2.0.0-beta.5";
 
 // ─── Runtime state (per plugin load) ───────────────────────────────────────
 
@@ -62,15 +63,16 @@ interface PluginRuntime {
 
 /** Locate the bundled viewer static assets relative to the plugin root. */
 function resolveViewerStaticRoot(): string | undefined {
-  // When the plugin ships as an npm tarball the built viewer sits at
-  // `<plugin>/web/dist/` (included via `package.json::files`). During local
-  // development `web/dist` is only present after `npm run build:web`.
-  // Either way we resolve relative to this file's directory.
+  // Built packages load from `<plugin>/dist/adapters`; source tests load
+  // from `<plugin>/adapters`. The viewer bundle remains at `web/dist`.
   try {
     const thisFile = fileURLToPath(import.meta.url);
     const adapterDir = path.dirname(thisFile); // .../adapters/openclaw
-    const candidate = path.resolve(adapterDir, "..", "..", "web", "dist");
-    return candidate;
+    const candidates = [
+      path.resolve(adapterDir, "..", "..", "..", "web", "dist"),
+      path.resolve(adapterDir, "..", "..", "web", "dist"),
+    ];
+    return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
   } catch {
     return undefined;
   }

--- a/apps/memos-local-plugin/adapters/openclaw/install.openclaw.sh
+++ b/apps/memos-local-plugin/adapters/openclaw/install.openclaw.sh
@@ -35,12 +35,10 @@ else
   warn "npm not found on PATH; skipping dependency install. The plugin will not run until you provide node_modules."
 fi
 
-# ── 2. viewer + site bundles ──────────────────────────────────────────────────
+# ── 2. viewer bundle ──────────────────────────────────────────────────────────
 if [[ -x "./node_modules/.bin/vite" ]]; then
   log "Building viewer bundle → web/dist/"
   ./node_modules/.bin/vite build --config vite.config.ts >/dev/null
-  log "Building site bundle → site/dist/"
-  ( cd site && ../node_modules/.bin/vite build >/dev/null )
 else
   warn "vite not found in node_modules; skipping bundle build"
 fi
@@ -49,4 +47,3 @@ log "OpenClaw adapter install complete."
 log "  Plugin code:   $PREFIX"
 log "  Runtime data:  $HOME_DIR"
 log "  Viewer:        http://127.0.0.1:18910/"
-log "  Site:          http://127.0.0.1:18910/site/"

--- a/apps/memos-local-plugin/core/storage/migrator.ts
+++ b/apps/memos-local-plugin/core/storage/migrator.ts
@@ -43,7 +43,13 @@ export interface MigrationsResult {
  */
 export function defaultMigrationsDir(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  return path.join(here, "migrations");
+  const compiled = path.join(here, "migrations");
+  if (fs.existsSync(compiled)) return compiled;
+
+  // Local package installs keep source files for debugging; this fallback
+  // makes compiled code resilient if runtime assets were not copied.
+  const source = path.resolve(here, "..", "..", "..", "core", "storage", "migrations");
+  return fs.existsSync(source) ? source : compiled;
 }
 
 export function discoverMigrations(dir: string): MigrationFile[] {

--- a/apps/memos-local-plugin/install.ps1
+++ b/apps/memos-local-plugin/install.ps1
@@ -59,10 +59,10 @@ if ($Uninstall) {
   exit 0
 }
 
-# 1. deploy source
+# 1. deploy package contents
 Write-Info "Deploying plugin code -> $Prefix"
 New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
-$exclude = @("node_modules","dist","web\dist","site\dist","tests",".git")
+$exclude = @("node_modules","tests",".git")
 robocopy $ScriptDir $Prefix /MIR /XD $exclude | Out-Null
 
 # 2. runtime dirs

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -86,6 +86,7 @@ NPM_PACKAGE="@memtensor/memos-local-plugin"
 OPENCLAW_PORT="18799"
 HERMES_PORT="18800"
 REQUIRED_NODE_MAJOR=20
+OPENCLAW_RUNTIME_ENTRY="./dist/adapters/openclaw/index.js"
 # Older plugin IDs disabled on install so they don't fight for the
 # memory slot. We never touch the old plugin's data.
 LEGACY_PLUGIN_IDS=("memos-local-openclaw-plugin")
@@ -420,6 +421,9 @@ install_openclaw() {
   fi
 
   deploy_tarball_to_prefix "${prefix}"
+  local runtime_entry="${prefix}/${OPENCLAW_RUNTIME_ENTRY#./}"
+  [[ -f "${runtime_entry}" ]] \
+    || die "OpenClaw runtime entry missing: ${OPENCLAW_RUNTIME_ENTRY}. Reinstall a package built with dist/ runtime output."
 
   step "Configuring runtime environment"
   ensure_runtime_home "openclaw" "${home}" "${prefix}"
@@ -440,7 +444,17 @@ install_openclaw() {
   "version": "${plugin_version}",
   "homepage": "https://github.com/MemTensor/MemOS",
   "requirements": { "node": ">=${REQUIRED_NODE_MAJOR}.0.0" },
-  "extensions": ["./adapters/openclaw/index.ts"],
+  "extensions": ["${OPENCLAW_RUNTIME_ENTRY}"],
+  "contracts": {
+    "tools": [
+      "memory_search",
+      "memory_get",
+      "memory_timeline",
+      "skill_list",
+      "memory_environment",
+      "skill_get"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": true,
@@ -516,6 +530,11 @@ if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId]
   config.plugins.entries[pluginId] = {};
 }
 config.plugins.entries[pluginId].enabled = true;
+if (!config.plugins.entries[pluginId].hooks || typeof config.plugins.entries[pluginId].hooks !== 'object' || Array.isArray(config.plugins.entries[pluginId].hooks)) {
+  config.plugins.entries[pluginId].hooks = {};
+}
+config.plugins.entries[pluginId].hooks.allowConversationAccess = true;
+config.plugins.entries[pluginId].hooks.allowPromptInjection = true;
 
 if (!config.plugins.installs || typeof config.plugins.installs !== 'object') config.plugins.installs = {};
 const installsEntry = {

--- a/apps/memos-local-plugin/package.json
+++ b/apps/memos-local-plugin/package.json
@@ -3,16 +3,18 @@
   "version": "2.0.0-beta.5",
   "description": "Reflect2Evolve memory plugin: layered L1/L2/L3 memory, reflection-weighted value backprop, cross-task policy induction, skill crystallization, three-tier retrieval. Adapters for OpenClaw and Hermes Agent via a shared algorithm core.",
   "type": "module",
-  "main": "core/index.ts",
+  "main": "dist/core/index.js",
+  "types": "dist/core/index.d.ts",
   "openclaw": {
     "id": "memos-local-plugin",
     "kind": "memory",
     "extensions": [
-      "./adapters/openclaw/index.ts"
+      "./dist/adapters/openclaw/index.js"
     ],
     "installDependencies": true
   },
   "files": [
+    "dist",
     "bridge.cts",
     "bridge",
     "core",
@@ -20,25 +22,26 @@
     "server",
     "adapters",
     "templates",
-    "web/dist",
-    "site/dist",
+    "web",
     "scripts",
     "install.sh",
     "install.ps1",
     "tsconfig.json",
+    "tsconfig.build.json",
     "tsconfig.web.json",
     "tsconfig.site.json",
     "README.md",
     "ARCHITECTURE.md",
     "CHANGELOG.md",
-    "AGENTS.md",
-    "docs"
+    "AGENTS.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-runtime-assets.cjs",
     "build:web": "vite build --config vite.config.ts",
     "build:site": "cd site && vite build",
+    "build:package": "npm run build && npm run build:web",
     "build:all": "npm run build && npm run build:web && npm run build:site",
+    "prepack": "npm run build:package",
     "dev": "tsc -p tsconfig.json --watch",
     "web:dev": "vite --config vite.config.ts",
     "site:dev": "vite --config site/vite.config.ts",

--- a/apps/memos-local-plugin/scripts/copy-runtime-assets.cjs
+++ b/apps/memos-local-plugin/scripts/copy-runtime-assets.cjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+
+const assets = [
+  {
+    from: path.join(root, "core", "storage", "migrations"),
+    to: path.join(root, "dist", "core", "storage", "migrations"),
+  },
+];
+
+for (const asset of assets) {
+  if (!fs.existsSync(asset.from)) {
+    throw new Error(`Runtime asset source missing: ${asset.from}`);
+  }
+  fs.rmSync(asset.to, { recursive: true, force: true });
+  fs.mkdirSync(asset.to, { recursive: true });
+  for (const entry of fs.readdirSync(asset.from, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    fs.copyFileSync(path.join(asset.from, entry.name), path.join(asset.to, entry.name));
+  }
+}

--- a/apps/memos-local-plugin/templates/config.hermes.yaml
+++ b/apps/memos-local-plugin/templates/config.hermes.yaml
@@ -3,8 +3,8 @@
 # Keep this file short. Most plugin behavior is controlled by sensible
 # defaults baked into the code; only the fields below are likely to change
 # per user. If you need to tune an advanced option (algorithm thresholds,
-# log rotation, retrieval budgets, etc.) see docs/CONFIG-ADVANCED.md —
-# any field there can be added to this file and will take effect on reload.
+# log rotation, retrieval budgets, etc.) see docs/CONFIG-ADVANCED.md in
+# the source repo; any field there can be added here and will take effect.
 #
 # Sensitive fields (apiKey, teamToken, userToken) live HERE — there is no
 # .env file. install.sh sets this file's mode to 600.

--- a/apps/memos-local-plugin/templates/config.openclaw.yaml
+++ b/apps/memos-local-plugin/templates/config.openclaw.yaml
@@ -3,8 +3,8 @@
 # Keep this file short. Most plugin behavior is controlled by sensible
 # defaults baked into the code; only the fields below are likely to change
 # per user. If you need to tune an advanced option (algorithm thresholds,
-# log rotation, retrieval budgets, etc.) see docs/CONFIG-ADVANCED.md —
-# any field there can be added to this file and will take effect on reload.
+# log rotation, retrieval budgets, etc.) see docs/CONFIG-ADVANCED.md in
+# the source repo; any field there can be added here and will take effect.
 #
 # Sensitive fields (apiKey, teamToken, userToken) live HERE — there is no
 # .env file. install.sh sets this file's mode to 600.

--- a/apps/memos-local-plugin/tests/unit/install/install-sh.test.ts
+++ b/apps/memos-local-plugin/tests/unit/install/install-sh.test.ts
@@ -1,7 +1,7 @@
 /**
  * install.sh smoke tests.
  *
- * The new install.sh is minimal: only `--version` + `--port`, plus an
+ * The new install.sh is minimal: only `--version`, plus an
  * interactive picker (ENTER = auto-detect). It patches real host files
  * (~/.openclaw/openclaw.json etc.) and stops / starts the agent gateway,
  * so we deliberately keep unit tests narrow — they only exercise what
@@ -9,8 +9,7 @@
  *
  *   1. `--help` exits 0 and prints the usage banner.
  *   2. An unknown flag exits non-zero.
- *   3. A typo'd flag value (e.g. `--port` without a value) doesn't crash
- *      the script midway; it still reports an error cleanly.
+ *   3. Removed legacy flags report an error cleanly.
  *
  * End-to-end behaviour is verified manually (the script is driven
  * against real ~/.openclaw / ~/.hermes hosts during release testing).
@@ -19,9 +18,11 @@
 import { describe, expect, it } from "vitest";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const SCRIPT = path.join(REPO_ROOT, "install.sh");
+const PACKAGE_JSON = path.join(REPO_ROOT, "package.json");
 
 function run(args: string[], env: Record<string, string> = {}) {
   const r = spawnSync("bash", [SCRIPT, ...args], {
@@ -38,7 +39,7 @@ describe("install.sh — CLI surface", () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("Usage:");
     expect(r.stdout).toContain("--version");
-    expect(r.stdout).toContain("--port");
+    expect(r.stdout).not.toContain("bash install.sh --port");
   });
 
   it("prints usage on -h and exits 0", () => {
@@ -61,5 +62,41 @@ describe("install.sh — CLI surface", () => {
     // the docs/tests alongside it.
     const r = run(["--uninstall", "openclaw"]);
     expect(r.code).not.toBe(0);
+  });
+
+  it("rejects --port (fixed per-agent ports are used)", () => {
+    const r = run(["--port", "18799"]);
+    expect(r.code).not.toBe(0);
+    const combined = `${r.stdout}\n${r.stderr}`;
+    expect(combined).toContain("--port is no longer supported");
+  });
+
+  it("generates an OpenClaw manifest that points at compiled runtime output", () => {
+    const script = readFileSync(SCRIPT, "utf8");
+    expect(script).toContain('OPENCLAW_RUNTIME_ENTRY="./dist/adapters/openclaw/index.js"');
+    expect(script).toContain('"extensions": ["${OPENCLAW_RUNTIME_ENTRY}"]');
+    expect(script).toContain('"contracts": {');
+    expect(script).toContain('"memory_search"');
+    expect(script).toContain("hooks.allowConversationAccess = true");
+    expect(script).not.toContain('"extensions": ["./adapters/openclaw/index.ts"]');
+  });
+
+  it("publishes package runtime output and viewer sources without docs, tests, or site", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf8")) as {
+      files?: string[];
+      main?: string;
+      openclaw?: { extensions?: string[] };
+      scripts?: { build?: string };
+    };
+    expect(pkg.main).toBe("dist/core/index.js");
+    expect(pkg.scripts?.build).toContain("scripts/copy-runtime-assets.cjs");
+    expect(pkg.openclaw?.extensions).toContain("./dist/adapters/openclaw/index.js");
+    expect(pkg.files).toContain("dist");
+    expect(pkg.files).toContain("web");
+    expect(pkg.files).not.toContain("web/dist");
+    expect(pkg.files).not.toContain("docs");
+    expect(pkg.files).not.toContain("tests");
+    expect(pkg.files).not.toContain("site");
+    expect(pkg.files).not.toContain("site/dist");
   });
 });

--- a/apps/memos-local-plugin/tsconfig.build.json
+++ b/apps/memos-local-plugin/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "core/**/*.ts",
+    "agent-contract/**/*.ts",
+    "server/**/*.ts",
+    "bridge/**/*.ts",
+    "adapters/openclaw/**/*.ts",
+    "scripts/**/*.ts",
+    "site/scripts/**/*.ts",
+    "bridge.cts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "web",
+    "site/src",
+    "adapters/hermes",
+    "tests"
+  ]
+}


### PR DESCRIPTION
## Summary
- Package compiled OpenClaw runtime entrypoints and copied SQLite migration assets for memos-local-plugin installs.
- Declare OpenClaw tool contracts and hook permissions during install so current OpenClaw guardrails allow the plugin to register.
- Keep the memory viewer `web/` in the package while excluding docs/tests/site from npm artifacts.

## Test plan
- `npm run build`
- `npm test -- tests/unit/install/install-sh.test.ts`