### PR TITLE
test(memos-local-plugin): assert lightweight summarizer filter

### DIFF
--- a/apps/memos-local-plugin/core/retrieval/retrieve.ts
+++ b/apps/memos-local-plugin/core/retrieval/retrieve.ts
@@ -352,8 +352,8 @@ async function runAll(
     // candidates. A small LLM round-trip (see `llm-filter.ts`) prunes
     // items that share surface keywords with the query but aren't
     // actually relevant. Full mode fails open to preserve recall;
-    // lightweight mode fails closed because it promises LLM-screened raw
-    // memories only.
+    // lightweight mode fails closed because it promises summarizer-LLM
+    // screened raw memories only.
     const queryText =
       (ctx as { userText?: string }).userText ?? compiled.text ?? "";
     const filterResult = await llmFilterCandidates(

--- a/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
@@ -295,12 +295,17 @@ describe("retrieval/integration", () => {
     expect(res.packet.snippets.every((s) => s.refKind !== "skill")).toBe(true);
   });
 
-  it("lightweight mode only returns trace memories after LLM filter succeeds", async () => {
+  it("lightweight mode only returns trace memories after summarizer filter succeeds", async () => {
+    let filterCalls = 0;
     const llm: any = {
-      completeJson: async () => ({
-        value: { selected: [1], sufficient: true },
-        servedBy: "fake",
-      }),
+      completeJson: async (_messages: unknown, opts: { op?: string }) => {
+        filterCalls++;
+        expect(opts.op).toContain("retrieval.filter");
+        return {
+          value: { selected: [1], sufficient: true },
+          servedBy: "fake",
+        };
+      },
     };
     const res = await turnStartRetrieve(
       {
@@ -328,9 +333,10 @@ describe("retrieval/integration", () => {
     expect(res.stats.tier3Count).toBe(0);
     expect(res.stats.llmFilterOutcome).toBe("llm_filtered");
     expect(res.stats.emptyPacket).toBe(false);
+    expect(filterCalls).toBe(1);
   });
 
-  it("lightweight mode returns no memories when LLM filter is unavailable", async () => {
+  it("lightweight mode returns no memories when summarizer filter is unavailable", async () => {
     const res = await turnStartRetrieve(
       {
         ...makeDeps(handle),


### PR DESCRIPTION
## Summary\n- Clarify that lightweight retrieval fails closed on the summarizer LLM filter\n- Assert lightweight trace recall calls the retrieval.filter summarizer path\n- Rename unavailable-filter test to refer to the summarizer filter\n\n## Tests\n- npm test -- tests/unit/retrieval/integration.test.ts\n- npm run lint\n- npm run build