### PR TITLE
fix(memos-local-plugin): ignore lightweight action vectors

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -3658,14 +3658,16 @@ export function createMemoryCore(
           sourceText: row.summary?.trim() || row.userText.trim() || "(empty)",
           update: (vec) => handle.repos.traces.updateVector(row.id, "vecSummary", vec),
         });
-        slots.push({
-          kind: "trace",
-          id: row.id,
-          field: "vec_action",
-          vec: row.vecAction,
-          sourceText: traceActionEmbeddingText(row),
-          update: (vec) => handle.repos.traces.updateVector(row.id, "vecAction", vec),
-        });
+        if (!isLightweightMemoryTrace(row)) {
+          slots.push({
+            kind: "trace",
+            id: row.id,
+            field: "vec_action",
+            vec: row.vecAction,
+            sourceText: traceActionEmbeddingText(row),
+            update: (vec) => handle.repos.traces.updateVector(row.id, "vecAction", vec),
+          });
+        }
       }
       if (rows.length < pageSize) break;
     }
@@ -3721,6 +3723,10 @@ export function createMemoryCore(
 
   function slotNeedsRepair(slot: EmbeddingSlot, dimension: number): boolean {
     return !slot.vec || (dimension > 0 && slot.vec.length !== dimension);
+  }
+
+  function isLightweightMemoryTrace(row: TraceRow): boolean {
+    return row.tags.includes("lightweight_memory");
   }
 
   function emptyEmbeddingStatsByKind(): EmbeddingMaintenanceStats["byKind"] {

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -24,7 +24,7 @@ import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
 import { makeTmpHome, type TmpHomeContext } from "../../helpers/tmp-home.js";
 import { fakeEmbedder } from "../../helpers/fake-embedder.js";
 import type { MemosError } from "../../../agent-contract/errors.js";
-import type { SkillId, SkillRow } from "../../../core/types.js";
+import type { SkillId, SkillRow, TraceRow } from "../../../core/types.js";
 
 let db: TmpDbHandle | null = null;
 let pipeline: PipelineHandle | null = null;
@@ -190,6 +190,83 @@ describe("MemoryCore façade", () => {
     expect(fixed.statsAfter.dimMismatch).toBe(0);
     row = db!.repos.traces.getById("tr_imported" as never);
     expect(row?.vecSummary?.length).toBe(TEST_EMBED_DIMENSIONS);
+  });
+
+  it("does not require action vectors for lightweight memory traces", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+
+    db!.repos.sessions.upsert({
+      id: "se_lightweight",
+      agent: "openclaw",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_700_000_000_000,
+      lastSeenAt: 1_700_000_000_000,
+      meta: {},
+    });
+    db!.repos.episodes.insert({
+      id: "ep_lightweight",
+      sessionId: "se_lightweight",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_000_001,
+      traceIds: ["tr_lightweight"] as never,
+      rTask: null,
+      status: "closed",
+      meta: { lightweightMemory: true },
+    });
+    db!.repos.traces.insert({
+      id: "tr_lightweight",
+      episodeId: "ep_lightweight",
+      sessionId: "se_lightweight",
+      ownerAgentKind: "openclaw",
+      ownerProfileId: "main",
+      ownerWorkspaceId: null,
+      ts: 1_700_000_000_000,
+      userText: "What changed in the repo?",
+      agentText: "The branch adds lightweight memory mode.",
+      summary: "Repo branch lightweight memory change",
+      share: null,
+      toolCalls: [],
+      agentThinking: null,
+      reflection: null,
+      value: 0,
+      alpha: 0,
+      rHuman: null,
+      priority: 0.5,
+      tags: ["lightweight_memory"],
+      errorSignatures: [],
+      vecSummary: new Float32Array(TEST_EMBED_DIMENSIONS),
+      vecAction: null,
+      turnId: 1_700_000_000_000,
+      schemaVersion: 1,
+    } as TraceRow);
+
+    const before = await core.embeddingMaintenanceStats();
+    expect(before.byKind.trace.totalSlots).toBe(1);
+    expect(before.byKind.trace.ready).toBe(1);
+    expect(before.byKind.trace.missing).toBe(0);
+    expect(before.needsRepair).toBe(0);
+
+    const repaired = await core.rebuildEmbeddings({ mode: "repair", limit: 10 });
+    expect(repaired.processed).toBe(0);
+    expect(repaired.updated).toBe(0);
+
+    const rebuilt = await core.rebuildEmbeddings({ mode: "rebuild", limit: 10 });
+    expect(rebuilt.processed).toBe(1);
+    expect(rebuilt.updated).toBe(1);
+    const row = db!.repos.traces.getById("tr_lightweight" as never);
+    expect(row?.vecSummary?.length).toBe(TEST_EMBED_DIMENSIONS);
+    expect(row?.vecAction).toBeNull();
   });
 
   it("onTurnStart returns a RetrievalResultDTO with tier latencies", async () => {


### PR DESCRIPTION
## Summary
- stop embedding maintenance from treating lightweight memory trace action vectors as required slots
- keep lightweight trace summary vectors indexed and rebuildable
- add regression coverage for stats, repair, and rebuild behavior

## Tests
- npm test -- tests/unit/pipeline/memory-core.test.ts
- npm test
- npm run lint
- npm run build

## Notes
Lightweight memory intentionally stores only vec_summary. The previous maintenance stats counted the intentionally empty vec_action field as missing, so Settings reported missing embeddings for new lightweight chat memories even though retrieval had a summary index.