### PR TITLE
feat: persist trace policy links

### DIFF
--- a/apps/memos-local-plugin/core/config/defaults.ts
+++ b/apps/memos-local-plugin/core/config/defaults.ts
@@ -123,6 +123,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
       minTraceValue: 0.005,
       useLlm: true,
       traceCharCap: 3_000,
+      gainEmaAlpha: 0.4,
       archiveGain: -0.05,
     },
     l3Abstraction: {

--- a/apps/memos-local-plugin/core/config/schema.ts
+++ b/apps/memos-local-plugin/core/config/schema.ts
@@ -185,6 +185,8 @@ const AlgorithmSchema = Type.Object({
     useLlm: Bool(true),
     /** Character cap for traces handed into the `l2.induction` prompt. */
     traceCharCap: NumberInRange(3_000, 600, 16_000),
+    /** EMA alpha for gain updates. 1 means overwrite, lower values preserve history. */
+    gainEmaAlpha: NumberInRange(0.4, 0, 1),
     /** Archive active policies whose gain dips below this value. */
     archiveGain: NumberInRange(-0.05, -1, 1),
   }, { default: {} }),

--- a/apps/memos-local-plugin/core/memory/l2/gain.ts
+++ b/apps/memos-local-plugin/core/memory/l2/gain.ts
@@ -60,6 +60,7 @@ export const V7_NEUTRAL_BASELINE = 0.5;
  * samples. Five is roughly "one short episode worth" of signal.
  */
 export const WITHOUT_PRIOR_PSEUDOCOUNT = 5;
+export const MIN_ADAPTIVE_BASELINE = 0.2;
 
 export interface ComputeGainOpts {
   tauSoftmax: number;
@@ -70,10 +71,15 @@ export function computeGain(input: GainInput, opts: ComputeGainOpts): GainResult
   const withMean = arithmeticMeanValue(input.withTraces);
   const withoutMean = arithmeticMeanValue(input.withoutTraces);
   const effectiveWith = input.withTraces.length >= 3 ? weightedWith : withMean;
+  const allTraces = [...input.withTraces, ...input.withoutTraces];
+  const poolMean = allTraces.length > 0
+    ? arithmeticMeanValue(allTraces)
+    : V7_NEUTRAL_BASELINE;
+  const baseline = adaptiveBaseline(poolMean);
   const blendedWithout = shrinkTowardBaseline(
     withoutMean,
     input.withoutTraces.length,
-    V7_NEUTRAL_BASELINE,
+    baseline,
     WITHOUT_PRIOR_PSEUDOCOUNT,
   );
   const gain = effectiveWith - blendedWithout;
@@ -85,7 +91,25 @@ export function computeGain(input: GainInput, opts: ComputeGainOpts): GainResult
     withCount: input.withTraces.length,
     withoutCount: input.withoutTraces.length,
     weightedWith,
+    poolMean,
+    baseline,
   };
+}
+
+export function adaptiveBaseline(poolMean: number): number {
+  if (!Number.isFinite(poolMean)) return V7_NEUTRAL_BASELINE;
+  return Math.max(MIN_ADAPTIVE_BASELINE, Math.min(V7_NEUTRAL_BASELINE, poolMean));
+}
+
+export function smoothGain(args: {
+  newGain: number;
+  currentGain: number;
+  alpha: number;
+  isFirst: boolean;
+}): number {
+  if (args.isFirst) return args.newGain;
+  const alpha = clamp01(args.alpha);
+  return alpha * args.newGain + (1 - alpha) * args.currentGain;
 }
 
 /**
@@ -103,6 +127,11 @@ function shrinkTowardBaseline(
   const denom = nObserved + priorPseudocount;
   if (denom <= 0) return priorMean;
   return (empiricalMean * nObserved + priorMean * priorPseudocount) / denom;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
 }
 
 /**

--- a/apps/memos-local-plugin/core/memory/l2/l2.ts
+++ b/apps/memos-local-plugin/core/memory/l2/l2.ts
@@ -34,7 +34,7 @@ import { L2_INDUCTION_PROMPT } from "../../llm/prompts/l2-induction.js";
 import { associateTraces } from "./associate.js";
 import { makeCandidatePool } from "./candidate-pool.js";
 import { buildPolicyRow, induceDraft } from "./induce.js";
-import { applyGain, computeGain } from "./gain.js";
+import { applyGain, computeGain, smoothGain } from "./gain.js";
 import { signatureOf } from "./signature.js";
 import { tracePolicySimilarity } from "./similarity.js";
 import type {
@@ -48,7 +48,7 @@ import type {
 } from "./types.js";
 
 export interface RunL2Deps {
-  repos: Pick<Repos, "candidatePool" | "embeddingRetryQueue" | "policies" | "traces">;
+  repos: Pick<Repos, "candidatePool" | "embeddingRetryQueue" | "policies" | "tracePolicyLinks" | "traces">;
   db: Parameters<typeof makeCandidatePool>[0]["db"];
   llm: LlmClient | null;
   log: Logger;
@@ -94,6 +94,19 @@ export async function runL2(
     if (!tr) continue;
     a.signature = signatureOf(tr);
     if (a.matchedPolicyId) {
+      try {
+        repos.tracePolicyLinks.link({
+          traceId: a.traceId,
+          policyId: a.matchedPolicyId,
+          episodeId: input.episodeId,
+          now: input.now ?? Date.now(),
+        });
+      } catch (err) {
+        warnings.push(stageWarn("trace-policy-link", err, {
+          traceId: a.traceId,
+          policyId: a.matchedPolicyId,
+        }));
+      }
       emit(bus, {
         kind: "l2.trace.associated",
         episodeId: input.episodeId,
@@ -187,6 +200,20 @@ export async function runL2(
         const evidence = inductionEvidenceByPolicy.get(dup.id) ?? new Set<string>();
         for (const id of bucket.evidenceTraceIds) evidence.add(id);
         inductionEvidenceByPolicy.set(dup.id, evidence);
+        for (const traceId of bucket.evidenceTraceIds) {
+          const trace = traces.find((t) => t.id === traceId);
+          if (!trace) continue;
+          try {
+            repos.tracePolicyLinks.link({
+              traceId,
+              policyId: dup.id,
+              episodeId: trace.episodeId,
+              now: input.now ?? Date.now(),
+            });
+          } catch (err) {
+            warnings.push(stageWarn("trace-policy-link", err, { traceId, policyId: dup.id }));
+          }
+        }
         continue;
       }
 
@@ -241,6 +268,23 @@ export async function runL2(
           duplicate.id,
           new Set(bucket.evidenceTraceIds as string[]),
         );
+        for (const traceId of bucket.evidenceTraceIds) {
+          const trace = traces.find((t) => t.id === traceId);
+          if (!trace) continue;
+          try {
+            repos.tracePolicyLinks.link({
+              traceId,
+              policyId: duplicate.id,
+              episodeId: trace.episodeId,
+              now: input.now ?? Date.now(),
+            });
+          } catch (err) {
+            warnings.push(stageWarn("trace-policy-link", err, {
+              traceId,
+              policyId: duplicate.id,
+            }));
+          }
+        }
         inductions.push({
           signature: bucket.signature,
           policyId: duplicate.id,
@@ -275,6 +319,23 @@ export async function runL2(
           policy.id,
           new Set(bucket.evidenceTraceIds as string[]),
         );
+        for (const traceId of bucket.evidenceTraceIds) {
+          const trace = traces.find((t) => t.id === traceId);
+          if (!trace) continue;
+          try {
+            repos.tracePolicyLinks.link({
+              traceId,
+              policyId: policy.id,
+              episodeId: trace.episodeId,
+              now: input.now ?? Date.now(),
+            });
+          } catch (err) {
+            warnings.push(stageWarn("trace-policy-link", err, {
+              traceId,
+              policyId: policy.id,
+            }));
+          }
+        }
         inductions.push({
           signature: bucket.signature,
           policyId: policy.id,
@@ -323,6 +384,10 @@ export async function runL2(
       if (inductionIds) {
         for (const id of inductionIds) withIds.add(id);
       }
+      const newSupportIds = new Set(withIds);
+      for (const id of repos.tracePolicyLinks.getWithTraceIds(policy.id)) {
+        withIds.add(id);
+      }
 
       // Gain is computed over ALL traces currently in scope — the
       // current episode's traces PLUS the induction evidence traces
@@ -332,29 +397,40 @@ export async function runL2(
       // gain. Pull missing induction traces from the repo.
       const traceById = new Map<string, TraceRow>();
       for (const t of input.traces) traceById.set(t.id, t);
-      if (inductionIds) {
-        for (const id of inductionIds) {
-          if (traceById.has(id)) continue;
-          const t = repos.traces.getById(id as TraceRow["id"]);
-          if (t) traceById.set(t.id, t);
+      for (const id of withIds) {
+        if (traceById.has(id)) continue;
+        const t = repos.traces.getById(id as TraceRow["id"]);
+        if (t) traceById.set(t.id, t);
+      }
+      for (const episodeId of repos.tracePolicyLinks.getLinkedEpisodeIds(policy.id)) {
+        for (const t of repos.traces.list({ episodeId, limit: 50, newestFirst: true })) {
+          traceById.set(t.id, t);
         }
       }
-      const allTraces = Array.from(traceById.values());
+      const allTraces = Array.from(traceById.values())
+        .sort((a, b) => b.ts - a.ts || b.id.localeCompare(a.id));
 
-      const withTraces: TraceRow[] = allTraces.filter((t) => withIds.has(t.id));
-      const withoutTraces: TraceRow[] = allTraces.filter((t) => !withIds.has(t.id));
+      const withTraces: TraceRow[] = allTraces.filter((t) => withIds.has(t.id)).slice(0, 50);
+      const withoutTraces: TraceRow[] = allTraces.filter((t) => !withIds.has(t.id)).slice(0, 50);
 
-      const gain = computeGain(
+      const rawGain = computeGain(
         { policyId: policy.id, withTraces, withoutTraces },
         { tauSoftmax: config.tauSoftmax },
       );
+      const smoothedGainValue = smoothGain({
+        newGain: rawGain.gain,
+        currentGain: policy.gain,
+        alpha: config.gainEmaAlpha,
+        isFirst: policy.support === 0,
+      });
+      const gain = { ...rawGain, gain: smoothedGainValue };
 
       // `deltaSupport` must reflect only the *new* positive evidence
       // we just observed — both fresh associations AND the induction
       // evidence for a newly-minted policy. Previously only `withIds`
       // from associations contributed, so a new policy's support
       // stayed at 0 until someone re-associated in a later round.
-      const deltaSupport = withIds.size;
+      const deltaSupport = newSupportIds.size;
 
       const persisted = applyGain({
         gain,

--- a/apps/memos-local-plugin/core/memory/l2/subscriber.ts
+++ b/apps/memos-local-plugin/core/memory/l2/subscriber.ts
@@ -24,7 +24,7 @@ import type { L2Config, L2EventBus } from "./types.js";
 
 export interface L2SubscriberDeps {
   db: StorageDb;
-  repos: Pick<Repos, "candidatePool" | "embeddingRetryQueue" | "policies" | "traces">;
+  repos: Pick<Repos, "candidatePool" | "embeddingRetryQueue" | "policies" | "tracePolicyLinks" | "traces">;
   rewardBus: RewardEventBus;
   l2Bus: L2EventBus;
   llm: LlmClient | null;

--- a/apps/memos-local-plugin/core/memory/l2/types.ts
+++ b/apps/memos-local-plugin/core/memory/l2/types.ts
@@ -47,6 +47,8 @@ export interface L2Config {
   minEpisodesForInduction: number;
   /** Character cap for traces passed into the induction prompt. */
   inductionTraceCharCap: number;
+  /** EMA alpha for gain smoothing. */
+  gainEmaAlpha: number;
 }
 
 // ─── Pattern signature ─────────────────────────────────────────────────────
@@ -129,6 +131,10 @@ export interface GainResult {
   withoutCount: number;
   /** V7 §0.6 eq. 3: softmax(V/τ) mean. Used when `withCount ≥ 3`. */
   weightedWith: number;
+  /** Mean value across with + without traces; used to derive the adaptive baseline. */
+  poolMean: number;
+  /** Shrinkage baseline after adapting to the participating trace pool. */
+  baseline: number;
 }
 
 // ─── Inputs / outputs for the orchestrator ─────────────────────────────────

--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -126,6 +126,7 @@ export function extractAlgorithmConfig(
       minTraceValue: alg.l2Induction.minTraceValue,
       minEpisodesForInduction: alg.l2Induction.minEpisodesForInduction,
       inductionTraceCharCap: alg.l2Induction.traceCharCap,
+      gainEmaAlpha: alg.l2Induction.gainEmaAlpha,
     },
     l3Abstraction: alg.l3Abstraction,
     skill: alg.skill,

--- a/apps/memos-local-plugin/core/storage/migrations/010-trace-policy-links.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/010-trace-policy-links.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS trace_policy_links (
+  trace_id   TEXT    NOT NULL REFERENCES traces(id) ON DELETE CASCADE,
+  policy_id  TEXT    NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+  episode_id TEXT    NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (trace_id, policy_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_tpl_policy ON trace_policy_links(policy_id);
+CREATE INDEX IF NOT EXISTS idx_tpl_episode ON trace_policy_links(episode_id);

--- a/apps/memos-local-plugin/core/storage/repos/index.ts
+++ b/apps/memos-local-plugin/core/storage/repos/index.ts
@@ -18,6 +18,7 @@ import { makePoliciesRepo } from "./policies.js";
 import { makeSessionsRepo } from "./sessions.js";
 import { makeSkillTrialsRepo } from "./skill_trials.js";
 import { makeSkillsRepo } from "./skills.js";
+import { makeTracePolicyLinksRepo } from "./trace-policy-links.js";
 import { makeTracesRepo } from "./traces.js";
 import { makeWorldModelRepo } from "./world_model.js";
 
@@ -35,6 +36,7 @@ export interface Repos {
   sessions: ReturnType<typeof makeSessionsRepo>;
   skillTrials: ReturnType<typeof makeSkillTrialsRepo>;
   skills: ReturnType<typeof makeSkillsRepo>;
+  tracePolicyLinks: ReturnType<typeof makeTracePolicyLinksRepo>;
   traces: ReturnType<typeof makeTracesRepo>;
   worldModel: ReturnType<typeof makeWorldModelRepo>;
 }
@@ -54,6 +56,7 @@ export function makeRepos(db: StorageDb): Repos {
     sessions: makeSessionsRepo(db),
     skillTrials: makeSkillTrialsRepo(db),
     skills: makeSkillsRepo(db),
+    tracePolicyLinks: makeTracePolicyLinksRepo(db),
     traces: makeTracesRepo(db),
     worldModel: makeWorldModelRepo(db),
   };
@@ -73,5 +76,6 @@ export { makePoliciesRepo } from "./policies.js";
 export { makeSessionsRepo } from "./sessions.js";
 export { makeSkillTrialsRepo } from "./skill_trials.js";
 export { makeSkillsRepo } from "./skills.js";
+export { makeTracePolicyLinksRepo } from "./trace-policy-links.js";
 export { makeTracesRepo } from "./traces.js";
 export { makeWorldModelRepo } from "./world_model.js";

--- a/apps/memos-local-plugin/core/storage/repos/trace-policy-links.ts
+++ b/apps/memos-local-plugin/core/storage/repos/trace-policy-links.ts
@@ -1,0 +1,51 @@
+import type { EpisodeId, PolicyId, TraceId } from "../../types.js";
+import type { StorageDb } from "../types.js";
+
+export function makeTracePolicyLinksRepo(db: StorageDb) {
+  const insert = db.prepare<{
+    trace_id: TraceId;
+    policy_id: PolicyId;
+    episode_id: EpisodeId;
+    created_at: number;
+  }>(
+    `INSERT OR IGNORE INTO trace_policy_links
+       (trace_id, policy_id, episode_id, created_at)
+     VALUES (@trace_id, @policy_id, @episode_id, @created_at)`,
+  );
+  const selectTraceIds = db.prepare<{ policy_id: PolicyId }, { trace_id: TraceId }>(
+    `SELECT trace_id
+       FROM trace_policy_links
+      WHERE policy_id=@policy_id
+      ORDER BY created_at DESC, trace_id DESC`,
+  );
+  const selectEpisodeIds = db.prepare<{ policy_id: PolicyId }, { episode_id: EpisodeId }>(
+    `SELECT DISTINCT episode_id
+       FROM trace_policy_links
+      WHERE policy_id=@policy_id
+      ORDER BY episode_id`,
+  );
+
+  return {
+    link(args: {
+      traceId: TraceId;
+      policyId: PolicyId;
+      episodeId: EpisodeId;
+      now?: number;
+    }): void {
+      insert.run({
+        trace_id: args.traceId,
+        policy_id: args.policyId,
+        episode_id: args.episodeId,
+        created_at: args.now ?? Date.now(),
+      });
+    },
+
+    getWithTraceIds(policyId: PolicyId): TraceId[] {
+      return selectTraceIds.all({ policy_id: policyId }).map((r) => r.trace_id);
+    },
+
+    getLinkedEpisodeIds(policyId: PolicyId): EpisodeId[] {
+      return selectEpisodeIds.all({ policy_id: policyId }).map((r) => r.episode_id);
+    },
+  };
+}

--- a/apps/memos-local-plugin/tests/unit/memory/l2/gain.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/gain.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { applyGain, computeGain, nextStatus } from "../../../../core/memory/l2/gain.js";
+import { applyGain, computeGain, nextStatus, smoothGain } from "../../../../core/memory/l2/gain.js";
 import type { PolicyId, TraceRow } from "../../../../core/types.js";
 
 function mkTrace(value: number): TraceRow {
@@ -30,7 +30,7 @@ function mkTrace(value: number): TraceRow {
 }
 
 describe("memory/l2/gain", () => {
-  it("computeGain returns V_with − V_without using arithmetic mean for <3 traces", () => {
+  it("computeGain uses an adaptive shrinkage baseline for low-value trace pools", () => {
     const g = computeGain(
       {
         policyId: "po_1" as PolicyId,
@@ -41,8 +41,23 @@ describe("memory/l2/gain", () => {
     );
     expect(g.withMean).toBeCloseTo(0.7, 5);
     expect(g.withoutMean).toBeCloseTo(0.15, 5);
-    expect(g.gain).toBeCloseTo(0.55, 5);
+    expect(g.poolMean).toBeCloseTo(0.425, 5);
+    expect(g.baseline).toBeCloseTo(0.425, 5);
+    expect(g.gain).toBeCloseTo(0.35357143, 5);
     expect(g.withCount).toBe(2);
+  });
+
+  it("keeps the neutral baseline for high-value trace pools", () => {
+    const g = computeGain(
+      {
+        policyId: "po_1" as PolicyId,
+        withTraces: [mkTrace(0.8), mkTrace(0.7)],
+        withoutTraces: [mkTrace(0.6), mkTrace(0.55)],
+      },
+      { tauSoftmax: 0.5 },
+    );
+    expect(g.poolMean).toBeGreaterThan(0.5);
+    expect(g.baseline).toBeCloseTo(0.5, 5);
   });
 
   it("uses value-weighted mean for the with-set when count ≥ 3", () => {
@@ -112,6 +127,8 @@ describe("memory/l2/gain", () => {
         withCount: 4,
         withoutCount: 2,
         weightedWith: 0.55,
+        poolMean: 0.35,
+        baseline: 0.35,
       },
       deltaSupport: 2,
       currentStatus: "candidate",
@@ -130,5 +147,14 @@ describe("memory/l2/gain", () => {
       status: "active",
       updatedAt: 1_000,
     });
+  });
+
+  it("smoothGain preserves existing signal after the first update", () => {
+    expect(
+      smoothGain({ newGain: -0.15, currentGain: 0.1, alpha: 0.4, isFirst: false }),
+    ).toBeCloseTo(0, 5);
+    expect(
+      smoothGain({ newGain: -0.15, currentGain: 0.1, alpha: 0.4, isFirst: true }),
+    ).toBeCloseTo(-0.15, 5);
   });
 });

--- a/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
@@ -42,6 +42,7 @@ function cfg(): L2Config {
     minTraceValue: 0.1,
     minEpisodesForInduction: 2,
     inductionTraceCharCap: 2_000,
+    gainEmaAlpha: 0.4,
   };
 }
 
@@ -725,5 +726,93 @@ describe("memory/l2/integration", () => {
       deps,
     );
     expect(r3.inductions.some((i) => i.policyId !== null)).toBe(true);
+  });
+
+  it("recomputes gain from historical trace-policy links and smooths the update", async () => {
+    ensureEpisode(handle, "ep_hist_a", "s_int");
+    ensureEpisode(handle, "ep_hist_b", "s_int");
+    const oldWith = mkTrace({
+      id: "tr_hist_with_old",
+      episodeId: "ep_hist_a",
+      value: 0.7,
+      ts: NOW as never,
+      vecSummary: vec([1, 0, 0]),
+    });
+    const oldWithout = mkTrace({
+      id: "tr_hist_without_old",
+      episodeId: "ep_hist_a",
+      value: 0.6,
+      ts: (NOW + 1) as never,
+      vecSummary: vec([0, 1, 0]),
+    });
+    const newWith = mkTrace({
+      id: "tr_hist_with_new",
+      episodeId: "ep_hist_b",
+      value: 0.3,
+      ts: (NOW + 2) as never,
+      vecSummary: vec([1, 0, 0]),
+    });
+    const newWithout = mkTrace({
+      id: "tr_hist_without_new",
+      episodeId: "ep_hist_b",
+      value: 0.35,
+      ts: (NOW + 3) as never,
+      vecSummary: vec([0, 1, 0]),
+    });
+    for (const t of [oldWith, oldWithout, newWith, newWithout]) {
+      handle.repos.traces.insert(t);
+    }
+    handle.repos.policies.insert({
+      id: "po_hist" as never,
+      title: "retry failed tools once with a corrected input",
+      trigger: "tool call fails but a corrected retry may recover",
+      procedure: "inspect the error, adjust the input, retry once, then explain fallback",
+      verification: "the retry resolves the error or the fallback is explicit",
+      boundary: "do not retry when the error is permanent",
+      support: 3,
+      gain: 0.1,
+      status: "active",
+      sourceEpisodeIds: ["ep_hist_a" as EpisodeId],
+      inducedBy: "unit-test",
+      decisionGuidance: { preference: [], antiPattern: [] },
+      vec: vec([1, 0, 0]),
+      createdAt: NOW as never,
+      updatedAt: NOW as never,
+    });
+    handle.repos.tracePolicyLinks.link({
+      traceId: oldWith.id,
+      policyId: "po_hist" as never,
+      episodeId: oldWith.episodeId,
+      now: NOW,
+    });
+
+    await runL2(
+      {
+        episodeId: "ep_hist_b" as EpisodeId,
+        sessionId: "s_int" as SessionId,
+        traces: [newWith, newWithout],
+        trigger: "manual",
+        now: NOW + 10,
+      },
+      {
+        db: handle.db,
+        repos: handle.repos,
+        llm: fakeLlm({ completeJson: {} }),
+        log: rootLogger.child({ channel: "core.memory.l2" }),
+        bus: createL2EventBus(),
+        config: { ...cfg(), minSimilarity: 0.7, gainEmaAlpha: 0.4 },
+        thresholds: { minSupport: 3, minGain: 0.15, archiveGain: -0.05 },
+      },
+    );
+
+    const updated = handle.repos.policies.getById("po_hist" as never)!;
+    expect(handle.repos.tracePolicyLinks.getWithTraceIds("po_hist" as never).sort()).toEqual([
+      "tr_hist_with_new",
+      "tr_hist_with_old",
+    ]);
+    expect(updated.support).toBe(4);
+    expect(updated.gain).toBeGreaterThan(0);
+    expect(updated.gain).toBeLessThan(0.1);
+    expect(updated.status).toBe("active");
   });
 });

--- a/apps/memos-local-plugin/tests/unit/memory/l2/subscriber.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/subscriber.test.ts
@@ -36,6 +36,7 @@ function cfg(): L2Config {
     minTraceValue: 0.1,
     minEpisodesForInduction: 5, // keep induction off for this test
     inductionTraceCharCap: 2_000,
+    gainEmaAlpha: 0.4,
   };
 }
 


### PR DESCRIPTION
## Summary
- persist trace-policy evidence links in storage and expose a repo for historical lookup
- include linked traces and episodes when recomputing L2 policy gain
- add adaptive gain baseline and EMA smoothing config with focused L2 tests

## Tests
- npm run lint
- npx vitest run tests/unit/memory/l2/gain.test.ts tests/unit/memory/l2/l2.integration.test.ts tests/unit/memory/l2/subscriber.test.ts