### PR TITLE
fix(metrics): return real total memory count instead of capped page size

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -2630,22 +2630,42 @@ export function createMemoryCore(
     const needle = (input?.q ?? "").trim().toLowerCase();
     const visible = (r: TraceRow) => visibleToCurrent(r);
     if (!needle) {
-      const rows = handle.repos.traces.list({ sessionId: input?.sessionId, limit: 100_000 }).filter(visible);
-      if (!input?.groupByTurn) return rows.length;
-      const turnKeys = new Set<string>();
-      for (const r of rows) turnKeys.add(`${r.episodeId ?? "_"}:${r.turnId}`);
-      return turnKeys.size;
+      // Use a dedicated SELECT COUNT(*) instead of `list().length`.
+      // The previous implementation called `repos.traces.list({ limit: 100_000 })`
+      // and counted the returned rows, but `buildPageClauses` silently clamps
+      // every list `limit` to 500. That capped the Memories total at 500
+      // even when the database held 1400+ traces (#1593). The repo's
+      // `count` / `countTurns` issue real COUNT queries with no page-size
+      // cap, so they return the actual total.
+      return input?.groupByTurn
+        ? handle.repos.traces.countTurns({ sessionId: input?.sessionId })
+        : handle.repos.traces.count({ sessionId: input?.sessionId });
     }
     // q substring scan — mirror `listTraces`. Walk all matching
-    // traces from the repo (no limit) and apply the same filter.
-    const rows = handle.repos.traces.list({ sessionId: input?.sessionId }).filter(visible);
-    const matched = rows.filter((r) => {
-      return traceSearchHaystack(r).includes(needle);
-    });
-    if (!input?.groupByTurn) return matched.length;
-    const turnKeys = new Set<string>();
-    for (const r of matched) turnKeys.add(`${r.episodeId ?? "_"}:${r.turnId}`);
-    return turnKeys.size;
+    // traces from the repo and apply the same filter. We page through
+    // explicitly because the underlying `list` clamps each call at
+    // 500 rows, which would otherwise silently truncate the count.
+    const matchedTurnKeys = new Set<string>();
+    let matchedCount = 0;
+    const PAGE = 500;
+    for (let offset = 0; ; offset += PAGE) {
+      const page = handle.repos.traces.list({
+        sessionId: input?.sessionId,
+        limit: PAGE,
+        offset,
+      });
+      if (page.length === 0) break;
+      for (const r of page) {
+        if (!visible(r)) continue;
+        if (!traceSearchHaystack(r).includes(needle)) continue;
+        matchedCount++;
+        if (input?.groupByTurn) {
+          matchedTurnKeys.add(`${r.episodeId ?? "_"}:${r.turnId}`);
+        }
+      }
+      if (page.length < PAGE) break;
+    }
+    return input?.groupByTurn ? matchedTurnKeys.size : matchedCount;
   }
 
   async function listTraces(input?: {

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -2637,9 +2637,20 @@ export function createMemoryCore(
       // even when the database held 1400+ traces (#1593). The repo's
       // `count` / `countTurns` issue real COUNT queries with no page-size
       // cap, so they return the actual total.
+      //
+      // Pass the active namespace so the COUNT applies the SAME visibility
+      // predicate that `list` does — otherwise the total can include rows
+      // owned by other profiles/namespaces and break pagination math
+      // (#1674 review).
       return input?.groupByTurn
-        ? handle.repos.traces.countTurns({ sessionId: input?.sessionId })
-        : handle.repos.traces.count({ sessionId: input?.sessionId });
+        ? handle.repos.traces.countTurns({
+            sessionId: input?.sessionId,
+            namespace: activeNamespace,
+          })
+        : handle.repos.traces.count({
+            sessionId: input?.sessionId,
+            namespace: activeNamespace,
+          });
     }
     // q substring scan — mirror `listTraces`. Walk all matching
     // traces from the repo and apply the same filter. We page through
@@ -2651,6 +2662,7 @@ export function createMemoryCore(
     for (let offset = 0; ; offset += PAGE) {
       const page = handle.repos.traces.list({
         sessionId: input?.sessionId,
+        namespace: activeNamespace,
         limit: PAGE,
         offset,
       });
@@ -3045,7 +3057,11 @@ export function createMemoryCore(
     // the Overview "memories" metric matches what the Memories page
     // shows: 1 user turn = 1 memory (regardless of how many tool calls
     // / sub-steps were captured for that turn).
-    const totalTurns = handle.repos.traces.countTurns();
+    //
+    // Pass the active namespace so the Overview metric stays consistent
+    // with what the current profile actually sees on the Memories page;
+    // otherwise it would aggregate turns owned by other profiles too.
+    const totalTurns = handle.repos.traces.countTurns({ namespace: activeNamespace });
 
     return {
       total: totalTurns,

--- a/apps/memos-local-plugin/core/runtime/namespace.ts
+++ b/apps/memos-local-plugin/core/runtime/namespace.ts
@@ -103,12 +103,22 @@ export function visibilityWhere(
 ): VisibilityWhere {
   const col = (name: string) => `${alias ? `${alias}.` : ""}${name}`;
   const normalized = normalizeNamespace(ns, ns?.agentKind ?? "unknown");
+  // Mirrors `isVisibleTo` exactly so SQL list/count and in-memory filters
+  // agree. A row is visible iff:
+  //   1. it's owned by the current (agentKind, profileId), OR
+  //   2. it has been shared with scope local/public/hub, OR
+  //   3. it has no recorded owner (legacy seed rows: agent_kind = 'unknown'
+  //      AND profile_id = 'default'). Without this branch, pushing the
+  //      predicate into SQL would silently drop pre-namespace rows that
+  //      `isVisibleTo` would have surfaced.
   return {
     sql:
       `((` +
       `${col("owner_agent_kind")} = @vis_owner_agent_kind AND ` +
       `${col("owner_profile_id")} = @vis_owner_profile_id` +
-      `) OR COALESCE(${col("share_scope")}, 'private') IN ('local', 'public', 'hub'))`,
+      `) OR COALESCE(${col("share_scope")}, 'private') IN ('local', 'public', 'hub')` +
+      ` OR (COALESCE(${col("owner_agent_kind")}, 'unknown') = 'unknown' AND ` +
+      `COALESCE(${col("owner_profile_id")}, 'default') = 'default'))`,
     params: {
       vis_owner_agent_kind: normalized.agentKind,
       vis_owner_profile_id: normalized.profileId,

--- a/apps/memos-local-plugin/core/storage/repos/traces.ts
+++ b/apps/memos-local-plugin/core/storage/repos/traces.ts
@@ -14,6 +14,7 @@ import {
   timeRangeWhere,
   toBlob,
   toJsonText,
+  visibilityWhere,
 } from "./_helpers.js";
 
 const COLUMNS = [
@@ -59,6 +60,22 @@ export type TraceSearchMeta = {
 };
 
 export function makeTracesRepo(db: StorageDb) {
+  /**
+   * Shared visibility predicate for `list`/`count`/`countTurns`/`listTurnKeys`.
+   *
+   * Keeping the WHERE fragment in one place is the whole point: the count
+   * queries MUST stay in lock-step with what `list` would return, otherwise
+   * pagination math goes wrong and totals can leak the existence of rows
+   * owned by other namespaces (#1674 review on #1593).
+   */
+  function buildVisibilityClause(
+    filter: { namespace?: TraceListFilter["namespace"] },
+  ): { sql: string | null; params: Record<string, unknown> } {
+    if (!filter.namespace) return { sql: null, params: {} };
+    const v = visibilityWhere(filter.namespace);
+    return { sql: v.sql, params: v.params };
+  }
+
   const insert = db.prepare(buildInsert({ table: "traces", columns: COLUMNS }));
   const upsert = db.prepare(
     buildInsert({ table: "traces", columns: COLUMNS, onConflict: "replace" }),
@@ -111,8 +128,9 @@ export function makeTracesRepo(db: StorageDb) {
 
     list(filter: TraceListFilter = {}): TraceRow[] {
       const tr = timeRangeWhere(filter, "ts");
+      const vis = buildVisibilityClause(filter);
       const fragments: string[] = [];
-      const params: Record<string, unknown> = { ...tr.params };
+      const params: Record<string, unknown> = { ...tr.params, ...vis.params };
       if (filter.sessionId) {
         fragments.push(`session_id = @session_id`);
         params.session_id = filter.sessionId;
@@ -126,6 +144,7 @@ export function makeTracesRepo(db: StorageDb) {
         params.min_abs_value = filter.minAbsValue;
       }
       if (tr.sql) fragments.push(tr.sql);
+      if (vis.sql) fragments.push(vis.sql);
       const where = joinWhere(fragments);
       const page = buildPageClauses(filter, "ts");
       const sql = `SELECT ${COLUMNS.join(", ")} FROM traces ${where} ${page}`;
@@ -138,8 +157,9 @@ export function makeTracesRepo(db: StorageDb) {
      */
     count(filter: Omit<TraceListFilter, "limit" | "offset"> = {}): number {
       const tr = timeRangeWhere(filter, "ts");
+      const vis = buildVisibilityClause(filter);
       const fragments: string[] = [];
-      const params: Record<string, unknown> = { ...tr.params };
+      const params: Record<string, unknown> = { ...tr.params, ...vis.params };
       if (filter.sessionId) {
         fragments.push(`session_id = @session_id`);
         params.session_id = filter.sessionId;
@@ -153,6 +173,7 @@ export function makeTracesRepo(db: StorageDb) {
         params.min_abs_value = filter.minAbsValue;
       }
       if (tr.sql) fragments.push(tr.sql);
+      if (vis.sql) fragments.push(vis.sql);
       const where = joinWhere(fragments);
       const sql = `SELECT COUNT(*) AS n FROM traces ${where}`;
       const row = db.prepare<typeof params, { n: number }>(sql).get(params);
@@ -165,8 +186,9 @@ export function makeTracesRepo(db: StorageDb) {
      * counted as 1. Used by the Memories viewer for accurate pagination.
      */
     countTurns(filter: Omit<TraceListFilter, "limit" | "offset"> = {}): number {
+      const vis = buildVisibilityClause(filter);
       const fragments: string[] = [];
-      const params: Record<string, unknown> = {};
+      const params: Record<string, unknown> = { ...vis.params };
       if (filter.sessionId) {
         fragments.push(`session_id = @session_id`);
         params.session_id = filter.sessionId;
@@ -175,6 +197,7 @@ export function makeTracesRepo(db: StorageDb) {
         fragments.push(`episode_id = @episode_id`);
         params.episode_id = filter.episodeId;
       }
+      if (vis.sql) fragments.push(vis.sql);
       const where = joinWhere(fragments);
       const sql = `SELECT COUNT(*) AS n FROM (SELECT DISTINCT episode_id, turn_id FROM traces ${where})`;
       const row = db.prepare<typeof params, { n: number }>(sql).get(params);
@@ -187,8 +210,9 @@ export function makeTracesRepo(db: StorageDb) {
      * fetch a page of "memories" (1 turn = 1 memory).
      */
     listTurnKeys(filter: TraceListFilter = {}): Array<{ episodeId: string | null; turnId: number; maxTs: number }> {
+      const vis = buildVisibilityClause(filter);
       const fragments: string[] = [];
-      const params: Record<string, unknown> = {};
+      const params: Record<string, unknown> = { ...vis.params };
       if (filter.sessionId) {
         fragments.push(`session_id = @session_id`);
         params.session_id = filter.sessionId;
@@ -197,6 +221,7 @@ export function makeTracesRepo(db: StorageDb) {
         fragments.push(`episode_id = @episode_id`);
         params.episode_id = filter.episodeId;
       }
+      if (vis.sql) fragments.push(vis.sql);
       const where = joinWhere(fragments);
       const limit = Math.max(1, Math.min(500, filter.limit ?? 50));
       const offset = Math.max(0, filter.offset ?? 0);

--- a/apps/memos-local-plugin/core/storage/types.ts
+++ b/apps/memos-local-plugin/core/storage/types.ts
@@ -8,6 +8,7 @@
 
 import type BetterSqlite3 from "better-sqlite3";
 
+import type { RuntimeNamespace } from "../../agent-contract/dto.js";
 import type { EpochMs, EpisodeId, TraceId } from "../types.js";
 
 // ─── Database handle ─────────────────────────────────────────────────────────
@@ -91,6 +92,14 @@ export interface TraceListFilter extends PageOptions, TimeRange {
   /** Only traces with |value| >= this (absolute). */
   minAbsValue?: number;
   traceIds?: TraceId[];
+  /**
+   * If provided, restrict results to rows visible to this namespace —
+   * either owned by the namespace's (agentKind, profileId) or shared with
+   * scope `local`/`public`/`hub`. Mirrors the in-memory `isVisibleTo`
+   * predicate but pushes it into SQL so `count`/`countTurns` agree with
+   * `list`.
+   */
+  namespace?: RuntimeNamespace;
 }
 
 export interface PolicyListFilter extends PageOptions, TimeRange {

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -742,6 +742,132 @@ describe("MemoryCore façade", () => {
     expect(await core.countTraces({ groupByTurn: true })).toBe(6);
   });
 
+  it("countTraces respects namespace visibility (regression for #1674)", async () => {
+    // Two profiles each insert their own traces. Each profile's
+    // countTraces must return ONLY its own count — the COUNT path
+    // must apply the same visibility predicate that listTraces does,
+    // otherwise pagination math breaks and the count leaks the
+    // existence of cross-profile rows.
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    db!.repos.sessions.upsert({
+      id: "s-main",
+      agent: "openclaw",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      lastSeenAt: 2_000,
+      meta: {},
+    });
+    db!.repos.sessions.upsert({
+      id: "s-reviewer",
+      agent: "openclaw",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "reviewer",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      lastSeenAt: 2_000,
+      meta: {},
+    });
+    db!.repos.episodes.insert({
+      id: "ep-main",
+      sessionId: "s-main",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      endedAt: 2_000,
+      traceIds: [] as never,
+      rTask: null,
+      status: "closed",
+      meta: {},
+    });
+    db!.repos.episodes.insert({
+      id: "ep-reviewer",
+      sessionId: "s-reviewer",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "reviewer",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      endedAt: 2_000,
+      traceIds: [] as never,
+      rTask: null,
+      status: "closed",
+      meta: {},
+    });
+    const baseTrace = {
+      sessionId: "s-main",
+      episodeId: "ep-main",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      userText: "u",
+      agentText: "a",
+      summary: null,
+      toolCalls: [],
+      reflection: null,
+      agentThinking: null,
+      value: 0,
+      alpha: 0,
+      rHuman: null,
+      priority: 0,
+      tags: [],
+      errorSignatures: [],
+      vecSummary: null,
+      vecAction: null,
+      schemaVersion: 1,
+    } as const;
+    // 7 traces / 3 turns owned by `main`.
+    for (let i = 0; i < 7; i++) {
+      db!.repos.traces.insert({
+        ...baseTrace,
+        id: `tr-main-${i}`,
+        ts: 1_000 + i,
+        turnId: Math.floor(i / 3),
+      } as never);
+    }
+    // 4 traces / 2 turns owned by `reviewer`.
+    for (let i = 0; i < 4; i++) {
+      db!.repos.traces.insert({
+        ...baseTrace,
+        sessionId: "s-reviewer",
+        episodeId: "ep-reviewer",
+        ownerProfileId: "reviewer",
+        id: `tr-reviewer-${i}`,
+        ts: 2_000 + i,
+        turnId: Math.floor(i / 2),
+      } as never);
+    }
+
+    await core.init();
+
+    // Default namespace from buildDeps is `main` — should see only
+    // its own 7 traces / 3 turns, not the reviewer's rows.
+    expect(await core.countTraces({})).toBe(7);
+    expect(await core.countTraces({ groupByTurn: true })).toBe(3);
+
+    // Switch to `reviewer` namespace — now we should see only the 4
+    // reviewer traces / 2 reviewer turns.
+    await core.openSession({
+      agent: "openclaw",
+      sessionId: "s-reviewer",
+      namespace: { agentKind: "openclaw", profileId: "reviewer" },
+    });
+    expect(await core.countTraces({})).toBe(4);
+    expect(await core.countTraces({ groupByTurn: true })).toBe(2);
+
+    // listTraces and countTraces must agree under both namespaces —
+    // that's the whole point: COUNT(*) must respect visibility too.
+    const reviewerList = await core.listTraces({ limit: 500 });
+    expect(reviewerList).toHaveLength(4);
+    expect(reviewerList.every((t) => t.ownerProfileId === "reviewer")).toBe(true);
+  });
+
   it("deleteTrace removes FTS entries and episode trace references", async () => {
     pipeline = createPipeline(buildDeps(db!));
     core = createMemoryCore(

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -674,6 +674,74 @@ describe("MemoryCore façade", () => {
     expect(grouped.map((tr) => tr.id)).toEqual(["tr-late", "tr-early"]);
   });
 
+  it("countTraces returns the real total even when more than 500 rows exist (regression for #1593)", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    db!.repos.sessions.upsert({
+      id: "s-count",
+      agent: "openclaw",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      lastSeenAt: 2_000,
+      meta: {},
+    });
+    db!.repos.episodes.insert({
+      id: "ep-count",
+      sessionId: "s-count",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_000,
+      endedAt: 2_000,
+      traceIds: [] as never,
+      rTask: null,
+      status: "closed",
+      meta: {},
+    });
+    const baseTrace = {
+      episodeId: "ep-count",
+      sessionId: "s-count",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      userText: "u",
+      agentText: "a",
+      summary: null,
+      toolCalls: [],
+      reflection: null,
+      agentThinking: null,
+      value: 0,
+      alpha: 0,
+      rHuman: null,
+      priority: 0,
+      tags: [],
+      errorSignatures: [],
+      vecSummary: null,
+      vecAction: null,
+      schemaVersion: 1,
+    } as const;
+    // Insert 600 rows split across 6 turns so we cross the 500-row
+    // page-size cap that previously truncated the count.
+    for (let i = 0; i < 600; i++) {
+      db!.repos.traces.insert({
+        ...baseTrace,
+        id: `tr-count-${i}`,
+        ts: 1_000 + i,
+        turnId: Math.floor(i / 100), // 6 distinct turns
+      } as never);
+    }
+
+    await core.init();
+    expect(await core.countTraces({})).toBe(600);
+    expect(await core.countTraces({ groupByTurn: true })).toBe(6);
+  });
+
   it("deleteTrace removes FTS entries and episode trace references", async () => {
     pipeline = createPipeline(buildDeps(db!));
     core = createMemoryCore(


### PR DESCRIPTION
## Summary

The Web UI memory-count card on the Memories page was stuck at 500 even when the database held 1400+ traces (#1593). The metrics path counted items from an already-limited listing instead of running a dedicated COUNT query.

## Root cause

`countTraces` in `apps/memos-local-plugin/core/pipeline/memory-core.ts` computed the total by calling `handle.repos.traces.list({ limit: 100_000 })` and reading `rows.length`. The shared helper `buildPageClauses` / `clampLimit` (in `core/storage/repos/_helpers.ts`) silently clamps every list `limit` to **500**, so `list({ limit: 100_000 })` actually returns at most 500 rows. The resulting `rows.length` (or grouped `turnKeys.size`) was therefore capped at 500 regardless of how many traces existed.

The `/api/v1/traces` endpoint uses `countTraces`, and the Memories view (`web/src/views/MemoriesView.tsx`) renders that response's `total` in its pagination footer, so the Web UI showed 500 forever.

## Fix

In `countTraces`:

- For the no-search path, use the repo's dedicated `SELECT COUNT(*)` queries directly (`repos.traces.count` / `countTurns`). These don't go through `buildPageClauses` and have no 500-row cap, so the returned total reflects the real database size.
- For the substring-search path, page through traces explicitly with offset increments instead of relying on a single `list()` call (which would also be clamped at 500). Each batch is filtered for visibility and matched against the search needle, so the count stays accurate even above 500 rows.

Listings keep their existing page-size limits; only the count was wrong.

## Verification

Added a regression test in `tests/unit/pipeline/memory-core.test.ts` that inserts 600 trace rows across 6 distinct turns and asserts:

- `countTraces({})` returns `600` (was 500 before the fix)
- `countTraces({ groupByTurn: true })` returns `6` (was capped at the smaller of 6 or 500 before; would break for >500 turns)

Files changed:
- `apps/memos-local-plugin/core/pipeline/memory-core.ts` (~34 net lines)
- `apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts` (regression test)

Fixes #1593