### PR TITLE
fix(memos-local-plugin): persist lightweight model status

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -257,7 +257,6 @@ export async function bootstrapMemoryCoreFull(
       phase?: string;
     },
   ): void {
-    if (config.algorithm.lightweightMemory.enabled) return;
     try {
       repos.apiLogs.insert({
         toolName: "system_model_status",

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -20,6 +20,10 @@ import type { TraceDTO } from "../../../agent-contract/dto.js";
 import { rootLogger } from "../../../core/logger/index.js";
 import { DEFAULT_CONFIG } from "../../../core/config/defaults.js";
 import { resolveHome } from "../../../core/config/paths.js";
+import {
+  __resetHostLlmBridgeForTests,
+  type HostLlmBridge,
+} from "../../../core/llm/index.js";
 import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
 import { makeTmpHome, type TmpHomeContext } from "../../helpers/tmp-home.js";
 import { fakeEmbedder } from "../../helpers/fake-embedder.js";
@@ -105,6 +109,7 @@ afterEach(async () => {
   }
   db?.cleanup();
   db = null;
+  __resetHostLlmBridgeForTests();
 });
 
 describe("MemoryCore façade", () => {
@@ -993,6 +998,67 @@ describe("bootstrapMemoryCore", () => {
     expect(h2.ok).toBe(true);
     expect(h2.paths.home).toBe(home!.home.root);
     expect(h2.paths.db).toBe(home!.home.dbFile);
+  });
+
+  it("persists lightweight summarizer model status for Hermes overview", async () => {
+    home = await makeTmpHome({
+      agent: "hermes",
+      configYaml: `
+llm:
+  provider: host
+  model: hermes-summary-test
+algorithm:
+  lightweightMemory:
+    enabled: true
+`,
+    });
+    const bridge: HostLlmBridge = {
+      id: "test-host-llm",
+      async complete() {
+        return {
+          text: JSON.stringify({ summary: "Hermes remembered the overview status fact" }),
+          model: "hermes-summary-test",
+          durationMs: 1,
+        };
+      },
+    };
+    core = await bootstrapMemoryCore({
+      agent: "hermes",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "bootstrap-test",
+      hostLlmBridge: bridge,
+      now: () => 1_700_000_000_000,
+    });
+    await core.init();
+
+    const start = await core.onTurnStart({
+      agent: "hermes",
+      sessionId: "hermes-lightweight-status",
+      userText: "请记住 Hermes 摘要模型状态应该显示已调用",
+      ts: 1_700_000_000_000,
+    });
+    await core.onTurnEnd({
+      agent: "hermes",
+      sessionId: "hermes-lightweight-status",
+      episodeId: start.query.episodeId!,
+      agentText: "已记住。",
+      toolCalls: [],
+      ts: 1_700_000_000_100,
+    });
+
+    const logs = await core.listApiLogs({ toolName: "system_model_status", limit: 10 });
+    const llmRows = logs.logs
+      .map((row) => JSON.parse(row.outputJson) as { role?: string; status?: string; op?: string })
+      .filter((row) => row.role === "llm");
+    expect(llmRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "ok",
+          op: "capture.summarize",
+        }),
+      ]),
+    );
   });
 
   it("init() recovers orphaned open episodes left behind by a previous crash", async () => {


### PR DESCRIPTION
## Summary\n- Persist system_model_status rows even when lightweight memory mode is enabled\n- Keep Overview model cards accurate across Hermes bridge/viewer process boundaries\n- Add a Hermes lightweight regression test for capture.summarize model status\n\n## Tests\n- npm test -- tests/unit/pipeline/memory-core.test.ts\n- npm test -- tests/unit/retrieval/integration.test.ts\n- npm run lint\n- npm run build