### PR TITLE
feat(memos-local-plugin): make memory self-evolution opt-in

### DIFF
--- a/apps/memos-local-plugin/core/config/defaults.ts
+++ b/apps/memos-local-plugin/core/config/defaults.ts
@@ -55,7 +55,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   },
   algorithm: {
     lightweightMemory: {
-      enabled: false,
+      enabled: true,
     },
     capture: {
       maxTextChars: 4_000,

--- a/apps/memos-local-plugin/core/config/schema.ts
+++ b/apps/memos-local-plugin/core/config/schema.ts
@@ -97,8 +97,9 @@ const AlgorithmSchema = Type.Object({
      * Low-cost mode for users who only want raw conversation memory +
      * recall. When enabled, the runtime skips task/reward/L2/L3/skill
      * evolution and keeps only summarize + embedding + retrieval filter.
+     * The viewer exposes the inverse as "memory self-evolution".
      */
-    enabled: Bool(false),
+    enabled: Bool(true),
   }, { default: {} }),
   capture: Type.Object({
     /** Cap on agent/user text length (chars). Longer content is summarized. */

--- a/apps/memos-local-plugin/templates/config.hermes.yaml
+++ b/apps/memos-local-plugin/templates/config.hermes.yaml
@@ -29,7 +29,7 @@ llm:
 
 algorithm:
   lightweightMemory:
-    enabled: false         # true = only summarize + embed + recall; no tasks/skills/experiences/world models
+    enabled: true          # true = low-cost summaries only; false = memory self-evolution with tasks/experiences/world models/skills
 
 hub:
   enabled: false

--- a/apps/memos-local-plugin/templates/config.openclaw.yaml
+++ b/apps/memos-local-plugin/templates/config.openclaw.yaml
@@ -28,7 +28,7 @@ llm:
 
 algorithm:
   lightweightMemory:
-    enabled: false         # true = only summarize + embed + recall; no tasks/skills/experiences/world models
+    enabled: true          # true = low-cost summaries only; false = memory self-evolution with tasks/experiences/world models/skills
 
 hub:
   enabled: false

--- a/apps/memos-local-plugin/tests/unit/config/load.test.ts
+++ b/apps/memos-local-plugin/tests/unit/config/load.test.ts
@@ -81,14 +81,14 @@ viewer:
     expect(cfg.algorithm.skill.minSupport).toBe(DEFAULT_CONFIG.algorithm.skill.minSupport);
   });
 
-  it("defaults lightweight memory mode off and accepts explicit opt-in", () => {
+  it("defaults lightweight memory mode on and accepts explicit opt-out", () => {
     const base = resolveConfig({});
-    expect(base.algorithm.lightweightMemory.enabled).toBe(false);
+    expect(base.algorithm.lightweightMemory.enabled).toBe(true);
 
     const cfg = resolveConfig({
-      algorithm: { lightweightMemory: { enabled: true } },
+      algorithm: { lightweightMemory: { enabled: false } },
     });
-    expect(cfg.algorithm.lightweightMemory.enabled).toBe(true);
+    expect(cfg.algorithm.lightweightMemory.enabled).toBe(false);
   });
 
   it("does not expose embedding dimensions as user config", () => {

--- a/apps/memos-local-plugin/viewer/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/i18n.ts
@@ -422,7 +422,8 @@ const en = {
   "policies.empty": "No experiences yet.",
   "policies.empty.hint":
     "Experiences appear after a few successful conversations share the same approach.",
-  "policies.lightweight.empty": "Lightweight mode does not generate experiences.",
+  "policies.lightweight.empty":
+    "Only basic summary memories are being saved. Enable memory self-evolution to automatically distill reusable experiences.",
   "policies.col.trigger": "Trigger",
   "policies.col.procedure": "Procedure",
   "policies.col.verification": "Verification",
@@ -464,7 +465,8 @@ const en = {
   "worldModels.empty": "Nothing here yet.",
   "worldModels.empty.hint":
     "Environment knowledge builds up once several experiences share the same structure.",
-  "worldModels.lightweight.empty": "Lightweight mode does not generate environment knowledge.",
+  "worldModels.lightweight.empty":
+    "Only basic summary memories are being saved. Enable memory self-evolution to automatically build environment knowledge.",
   "worldModels.col.body": "Description",
   "worldModels.structure.title": "Structured cognition (with evidence)",
   "worldModels.structure.environment": "Environment topology (ℰ)",
@@ -484,7 +486,8 @@ const en = {
   "tasks.search.placeholder": "Search tasks…",
   "tasks.empty": "No tasks yet.",
   "tasks.empty.filtered": "No tasks match the current filter.",
-  "tasks.lightweight.empty": "Lightweight mode does not generate task views.",
+  "tasks.lightweight.empty":
+    "Only basic summary memories are being saved. Enable memory self-evolution to automatically organize conversations into task views.",
   "tasks.untitled": "Untitled task",
   "tasks.detail.id": "Task {id}",
   "tasks.detail.fallbackTitle": "Task detail",
@@ -581,7 +584,8 @@ const en = {
   "skills.empty": "No skills yet.",
   "skills.empty.hint":
     "The agent turns a reliable experience into a callable skill once it's proven useful across several similar tasks.",
-  "skills.lightweight.empty": "Lightweight mode does not generate skills.",
+  "skills.lightweight.empty":
+    "Only basic summary memories are being saved. Enable memory self-evolution to automatically crystallize reusable skills.",
   "skills.detail.desc": "Invocation guide",
   "skills.detail.files": "Skill files",
   "skills.detail.content": "SKILL.md content",
@@ -874,9 +878,9 @@ const en = {
   "settings.general.theme.light": "Light",
   "settings.general.theme.dark": "Dark",
   "settings.general.theme.auto": "System",
-  "settings.general.lightweightMemory": "Lightweight memory mode",
+  "settings.general.lightweightMemory": "Enable memory self-evolution",
   "settings.general.lightweightMemory.desc":
-    "Only summarize and index raw memories; skips task, experience, environment and skill evolution. Save and restart to apply.",
+    "Automatically distill tasks, experiences, environment knowledge and skills beyond basic summary memory. Uses more model calls and is best for heavy memory workflows. Save and restart to apply.",
   "settings.general.detailedLogs": "Show detailed debug logs",
   "settings.general.detailedLogs.desc":
     "Enable chain view, failure-only filtering, and task, experience, skill, environment and system log categories.",
@@ -1262,7 +1266,8 @@ const zh: Record<TranslationKey, string> = {
   "policies.filter.archived": "已归档",
   "policies.empty": "尚未结晶出经验。",
   "policies.empty.hint": "当几次成功对话用的是同一套做法后，这里会出现相应的经验条目。",
-  "policies.lightweight.empty": "轻量模式不生成经验。",
+  "policies.lightweight.empty":
+    "当前仅保存基础摘要记忆。启用记忆自进化后，系统会自动提炼可复用经验。",
   "policies.col.trigger": "触发",
   "policies.col.procedure": "流程",
   "policies.col.verification": "验证",
@@ -1299,7 +1304,8 @@ const zh: Record<TranslationKey, string> = {
   "worldModels.search.placeholder": "搜索环境认知…",
   "worldModels.empty": "暂无环境认知。",
   "worldModels.empty.hint": "当多条经验展现出相同的规律时，会自动凝聚成这里的环境认知。",
-  "worldModels.lightweight.empty": "轻量模式不生成环境认知。",
+  "worldModels.lightweight.empty":
+    "当前仅保存基础摘要记忆。启用记忆自进化后，系统会自动建立环境认知。",
   "worldModels.col.body": "内容",
   "worldModels.structure.title": "结构化认知（带证据锚点）",
   "worldModels.structure.environment": "环境拓扑（ℰ）",
@@ -1318,7 +1324,8 @@ const zh: Record<TranslationKey, string> = {
   "tasks.search.placeholder": "搜索任务…",
   "tasks.empty": "暂无任务。",
   "tasks.empty.filtered": "当前筛选条件下没有匹配的任务。",
-  "tasks.lightweight.empty": "轻量模式不生成任务视图。",
+  "tasks.lightweight.empty":
+    "当前仅保存基础摘要记忆。启用记忆自进化后，系统会自动整理任务视图。",
   "tasks.untitled": "未命名任务",
   "tasks.detail.id": "任务 {id}",
   "tasks.detail.fallbackTitle": "任务详情",
@@ -1404,7 +1411,8 @@ const zh: Record<TranslationKey, string> = {
   "skills.filter.visibility.private": "私有",
   "skills.empty": "尚无技能。",
   "skills.empty.hint": "当一条经验在多个相似任务里都好用，插件会把它沉淀成一个可直接调用的技能。",
-  "skills.lightweight.empty": "轻量模式不生成技能。",
+  "skills.lightweight.empty":
+    "当前仅保存基础摘要记忆。启用记忆自进化后，系统会自动沉淀可复用技能。",
   "skills.detail.desc": "调用指南",
   "skills.detail.files": "技能文件",
   "skills.detail.content": "SKILL.md 内容",
@@ -1677,9 +1685,9 @@ const zh: Record<TranslationKey, string> = {
   "settings.general.theme.light": "浅色",
   "settings.general.theme.dark": "深色",
   "settings.general.theme.auto": "跟随系统",
-  "settings.general.lightweightMemory": "轻量记忆模式",
+  "settings.general.lightweightMemory": "启用记忆自进化",
   "settings.general.lightweightMemory.desc":
-    "仅摘要并索引原始记忆；跳过任务、经验、环境认知和技能进化。保存并重启后生效。",
+    "在基础摘要记忆之外，自动沉淀任务、经验、环境认知和技能。会调用更多模型能力，适合重度记忆使用场景。保存并重启后生效。",
   "settings.general.detailedLogs": "显示详细调试日志",
   "settings.general.detailedLogs.desc":
     "开启后显示链路视图、仅看失败筛选，以及任务、经验、技能、环境认知和系统日志分类。",

--- a/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
@@ -5,7 +5,7 @@
  *                   each with a "测试" button that calls
  *                   `POST /api/v1/models/test`.
  *   - Team Sharing — hub on/off + address + tokens.
- *   - General     — language, theme, lightweight memory, logging,
+ *   - General     — language, theme, memory self-evolution, logging,
  *                   telemetry, password protection, and danger zone.
  *
  * Save flow: `PATCH /api/v1/config` → show restart overlay → call
@@ -903,8 +903,8 @@ function GeneralTab({
             <p class="card__subtitle">{t("settings.general.lightweightMemory.desc")}</p>
           </div>
           <ToggleSwitch
-            checked={algorithm.lightweightMemory?.enabled === true}
-            onChange={(v) => onPatchAlgorithm({ lightweightMemory: { enabled: v } })}
+            checked={algorithm.lightweightMemory?.enabled === false}
+            onChange={(v) => onPatchAlgorithm({ lightweightMemory: { enabled: !v } })}
           />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- default new configs to low-cost summary memory
- present the setting as an opt-in memory self-evolution capability
- update task, experience, environment, and skill empty states to guide users toward enabling self-evolution

## Tests
- npm test -- tests/unit/config/load.test.ts tests/unit/config/writer.test.ts
- npm run lint
- npm run build