### PR TITLE
feat: reorganize memory injection sections and tool hints

### DIFF
--- a/apps/memos-local-plugin/core/retrieval/injector.ts
+++ b/apps/memos-local-plugin/core/retrieval/injector.ts
@@ -267,7 +267,10 @@ function renderTrace(c: TraceCandidate): InjectionSnippet {
   if (c.userText) parts.push(`[user] ${c.userText}`);
   if (c.agentText) parts.push(`[assistant] ${c.agentText}`);
   if (c.reflection) parts.push(`[note] ${c.reflection}`);
-  const body = truncate(parts.join("\n"));
+  const body = withToolFollowUp(
+    truncate(parts.join("\n")),
+    `→ call \`memos_get(id="${c.refId}", kind="trace")\` for the full turn`,
+  );
   const when = formatMemoryTimestamp(c.ts);
   return {
     refKind: "trace",
@@ -281,12 +284,15 @@ function renderEpisode(c: EpisodeCandidate): InjectionSnippet {
   // Episode summary already comes with step-by-step action sequence
   // (see tier2-trace.ts::renderEpisodeSummary). Keep prompt-facing text
   // free of retrieval metrics; they are useful for logs, not for answers.
-  const body = truncate(stripEpisodePromptMetrics(c.summary));
+  const body = withToolFollowUp(
+    truncate(stripEpisodePromptMetrics(c.summary)),
+    `→ call \`memos_timeline(episodeId="${c.refId}")\` for the full step-by-step traces`,
+  );
   const when = formatMemoryTimestamp(c.ts);
   return {
     refKind: "episode",
     refId: c.refId,
-    title: `Sub-task · ${when}`,
+    title: `Past task · ${when}`,
     body,
   };
 }
@@ -314,12 +320,18 @@ function renderExperience(c: ExperienceCandidate): InjectionSnippet {
     refKind: "experience",
     refId: c.refId,
     title: c.title,
-    body: truncate(parts.join("\n")),
+    body: withToolFollowUp(
+      truncate(parts.join("\n")),
+      `→ call \`memos_get(id="${c.refId}", kind="policy")\` for the full experience`,
+    ),
   };
 }
 
 function renderWorldModel(c: WorldModelCandidate): InjectionSnippet {
-  const body = truncate(`World model: ${c.title}\n${c.body}`);
+  const body = withToolFollowUp(
+    truncate(`World model: ${c.title}\n${c.body}`),
+    `→ call \`memos_get(id="${c.refId}", kind="world_model")\` for the full environment knowledge`,
+  );
   return {
     refKind: "world-model",
     refId: c.refId,
@@ -345,6 +357,14 @@ function renderWorldModel(c: WorldModelCandidate): InjectionSnippet {
  * in these memories.
  *
  * ## Memories
+ *
+ * ### Similar Past Tasks
+ *
+ * 1. [Past task · 2026-03-05 10:12]
+ *    Past similar episode
+ *    step 1 …
+ *
+ * ### Relevant Trace Memories
  *
  * 1. [Trace · 2026-03-05 10:12]
  *    [user] 我喜欢的运动是游泳
@@ -374,11 +394,8 @@ function renderWholePacket(
   const parts: string[] = [header];
 
   const skills = snippets.filter((s) => s.refKind === "skill");
-  const traces = snippets.filter(
-    (s) =>
-      s.refKind === "trace" ||
-      s.refKind === "episode",
-  );
+  const episodes = snippets.filter((s) => s.refKind === "episode");
+  const traces = snippets.filter((s) => s.refKind === "trace");
   const experiences = snippets.filter((s) => s.refKind === "experience");
   const worlds = snippets.filter((s) => s.refKind === "world-model");
 
@@ -398,12 +415,7 @@ function renderWholePacket(
     });
   }
 
-  if (traces.length > 0) {
-    parts.push("## Memories\n");
-    traces.forEach((s, i) => {
-      parts.push(renderNumberedSnippet(s, i + 1));
-    });
-  }
+  parts.push(...renderMemoriesSection(episodes, traces));
 
   if (experiences.length > 0) {
     parts.push("## Experiences\n");
@@ -425,8 +437,30 @@ function renderWholePacket(
   // "preferred / avoided" lines distilled from past failures + fixes.
   if (guidanceBlock) parts.push(guidanceBlock);
 
-  parts.push(footerFor(opts.skillMode, skills.length > 0));
+  parts.push(footerFor(opts.skillMode, snippets));
   return parts.join("\n\n");
+}
+
+function renderMemoriesSection(
+  episodes: readonly InjectionSnippet[],
+  traces: readonly InjectionSnippet[],
+): string[] {
+  if (episodes.length === 0 && traces.length === 0) return [];
+
+  const parts: string[] = ["## Memories"];
+  if (episodes.length > 0) {
+    parts.push("### Similar Past Tasks");
+    episodes.forEach((s, i) => {
+      parts.push(renderNumberedSnippet(s, i + 1));
+    });
+  }
+  if (traces.length > 0) {
+    parts.push("### Relevant Trace Memories");
+    traces.forEach((s, i) => {
+      parts.push(renderNumberedSnippet(s, i + 1));
+    });
+  }
+  return parts;
 }
 
 /**
@@ -493,7 +527,7 @@ const HEADER_BY_REASON: Record<RetrievalReason, string> = {
     "distilled from similar past situations. Please adapt your plan accordingly.",
 };
 
-const FOOTER_LINES_COMMON: readonly string[] = [
+const FOOTER_LINES_SEARCH: readonly string[] = [
   "- `memos_search(query, maxResults?)` — re-query with a shorter / rephrased string",
 ];
 
@@ -501,16 +535,50 @@ const FOOTER_LINES_SKILL_SUMMARY: readonly string[] = [
   "- `memos_skill_get(id)` — load the full procedure/verification of a candidate skill listed above",
 ];
 
+const FOOTER_LINES_TIMELINE: readonly string[] = [
+  "- `memos_timeline(episodeId, limit?)` — expand a similar past task into step-by-step traces",
+];
+
+const FOOTER_LINES_TRACE_GET: readonly string[] = [
+  "- `memos_get(id, kind=\"trace\")` — fetch a full trace turn by id",
+];
+
+const FOOTER_LINES_POLICY_GET: readonly string[] = [
+  "- `memos_get(id, kind=\"policy\")` — fetch a full experience by id",
+];
+
+const FOOTER_LINES_WORLD_MODEL: readonly string[] = [
+  "- `memos_get(id, kind=\"world_model\")` — fetch full environment knowledge by id",
+];
+
 function footerFor(
   skillMode: SkillInjectionMode,
-  hasSkills: boolean,
+  snippets: readonly InjectionSnippet[],
 ): string {
+  const kinds = new Set(snippets.map((s) => s.refKind));
   const lines: string[] = ["Available follow-up tools:"];
-  if (skillMode === "summary" && hasSkills) {
+  if (skillMode === "summary" && kinds.has("skill")) {
     lines.push(...FOOTER_LINES_SKILL_SUMMARY);
   }
-  lines.push(...FOOTER_LINES_COMMON);
+  if (kinds.has("episode")) {
+    lines.push(...FOOTER_LINES_TIMELINE);
+  }
+  if (kinds.has("trace")) {
+    lines.push(...FOOTER_LINES_TRACE_GET);
+  }
+  if (kinds.has("experience")) {
+    lines.push(...FOOTER_LINES_POLICY_GET);
+  }
+  if (kinds.has("world-model")) {
+    lines.push(...FOOTER_LINES_WORLD_MODEL);
+  }
+  lines.push(...FOOTER_LINES_SEARCH);
   return lines.join("\n");
+}
+
+function withToolFollowUp(body: string, hint: string): string {
+  if (!hint) return body;
+  return body ? `${body}\n${hint}` : hint;
 }
 
 function indentBlock(s: string): string {

--- a/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
@@ -165,6 +165,7 @@ describe("retrieval/injector", () => {
     });
 
     expect(packet.rendered).toContain("## Memories");
+    expect(packet.rendered).toContain("### Relevant Trace Memories");
     expect(packet.rendered).toContain("## Experiences");
     expect(packet.rendered).toContain("## Environment Knowledge");
     expect(packet.rendered.indexOf("## Memories")).toBeLessThan(
@@ -180,7 +181,7 @@ describe("retrieval/injector", () => {
     expect(packet.rendered).toContain(
       "Check: Issuer/CUSIP come from the row fields.",
     );
-    expect(packet.rendered).not.toContain("p_exp");
+    expect(packet.rendered).not.toContain('refId="p_exp"');
     expect(packet.rendered).not.toContain("Type:");
     expect(packet.rendered).not.toContain("confidence=");
     expect(packet.rendered).not.toContain("evidence=");
@@ -230,7 +231,53 @@ describe("retrieval/injector", () => {
 
     expect(packet.rendered).toContain("Past similar episode");
     expect(packet.rendered).toContain("install libpq-dev");
+    expect(packet.rendered).toContain('memos_timeline(episodeId="e_noisy")');
     expect(packet.rendered).not.toMatch(/best V|goal-sim|V=/);
+  });
+
+  it("splits memories into past-task and trace subsections with per-item tool hints", () => {
+    const { packet } = toPacket({
+      ranked: [rc(episode("e1")), rc(trace("t1"))],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_mem_sections" as never,
+      episodeId: "ep_mem_sections" as never,
+    });
+
+    expect(packet.rendered).toContain("## Memories");
+    expect(packet.rendered).toContain("### Similar Past Tasks");
+    expect(packet.rendered).toContain("### Relevant Trace Memories");
+    expect(packet.rendered.indexOf("### Similar Past Tasks")).toBeLessThan(
+      packet.rendered.indexOf("### Relevant Trace Memories"),
+    );
+    expect(packet.rendered).toContain("Past task ·");
+    expect(packet.rendered).toContain("Trace ·");
+    expect(packet.rendered).not.toContain("Sub-task ·");
+    expect(packet.rendered).toContain('memos_timeline(episodeId="e1")');
+    expect(packet.rendered).toContain('memos_get(id="t1", kind="trace")');
+    expect(packet.rendered).toContain("`memos_timeline(episodeId, limit?)`");
+    expect(packet.rendered).toContain('`memos_get(id, kind="trace")`');
+  });
+
+  it("adds footer tool hints for experiences and world models", () => {
+    const { packet } = toPacket({
+      ranked: [rc(experience("p_footer")), rc(world("w_footer"))],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_footer" as never,
+      episodeId: "ep_footer" as never,
+    });
+
+    expect(packet.rendered).not.toContain("## Memories");
+    expect(packet.rendered).toContain('memos_get(id="p_footer", kind="policy")');
+    expect(packet.rendered).toContain(
+      'memos_get(id="w_footer", kind="world_model")',
+    );
+    expect(packet.rendered).toContain('`memos_get(id, kind="policy")`');
+    expect(packet.rendered).toContain('`memos_get(id, kind="world_model")`');
+    expect(packet.rendered).toContain("memos_search");
   });
 
   it("default skill rendering is summary mode (descriptor + memos_skill_get hint, no full guide)", () => {
@@ -338,7 +385,8 @@ describe("retrieval/injector", () => {
       sessionId: "sess_t4" as never,
       episodeId: "ep_t4" as never,
     });
-    expect(packet.snippets[0]!.body.length).toBeLessThanOrEqual(700);
+    expect(packet.snippets[0]!.body.length).toBeLessThanOrEqual(720);
     expect(packet.snippets[0]!.body).toContain("[truncated]");
+    expect(packet.snippets[0]!.body).toContain('memos_get(id="huge", kind="trace")');
   });
 });


### PR DESCRIPTION
## Summary

This change reorganizes tier-2 memory injection output so episode rollups and trace memories are easier to read, and it adds explicit follow-up tool guidance for expanding injected snippets.

## Changes

- Split `## Memories` into `### Similar Past Tasks` and `### Relevant Trace Memories`.
- Rename episode titles from `Sub-task` to `Past task`.
- Add per-snippet `memos_timeline` / `memos_get` hints for episode, trace, experience, and world-model snippets.
- Generate follow-up tool footers from the snippet kinds present in the injected packet.
- Keep episode and trace entries in the same packet without suppressing member traces.

## Testing

- `npm test -- tests/unit/retrieval/injector.test.ts`

Made with [Cursor](https://cursor.com)