### PR TITLE
fix(memos-local-plugin): preserve OpenClaw memory context

### DIFF
--- a/apps/memos-local-plugin/adapters/openclaw/bridge.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/bridge.ts
@@ -70,6 +70,7 @@ import type {
 
 const TOOL_RESULT_ROLES = new Set([
   "toolResult",      // pi-ai canonical
+  "toolresult",      // lower-case gateway/UI normalizer variants
   "tool",            // OpenAI legacy
   "tool_result",     // some Anthropic SDKs / older bridges
   "tool_response",   // older variants
@@ -156,13 +157,13 @@ export function flattenMessages(input: unknown[] | undefined): FlatMessage[] {
           textBuf += (textBuf ? "\n" : "") + b.text;
         } else if (type === "thinking" && typeof b.thinking === "string") {
           thinkingBuf += (thinkingBuf ? "\n\n" : "") + b.thinking;
-        } else if (type === "toolCall") {
+        } else if (isToolCallBlockType(type)) {
           inlineToolCalls.push({
             role: "tool_call",
             content: "",
             toolName: typeof b.name === "string" ? b.name : "unknown",
-            toolCallId: typeof b.id === "string" ? b.id : undefined,
-            toolInput: b.arguments,
+            toolCallId: pickToolCallId(b, m),
+            toolInput: pickToolInput(b),
             ts,
           });
         } else if (!type && typeof b.text === "string") {
@@ -244,6 +245,63 @@ export function flattenMessages(input: unknown[] | undefined): FlatMessage[] {
   }
 
   return out;
+}
+
+function isToolCallBlockType(type: string): boolean {
+  const normalized = type.trim().toLowerCase();
+  return (
+    normalized === "toolcall" ||
+    normalized === "tool_call" ||
+    normalized === "tooluse" ||
+    normalized === "tool_use" ||
+    normalized === "functioncall" ||
+    normalized === "function_call"
+  );
+}
+
+function pickToolCallId(
+  block: Record<string, unknown>,
+  message?: Record<string, unknown>,
+): string | undefined {
+  return firstString(
+    block.id,
+    block.toolCallId,
+    block.tool_call_id,
+    block.callId,
+    block.call_id,
+    block.toolUseId,
+    block.tool_use_id,
+    message?.toolCallId,
+    message?.tool_call_id,
+  );
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function pickToolInput(block: Record<string, unknown>): unknown {
+  if ("arguments" in block) return block.arguments;
+  if ("args" in block) return block.args;
+  if ("input" in block) return block.input;
+  if (typeof block.partialJson === "string") {
+    try {
+      return JSON.parse(block.partialJson);
+    } catch {
+      return block.partialJson;
+    }
+  }
+  if (typeof block.partialArgs === "string") {
+    try {
+      return JSON.parse(block.partialArgs);
+    } catch {
+      return block.partialArgs;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -526,8 +584,25 @@ export function extractTurn(messages: FlatMessage[], now: number): CapturedTurn 
   const userText = messages[lastUserIdx].content.trim();
   const tail = messages.slice(lastUserIdx + 1);
 
-  const pendingCalls = new Map<string, Partial<ToolCallDTO> & { _id?: string }>();
+  type PendingToolCall = Partial<ToolCallDTO> & { _id?: string };
+  const pendingCalls = new Map<string, PendingToolCall[]>();
   const toolCalls: ToolCallDTO[] = [];
+
+  const enqueuePendingCall = (key: string, stub: PendingToolCall): void => {
+    const queue = pendingCalls.get(key);
+    if (queue) {
+      queue.push(stub);
+    } else {
+      pendingCalls.set(key, [stub]);
+    }
+  };
+  const takePendingCall = (key: string): PendingToolCall | undefined => {
+    const queue = pendingCalls.get(key);
+    if (!queue || queue.length === 0) return undefined;
+    const stub = queue.shift();
+    if (queue.length === 0) pendingCalls.delete(key);
+    return stub;
+  };
 
   // Two separate buffers accumulate content not yet assigned to a tool.
   //
@@ -561,7 +636,7 @@ export function extractTurn(messages: FlatMessage[], now: number): CapturedTurn 
       pendingAssistant = [];
 
       const key = m.toolCallId ?? m.toolName;
-      pendingCalls.set(key, {
+      enqueuePendingCall(key, {
         _id: m.toolCallId,
         name: m.toolName,
         input: m.toolInput,
@@ -572,7 +647,7 @@ export function extractTurn(messages: FlatMessage[], now: number): CapturedTurn 
     }
     if (m.role === "tool_result") {
       const key = m.toolCallId ?? m.toolName ?? "";
-      const stub = pendingCalls.get(key);
+      const stub = key ? takePendingCall(key) : undefined;
       const errorCode = stub
         ? m.errorCode ?? (m.isError ? "tool_error" : undefined)
         : m.errorCode ?? (m.isError ? "tool_error" : undefined);
@@ -581,25 +656,28 @@ export function extractTurn(messages: FlatMessage[], now: number): CapturedTurn 
         input: stub?.input,
         output: m.content || undefined,
         errorCode,
+        toolCallId: stub?._id ?? m.toolCallId,
         startedAt: stub?.startedAt ?? (m.ts ?? now),
         endedAt: m.ts ?? now,
         thinkingBefore: stub?.thinkingBefore,
       });
-      if (key) pendingCalls.delete(key);
       continue;
     }
   }
 
-  for (const stub of pendingCalls.values()) {
-    if (!stub.name) continue;
-    toolCalls.push({
-      name: stub.name,
-      input: stub.input,
-      output: undefined,
-      startedAt: stub.startedAt ?? now,
-      endedAt: now,
-      thinkingBefore: stub.thinkingBefore,
-    });
+  for (const queue of pendingCalls.values()) {
+    for (const stub of queue) {
+      if (!stub.name) continue;
+      toolCalls.push({
+        name: stub.name,
+        input: stub.input,
+        output: undefined,
+        toolCallId: stub._id,
+        startedAt: stub.startedAt ?? now,
+        endedAt: now,
+        thinkingBefore: stub.thinkingBefore,
+      });
+    }
   }
 
   const agentThinking = pendingThinking.join("\n\n").trim();
@@ -609,6 +687,56 @@ export function extractTurn(messages: FlatMessage[], now: number): CapturedTurn 
     agentThinking: agentThinking || undefined,
     toolCalls,
   };
+}
+
+function mergeToolCalls(
+  captured: readonly ToolCallDTO[],
+  observed: readonly ToolCallDTO[],
+): ToolCallDTO[] {
+  if (observed.length === 0) return [...captured];
+  const out = captured.map((tc) => ({ ...tc }));
+  for (const obs of observed) {
+    const idx = out.findIndex((existing) => toolCallsMatch(existing, obs));
+    if (idx >= 0) {
+      out[idx] = mergeToolCall(out[idx]!, obs);
+    } else {
+      out.push({ ...obs });
+    }
+  }
+  return out.sort((a, b) => {
+    const at = a.startedAt ?? a.endedAt ?? 0;
+    const bt = b.startedAt ?? b.endedAt ?? 0;
+    return at - bt;
+  });
+}
+
+function mergeToolCall(existing: ToolCallDTO, observed: ToolCallDTO): ToolCallDTO {
+  return {
+    ...observed,
+    ...existing,
+    input: existing.input ?? observed.input,
+    output: existing.output ?? observed.output,
+    errorCode: existing.errorCode ?? observed.errorCode,
+    toolCallId: existing.toolCallId ?? observed.toolCallId,
+    startedAt: existing.startedAt ?? observed.startedAt,
+    endedAt: existing.endedAt ?? observed.endedAt,
+    thinkingBefore: existing.thinkingBefore ?? observed.thinkingBefore,
+    assistantTextBefore: existing.assistantTextBefore ?? observed.assistantTextBefore,
+  };
+}
+
+function toolCallsMatch(a: ToolCallDTO, b: ToolCallDTO): boolean {
+  if (a.toolCallId && b.toolCallId) return a.toolCallId === b.toolCallId;
+  if (a.toolCallId || b.toolCallId) return false;
+  return a.name === b.name && stableStringify(a.input) === stableStringify(b.input);
+}
+
+function stableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 // ─── Session identity ──────────────────────────────────────────────────────
@@ -781,7 +909,16 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
   let episodeBindingSeq = 0;
   // Per-toolCallId start timestamps so `after_tool_call` can compute duration
   // when the host doesn't populate `durationMs`.
-  const toolCallStartedAt = new Map<string, { ts: number; sessionId: SessionId }>();
+  const toolCallStartedAt = new Map<string, {
+    ts: number;
+    sessionId: SessionId;
+    runId?: string;
+    toolName?: string;
+    params?: Record<string, unknown>;
+  }>();
+  type ObservedToolCall = ToolCallDTO & { runId?: string; order: number };
+  const observedToolCallsBySession = new Map<SessionId, ObservedToolCall[]>();
+  let observedToolCallSeq = 0;
   const spawnedSubagents = new Map<string, {
     event: SubagentSpawnedEvent;
     ctx: PluginHookSubagentContext;
@@ -790,6 +927,40 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
     parentEpisodeId?: EpisodeId;
   }>();
   const pendingSubagentSessions = new Set<SessionId>();
+
+  function rememberObservedToolCall(
+    sessionId: SessionId,
+    runId: string | undefined,
+    tc: ToolCallDTO,
+  ): void {
+    const list = observedToolCallsBySession.get(sessionId) ?? [];
+    list.push({ ...tc, runId, order: ++observedToolCallSeq });
+    observedToolCallsBySession.set(sessionId, list.slice(-200));
+  }
+
+  function takeObservedToolCalls(
+    sessionId: SessionId,
+    runId: string | undefined,
+  ): ToolCallDTO[] {
+    const list = observedToolCallsBySession.get(sessionId) ?? [];
+    if (list.length === 0) return [];
+
+    const matched: ObservedToolCall[] = [];
+    const rest: ObservedToolCall[] = [];
+    for (const tc of list) {
+      const sameRun = runId ? tc.runId === runId || !tc.runId : true;
+      if (sameRun) matched.push(tc);
+      else rest.push(tc);
+    }
+
+    if (rest.length > 0) observedToolCallsBySession.set(sessionId, rest);
+    else observedToolCallsBySession.delete(sessionId);
+
+    return matched
+      .slice()
+      .sort((a, b) => (a.startedAt ?? a.order) - (b.startedAt ?? b.order))
+      .map(({ runId: _runId, order: _order, ...tc }) => tc);
+  }
 
   async function ensureSession(
     agentId: string | undefined,
@@ -1052,8 +1223,12 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
         });
         return;
       }
+      const toolCalls = mergeToolCalls(
+        turn.toolCalls,
+        takeObservedToolCalls(sessionId, ctx.runId),
+      );
       const isSubagentAnnouncement = isOpenClawSubagentAnnouncementPrompt(turn.userText);
-      const hasSubagentSpawn = turn.toolCalls.some((tc) => tc.name === "sessions_spawn");
+      const hasSubagentSpawn = toolCalls.some((tc) => tc.name === "sessions_spawn");
 
       // Resolve (or lazily open) the target episode. Three cases:
       //   1. `before_prompt_build` already ran this turn → we have the
@@ -1088,7 +1263,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
         episodeId,
         agentText: turn.agentText,
         agentThinking: turn.agentThinking,
-        toolCalls: turn.toolCalls,
+        toolCalls,
         reflection: turn.reflection,
         contextHints: { namespace },
         ts: now(),
@@ -1101,7 +1276,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
         sessionId,
         traceId: res.traceId,
         episodeId: res.episodeId,
-        tools: turn.toolCalls.length,
+        tools: toolCalls.length,
         success: event.success,
         durationMs: event.durationMs,
       });
@@ -1120,6 +1295,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
         await opts.core.closeSession(sessionId);
         messageCursor.delete(sessionId);
         forgetSessionBindings(sessionId);
+        observedToolCallsBySession.delete(sessionId);
         lastUserTextBySession.delete(sessionId);
       }
     } catch (err) {
@@ -1131,13 +1307,20 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
   }
 
   function handleBeforeToolCall(
-    _event: BeforeToolCallEvent,
+    event: BeforeToolCallEvent,
     ctx: PluginHookToolContext,
   ): void {
-    if (!ctx.toolCallId) return;
+    const toolCallId = ctx.toolCallId ?? event.toolCallId;
+    if (!toolCallId) return;
     if (isEphemeralSessionKey(ctx.sessionKey)) return;
     const sessionId = bridgeSessionId(ctx.agentId ?? "main", ctx.sessionKey ?? "default");
-    toolCallStartedAt.set(ctx.toolCallId, { ts: now(), sessionId });
+    toolCallStartedAt.set(toolCallId, {
+      ts: now(),
+      sessionId,
+      runId: ctx.runId ?? event.runId,
+      toolName: ctx.toolName ?? event.toolName,
+      params: event.params,
+    });
   }
 
   async function handleAfterToolCall(
@@ -1147,8 +1330,9 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
     if (isEphemeralSessionKey(ctx.sessionKey)) return;
     try {
       const sessionId = bridgeSessionId(ctx.agentId ?? "main", ctx.sessionKey ?? "default");
-      const started = ctx.toolCallId ? toolCallStartedAt.get(ctx.toolCallId) : undefined;
-      if (ctx.toolCallId) toolCallStartedAt.delete(ctx.toolCallId);
+      const toolCallId = ctx.toolCallId ?? event.toolCallId;
+      const started = toolCallId ? toolCallStartedAt.get(toolCallId) : undefined;
+      if (toolCallId) toolCallStartedAt.delete(toolCallId);
 
       const endedAt = now();
       const durationMs =
@@ -1157,11 +1341,22 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
           : started
           ? Math.max(0, endedAt - started.ts)
           : 0;
+      const toolName = event.toolName || started?.toolName || ctx.toolName || "unknown";
+      const startedAt = started?.ts;
+      rememberObservedToolCall(sessionId, ctx.runId ?? event.runId ?? started?.runId, {
+        name: toolName,
+        input: event.params ?? started?.params,
+        output: event.result,
+        errorCode: event.error,
+        toolCallId,
+        startedAt,
+        endedAt,
+      });
 
       opts.core.recordToolOutcome({
         sessionId,
         episodeId: currentEpisodeId(sessionId),
-        tool: event.toolName,
+        tool: toolName,
         success: !event.error,
         errorCode: event.error,
         durationMs,
@@ -1211,6 +1406,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
       await opts.core.closeSession(sessionId);
       messageCursor.delete(sessionId);
       forgetSessionBindings(sessionId);
+      observedToolCallsBySession.delete(sessionId);
       lastUserTextBySession.delete(sessionId);
       opts.log.debug("memos.session.ended", {
         sessionId: event.sessionId,

--- a/apps/memos-local-plugin/core/retrieval/ALGORITHMS.md
+++ b/apps/memos-local-plugin/core/retrieval/ALGORITHMS.md
@@ -101,7 +101,7 @@ Tier 2 returns single-trace hits *and* episode-level summaries:
 
 1. Bucket the candidate traces by `episode_id`.
 2. For any bucket with ≥ 2 traces, emit an `EpisodeCandidate`:
-   - `summary` = "episode N steps · best V=x\n· reflection: …\n· user: …"
+   - `summary` = "Past similar episode\nstep 1\n  summary/user/agent/reflection: …"
    - `maxValue` = max of member traces
    - `meanPriority` = mean of member priorities
 3. Sort episode rollups by `(maxValue, cosine)` desc, keep top `tier2TopK`.

--- a/apps/memos-local-plugin/core/retrieval/injector.ts
+++ b/apps/memos-local-plugin/core/retrieval/injector.ts
@@ -267,9 +267,9 @@ function renderTrace(c: TraceCandidate): InjectionSnippet {
 
 function renderEpisode(c: EpisodeCandidate): InjectionSnippet {
   // Episode summary already comes with step-by-step action sequence
-  // (see tier2-trace.ts::renderEpisodeSummary), so we drop the raw
-  // V-score prefix and hand the summary through as-is.
-  const body = truncate(c.summary);
+  // (see tier2-trace.ts::renderEpisodeSummary). Keep prompt-facing text
+  // free of retrieval metrics; they are useful for logs, not for answers.
+  const body = truncate(stripEpisodePromptMetrics(c.summary));
   const when = new Date(c.ts).toISOString().slice(0, 16).replace("T", " ");
   return {
     refKind: "episode",
@@ -277,6 +277,15 @@ function renderEpisode(c: EpisodeCandidate): InjectionSnippet {
     title: `Sub-task · ${when}`,
     body,
   };
+}
+
+function stripEpisodePromptMetrics(summary: string): string {
+  return summary
+    .replace(
+      /^episode\s+\d+\s+steps\s*·\s*best\s+V=[+-]?\d+(?:\.\d+)?\s*·\s*goal-sim=[+-]?\d+(?:\.\d+)?/i,
+      "Past similar episode",
+    )
+    .replace(/\bstep\s+(\d+)\s+\(V=[+-]?\d+(?:\.\d+)?\)/gi, "step $1");
 }
 
 function renderExperience(c: ExperienceCandidate): InjectionSnippet {

--- a/apps/memos-local-plugin/core/retrieval/tier2-trace.ts
+++ b/apps/memos-local-plugin/core/retrieval/tier2-trace.ts
@@ -421,11 +421,11 @@ function dedupChannels(channels: readonly ChannelRank[]): ChannelRank[] {
   return Array.from(best.values());
 }
 
-function renderEpisodeSummary(best: TraceCandidate, members: readonly TraceCandidate[]): string {
-  const header = `episode ${members.length} steps · best V=${best.value.toFixed(2)} · goal-sim=${best.cosine.toFixed(2)}`;
+function renderEpisodeSummary(_best: TraceCandidate, members: readonly TraceCandidate[]): string {
+  const header = "Past similar episode";
   const MAX_STEPS = 6;
   const steps = members.slice(0, MAX_STEPS).map((m, idx) => {
-    const parts: string[] = [`step ${idx + 1} (V=${m.value.toFixed(2)})`];
+    const parts: string[] = [`step ${idx + 1}`];
     const s = m.summary?.trim().replace(/\s+/g, " ") ?? "";
     if (s) {
       parts.push(`summary: ${s.slice(0, 160)}`);

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -530,9 +530,16 @@ if (!config.plugins.entries[pluginId] || typeof config.plugins.entries[pluginId]
   config.plugins.entries[pluginId] = {};
 }
 config.plugins.entries[pluginId].enabled = true;
-// Do not write hook capability flags here. Current OpenClaw validates
-// plugin entries strictly and rejects unknown hook keys.
-if (config.plugins.entries[pluginId].hooks) delete config.plugins.entries[pluginId].hooks;
+if (
+  !config.plugins.entries[pluginId].hooks ||
+  typeof config.plugins.entries[pluginId].hooks !== 'object' ||
+  Array.isArray(config.plugins.entries[pluginId].hooks)
+) {
+  config.plugins.entries[pluginId].hooks = {};
+}
+// OpenClaw gates transcript-bearing hooks for non-bundled plugins. Without
+// this, `agent_end` is blocked, so turns are recalled but never captured.
+config.plugins.entries[pluginId].hooks.allowConversationAccess = true;
 
 if (!config.plugins.installs || typeof config.plugins.installs !== 'object') config.plugins.installs = {};
 const installsEntry = {

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-bridge.test.ts
@@ -157,6 +157,39 @@ describe("flattenMessages", () => {
     expect(toolResult.isError).toBe(false);
   });
 
+  it("accepts OpenClaw lowercase/alias tool-call content blocks", () => {
+    const flat = flattenMessages([
+      { role: "user", content: "read two files" },
+      {
+        role: "assistant",
+        toolCallId: "fallback-id",
+        content: [
+          { type: "toolcall", id: "call_1", name: "read", arguments: { path: "a.md" } },
+          { type: "tool_use", toolUseId: "call_2", name: "read", input: { path: "b.md" } },
+          { type: "functionCall", name: "exec", args: { command: "pwd" } },
+        ],
+      },
+    ]);
+
+    const calls = flat.filter((m) => m.role === "tool_call");
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toMatchObject({
+      toolCallId: "call_1",
+      toolName: "read",
+      toolInput: { path: "a.md" },
+    });
+    expect(calls[1]).toMatchObject({
+      toolCallId: "call_2",
+      toolName: "read",
+      toolInput: { path: "b.md" },
+    });
+    expect(calls[2]).toMatchObject({
+      toolCallId: "fallback-id",
+      toolName: "exec",
+      toolInput: { command: "pwd" },
+    });
+  });
+
   it("accepts OpenAI-legacy assistant.tool_calls + role: 'tool' for results", () => {
     // Older bridges and our own historical tests use this shape — keep
     // it working so we don't regress on multi-host setups.
@@ -298,6 +331,7 @@ describe("extractTurn", () => {
     expect(turn!.toolCalls[0].name).toBe("sh");
     expect(turn!.toolCalls[0].input).toEqual({ cmd: "ls" });
     expect(turn!.toolCalls[0].output).toContain("a.txt");
+    expect(turn!.toolCalls[0].toolCallId).toBe("c1");
     expect(turn!.toolCalls[0].thinkingBefore).toBe("running ls");
   });
 
@@ -553,6 +587,30 @@ describe("extractTurn", () => {
     expect(turn!.toolCalls).toHaveLength(1);
     expect(turn!.toolCalls[0].name).toBe("x");
     expect(turn!.toolCalls[0].output).toBeUndefined();
+  });
+
+  it("keeps parallel same-name tool calls when ids are missing", () => {
+    const flat = flattenMessages([
+      { role: "user", content: "read both files" },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolcall", name: "read", arguments: { path: "a.md" } },
+          { type: "toolcall", name: "read", arguments: { path: "b.md" } },
+        ],
+      },
+      { role: "toolResult", toolName: "read", content: "A" },
+      { role: "toolResult", toolName: "read", content: "B" },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ]);
+
+    const turn = extractTurn(flat, 0);
+    expect(turn!.toolCalls).toHaveLength(2);
+    expect(turn!.toolCalls.map((tc) => tc.input)).toEqual([
+      { path: "a.md" },
+      { path: "b.md" },
+    ]);
+    expect(turn!.toolCalls.map((tc) => tc.output)).toEqual(["A", "B"]);
   });
 
   it("returns null when the list has no user message", () => {
@@ -956,6 +1014,59 @@ describe("createOpenClawBridge", () => {
     // new topic. We assert the trace was captured, not the closure.
     expect(events).toContain("trace.created");
     expect(events).not.toContain("episode.closed");
+  });
+
+  it("uses tool hook observations when agent_end transcript omits tool blocks", async () => {
+    const mc = buildCore();
+    await mc.init();
+
+    const bridge = createOpenClawBridge({
+      agent: "openclaw",
+      core: mc,
+      log: silentLogger(),
+    });
+    const runCtx = hookCtx({ sessionKey: "s-cached-tools", runId: "run-cached-tools" });
+    const toolCtx: PluginHookToolContext = {
+      toolName: "sh",
+      toolCallId: "call_cached",
+      agentId: "main",
+      sessionKey: "s-cached-tools",
+      sessionId: "host-s-cached-tools",
+      runId: "run-cached-tools",
+    };
+
+    await bridge.handleBeforePrompt({ prompt: "deploy with hooks", messages: [] }, runCtx);
+    bridge.handleBeforeToolCall(
+      { toolName: "sh", params: { cmd: "deploy" }, toolCallId: "call_cached" },
+      toolCtx,
+    );
+    await bridge.handleAfterToolCall(
+      {
+        toolName: "sh",
+        params: { cmd: "deploy" },
+        toolCallId: "call_cached",
+        result: "ok",
+        durationMs: 25,
+      },
+      toolCtx,
+    );
+    await bridge.handleAgentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "user", content: "deploy with hooks" },
+          { role: "assistant", content: [{ type: "text", text: "done" }] },
+        ],
+        durationMs: 50,
+      },
+      runCtx,
+    );
+    await (pipeline as PipelineHandle).flush();
+
+    const traces = await mc.listTraces({ groupByTurn: true });
+    expect(traces).toHaveLength(2);
+    expect(traces.some((tr) => tr.toolCalls?.[0]?.name === "sh")).toBe(true);
+    expect(traces.some((tr) => tr.agentText === "done")).toBe(true);
   });
 
   it("handleAgentEnd works even when before_prompt_build was never called (lazy episode open)", async () => {

--- a/apps/memos-local-plugin/tests/unit/install/install-sh.test.ts
+++ b/apps/memos-local-plugin/tests/unit/install/install-sh.test.ts
@@ -77,7 +77,7 @@ describe("install.sh — CLI surface", () => {
     expect(script).toContain('"extensions": ["${OPENCLAW_RUNTIME_ENTRY}"]');
     expect(script).toContain('"contracts": {');
     expect(script).toContain('"memory_search"');
-    expect(script).toContain("if (config.plugins.entries[pluginId].hooks) delete config.plugins.entries[pluginId].hooks");
+    expect(script).toContain("config.plugins.entries[pluginId].hooks.allowConversationAccess = true");
     expect(script).not.toContain('"extensions": ["./adapters/openclaw/index.ts"]');
   });
 

--- a/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
@@ -209,6 +209,30 @@ describe("retrieval/injector", () => {
     expect(packet.rendered).not.toContain('refId="sA"');
   });
 
+  it("strips episode retrieval metrics from prompt-facing memory text", () => {
+    const noisyEpisode = episode("e_noisy");
+    noisyEpisode.summary = [
+      "episode 3 steps · best V=0.82 · goal-sim=0.64",
+      "step 1 (V=0.12)",
+      "  user: install failed",
+      "step 2 (V=0.82)",
+      "  summary: install libpq-dev before retrying pip",
+    ].join("\n");
+
+    const { packet } = toPacket({
+      ranked: [rc(noisyEpisode)],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_episode_metrics" as never,
+      episodeId: "ep_episode_metrics" as never,
+    });
+
+    expect(packet.rendered).toContain("Past similar episode");
+    expect(packet.rendered).toContain("install libpq-dev");
+    expect(packet.rendered).not.toMatch(/best V|goal-sim|V=/);
+  });
+
   it("default skill rendering is summary mode (descriptor + skill_get hint, no full guide)", () => {
     // Multi-section guide: blank-line-separated paragraphs. Summary
     // mode must keep only the first paragraph and drop the procedure.

--- a/apps/memos-local-plugin/tests/unit/retrieval/tier2.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/tier2.test.ts
@@ -138,7 +138,8 @@ describe("retrieval/tier2 (with real sqlite)", () => {
     );
     if (out.traces.length >= 2) {
       expect(out.episodes.length).toBeGreaterThanOrEqual(1);
-      expect(out.episodes[0]!.summary).toContain("episode");
+      expect(out.episodes[0]!.summary).toContain("Past similar episode");
+      expect(out.episodes[0]!.summary).not.toMatch(/best V|goal-sim|V=/);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Preserve OpenClaw tool-call observations when `agent_end` transcripts omit tool blocks, so memory capture still records tool activity.
- Enable OpenClaw conversation access during install so turns can be captured after recall.
- Remove retrieval scores such as `best V` and `goal-sim` from episode prompt injection.

## Test plan
- `npm test -- tests/unit/adapters/openclaw-bridge.test.ts tests/unit/install/install-sh.test.ts tests/unit/retrieval/tier2.test.ts tests/unit/retrieval/injector.test.ts`
- IDE diagnostics: no linter errors in touched TypeScript test/source files.