### PR TITLE
feat: configure embedding rebuild batch size

### DIFF
--- a/apps/memos-local-plugin/package-lock.json
+++ b/apps/memos-local-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memtensor/memos-local-plugin",
-      "version": "2.0.1",
+      "version": "2.0.2-beta.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/memos-local-plugin/package.json
+++ b/apps/memos-local-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.1",
   "description": "Reflect2Evolve memory plugin: layered L1/L2/L3 memory, reflection-weighted value backprop, cross-task policy induction, skill crystallization, three-tier retrieval. Adapters for OpenClaw and Hermes Agent via a shared algorithm core.",
   "type": "module",
   "main": "dist/core/index.js",

--- a/apps/memos-local-plugin/viewer/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/i18n.ts
@@ -825,6 +825,10 @@ const en = {
     "Ready {ready}/{total}; missing {missing}; dimension mismatch {mismatch}; current dim {dim}.",
   "settings.embedding.maintenance.unavailable":
     "Configure an embedding provider before repairing or rebuilding vectors.",
+  "settings.embedding.batchSize.label": "Items per request",
+  "settings.embedding.batchSize.option": "{n} items per request",
+  "settings.embedding.batchSize.hint":
+    "Larger batches usually rebuild faster, but may hit provider limits or timeouts.",
   "settings.embedding.repair": "Repair missing/mismatched",
   "settings.embedding.rebuild": "Rebuild all vectors",
   "settings.embedding.rebuild.running": "Rebuilding embeddings…",
@@ -1621,6 +1625,9 @@ const zh: Record<TranslationKey, string> = {
   "settings.embedding.maintenance.stats":
     "可用 {ready}/{total}；缺失 {missing}；维度不匹配 {mismatch}；当前维度 {dim}。",
   "settings.embedding.maintenance.unavailable": "请先配置嵌入模型，再修复或重建向量。",
+  "settings.embedding.batchSize.label": "每次请求条数",
+  "settings.embedding.batchSize.option": "每次请求 {n} 条",
+  "settings.embedding.batchSize.hint": "每次请求条数越大通常重建越快，但可能触发模型服务限流或超时。",
   "settings.embedding.repair": "修复缺失/错维",
   "settings.embedding.rebuild": "全量重建向量",
   "settings.embedding.rebuild.running": "正在重建向量…",

--- a/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
@@ -71,6 +71,10 @@ interface EmbeddingMaintenanceRunResult {
   error?: string;
 }
 
+const EMBEDDING_REBUILD_BATCH_STORAGE_KEY = "memos.embeddingRebuildBatchSize";
+const EMBEDDING_REBUILD_BATCH_OPTIONS = [10, 20, 50, 100, 200, 500] as const;
+type EmbeddingRebuildBatchSize = typeof EMBEDDING_REBUILD_BATCH_OPTIONS[number];
+
 const EMBEDDING_PROVIDERS = [
   "local",
   "openai_compatible",
@@ -536,6 +540,7 @@ function EmbeddingMaintenancePanel() {
   const [stats, setStats] = useState<EmbeddingMaintenanceStats | null>(null);
   const [running, setRunning] = useState<"repair" | "rebuild" | null>(null);
   const [status, setStatus] = useState<{ kind: "ok" | "error" | "muted"; text: string } | null>(null);
+  const [batchSize, setBatchSize] = useState<EmbeddingRebuildBatchSize>(() => loadEmbeddingRebuildBatchSize());
 
   const refresh = async () => {
     try {
@@ -559,7 +564,7 @@ function EmbeddingMaintenancePanel() {
       for (;;) {
         const r = await api.post<EmbeddingMaintenanceRunResult>(
           "/api/v1/embeddings/rebuild",
-          { mode, offset, limit: 100 },
+          { mode, offset, limit: batchSize },
         );
         updated += r.updated;
         failed += r.failed;
@@ -616,6 +621,33 @@ function EmbeddingMaintenancePanel() {
           <div class="muted" style="font-size:var(--fs-xs);margin-top:2px">
             {healthText}
           </div>
+          <label
+            class="hstack"
+            style="gap:var(--sp-2);align-items:center;margin-top:var(--sp-3);font-size:var(--fs-xs);color:var(--fg-muted);flex-wrap:wrap"
+          >
+            <span>{t("settings.embedding.batchSize.label")}</span>
+            <select
+              class="input"
+              value={batchSize}
+              disabled={!!running}
+              aria-label={t("settings.embedding.batchSize.label")}
+              style="width:auto;min-width:150px;height:32px;padding-top:0;padding-bottom:0;font-size:var(--fs-xs)"
+              onChange={(e) => {
+                const next = normalizeEmbeddingRebuildBatchSize((e.target as HTMLSelectElement).value);
+                setBatchSize(next);
+                localStorage.setItem(EMBEDDING_REBUILD_BATCH_STORAGE_KEY, String(next));
+              }}
+            >
+              {EMBEDDING_REBUILD_BATCH_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {t("settings.embedding.batchSize.option", { n })}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div class="muted" style="font-size:var(--fs-2xs);margin-top:4px;max-width:560px">
+            {t("settings.embedding.batchSize.hint")}
+          </div>
         </div>
         <div class="hstack" style="gap:var(--sp-2);flex-wrap:wrap">
           <button class="btn btn--sm" onClick={() => void refresh()} disabled={!!running}>
@@ -653,6 +685,17 @@ function EmbeddingMaintenancePanel() {
       )}
     </div>
   );
+}
+
+function loadEmbeddingRebuildBatchSize(): EmbeddingRebuildBatchSize {
+  return normalizeEmbeddingRebuildBatchSize(localStorage.getItem(EMBEDDING_REBUILD_BATCH_STORAGE_KEY));
+}
+
+function normalizeEmbeddingRebuildBatchSize(value: unknown): EmbeddingRebuildBatchSize {
+  const n = Number(value);
+  return EMBEDDING_REBUILD_BATCH_OPTIONS.includes(n as EmbeddingRebuildBatchSize)
+    ? n as EmbeddingRebuildBatchSize
+    : 100;
 }
 
 // ─── Hub tab ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add an embedding maintenance setting for rebuild request batch size
- expose user-friendly 10/20/50/100/200/500 items-per-request options
- persist the selected value in local storage and localize the UI in English and Chinese

## Tests
- npm run lint