### PR TITLE
Enrich reflection synthesis context

### DIFF
--- a/apps/memos-local-plugin/core/capture/alpha-scorer.ts
+++ b/apps/memos-local-plugin/core/capture/alpha-scorer.ts
@@ -31,6 +31,7 @@ export interface AlphaInput {
   reflectionText: string;
   episodeId?: string;
   phase?: string;
+  taskSummary?: string | null;
 }
 
 export interface AlphaOutput {
@@ -48,6 +49,9 @@ export async function scoreReflection(
 
   const thinking = (input.step.agentThinking ?? "").trim();
   const userPayload = [
+    `TASK CONTEXT:`,
+    input.taskSummary?.trim().slice(0, 1_200) || "(none)",
+    ``,
     `STATE:`,
     input.step.userText.slice(0, 1_200) || "(none)",
     ``,
@@ -130,6 +134,7 @@ export async function scoreReflection(
     usable,
     rawAlpha,
     model: rsp.servedBy,
+    reason,
   });
 
   return { alpha: finalAlpha, usable, reason, model: rsp.servedBy };

--- a/apps/memos-local-plugin/core/capture/batch-scorer.ts
+++ b/apps/memos-local-plugin/core/capture/batch-scorer.ts
@@ -57,6 +57,7 @@ export interface BatchScoreOptions {
   synthReflections: boolean;
   episodeId?: string;
   phase?: string;
+  taskSummary?: string | null;
   /**
    * Cap per-field text we shovel into the prompt. Default 1_200 chars per
    * `state`/`outcome`, 1_500 per `action`. Mirrors per-step prompts.
@@ -122,6 +123,7 @@ export async function batchScoreReflections(
 
   const payload = {
     host_context: batchHostContext(inputs, llm),
+    task_context: opts.taskSummary?.trim().slice(0, 1_200) || null,
     steps: inputs.map((input, i) => ({
       idx: i,
       state: clip(input.step.userText, fieldChars.state),
@@ -188,6 +190,7 @@ export async function batchScoreReflections(
     const usable = Boolean(raw.usable);
     const rawAlpha = clamp01(numOrZero(raw.alpha));
     const alpha = usable ? rawAlpha : 0;
+    const reason = typeof raw.reason === "string" ? sanitizeDerivedText(raw.reason) : null;
 
     let finalText: string | null;
     let source: ReflectionScore["source"];
@@ -210,6 +213,7 @@ export async function batchScoreReflections(
       text: finalText,
       alpha,
       usable: usable && finalText !== null,
+      reason,
       source,
       model: rsp.servedBy,
     };

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -440,12 +440,22 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     const reflectStart = now();
     const rLlm = deps.reflectLlm ?? deps.llm;
     const useBatch = shouldBatch(deps.cfg, normalized.length, rLlm !== null);
+    const taskSummary = buildTaskReflectionSummary(input.episode, normalized);
+    log.info("capture.reflect.scoring.start", {
+      episodeId: input.episode.id,
+      sessionId: input.episode.sessionId,
+      steps: normalized.length,
+      mode: useBatch ? "batch" : "per_step",
+      provider: rLlm?.provider ?? "none",
+      model: rLlm?.model ?? "none",
+      taskSummary: taskSummary ? taskSummary.slice(0, 240) : null,
+    });
     let scored: ScoredStep[] = [];
     if (useBatch) {
-      scored = await runBatchScoring(normalized, rLlm!, deps, warnings, llmCalls, input.episode.id);
+      scored = await runBatchScoring(normalized, rLlm!, deps, warnings, llmCalls, input.episode.id, taskSummary);
     }
     if (!useBatch || scored.length === 0) {
-      scored = await runPerStepScoring(normalized, rLlm, deps, warnings, llmCalls, input.episode.id);
+      scored = await runPerStepScoring(normalized, rLlm, deps, warnings, llmCalls, input.episode.id, taskSummary);
     }
     const reflectMs = now() - reflectStart;
 
@@ -465,6 +475,20 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
         continue;
       }
       try {
+        log.info("capture.reflect.trace.scored", {
+          episodeId: input.episode.id,
+          sessionId: input.episode.sessionId,
+          traceId: row.id,
+          stepKey: s.key,
+          ts: s.ts,
+          turnId: pickTurnId(s.meta, s.ts),
+          alpha: s.reflection.alpha ?? 0,
+          usable: s.reflection.usable,
+          reason: s.reflection.reason ?? null,
+          source: s.reflection.source,
+          model: s.reflection.model ?? null,
+          reflection: s.reflection.text,
+        });
         deps.tracesRepo.updateReflection(row.id, {
           reflection: s.reflection.text,
           alpha: s.reflection.alpha ?? 0,
@@ -998,6 +1022,7 @@ async function runBatchScoring(
   warnings: CaptureResult["warnings"],
   llmCalls: { reflectionSynth: number; alphaScoring: number; batchedReflection: number },
   episodeId: string,
+  taskSummary: string | null,
 ): Promise<ScoredStep[]> {
   const inputs: BatchScoreInput[] = normalized.map((step) => ({
     step,
@@ -1009,6 +1034,7 @@ async function runBatchScoring(
       synthReflections: deps.cfg.synthReflections,
       episodeId,
       phase: "reflect",
+      taskSummary,
     });
     llmCalls.batchedReflection += 1;
     return normalized.map((step, i) => ({
@@ -1035,12 +1061,13 @@ async function runPerStepScoring(
   warnings: CaptureResult["warnings"],
   llmCalls: { reflectionSynth: number; alphaScoring: number },
   episodeId: string,
+  taskSummary: string | null,
 ): Promise<ScoredStep[]> {
   const concurrency = Math.max(1, deps.cfg.llmConcurrency);
   return runConcurrently(normalized, concurrency, async (step): Promise<ScoredStep> => {
-    const { score, synthCount } = await resolveReflection(step, llm, deps, warnings, episodeId);
+    const { score, synthCount } = await resolveReflection(step, llm, deps, warnings, episodeId, taskSummary);
     llmCalls.reflectionSynth += synthCount;
-    const finalScore = await resolveAlpha(step, score, llm, deps, warnings, episodeId);
+    const finalScore = await resolveAlpha(step, score, llm, deps, warnings, episodeId, taskSummary);
     if (finalScore !== score) llmCalls.alphaScoring += 1;
     return { ...step, reflection: finalScore };
   });
@@ -1052,6 +1079,7 @@ async function resolveReflection(
   deps: CaptureDeps,
   warnings: CaptureResult["warnings"],
   episodeId: string,
+  taskSummary: string | null,
 ): Promise<{ score: ReflectionScore; synthCount: number }> {
   const adapterProvided = step.rawReflection !== null && step.rawReflection.trim().length > 0;
   const extracted = extractReflection(step);
@@ -1065,7 +1093,7 @@ async function resolveReflection(
     return { score: disabledScore(null, "none"), synthCount: 0 };
   }
   try {
-    const synth = await synthesizeReflection(llm, step, { episodeId, phase: "reflect" });
+    const synth = await synthesizeReflection(llm, step, { episodeId, phase: "reflect", taskSummary });
     if (synth.text) {
       return {
         score: { text: synth.text, alpha: null, usable: true, source: "synth", model: synth.model },
@@ -1090,6 +1118,7 @@ async function resolveAlpha(
   deps: CaptureDeps,
   warnings: CaptureResult["warnings"],
   episodeId: string,
+  taskSummary: string | null,
 ): Promise<ReflectionScore> {
   if (!current.text) return current; // nothing to grade
   if (!deps.cfg.alphaScoring || !llm) return current;
@@ -1100,11 +1129,13 @@ async function resolveAlpha(
       reflectionText: current.text,
       episodeId,
       phase: "reflect",
+      taskSummary,
     });
     return {
       ...current,
       alpha: scored.alpha,
       usable: scored.usable,
+      reason: scored.reason,
       model: scored.model,
     };
   } catch (err) {
@@ -1152,6 +1183,28 @@ function traceActionText(row: Pick<TraceRow, "agentText" | "toolCalls">): string
   return [row.agentText.trim(), toolSig].filter((s) => s.length > 0).join("\n---\n") || "(empty)";
 }
 
+function buildTaskReflectionSummary(
+  episode: CaptureInput["episode"],
+  steps: readonly NormalizedStep[],
+): string | null {
+  const firstUser = episode.turns.find((t) => t.role === "user" && t.content.trim());
+  const finalAssistant = [...episode.turns]
+    .reverse()
+    .find((t) => t.role === "assistant" && t.content.trim());
+  const toolNames = Array.from(
+    new Set(steps.flatMap((s) => s.toolCalls.map((t) => t.name).filter(Boolean))),
+  ).slice(0, 12);
+
+  const parts = [
+    firstUser ? `Task: ${clipForPrompt(firstUser.content, 500)}` : "",
+    `Intent: ${episode.intent.kind} (${episode.intent.reason})`,
+    finalAssistant ? `Final assistant response: ${clipForPrompt(finalAssistant.content, 500)}` : "",
+    toolNames.length > 0 ? `Tools used: ${toolNames.join(", ")}` : "",
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
 function stringMeta(meta: Record<string, unknown>, key: string): string | undefined {
   const value = meta[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -1165,6 +1218,10 @@ function safeStringify(v: unknown): string {
   } catch {
     return String(v);
   }
+}
+
+function clipForPrompt(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}...` : s;
 }
 
 function mergeTurnSteps(

--- a/apps/memos-local-plugin/core/capture/reflection-synth.ts
+++ b/apps/memos-local-plugin/core/capture/reflection-synth.ts
@@ -29,15 +29,24 @@ export interface SynthesizedReflection {
   model: string;
 }
 
+export interface ReflectionSynthContext {
+  episodeId?: string;
+  phase?: string;
+  taskSummary?: string | null;
+}
+
 export async function synthesizeReflection(
   llm: LlmClient,
   step: NormalizedStep,
-  context?: { episodeId?: string; phase?: string },
+  context?: ReflectionSynthContext,
 ): Promise<SynthesizedReflection> {
   const log = rootLogger.child({ channel: "core.capture.reflection" });
 
   const thinking = (step.agentThinking ?? "").trim();
   const userPayload = [
+    `TASK CONTEXT:`,
+    context?.taskSummary?.trim().slice(0, 1_200) || "(none)",
+    ``,
     `USER/OBSERVATION:`,
     step.userText.slice(0, 1_200) || "(none)",
     ``,
@@ -55,6 +64,9 @@ export async function synthesizeReflection(
           )
           .join("\n")}`
       : "",
+    ``,
+    `OUTCOME:`,
+    lastToolOutcome(step),
   ]
     .filter(Boolean)
     .join("\n");
@@ -98,4 +110,24 @@ function safeStringify(v: unknown): string {
   } catch {
     return String(v);
   }
+}
+
+function lastToolOutcome(step: NormalizedStep): string {
+  const last = step.toolCalls[step.toolCalls.length - 1];
+  if (!last) return "(assistant-only step)";
+  return (last.errorCode ? `ERROR[${last.errorCode}] ` : "") + truncate(outputOf(last), 600);
+}
+
+function outputOf(t: { output?: unknown }): string {
+  if (t.output === undefined || t.output === null) return "";
+  if (typeof t.output === "string") return t.output;
+  try {
+    return JSON.stringify(t.output);
+  } catch {
+    return String(t.output);
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "…" : s;
 }

--- a/apps/memos-local-plugin/core/capture/types.ts
+++ b/apps/memos-local-plugin/core/capture/types.ts
@@ -70,6 +70,8 @@ export interface ReflectionScore {
   alpha: number | null;
   /** LLM `usable` flag: false → alpha forced to 0 per V7 eq. 5. */
   usable: boolean;
+  /** Optional LLM explanation for the α/usable decision. */
+  reason?: string | null;
   /** Source of the reflection text. */
   source: "adapter" | "extracted" | "synth" | "none";
   /** Optional LLM servedBy model label for audit. */

--- a/apps/memos-local-plugin/tests/unit/capture/capture.test.ts
+++ b/apps/memos-local-plugin/tests/unit/capture/capture.test.ts
@@ -423,6 +423,7 @@ describe("capture/pipeline (end-to-end)", () => {
     const t = tmp.repos.traces.getById(result.traceIds[0]!)!;
     expect(t.reflection).toContain("shell tool");
     expect(t.alpha).toBeCloseTo(0.8, 5);
+    expect(result.traces[0]?.reflection.reason).toBe("concrete");
   });
 
   it("clamps α to 0 when LLM marks reflection unusable", async () => {

--- a/apps/memos-local-plugin/tests/unit/capture/reflection-synth.test.ts
+++ b/apps/memos-local-plugin/tests/unit/capture/reflection-synth.test.ts
@@ -38,6 +38,34 @@ describe("capture/reflection-synth", () => {
     expect(out.model).toBe("openai_compatible");
   });
 
+  it("injects task context and last tool outcome into the prompt", async () => {
+    let userPrompt = "";
+    const llm = fakeLlm({
+      complete: {
+        "capture.reflection.synth": (input) => {
+          const messages = input as Array<{ role: string; content: string }>;
+          userPrompt = messages.find((m) => m.role === "user")?.content ?? "";
+          return "I checked the working directory because the task needed the project path.";
+        },
+      },
+    });
+
+    await synthesizeReflection(
+      llm,
+      step({
+        userText: "where am I?",
+        agentText: "checking pwd",
+        toolCalls: [{ name: "shell", input: { command: "pwd" }, output: "/tmp/project" }],
+      }),
+      { episodeId: "ep_1", phase: "reflect", taskSummary: "Task: inspect current project" },
+    );
+
+    expect(userPrompt).toContain("TASK CONTEXT:");
+    expect(userPrompt).toContain("Task: inspect current project");
+    expect(userPrompt).toContain("OUTCOME:");
+    expect(userPrompt).toContain("/tmp/project");
+  });
+
   it("returns null on the NO_REFLECTION sentinel", async () => {
     const llm = fakeLlm({
       complete: { "capture.reflection.synth": "NO_REFLECTION" },


### PR DESCRIPTION
## Summary
- Inject task context and the latest tool outcome into reflection synthesis prompts.
- Preserve alpha scorer reasons on `ReflectionScore` and emit per-trace reflect logs with alpha, usability, reason, source, model, and reflection text.
- Pass the same task context through batch scoring payloads for consistency.

## Test plan
- `npm run test -- tests/unit/capture/reflection-synth.test.ts tests/unit/capture/capture.test.ts tests/unit/capture/capture-batch.test.ts`
- `npm run lint`


Made with [Cursor](https://cursor.com)