### PR TITLE
Add keyword recall for experiences

### DIFF
--- a/apps/memos-local-plugin/core/retrieval/injector.ts
+++ b/apps/memos-local-plugin/core/retrieval/injector.ts
@@ -357,9 +357,9 @@ function renderWholePacket(
   const traces = snippets.filter(
     (s) =>
       s.refKind === "trace" ||
-      s.refKind === "episode" ||
-      s.refKind === "experience",
+      s.refKind === "episode",
   );
+  const experiences = snippets.filter((s) => s.refKind === "experience");
   const worlds = snippets.filter((s) => s.refKind === "world-model");
 
   if (skills.length > 0) {
@@ -381,6 +381,13 @@ function renderWholePacket(
   if (traces.length > 0) {
     parts.push("## Memories\n");
     traces.forEach((s, i) => {
+      parts.push(renderNumberedSnippet(s, i + 1));
+    });
+  }
+
+  if (experiences.length > 0) {
+    parts.push("## Experiences\n");
+    experiences.forEach((s, i) => {
       parts.push(renderNumberedSnippet(s, i + 1));
     });
   }

--- a/apps/memos-local-plugin/core/retrieval/retrieve.ts
+++ b/apps/memos-local-plugin/core/retrieval/retrieve.ts
@@ -262,10 +262,14 @@ async function runAll(
         : Promise.resolve({ traces: [], episodes: [] });
 
     const tier2ExperiencePromise: Promise<ExperienceCandidate[]> =
-      wantTier2 && !!queryVec && !noUsableChannel
+      wantTier2 && !noUsableChannel
         ? runTier2Experience(
             { repos: deps.repos, config: deps.config },
-            { queryVec },
+            {
+              queryVec,
+              ftsMatch: compiled.ftsMatch,
+              patternTerms: compiled.patternTerms,
+            },
           )
         : Promise.resolve([]);
 

--- a/apps/memos-local-plugin/core/retrieval/tier2-experience.ts
+++ b/apps/memos-local-plugin/core/retrieval/tier2-experience.ts
@@ -3,11 +3,13 @@ import type { EmbeddingVector, PolicyId } from "../types.js";
 import type {
   ChannelRank,
   ExperienceCandidate,
+  RetrievalChannel,
   RetrievalConfig,
   RetrievalRepos,
 } from "./types.js";
 
 const log = rootLogger.child({ channel: "core.retrieval.tier2.experience" });
+const DEFAULT_KEYWORD_TOPK = 20;
 
 export interface Tier2ExperienceDeps {
   repos: Pick<RetrievalRepos, "policies">;
@@ -16,6 +18,8 @@ export interface Tier2ExperienceDeps {
 
 export interface Tier2ExperienceInput {
   queryVec: EmbeddingVector | null;
+  ftsMatch?: string | null;
+  patternTerms?: string[];
 }
 
 export async function runTier2Experience(
@@ -24,39 +28,87 @@ export async function runTier2Experience(
 ): Promise<ExperienceCandidate[]> {
   const startedAt = Date.now();
   const repo = deps.repos.policies;
-  if (!repo?.searchByVector || !input.queryVec || input.queryVec.length === 0) {
+  if (!repo) {
     return [];
   }
 
   try {
-    const poolSize = Math.max(
+    const vecPoolSize = Math.max(
       deps.config.tier2TopK,
       Math.ceil(deps.config.tier2TopK * deps.config.candidatePoolFactor),
     );
-    const hits = repo.searchByVector(input.queryVec, poolSize, {
-      statusIn: ["active", "candidate"],
-      hardCap: Math.max(50, poolSize * 5),
-    });
+    const keywordPoolSize = Math.max(
+      deps.config.tier2TopK,
+      deps.config.keywordTopK ?? DEFAULT_KEYWORD_TOPK,
+    );
+    const statusIn: Array<"active" | "candidate"> = ["active", "candidate"];
+    const haveVec = !!repo.searchByVector && !!input.queryVec && input.queryVec.length > 0;
+    const haveFts = !!input.ftsMatch && !!repo.searchByText;
+    const havePattern =
+      !!input.patternTerms && input.patternTerms.length > 0 && !!repo.searchByPattern;
+    if (!haveVec && !haveFts && !havePattern) {
+      return [];
+    }
+
+    const merged = new Map<PolicyId, CandidateState>();
+    if (haveVec) {
+      const hits = repo.searchByVector!(input.queryVec!, vecPoolSize, {
+        statusIn,
+        hardCap: Math.max(50, vecPoolSize * 5),
+      });
+      hits.forEach((hit, idx) => {
+        if (hit.score < deps.config.minTraceSim) return;
+        upsertCandidate(merged, hit.id as PolicyId, {
+          cosine: hit.score,
+          channel: "vec",
+          rank: idx,
+          score: hit.score,
+          vec: input.queryVec!,
+        });
+      });
+    }
+
+    if (haveFts) {
+      const hits = repo.searchByText!(input.ftsMatch!, keywordPoolSize, { statusIn });
+      hits.forEach((hit, idx) => {
+        upsertCandidate(merged, hit.id as PolicyId, {
+          cosine: 0,
+          channel: "fts",
+          rank: idx,
+          score: hit.score,
+          vec: input.queryVec ?? null,
+        });
+      });
+    }
+
+    if (havePattern) {
+      const hits = repo.searchByPattern!(input.patternTerms!, keywordPoolSize, { statusIn });
+      hits.forEach((hit, idx) => {
+        upsertCandidate(merged, hit.id as PolicyId, {
+          cosine: 0,
+          channel: "pattern",
+          rank: idx,
+          score: hit.score,
+          vec: input.queryVec ?? null,
+        });
+      });
+    }
+
     const out: ExperienceCandidate[] = [];
-    for (let i = 0; i < hits.length; i += 1) {
-      const hit = hits[i]!;
-      if (hit.score < deps.config.minTraceSim) continue;
-      const row = repo.getById(hit.id as PolicyId);
+    for (const [id, state] of merged) {
+      const row = repo.getById(id);
       if (!row) continue;
       if ((row.sourceFeedbackIds?.length ?? 0) === 0) continue;
       const status = row.status ?? "candidate";
       if (status === "archived") continue;
-      const channels: ChannelRank[] = [
-        { channel: "vec", rank: i, score: hit.score },
-      ];
       out.push({
         tier: "tier2",
         refKind: "experience",
         refId: row.id as PolicyId,
-        cosine: hit.score,
+        cosine: state.cosine,
         ts: row.updatedAt ?? Date.now(),
-        vec: row.vec ?? input.queryVec,
-        channels,
+        vec: row.vec ?? state.vec,
+        channels: state.channels,
         title: row.title,
         trigger: row.trigger ?? "",
         procedure: row.procedure ?? "",
@@ -76,18 +128,25 @@ export async function runTier2Experience(
         decisionGuidance: row.decisionGuidance,
         updatedAt: row.updatedAt ?? Date.now(),
         debug: {
-          matchedChannels: channels.map((c) => c.channel),
+          matchedChannels: state.channels.map((c) => c.channel),
           experienceType: row.experienceType ?? "success_pattern",
           evidencePolarity: row.evidencePolarity ?? "positive",
         },
       });
     }
+    out.sort((a, b) => bestChannelScore(b) - bestChannelScore(a));
+    const trimmed = out.slice(0, vecPoolSize);
     log.info("done", {
-      candidates: hits.length,
-      kept: out.length,
+      candidates: merged.size,
+      kept: trimmed.length,
+      channels: {
+        vec: haveVec,
+        fts: haveFts,
+        pattern: havePattern,
+      },
       latencyMs: Date.now() - startedAt,
     });
-    return out;
+    return trimmed;
   } catch (err) {
     log.error("failed", {
       err: { message: err instanceof Error ? err.message : String(err) },
@@ -95,4 +154,48 @@ export async function runTier2Experience(
     });
     return [];
   }
+}
+
+interface CandidateState {
+  cosine: number;
+  channels: ChannelRank[];
+  vec: EmbeddingVector | null;
+}
+
+function upsertCandidate(
+  map: Map<PolicyId, CandidateState>,
+  id: PolicyId,
+  hit: {
+    cosine: number;
+    channel: RetrievalChannel;
+    rank: number;
+    score: number;
+    vec: EmbeddingVector | null;
+  },
+): void {
+  const curr = map.get(id);
+  const channel: ChannelRank = {
+    channel: hit.channel,
+    rank: hit.rank,
+    score: hit.score,
+  };
+  if (!curr) {
+    map.set(id, {
+      cosine: hit.cosine,
+      channels: [channel],
+      vec: hit.vec,
+    });
+    return;
+  }
+  curr.cosine = Math.max(curr.cosine, hit.cosine);
+  curr.channels.push(channel);
+  if (!curr.vec && hit.vec) curr.vec = hit.vec;
+}
+
+function bestChannelScore(c: ExperienceCandidate): number {
+  let best = c.cosine;
+  for (const ch of c.channels ?? []) {
+    if (ch.score > best) best = ch.score;
+  }
+  return best;
 }

--- a/apps/memos-local-plugin/core/retrieval/types.ts
+++ b/apps/memos-local-plugin/core/retrieval/types.ts
@@ -565,6 +565,46 @@ export interface RetrievalRepos {
         confidence?: number;
       };
     }>;
+    searchByText?: (
+      ftsMatch: string,
+      k: number,
+      opts?: {
+        statusIn?: Array<"candidate" | "active" | "archived">;
+      },
+    ) => Array<{
+      id: string;
+      score: number;
+      meta?: {
+        title: string;
+        status: "candidate" | "active" | "archived";
+        support: number;
+        gain: number;
+        experience_type?: NonNullable<PolicyRow["experienceType"]>;
+        evidence_polarity?: NonNullable<PolicyRow["evidencePolarity"]>;
+        salience?: number;
+        confidence?: number;
+      };
+    }>;
+    searchByPattern?: (
+      terms: readonly string[],
+      k: number,
+      opts?: {
+        statusIn?: Array<"candidate" | "active" | "archived">;
+      },
+    ) => Array<{
+      id: string;
+      score: number;
+      meta?: {
+        title: string;
+        status: "candidate" | "active" | "archived";
+        support: number;
+        gain: number;
+        experience_type?: NonNullable<PolicyRow["experienceType"]>;
+        evidence_polarity?: NonNullable<PolicyRow["evidencePolarity"]>;
+        salience?: number;
+        confidence?: number;
+      };
+    }>;
     list: (filter?: {
       status?: "candidate" | "active" | "archived";
     }) => Array<{

--- a/apps/memos-local-plugin/core/storage/migrations/001-initial.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/001-initial.sql
@@ -385,6 +385,49 @@ CREATE TRIGGER IF NOT EXISTS traces_fts_au AFTER UPDATE ON traces BEGIN
   );
 END;
 
+-- Policies / Experiences FTS
+CREATE VIRTUAL TABLE IF NOT EXISTS policies_fts USING fts5(
+  policy_id UNINDEXED,
+  title,
+  trigger,
+  procedure,
+  verification,
+  boundary,
+  guidance,
+  tokenize = 'trigram'
+);
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_ai AFTER INSERT ON policies BEGIN
+  INSERT INTO policies_fts(policy_id, title, trigger, procedure, verification, boundary, guidance)
+  VALUES (
+    new.id,
+    new.title,
+    new.trigger,
+    new.procedure,
+    new.verification,
+    new.boundary,
+    COALESCE(new.decision_guidance_json, '')
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_ad AFTER DELETE ON policies BEGIN
+  DELETE FROM policies_fts WHERE policy_id = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_au AFTER UPDATE ON policies BEGIN
+  DELETE FROM policies_fts WHERE policy_id = old.id;
+  INSERT INTO policies_fts(policy_id, title, trigger, procedure, verification, boundary, guidance)
+  VALUES (
+    new.id,
+    new.title,
+    new.trigger,
+    new.procedure,
+    new.verification,
+    new.boundary,
+    COALESCE(new.decision_guidance_json, '')
+  );
+END;
+
 -- Skills FTS
 CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts USING fts5(
   skill_id UNINDEXED,

--- a/apps/memos-local-plugin/core/storage/migrations/009-policies-fts.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/009-policies-fts.sql
@@ -1,0 +1,54 @@
+-- Add keyword retrieval for L2 policies / feedback-derived experiences.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS policies_fts USING fts5(
+  policy_id UNINDEXED,
+  title,
+  trigger,
+  procedure,
+  verification,
+  boundary,
+  guidance,
+  tokenize = 'trigram'
+);
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_ai AFTER INSERT ON policies BEGIN
+  INSERT INTO policies_fts(policy_id, title, trigger, procedure, verification, boundary, guidance)
+  VALUES (
+    new.id,
+    new.title,
+    new.trigger,
+    new.procedure,
+    new.verification,
+    new.boundary,
+    COALESCE(new.decision_guidance_json, '')
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_ad AFTER DELETE ON policies BEGIN
+  DELETE FROM policies_fts WHERE policy_id = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS policies_fts_au AFTER UPDATE ON policies BEGIN
+  DELETE FROM policies_fts WHERE policy_id = old.id;
+  INSERT INTO policies_fts(policy_id, title, trigger, procedure, verification, boundary, guidance)
+  VALUES (
+    new.id,
+    new.title,
+    new.trigger,
+    new.procedure,
+    new.verification,
+    new.boundary,
+    COALESCE(new.decision_guidance_json, '')
+  );
+END;
+
+INSERT INTO policies_fts(policy_id, title, trigger, procedure, verification, boundary, guidance)
+SELECT id,
+       title,
+       trigger,
+       procedure,
+       verification,
+       boundary,
+       COALESCE(decision_guidance_json, '')
+  FROM policies
+ WHERE id NOT IN (SELECT policy_id FROM policies_fts);

--- a/apps/memos-local-plugin/core/storage/repos/policies.ts
+++ b/apps/memos-local-plugin/core/storage/repos/policies.ts
@@ -189,6 +189,117 @@ export function makePoliciesRepo(db: StorageDb) {
       );
     },
 
+    /**
+     * Keyword channel — FTS5 trigram MATCH against `policies_fts`.
+     * Indexes the same user-facing fields the prompt renderer injects:
+     * title, trigger, procedure, verification, boundary and guidance.
+     */
+    searchByText(
+      ftsMatch: string,
+      k: number,
+      opts: { statusIn?: PolicyRow["status"][] } = {},
+    ): Array<VectorHit<string, PolicySearchMeta>> {
+      if (!ftsMatch || k <= 0) return [];
+      const params: Record<string, unknown> = {
+        match: ftsMatch,
+        k: Math.max(1, Math.min(200, Math.floor(k))),
+      };
+      const whereParts: string[] = [];
+      if (opts.statusIn && opts.statusIn.length > 0) {
+        const placeholders = opts.statusIn.map((_, i) => `@status_${i}`).join(",");
+        whereParts.push(`p.status IN (${placeholders})`);
+        opts.statusIn.forEach((st, i) => {
+          params[`status_${i}`] = st;
+        });
+      }
+      const extra = whereParts.length > 0 ? ` AND ${whereParts.join(" AND ")}` : "";
+      const sql = `
+        SELECT p.id AS id,
+               p.title AS title,
+               p.status AS status,
+               p.support AS support,
+               p.gain AS gain,
+               p.experience_type AS experience_type,
+               p.evidence_polarity AS evidence_polarity,
+               p.salience AS salience,
+               p.confidence AS confidence,
+               p.owner_agent_kind AS owner_agent_kind,
+               p.owner_profile_id AS owner_profile_id,
+               p.owner_workspace_id AS owner_workspace_id
+          FROM policies_fts f
+          JOIN policies     p ON p.id = f.policy_id
+         WHERE policies_fts MATCH @match${extra}
+         ORDER BY rank
+         LIMIT @k`;
+      const rows = db
+        .prepare<typeof params, RawPolicySearchRow>(sql)
+        .all(params);
+      return rows.map((r, idx) => ({
+        id: r.id,
+        score: 1 / (idx + 1),
+        meta: policySearchMeta(r),
+      }));
+    },
+
+    /**
+     * Pattern channel — substring fallback for short queries (2-char CJK,
+     * short ids, etc.) that cannot arm the trigram FTS channel.
+     */
+    searchByPattern(
+      terms: readonly string[],
+      k: number,
+      opts: { statusIn?: PolicyRow["status"][] } = {},
+    ): Array<VectorHit<string, PolicySearchMeta>> {
+      if (!terms || terms.length === 0 || k <= 0) return [];
+      const dedup = Array.from(new Set(terms.map((t) => String(t).trim()).filter(Boolean)));
+      if (dedup.length === 0) return [];
+      const params: Record<string, unknown> = {
+        k: Math.max(1, Math.min(200, Math.floor(k))),
+      };
+      const ors: string[] = [];
+      dedup.slice(0, 16).forEach((t, i) => {
+        const key = `pat_${i}`;
+        const escaped = t.replace(/[\\%_]/g, (m) => `\\${m}`);
+        params[key] = `%${escaped}%`;
+        ors.push(
+          `(title LIKE @${key} ESCAPE '\\' OR trigger LIKE @${key} ESCAPE '\\' OR procedure LIKE @${key} ESCAPE '\\' OR verification LIKE @${key} ESCAPE '\\' OR boundary LIKE @${key} ESCAPE '\\' OR decision_guidance_json LIKE @${key} ESCAPE '\\')`,
+        );
+      });
+      const whereParts: string[] = [`(${ors.join(" OR ")})`];
+      if (opts.statusIn && opts.statusIn.length > 0) {
+        const placeholders = opts.statusIn.map((_, i) => `@status_${i}`).join(",");
+        whereParts.push(`status IN (${placeholders})`);
+        opts.statusIn.forEach((st, i) => {
+          params[`status_${i}`] = st;
+        });
+      }
+      const sql = `
+        SELECT id,
+               title,
+               status,
+               support,
+               gain,
+               experience_type,
+               evidence_polarity,
+               salience,
+               confidence,
+               owner_agent_kind,
+               owner_profile_id,
+               owner_workspace_id
+          FROM policies
+         WHERE ${whereParts.join(" AND ")}
+         ORDER BY updated_at DESC
+         LIMIT @k`;
+      const rows = db
+        .prepare<typeof params, RawPolicySearchRow>(sql)
+        .all(params);
+      return rows.map((r, idx) => ({
+        id: r.id,
+        score: 1 / (idx + 1),
+        meta: policySearchMeta(r),
+      }));
+    },
+
     deleteById(id: PolicyId): void {
       db.prepare<{ id: string }>(`DELETE FROM policies WHERE id=@id`).run({ id });
     },
@@ -307,6 +418,22 @@ interface RawPolicyRow {
   edited_at: number | null;
 }
 
+type RawPolicySearchRow = Pick<
+  RawPolicyRow,
+  | "id"
+  | "title"
+  | "status"
+  | "support"
+  | "gain"
+  | "experience_type"
+  | "evidence_polarity"
+  | "salience"
+  | "confidence"
+  | "owner_agent_kind"
+  | "owner_profile_id"
+  | "owner_workspace_id"
+>;
+
 const EMPTY_GUIDANCE: PolicyRow["decisionGuidance"] = Object.freeze({
   preference: [] as string[],
   antiPattern: [] as string[],
@@ -386,6 +513,22 @@ function mapRow(r: RawPolicyRow): PolicyRow {
           }
         : null,
     editedAt: r.edited_at,
+  };
+}
+
+function policySearchMeta(r: RawPolicySearchRow): PolicySearchMeta {
+  return {
+    title: r.title,
+    status: r.status,
+    support: r.support,
+    gain: r.gain,
+    experience_type: normalizeExperienceType(r.experience_type),
+    evidence_polarity: normalizeEvidencePolarity(r.evidence_polarity),
+    salience: finiteOr(r.salience, 0),
+    confidence: finiteOr(r.confidence, 0.5),
+    owner_agent_kind: r.owner_agent_kind,
+    owner_profile_id: r.owner_profile_id,
+    owner_workspace_id: r.owner_workspace_id,
   };
 }
 

--- a/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
@@ -4,6 +4,7 @@ import { toPacket } from "../../../core/retrieval/injector.js";
 import type { RankedCandidate } from "../../../core/retrieval/ranker.js";
 import type {
   EpisodeCandidate,
+  ExperienceCandidate,
   SkillCandidate,
   TraceCandidate,
   WorldModelCandidate,
@@ -72,6 +73,38 @@ function episode(id: string): EpisodeCandidate {
   };
 }
 
+function experience(id: string): ExperienceCandidate {
+  return {
+    tier: "tier2",
+    refKind: "experience",
+    refId: id as never,
+    cosine: 0.8,
+    ts: NOW as never,
+    vec: null,
+    title: `Experience ${id}`,
+    trigger: "similar SEC 13F parsing task",
+    procedure: "Use holdings table columns directly.",
+    verification: "Issuer/CUSIP come from the row fields.",
+    boundary: "SEC 13F holdings extraction only.",
+    support: 1,
+    gain: 0.5,
+    status: "active",
+    experienceType: "failure_avoidance",
+    evidencePolarity: "negative",
+    salience: 0.9,
+    confidence: 0.8,
+    skillEligible: false,
+    sourceEpisodeIds: [],
+    sourceFeedbackIds: ["fb1" as never],
+    sourceTraceIds: [],
+    decisionGuidance: {
+      preference: [],
+      antiPattern: ["Do not infer issuer from filename."],
+    },
+    updatedAt: NOW as never,
+  };
+}
+
 function world(id: string): WorldModelCandidate {
   return {
     tier: "tier3",
@@ -92,6 +125,7 @@ describe("retrieval/injector", () => {
       rc(skill("s1")),
       rc(trace("t1")),
       rc(episode("e1")),
+      rc(experience("p1")),
       rc(world("w1")),
     ];
     const { packet, mapping } = toPacket({
@@ -102,12 +136,33 @@ describe("retrieval/injector", () => {
       sessionId: "sess_t1" as never,
       episodeId: "ep_t1" as never,
     });
-    expect(packet.snippets.length).toBe(4);
+    expect(packet.snippets.length).toBe(5);
     const kinds = packet.snippets.map((s) => s.refKind).sort();
-    expect(kinds).toEqual(["episode", "skill", "trace", "world-model"]);
+    expect(kinds).toEqual(["episode", "experience", "skill", "trace", "world-model"]);
     expect(packet.reason).toBe("turn_start");
     expect(mapping.length).toBe(packet.snippets.length);
     expect(packet.packetId).toMatch(/[a-z0-9_]+/);
+  });
+
+  it("renders experiences as their own top-level section", () => {
+    const { packet } = toPacket({
+      ranked: [rc(trace("t_mem")), rc(experience("p_exp")), rc(world("w_env"))],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_sections" as never,
+      episodeId: "ep_sections" as never,
+    });
+
+    expect(packet.rendered).toContain("## Memories");
+    expect(packet.rendered).toContain("## Experiences");
+    expect(packet.rendered).toContain("## Environment Knowledge");
+    expect(packet.rendered.indexOf("## Memories")).toBeLessThan(
+      packet.rendered.indexOf("## Experiences"),
+    );
+    expect(packet.rendered.indexOf("## Experiences")).toBeLessThan(
+      packet.rendered.indexOf("## Environment Knowledge"),
+    );
   });
 
   it("renders LLM-actionable prose (header, MUST-treat instructions, refId footer)", () => {

--- a/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
@@ -13,6 +13,7 @@ import {
 import type {
   EmbeddingVector,
   EpisodeId,
+  PolicyId,
   SessionId,
   SkillId,
   TraceId,
@@ -114,6 +115,34 @@ function seed(handle: TmpDbHandle) {
     version: 1,
   });
 
+  handle.repos.policies.insert({
+    id: "po_sec13f_issuer" as PolicyId,
+    title: "SEC 13F issuer CUSIP parsing guardrail",
+    trigger: "Parse SEC 13F holdings and extract issuer/CUSIP fields",
+    procedure: "Use holdings table columns directly; do not infer issuer from filenames.",
+    verification: "Issuer and CUSIP values align with the holdings row fields.",
+    boundary: "Only SEC 13F holdings extraction.",
+    support: 1,
+    gain: 0.7,
+    status: "active",
+    experienceType: "failure_avoidance",
+    evidencePolarity: "negative",
+    salience: 0.9,
+    confidence: 0.85,
+    skillEligible: false,
+    sourceEpisodeIds: ["ep1" as EpisodeId],
+    sourceFeedbackIds: ["fb_sec13f" as never],
+    sourceTraceIds: ["t_hi" as TraceId],
+    inducedBy: "unit",
+    decisionGuidance: {
+      preference: [],
+      antiPattern: ["Do not infer SEC 13F issuer from filenames."],
+    },
+    vec: vec([1, 0, 0]),
+    createdAt: NOW as never,
+    updatedAt: NOW as never,
+  });
+
   handle.repos.worldModel.upsert({
     id: "wm_docker" as WorldModelId,
     title: "docker-compose model",
@@ -138,6 +167,7 @@ function makeDeps(handle: TmpDbHandle): RetrievalDeps {
       skills: handle.repos.skills,
       traces: handle.repos.traces,
       worldModel: handle.repos.worldModel,
+      policies: handle.repos.policies,
     },
     embedder: fakeEmbedder,
     config: {
@@ -212,6 +242,36 @@ describe("retrieval/integration", () => {
 
     expect(res.packet.snippets).toEqual([]);
     expect(res.stats.rankedCount).toBe(0);
+  });
+
+  it("recalls feedback experiences through keyword channels when embeddings degrade", async () => {
+    const deps: RetrievalDeps = {
+      ...makeDeps(handle),
+      embedder: {
+        embed: async () => {
+          throw new Error("embedding down");
+        },
+      },
+    };
+
+    const res = await turnStartRetrieve(deps, {
+      reason: "turn_start",
+      agent: "openclaw",
+      sessionId: "s1" as SessionId,
+      userText: "SEC 13F issuer CUSIP parsing",
+      ts: NOW as never,
+    });
+
+    const experience = res.packet.snippets.find((s) => s.refKind === "experience");
+    expect(experience?.refId).toBe("po_sec13f_issuer");
+    expect(experience?.body).toContain("SEC 13F issuer CUSIP");
+    expect(res.packet.rendered).toContain("## Experiences");
+    expect(res.packet.rendered).not.toContain("## Memories\n\n\n1. SEC 13F issuer");
+    expect(res.stats.embedding).toMatchObject({
+      attempted: true,
+      ok: false,
+      degraded: true,
+    });
   });
 
   it("tool_driven skips tier1 (no skill snippets)", async () => {

--- a/apps/memos-local-plugin/tests/unit/storage/repos.test.ts
+++ b/apps/memos-local-plugin/tests/unit/storage/repos.test.ts
@@ -178,6 +178,16 @@ describe("storage/repos — happy paths", () => {
         statusIn: ["active"],
       });
       expect(hits.map((h) => h.id)).toEqual(["p_active"]);
+
+      const textHits = repos.policies.searchByText('"active"', 5, {
+        statusIn: ["active"],
+      });
+      expect(textHits.map((h) => h.id)).toEqual(["p_active"]);
+
+      const patternHits = repos.policies.searchByPattern(["act"], 5, {
+        statusIn: ["active"],
+      });
+      expect(patternHits.map((h) => h.id)).toEqual(["p_active"]);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary
- Render recalled experiences in their own top-level prompt section beside memories, skills, and environment knowledge.
- Add policies FTS/pattern search so feedback-derived experiences can be recalled through keyword channels as well as vectors.
- Cover experience section rendering, degraded-embedding keyword recall, and policies keyword repository search.

## Test plan
- npm test -- tests/unit/retrieval/injector.test.ts tests/unit/retrieval/integration.test.ts tests/unit/storage/repos.test.ts
- npm run lint