### PR TITLE
fix: improve memos local plugin OpenClaw behavior

### DIFF
--- a/.test1.py
+++ b/.test1.py
@@ -1,0 +1,3 @@
+import jieba.analyse
+res = jieba.analyse.extract_tags("我爱旅游和烧烤", topK=12)
+print(res)

--- a/apps/memos-local-plugin/adapters/openclaw/tools.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/tools.ts
@@ -123,6 +123,28 @@ function clip(s: string | undefined, n: number): string {
   return s.length > n ? s.slice(0, n) + "…" : s;
 }
 
+type TextToolContent = Array<{ type: "text"; text: string }>;
+
+function textToolResult<T extends Record<string, unknown>>(
+  details: T,
+  text: string,
+): T & { content: TextToolContent; details: T } {
+  return {
+    ...details,
+    content: [{ type: "text", text }],
+    details,
+  };
+}
+
+function formatHitList(hits: Array<{ refKind: string; refId: string; score: number; snippet: string }>): string {
+  if (hits.length === 0) return "No relevant memories found.";
+  const lines = hits.map((h, i) => {
+    const snippet = h.snippet.trim() || "(empty snippet)";
+    return `${i + 1}. [${h.refKind}:${h.refId}] ${snippet} (score=${h.score.toFixed(3)})`;
+  });
+  return `Found ${hits.length} memories:\n\n${lines.join("\n")}`;
+}
+
 function sessionFromCtx(ctx: OpenClawPluginToolContext | undefined): string | undefined {
   const sessionKey = ctx?.sessionKey;
   if (!sessionKey) return undefined;
@@ -178,7 +200,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           query: params.query,
           topK: topKParams(params, maxResults),
         });
-        return {
+        const details = {
           hits: result.hits.map((h) => ({
             tier: h.tier,
             refKind: h.refKind,
@@ -188,6 +210,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           })),
           totalMs: Date.now() - started,
         };
+        return textToolResult(details, formatHitList(details.hits));
       },
     }),
     { name: "memory_search" },
@@ -207,8 +230,11 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const kind = params.kind ?? "trace";
         if (kind === "trace") {
           const trace = await core.getTrace(params.id as TraceId, namespaceFromCtx(ctx));
-          if (!trace) return { found: false, kind, id: params.id, body: "", meta: {} };
-          return {
+          if (!trace) {
+            const details = { found: false, kind, id: params.id, body: "", meta: {} };
+            return textToolResult(details, `No ${kind} memory found for id "${params.id}".`);
+          }
+          const details = {
             found: true,
             kind,
             id: trace.id,
@@ -226,11 +252,15 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
               })),
             },
           };
+          return textToolResult(details, details.body || trace.summary || trace.userText || `Found trace ${trace.id}.`);
         }
         if (kind === "policy") {
           const policy = await core.getPolicy(params.id, namespaceFromCtx(ctx));
-          if (!policy) return { found: false, kind, id: params.id, body: "", meta: {} };
-          return {
+          if (!policy) {
+            const details = { found: false, kind, id: params.id, body: "", meta: {} };
+            return textToolResult(details, `No ${kind} memory found for id "${params.id}".`);
+          }
+          const details = {
             found: true,
             kind,
             id: policy.id,
@@ -244,16 +274,21 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
               status: policy.status,
             },
           };
+          return textToolResult(details, details.body);
         }
         const wm = await core.getWorldModel(params.id, namespaceFromCtx(ctx));
-        if (!wm) return { found: false, kind, id: params.id, body: "", meta: {} };
-        return {
+        if (!wm) {
+          const details = { found: false, kind, id: params.id, body: "", meta: {} };
+          return textToolResult(details, `No ${kind} memory found for id "${params.id}".`);
+        }
+        const details = {
           found: true,
           kind,
           id: wm.id,
           body: clip(wm.body, bodyCap),
           meta: { title: wm.title, policyIds: wm.policyIds },
         };
+        return textToolResult(details, `${wm.title}\n\n${details.body}`.trim());
       },
     }),
     { name: "memory_get" },
@@ -272,7 +307,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const core = await resolveCore(opts);
         const traces = await core.timeline({ episodeId: params.episodeId as never, namespace: namespaceFromCtx(ctx) });
         const limited = traces.slice(0, params.limit ?? 20);
-        return {
+        const details = {
           episodeId: params.episodeId,
           traces: limited.map((t) => ({
             id: t.id,
@@ -283,6 +318,13 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
             value: t.value,
           })),
         };
+        const text = details.traces.length === 0
+          ? `No traces found for episode "${params.episodeId}".`
+          : `Episode ${params.episodeId} timeline:\n\n` +
+            details.traces
+              .map((t, i) => `${i + 1}. ${t.userText || t.agentText || t.id}`)
+              .join("\n");
+        return textToolResult(details, text);
       },
     }),
     { name: "memory_timeline" },
@@ -303,7 +345,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           limit: params.limit,
           namespace: namespaceFromCtx(ctx),
         });
-        return {
+        const details = {
           skills: skills.map((s) => ({
             id: s.id,
             name: s.name,
@@ -314,6 +356,11 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
             invocationGuide: clip(s.invocationGuide, bodyCap),
           })),
         };
+        const text = details.skills.length === 0
+          ? "No skills found."
+          : `Found ${details.skills.length} skills:\n\n` +
+            details.skills.map((s, i) => `${i + 1}. ${s.name} (${s.id}, ${s.status})`).join("\n");
+        return textToolResult(details, text);
       },
     }),
     { name: "skill_list" },
@@ -348,7 +395,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
         const core = await resolveCore(opts);
         if (!query) {
           const rows = await core.listWorldModels({ limit: cap, offset: 0, namespace: namespaceFromCtx(ctx) });
-          return {
+          const details = {
             worldModels: rows.map((w) => ({
               id: w.id,
               title: w.title,
@@ -358,6 +405,11 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
             })),
             queried: false,
           };
+          const text = details.worldModels.length === 0
+            ? "No environment knowledge found."
+            : `Environment knowledge:\n\n` +
+              details.worldModels.map((w, i) => `${i + 1}. ${w.title}\n${w.body}`).join("\n\n");
+          return textToolResult(details, text);
         }
         // With a query, go through `searchMemory` so tag filters +
         // cosine ranking apply, then keep only the tier-3 hits.
@@ -368,7 +420,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           topK: { tier1: 0, tier2: 0, tier3: cap },
         });
         const tier3 = res.hits.filter((h) => h.tier === 3);
-        return {
+        const details = {
           worldModels: tier3.map((h) => ({
             id: h.refId,
             title: (h.snippet ?? "").split("\n")[0]?.replace(/^World model:\s*/, "") ?? "",
@@ -378,6 +430,11 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           })),
           queried: true,
         };
+        const text = details.worldModels.length === 0
+          ? "No matching environment knowledge found."
+          : `Environment knowledge for "${query}":\n\n` +
+            details.worldModels.map((w, i) => `${i + 1}. ${w.title}\n${w.body}`).join("\n\n");
+        return textToolResult(details, text);
       },
     }),
     { name: "memory_environment" },
@@ -399,8 +456,11 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
           namespace: namespaceFromCtx(ctx),
           toolCallId,
         });
-        if (!skill) return { found: false, skill: null };
-        return {
+        if (!skill) {
+          const details = { found: false, skill: null };
+          return textToolResult(details, `No skill found for id "${params.id}".`);
+        }
+        const details = {
           found: true,
           skill: {
             id: skill.id,
@@ -418,6 +478,7 @@ export function registerOpenClawTools(api: OpenClawPluginApi, opts: ToolsOptions
             lastUsedAt: skill.lastUsedAt,
           },
         };
+        return textToolResult(details, `${skill.name}\n\n${skill.invocationGuide}`.trim());
       },
     }),
     { name: "skill_get" },

--- a/apps/memos-local-plugin/core/pipeline/retrieval-repos.ts
+++ b/apps/memos-local-plugin/core/pipeline/retrieval-repos.ts
@@ -18,6 +18,12 @@ export function wrapRetrievalRepos(repos: Repos, namespace: RuntimeNamespace): R
       searchByVector(query, k, opts) {
         return repos.skills.searchByVector(query, k, opts ?? {});
       },
+      searchByText(ftsMatch, k, opts) {
+        return repos.skills.searchByText(ftsMatch, k, opts ?? {});
+      },
+      searchByPattern(terms, k, opts) {
+        return repos.skills.searchByPattern(terms, k, opts ?? {});
+      },
       getById(id) {
         const row = repos.skills.getById(id);
         if (!row || !isVisibleTo(row, namespace)) return null;
@@ -34,6 +40,12 @@ export function wrapRetrievalRepos(repos: Repos, namespace: RuntimeNamespace): R
     traces: {
       searchByVector(query, k, opts) {
         return repos.traces.searchByVector(query, k, opts ?? {});
+      },
+      searchByText(ftsMatch, k, opts) {
+        return repos.traces.searchByText(ftsMatch, k, opts ?? {});
+      },
+      searchByPattern(terms, k, opts) {
+        return repos.traces.searchByPattern(terms, k, opts ?? {});
       },
       getManyByIds(ids) {
         const rows = repos.traces.getManyByIds(ids as readonly TraceId[]);
@@ -73,6 +85,12 @@ export function wrapRetrievalRepos(repos: Repos, namespace: RuntimeNamespace): R
     worldModel: {
       searchByVector(query, k, opts) {
         return repos.worldModel.searchByVector(query, k, opts ?? {});
+      },
+      searchByText(ftsMatch, k) {
+        return repos.worldModel.searchByText(ftsMatch, k);
+      },
+      searchByPattern(terms, k) {
+        return repos.worldModel.searchByPattern(terms, k);
       },
       getById(id) {
         const row = repos.worldModel.getById(id);

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -377,7 +377,7 @@ ensure_runtime_home() {
 wait_for_viewer() {
   local port="$1"
   local url="http://127.0.0.1:${port}"
-  local timeout="${2:-30}"
+  local timeout="${2:-60}"
   local frames=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
   local idx=0
   local elapsed=0
@@ -599,7 +599,7 @@ NODE
     return 0
   fi
 
-  warn "Memory Viewer did not respond within 30s."
+  warn "Memory Viewer did not respond within 60s."
   printf "       ${DIM}Check: /tmp/openclaw-memos-gateway.log or /tmp/openclaw/openclaw-*.log${NC}\n" >&2
   return 1
 }

--- a/apps/memos-local-plugin/openclaw.plugin.json
+++ b/apps/memos-local-plugin/openclaw.plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "memos-local-plugin",
+  "name": "MemOS Local",
+  "description": "Reflect2Evolve memory plugin with L1 traces, L2 policies, L3 world models, skill crystallization, and three-tier retrieval.",
+  "version": "2.0.0-beta.5",
+  "kind": "memory",
+  "contracts": {
+    "tools": [
+      "memory_search",
+      "memory_get",
+      "memory_timeline",
+      "memory_environment",
+      "skill_list",
+      "skill_get"
+    ]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {}
+  }
+}

--- a/apps/memos-local-plugin/package.json
+++ b/apps/memos-local-plugin/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "dist",
+    "openclaw.plugin.json",
     "bridge.cts",
     "bridge",
     "core",

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
@@ -1361,9 +1361,20 @@ describe("registerOpenClawTools", () => {
     const res = (await search.descriptor.execute("toolCall_1", {
       query: "anything",
       maxResults: 5,
-    })) as { hits: Array<unknown>; totalMs: number };
+    })) as {
+      hits: Array<unknown>;
+      totalMs: number;
+      content: Array<{ type: "text"; text: string }>;
+      details: { hits: Array<unknown>; totalMs: number };
+    };
     expect(Array.isArray(res.hits)).toBe(true);
     expect(res.totalMs).toBeGreaterThanOrEqual(0);
+    // Latest OpenClaw's MCP plugin-tools bridge serializes only
+    // `result.content`; keep that populated while preserving the older
+    // top-level object shape used by local tests and callers.
+    expect(res.content[0]?.type).toBe("text");
+    expect(res.content[0]?.text).toContain("memories");
+    expect(res.details.hits).toBe(res.hits);
   });
 
   it("memory_search maps per-tier topK params and keeps maxResults fallback", async () => {

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-e2e.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-e2e.test.ts
@@ -132,7 +132,7 @@ function silentLogger(): HostLogger {
   };
 }
 
-function buildDeps(h: TmpDbHandle): PipelineDeps {
+function buildDeps(h: TmpDbHandle, embedder: Embedder | null = semanticFakeEmbedder(DEFAULT_CONFIG.embedding.dimensions)): PipelineDeps {
   return {
     agent: "openclaw",
     home: resolveHome("openclaw", "/tmp/memos-e2e-test"),
@@ -141,15 +141,15 @@ function buildDeps(h: TmpDbHandle): PipelineDeps {
     repos: h.repos,
     llm: null,
     reflectLlm: null,
-    embedder: semanticFakeEmbedder(DEFAULT_CONFIG.embedding.dimensions),
+    embedder,
     log: rootLogger.child({ channel: "test.adapters.openclaw.e2e" }),
     namespace: { agentKind: "openclaw", profileId: "main" },
     now: () => 1_700_000_000_000,
   };
 }
 
-function buildCore(): MemoryCore {
-  pipeline = createPipeline(buildDeps(db!));
+function buildCore(embedder?: Embedder | null): MemoryCore {
+  pipeline = createPipeline(buildDeps(db!, embedder));
   const mc = createMemoryCore(
     pipeline,
     resolveHome("openclaw", "/tmp/memos-e2e-test"),
@@ -333,6 +333,38 @@ describe("OpenClaw adapter — end-to-end memory chain", () => {
     expect(search.hits.length).toBeGreaterThan(0);
     const allText = search.hits.map((h) => h.snippet).join("\n");
     expect(allText).toContain("榴莲");
+  });
+
+  it("retrieves freshly captured text through keyword fallback when embeddings are unavailable", async () => {
+    const mc = buildCore(null);
+    await mc.init();
+    const bridge = createOpenClawBridge({ agent: "openclaw", core: mc, log: silentLogger() });
+
+    await bridge.handleBeforePrompt(
+      { prompt: "记住：我喜欢蓝莓酸奶", messages: [] },
+      ctx({ sessionKey: "keyword-thread" }),
+    );
+    await bridge.handleAgentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "记住：我喜欢蓝莓酸奶" },
+          { role: "assistant", content: "好的，我记住了。" },
+        ],
+        durationMs: 80,
+      },
+      ctx({ sessionKey: "keyword-thread" }),
+    );
+    await (pipeline as PipelineHandle).flush();
+
+    const search = await mc.searchMemory({
+      agent: "openclaw",
+      query: "蓝莓酸奶",
+      topK: { tier1: 0, tier2: 5, tier3: 0 },
+    });
+
+    expect(search.hits.length).toBeGreaterThan(0);
+    expect(search.hits.map((h) => h.snippet).join("\n")).toContain("蓝莓酸奶");
   });
 
   it("toolCalls captured during agent_end are written into the trace row", async () => {


### PR DESCRIPTION
## Summary
- Add text `content` alongside structured details for OpenClaw memory tools so newer MCP plugin-tool bridges can display results.
- Preserve keyword fallback retrieval through namespace-wrapped repos and cover it with an OpenClaw e2e test.
- Package the OpenClaw plugin manifest and extend the default Memory Viewer readiness wait to 60s.

## Test plan
- Not run locally; changes were committed from the existing working tree as requested.