### PR TITLE
feat: collapsible chat messages for long user/assistant text

### DIFF
--- a/apps/memos-local-plugin/web/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/web/src/stores/i18n.ts
@@ -419,6 +419,8 @@ const en = {
   "tasks.chat.tool.noPayload": "(no input or output recorded)",
   "tasks.chat.tool.parallelBatch": "⚡ {n} tools in parallel · {ms}ms wall-clock",
   "tasks.chat.tool.parallelBatch.savings": "(would have been {sum}ms in series)",
+  "tasks.chat.expand": "Show more",
+  "tasks.chat.collapse": "Show less",
   "tasks.skipped.default":
     "This conversation was too brief to generate a summary or score — the task won't appear in search results.",
   "tasks.failed.default":
@@ -1094,6 +1096,8 @@ const zh: Record<TranslationKey, string> = {
   "tasks.chat.tool.noPayload": "（未记录输入或输出）",
   "tasks.chat.tool.parallelBatch": "⚡ {n} 个工具并行 · 实际耗时 {ms}ms",
   "tasks.chat.tool.parallelBatch.savings": "（串行需 {sum}ms）",
+  "tasks.chat.expand": "展开全文",
+  "tasks.chat.collapse": "收起",
   "tasks.skipped.default": "对话内容过少，未生成摘要，该任务不会出现在检索结果中。",
   "tasks.failed.default": "任务评分 R={rTask}，被视为失败交互，未来相似任务的检索权重会被下调。",
   "tasks.skip.reason.tooFewTurns": "对话轮次不足，需要至少 2 轮完整的问答交互才能生成摘要。",

--- a/apps/memos-local-plugin/web/src/styles/components.css
+++ b/apps/memos-local-plugin/web/src/styles/components.css
@@ -1365,6 +1365,41 @@
   padding: 10px 14px;
   border-radius: 12px 12px 12px 4px;
   word-break: break-word;
+  position: relative;
+}
+.chat-item__bubble--collapsed {
+  max-height: 120px;
+  overflow: hidden;
+}
+.chat-item__fade {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  background: linear-gradient(to bottom, transparent, var(--bg-card));
+  border-radius: 0 0 12px 4px;
+  pointer-events: none;
+}
+.chat-item--user .chat-item__bubble--collapsed .chat-item__fade,
+.chat-item--user .chat-item__fade {
+  background: linear-gradient(to bottom, transparent, rgba(124, 140, 245, 0.07));
+}
+.chat-item__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: var(--fs-xs);
+  color: var(--accent);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+.chat-item__toggle:hover {
+  background: var(--bg-hover);
 }
 .chat-item--user .chat-item__bubble {
   background: linear-gradient(135deg, rgba(124, 140, 245, 0.14), rgba(124, 140, 245, 0.07));

--- a/apps/memos-local-plugin/web/src/views/tasks-chat.tsx
+++ b/apps/memos-local-plugin/web/src/views/tasks-chat.tsx
@@ -19,6 +19,7 @@
  * `tests/unit/web/tasks-chat.test.ts` (no Preact dependency).
  */
 import type { JSX } from "preact";
+import { useState } from "preact/hooks";
 import { Icon } from "../components/Icon";
 import { Markdown } from "../components/Markdown";
 import { t } from "../stores/i18n";
@@ -132,8 +133,17 @@ function avatarFor(role: ChatRole): string {
   }
 }
 
+const COLLAPSE_THRESHOLD_USER = 200;
+const COLLAPSE_THRESHOLD_ASSISTANT = 600;
+
 export function ChatBubble({ msg }: { msg: ChatMsg }) {
   const time = formatTime(msg.ts);
+  const threshold =
+    msg.role === "user" ? COLLAPSE_THRESHOLD_USER : COLLAPSE_THRESHOLD_ASSISTANT;
+  const collapsible =
+    (msg.role === "user" || msg.role === "assistant") &&
+    msg.text.length > threshold;
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <div class={`chat-item chat-item--${msg.role}`}>
@@ -158,9 +168,23 @@ export function ChatBubble({ msg }: { msg: ChatMsg }) {
             <Markdown text={msg.text} />
           </div>
         ) : (
-          <div class="chat-item__bubble">
+          <div
+            class={`chat-item__bubble${collapsible && !expanded ? " chat-item__bubble--collapsed" : ""}`}
+          >
             <Markdown text={msg.text} />
+            {collapsible && !expanded && (
+              <div class="chat-item__fade" />
+            )}
           </div>
+        )}
+        {collapsible && (
+          <button
+            type="button"
+            class="chat-item__toggle"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? t("tasks.chat.collapse") : t("tasks.chat.expand")}
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Auto-collapse user messages (>200 chars) and assistant messages (>600 chars) to 120px height with fade overlay
- Toggle button "展开全文" / "收起" to expand/collapse
- Prevents long messages from overwhelming the task conversation view

## Test plan
- Open Tasks → click any episode with long conversation
- Verify long user/assistant messages show collapsed with fade + "展开全文" button
- Click to expand, verify full text shows; click "收起" to collapse again
- Short messages remain unchanged (no toggle button)
