### PR TITLE
feat(memos-local-plugin): Hermes viewer probe, node resolution, and bridge hardening

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -64,7 +64,7 @@ if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
 from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
-from daemon_manager import ensure_bridge_running  # noqa: E402
+from daemon_manager import ensure_bridge_running, ensure_viewer_daemon  # noqa: E402
 
 
 try:  # pragma: no cover — host-provided base class, absent in unit tests
@@ -309,15 +309,21 @@ class MemTensorProvider(MemoryProvider):
             logger.warning("MemOS: failed to start bridge — %s", err)
             return
         try:
-            self._bridge = MemosBridgeClient()
+            ensure_viewer_daemon()
+        except Exception as err:
+            logger.warning("MemOS: viewer daemon check failed — %s", err)
+        new_bridge: MemosBridgeClient | None = None
+        try:
+            new_bridge = MemosBridgeClient()
             # Register the fallback LLM handler BEFORE we open the
             # session so it is available the very first time the
             # plugin's facade asks for help (e.g. on the first
             # `turn.start` retrieval call).
-            self._bridge.register_host_handler(
+            new_bridge.register_host_handler(
                 "host.llm.complete",
                 self._handle_host_llm_complete,
             )
+            self._bridge = new_bridge
             self._open_session(session_id)
             logger.info(
                 "MemOS: bridge ready session=%s platform=%s (episode deferred)",
@@ -326,6 +332,9 @@ class MemTensorProvider(MemoryProvider):
             )
         except Exception as err:
             logger.warning("MemOS: bridge init failed — %s", err)
+            if new_bridge is not None:
+                with contextlib.suppress(Exception):
+                    new_bridge.close()
             self._bridge = None
         # Register a Hermes plugin hook to capture tool calls as they
         # happen. The `post_tool_call` hook fires after every tool
@@ -1433,7 +1442,7 @@ class MemTensorProvider(MemoryProvider):
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
         if self._bridge:
-            pid = self._bridge.pid
+            pid = getattr(self._bridge, "pid", "?")
             logger.info("MemOS: shutting down bridge (pid=%s)", pid)
             with contextlib.suppress(Exception):
                 self._bridge.close()
@@ -1652,7 +1661,7 @@ class MemTensorProvider(MemoryProvider):
                 return
 
             old_bridge = self._bridge
-            old_pid = old_bridge.pid if old_bridge else None
+            old_pid = getattr(old_bridge, "pid", None) if old_bridge else None
 
             if old_bridge:
                 logger.info("MemOS: closing old bridge (pid=%s)", old_pid)
@@ -1661,14 +1670,28 @@ class MemTensorProvider(MemoryProvider):
                 logger.info("MemOS: old bridge closed (pid=%s)", old_pid)
 
             ensure_bridge_running()
-            self._bridge = MemosBridgeClient()
-            logger.info("MemOS: new bridge created (pid=%s)", self._bridge.pid)
+            try:
+                ensure_viewer_daemon()
+            except Exception as err:
+                logger.warning("MemOS: viewer daemon check failed during reconnect — %s", err)
+            new_bridge: MemosBridgeClient | None = None
+            try:
+                new_bridge = MemosBridgeClient()
+                logger.info("MemOS: new bridge created (pid=%s)", getattr(new_bridge, "pid", "?"))
 
-            self._bridge.register_host_handler(
-                "host.llm.complete",
-                self._handle_host_llm_complete,
-            )
-            self._open_session(session_id, timeout=timeout)
+                new_bridge.register_host_handler(
+                    "host.llm.complete",
+                    self._handle_host_llm_complete,
+                )
+                self._bridge = new_bridge
+                self._open_session(session_id, timeout=timeout)
+            except Exception:
+                if new_bridge is not None:
+                    with contextlib.suppress(Exception):
+                        new_bridge.close()
+                if self._bridge is new_bridge:
+                    self._bridge = None
+                raise
 
     def _ensure_bridge(self, session_id: str = "", *, timeout: float = 30.0) -> bool:
         if self._bridge:

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -1,7 +1,7 @@
 """JSON-RPC 2.0 over stdio client for the MemOS bridge.
 
-Spawns ``node bridge.cts --agent=hermes`` as a subprocess and communicates
-via line-delimited JSON messages on its stdin/stdout. Responses are
+Spawns ``node bridge.cts --agent=hermes --no-viewer`` as a subprocess and
+communicates via line-delimited JSON messages on its stdin/stdout. Responses are
 matched by ``id``. Notifications (events + logs) are forwarded to
 registered callbacks on a reader thread.
 
@@ -70,6 +70,7 @@ class MemosBridgeClient:
         bridge_path: str | None = None,
         node_binary: str | None = None,
         agent: str = "hermes",
+        no_viewer: bool = True,
         extra_env: dict[str, str] | None = None,
     ) -> None:
         self._lock = threading.Lock()
@@ -110,15 +111,18 @@ class MemosBridgeClient:
         # Use tsx's real JS entrypoint when we are launching through a
         # specific Node binary.
         tsx_cli = plugin_root / "node_modules" / "tsx" / "dist" / "cli.mjs"
+        bridge_args = [script, f"--agent={agent}"]
+        if no_viewer:
+            bridge_args.append("--no-viewer")
         if tsx_cli.exists():
-            cmd = [node, str(tsx_cli), script, f"--agent={agent}"]
+            cmd = [node, str(tsx_cli), *bridge_args]
         else:
             # Fallback path: `node --import tsx` reproduces the same loader
             # inline. Requires tsx to be resolvable as a package from the
             # plugin root — true whenever node_modules exists. If tsx is
             # genuinely missing the child will fail fast with a loader
             # error the stderr reader will surface.
-            cmd = [node, "--import", "tsx", script, f"--agent={agent}"]
+            cmd = [node, "--import", "tsx", *bridge_args]
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -147,7 +151,7 @@ class MemosBridgeClient:
     @property
     def pid(self) -> int:
         """Return the PID of the bridge subprocess."""
-        return self._proc.pid
+        return int(getattr(self._proc, "pid", 0) or 0)
 
     # ─── Public API ──
 
@@ -228,7 +232,7 @@ class MemosBridgeClient:
             return
         self._closed = True
 
-        pid = self._proc.pid
+        pid = self.pid
 
         # 1. Close stdin (triggers bridge's graceful exit)
         with contextlib.suppress(Exception):

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -16,6 +16,7 @@ the dependency graph for the Hermes plugin stays acyclic:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
@@ -23,14 +24,22 @@ import signal
 import subprocess
 import threading
 import time
+import urllib.error
+import urllib.request
 
 from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
 
-_lock = threading.Lock()
+_lock = threading.RLock()
 _bridge_ok: bool | None = None
+_viewer_status: str | None = None
+_viewer_last_probe_at = 0.0
+_viewer_process: subprocess.Popen | None = None
+
+HERMES_VIEWER_PORT = 18800
+VIEWER_PROBE_TTL_SEC = 30.0
 
 
 def _bridge_script() -> Path:
@@ -38,7 +47,7 @@ def _bridge_script() -> Path:
 
 
 def _node_available() -> bool:
-    node = shutil.which("node")
+    node = _node_binary()
     if not node:
         return False
     try:
@@ -46,6 +55,41 @@ def _node_available() -> bool:
         return bool(out.strip())
     except Exception:
         return False
+
+
+def _installed_node_binary(plugin_root: Path) -> str | None:
+    marker = plugin_root / ".memos-node-bin"
+    try:
+        candidate = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def _node_binary() -> str | None:
+    plugin_root = _bridge_script().parent
+    return (
+        os.environ.get("MEMOS_NODE_BINARY")
+        or _installed_node_binary(plugin_root)
+        or shutil.which("node")
+    )
+
+
+def _bridge_command(*, daemon: bool) -> list[str]:
+    plugin_root = _bridge_script().parent
+    node = _node_binary()
+    if not node:
+        raise RuntimeError("Node.js not found on PATH")
+    script = str(_bridge_script())
+    tsx_cli = plugin_root / "node_modules" / "tsx" / "dist" / "cli.mjs"
+    bridge_args = [script, "--agent=hermes"]
+    if daemon:
+        bridge_args.append("--daemon")
+    if tsx_cli.exists():
+        return [node, str(tsx_cli), *bridge_args]
+    return [node, "--import", "tsx", *bridge_args]
 
 
 def ensure_bridge_running(*, probe_only: bool = False) -> bool:
@@ -70,6 +114,145 @@ def ensure_bridge_running(*, probe_only: bool = False) -> bool:
             return False
         _bridge_ok = True
         return True
+
+
+def _probe_viewer() -> str:
+    """Classify the service currently listening on Hermes' viewer port."""
+    ping_url = f"http://127.0.0.1:{HERMES_VIEWER_PORT}/api/v1/ping"
+    ping_status = _probe_json_url(ping_url)
+    if ping_status == "free":
+        return "free"
+    if isinstance(ping_status, dict) and ping_status.get("service") == "memos-local-plugin":
+        return "running_memos"
+
+    # Backwards compatibility for already-running viewers installed before
+    # `/api/v1/ping` carried a service marker.
+    health_url = f"http://127.0.0.1:{HERMES_VIEWER_PORT}/api/v1/health"
+    health_status = _probe_json_url(health_url)
+    if health_status == "free":
+        return "free"
+    if not isinstance(health_status, dict):
+        return "blocked"
+    if (
+        health_status.get("service") == "memos-local-plugin"
+        and health_status.get("agent") == "hermes"
+    ):
+        return "running_memos"
+    if health_status.get("agent") == "hermes" and isinstance(health_status.get("version"), str):
+        return "running_memos"
+    return "blocked"
+
+
+def _probe_json_url(url: str) -> dict | str:
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=1.5) as resp:
+            content_type = resp.headers.get("content-type", "")
+            raw = resp.read(8192)
+    except urllib.error.URLError as err:
+        reason = getattr(err, "reason", None)
+        errno = getattr(reason, "errno", None)
+        if errno in {61, 111}:  # macOS/Linux connection refused
+            return "free"
+        msg = str(err).lower()
+        if "connection refused" in msg or "failed to establish" in msg:
+            return "free"
+        return "blocked"
+    except TimeoutError:
+        return "blocked"
+    except Exception:
+        return "blocked"
+
+    if "json" not in content_type.lower() and raw[:1] not in (b"{", b"["):
+        return "blocked"
+    try:
+        import json
+
+        return json.loads(raw.decode("utf-8", errors="replace"))
+    except Exception:
+        return "blocked"
+
+
+def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
+    """Ensure the singleton Hermes Viewer daemon owns :18800.
+
+    Returns True when the MemOS Hermes Viewer is already running or was
+    started. Returns False when the port is occupied by another service, Node
+    is unavailable, or the daemon did not become healthy quickly. This status
+    must not affect stdio memory capture.
+    """
+    global _viewer_last_probe_at, _viewer_process, _viewer_status
+    with _lock:
+        now = time.time()
+        if (
+            probe_only
+            and _viewer_status == "running_memos"
+            and now - _viewer_last_probe_at < VIEWER_PROBE_TTL_SEC
+        ):
+            return True
+
+        status = _probe_viewer()
+        _viewer_status = status
+        _viewer_last_probe_at = now
+        if status == "running_memos":
+            return True
+        if status == "blocked":
+            logger.warning(
+                "MemOS: viewer port %d is occupied by a non-MemOS service; "
+                "memory capture will continue without the web panel",
+                HERMES_VIEWER_PORT,
+            )
+            return False
+        if probe_only:
+            return False
+        if not ensure_bridge_running():
+            return False
+
+        plugin_root = _bridge_script().parent
+        logs_dir = plugin_root / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        log_file = logs_dir / "daemon-start.log"
+        try:
+            log_handle = log_file.open("a", encoding="utf-8")
+            _viewer_process = subprocess.Popen(
+                _bridge_command(daemon=True),
+                cwd=str(plugin_root),
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                start_new_session=True,
+            )
+            log_handle.close()
+        except Exception as err:
+            with contextlib.suppress(Exception):
+                log_handle.close()  # type: ignore[possibly-undefined]
+            logger.warning("MemOS: failed to start viewer daemon — %s", err)
+            return False
+
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            if _viewer_process.poll() is not None:
+                logger.warning(
+                    "MemOS: viewer daemon exited early with code %s",
+                    _viewer_process.returncode,
+                )
+                return False
+            status = _probe_viewer()
+            _viewer_status = status
+            _viewer_last_probe_at = time.time()
+            if status == "running_memos":
+                logger.info("MemOS: viewer daemon running on port %d", HERMES_VIEWER_PORT)
+                return True
+            if status == "blocked":
+                logger.warning(
+                    "MemOS: viewer port %d became occupied by a non-MemOS service",
+                    HERMES_VIEWER_PORT,
+                )
+                return False
+            time.sleep(0.5)
+        logger.warning("MemOS: viewer daemon did not become healthy within 15s")
+        return False
 
 
 def shutdown_bridge() -> None:

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -3,7 +3,7 @@
  *
  * Started by non-TypeScript hosts (e.g. the Hermes Python client) via:
  *
- *   node_modules/.bin/tsx bridge.cts --agent=hermes
+ *   node_modules/.bin/tsx bridge.cts --agent=hermes --no-viewer
  *
  * The `.cts` extension is intentional: it lets the file be required
  * from CommonJS environments that spawn Node with `require("...")`
@@ -37,6 +37,7 @@ const BRIDGE_STATUS_FILE = "bridge-status.json";
 
 interface BridgeArgs {
   daemon: boolean;
+  noViewer: boolean;
   tcpPort?: number;
   agent: "openclaw" | "hermes";
 }
@@ -51,9 +52,10 @@ interface BridgeStatusSnapshot {
 }
 
 function parseArgs(argv: readonly string[]): BridgeArgs {
-  const args: BridgeArgs = { daemon: false, agent: "openclaw" };
+  const args: BridgeArgs = { daemon: false, noViewer: false, agent: "openclaw" };
   for (const raw of argv) {
     if (raw === "--daemon") args.daemon = true;
+    else if (raw === "--no-viewer") args.noViewer = true;
     else if (raw.startsWith("--tcp=")) args.tcpPort = Number(raw.slice(6));
     else if (raw === "--agent=hermes") args.agent = "hermes";
     else if (raw === "--agent=openclaw") args.agent = "openclaw";
@@ -295,39 +297,47 @@ async function main(): Promise<void> {
     bridgeStatus?.markDisconnected("Hermes chat disconnected");
   });
 
-  // Try to bind the viewer port. EADDRINUSE → stay headless.
+  // Try to bind the viewer port unless the caller requested a pure stdio
+  // bridge. Hermes chat uses --no-viewer; the standalone --daemon process is
+  // the single owner of :18800.
   let viewer: import("./server/types.js").ServerHandle | null = null;
-  try {
-    viewer = await startHttpServer(
-      {
-        core,
-        home,
-        logTail: () => memoryBuffer().tail({ limit: 200 }),
-        bridgeStatus: bridgeStatus ? () => bridgeStatus.snapshot() : undefined,
-        telemetry,
-      },
-      {
-        port: viewerPort,
-        host: config.viewer.bindHost,
-        staticRoot: path.resolve(__dirname, "viewer/dist"),
-        agent: args.agent,
-      },
-    );
+  if (args.noViewer) {
     process.stderr.write(
-      `bridge: viewer live at ${viewer.url} (agent=${args.agent})\n`,
+      `bridge: stdio mode running without viewer (agent=${args.agent})\n`,
     );
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    if (e?.code === "EADDRINUSE") {
-      process.stderr.write(
-        `bridge: viewer port :${viewerPort} is already in use — ` +
-          `${args.agent} will run headless (stdio only). ` +
-          `Free the port to expose the viewer.\n`,
+  } else {
+    try {
+      viewer = await startHttpServer(
+        {
+          core,
+          home,
+          logTail: () => memoryBuffer().tail({ limit: 200 }),
+          bridgeStatus: bridgeStatus ? () => bridgeStatus.snapshot() : undefined,
+          telemetry,
+        },
+        {
+          port: viewerPort,
+          host: config.viewer.bindHost,
+          staticRoot: path.resolve(__dirname, "viewer/dist"),
+          agent: args.agent,
+        },
       );
-    } else {
       process.stderr.write(
-        `bridge: viewer failed to start: ${e?.message ?? String(err)}\n`,
+        `bridge: viewer live at ${viewer.url} (agent=${args.agent})\n`,
       );
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code === "EADDRINUSE") {
+        process.stderr.write(
+          `bridge: viewer port :${viewerPort} is already in use — ` +
+            `${args.agent} will run headless (stdio only). ` +
+            `Free the port to expose the viewer.\n`,
+        );
+      } else {
+        process.stderr.write(
+          `bridge: viewer failed to start: ${e?.message ?? String(err)}\n`,
+        );
+      }
     }
   }
 

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -412,7 +412,7 @@ export function requireSession(
   // Public: auth endpoints + health (so the viewer can tell whether
   // the backend is up BEFORE unlocking).
   if (pathname.startsWith("/api/v1/auth/")) return true;
-  if (pathname === "/api/v1/health") return true;
+  if (pathname === "/api/v1/health" || pathname === "/api/v1/ping") return true;
 
   const state = readAuthState(homeDir);
   if (!state) return true; // password protection off → open

--- a/apps/memos-local-plugin/server/routes/health.ts
+++ b/apps/memos-local-plugin/server/routes/health.ts
@@ -10,11 +10,18 @@ import type { ServerDeps } from "../types.js";
 import type { RouteContext, Routes } from "./registry.js";
 
 export function registerHealthRoutes(routes: Routes, deps: ServerDeps): void {
+  const serviceIdentity = {
+    service: "memos-local-plugin",
+  };
   routes.set("GET /api/v1/health", async () => {
     const health = await deps.core.health();
     const bridge = deps.bridgeStatus?.();
-    return bridge ? { ...health, bridge } : health;
+    const identity = {
+      ...serviceIdentity,
+      agent: health.agent,
+    };
+    return bridge ? { ...health, ...identity, bridge } : { ...health, ...identity };
   });
-  routes.set("GET /api/v1/ping", () => ({ ok: true, ts: Date.now() }));
+  routes.set("GET /api/v1/ping", () => ({ ok: true, ...serviceIdentity, ts: Date.now() }));
   void ({} as RouteContext);
 }

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import io
 import json
 import sys
+import tempfile
 import threading
 import unittest
 
@@ -27,6 +28,7 @@ for _p in (_ADAPTER_ROOT, _PLUGIN_DIR):
         sys.path.insert(0, str(_p))
 
 import bridge_client as bridge_client_mod  # noqa: E402
+import daemon_manager as daemon_manager_mod  # noqa: E402
 
 from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
 
@@ -39,6 +41,7 @@ class FakePopen:
     """
 
     def __init__(self, *_args, **_kwargs) -> None:
+        self.cmd = list(_args[0]) if _args else []
         self.stdin = io.StringIO()
         self._stdin_lines: list[str] = []
         self.stdout = _ServerStream()
@@ -289,6 +292,13 @@ class BridgeClientTests(unittest.TestCase):
         client.close()
         client.close()  # second call must not raise
 
+    def test_stdio_bridge_starts_without_viewer_by_default(self) -> None:
+        client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+        assert self._fake is not None
+        cmd = getattr(self._fake, "cmd", [])
+        self.assertIn("--no-viewer", cmd)
+        client.close()
+
 
 class MemTensorProviderTests(unittest.TestCase):
     """Exercise `MemTensorProvider` against a mocked bridge."""
@@ -302,6 +312,7 @@ class MemTensorProviderTests(unittest.TestCase):
 
         self._patches = [
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
         ]
         for p in self._patches:
             p.start()
@@ -601,6 +612,61 @@ class MemTensorProviderTests(unittest.TestCase):
             loaded = yaml.safe_load(cfg_path.read_text())
             self.assertEqual(loaded["viewer"]["port"], 18920)
             self.assertEqual(loaded["llm"]["provider"], "openai_compatible")
+
+
+class ViewerDaemonTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        daemon_manager_mod._viewer_status = None
+        daemon_manager_mod._viewer_last_probe_at = 0.0
+        daemon_manager_mod._viewer_process = None
+
+    def test_existing_memos_viewer_is_reused(self) -> None:
+        with (
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="running_memos"),
+            patch.object(daemon_manager_mod.subprocess, "Popen") as popen,
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_viewer_daemon())
+            popen.assert_not_called()
+
+    def test_non_memos_port_occupant_blocks_daemon_start(self) -> None:
+        with (
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="blocked"),
+            patch.object(daemon_manager_mod.subprocess, "Popen") as popen,
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_viewer_daemon())
+            popen.assert_not_called()
+
+    def test_free_port_starts_daemon_once(self) -> None:
+        class FakeDaemon:
+            returncode = None
+
+            def poll(self):
+                return None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bridge_path = Path(tmp) / "bridge.cts"
+            bridge_path.write_text("", encoding="utf-8")
+            with (
+                patch.object(
+                    daemon_manager_mod,
+                    "_probe_viewer",
+                    side_effect=["free", "running_memos"],
+                ),
+                patch.object(daemon_manager_mod, "_bridge_script", return_value=bridge_path),
+                patch.object(daemon_manager_mod, "ensure_bridge_running", return_value=True),
+                patch.object(
+                    daemon_manager_mod,
+                    "_bridge_command",
+                    return_value=["node", "bridge.cts", "--agent=hermes", "--daemon"],
+                ),
+                patch.object(
+                    daemon_manager_mod.subprocess,
+                    "Popen",
+                    return_value=FakeDaemon(),
+                ) as popen,
+            ):
+                self.assertTrue(daemon_manager_mod.ensure_viewer_daemon())
+                popen.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
+++ b/apps/memos-local-plugin/tests/python/test_hermes_provider_pipeline.py
@@ -72,6 +72,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -132,6 +133,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
 
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", side_effect=bridge_factory),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -161,6 +163,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
 
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", side_effect=lambda: bridge_attempts.pop(0)),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -185,6 +188,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -209,6 +213,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         )
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -234,6 +239,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -251,6 +257,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -268,6 +275,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -298,6 +306,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -351,6 +360,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
             )
             with (
                 patch("memos_provider.ensure_bridge_running", return_value=True),
+                patch("memos_provider.ensure_viewer_daemon", return_value=True),
                 patch("memos_provider.MemosBridgeClient", return_value=bridge),
             ):
                 provider = memos_provider.MemTensorProvider()
@@ -373,6 +383,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -417,6 +428,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -462,6 +474,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()
@@ -504,6 +517,7 @@ class HermesProviderPipelineTests(unittest.TestCase):
         bridge = FakeBridge()
         with (
             patch("memos_provider.ensure_bridge_running", return_value=True),
+            patch("memos_provider.ensure_viewer_daemon", return_value=True),
             patch("memos_provider.MemosBridgeClient", return_value=bridge),
         ):
             provider = memos_provider.MemTensorProvider()


### PR DESCRIPTION
## Summary
Hermes local plugin: improve how the bridge and optional Hermes viewer are discovered and started, harden daemon coordination, and align server routes with the bridge.

## Changes
- **Node / bridge**: Resolve Node via `MEMOS_NODE_BINARY`, `.memos-node-bin`, or PATH; prefer local `tsx` CLI when present; centralize bridge argv construction.
- **Daemon**: Use RLock for shared state; add viewer port probing (`HERMES_VIEWER_PORT`), TTL-cached status, and optional viewer subprocess lifecycle helpers.
- **Server**: Small updates to `auth.ts` and `health.ts`; `bridge.cts` wiring adjustments.
- **Tests**: Extended Python coverage in `test_bridge_client.py` and `test_hermes_provider_pipeline.py`.

## Checks
- `ruff check` and `ruff format` on touched Python paths under `apps/memos-local-plugin`.

Base: latest `upstream/mem-agent-0514` per repo workflow.