### PR TITLE
fix(memos-local-plugin): start stdio before host LLM fallback

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+HOST_HANDLER_WAIT_SECONDS = 5.0
+
 
 def _installed_node_binary(plugin_root: Path) -> str | None:
     marker = plugin_root / ".memos-node-bin"
@@ -86,6 +88,7 @@ class MemosBridgeClient:
         # handler returns a JSON-serialisable value or raises to
         # surface a JSON-RPC error back to the bridge.
         self._host_handlers: dict[str, Callable[[dict[str, Any]], Any]] = {}
+        self._host_handlers_cv = threading.Condition()
         self._closed = False
 
         plugin_root = Path(__file__).resolve().parent.parent.parent.parent
@@ -225,12 +228,16 @@ class MemosBridgeClient:
         heavy work (e.g. an LLM call) are still expected to return
         within the bridge-side timeout (default 60 s).
         """
-        self._host_handlers[method] = handler
+        with self._host_handlers_cv:
+            self._host_handlers[method] = handler
+            self._host_handlers_cv.notify_all()
 
     def close(self) -> None:
         if self._closed:
             return
-        self._closed = True
+        with self._host_handlers_cv:
+            self._closed = True
+            self._host_handlers_cv.notify_all()
 
         pid = self.pid
 
@@ -315,7 +322,7 @@ class MemosBridgeClient:
                 and "result" not in msg
                 and "error" not in msg
             ):
-                handler = self._host_handlers.get(method)
+                handler = self._host_handler_for(method)
                 if handler is None:
                     self._send_response(
                         rpc_id,
@@ -343,6 +350,28 @@ class MemosBridgeClient:
                         },
                     )
                 continue
+
+    def _host_handler_for(
+        self,
+        method: str,
+        *,
+        timeout: float = HOST_HANDLER_WAIT_SECONDS,
+    ) -> Callable[[dict[str, Any]], Any] | None:
+        """Return a reverse-RPC handler, waiting briefly during startup.
+
+        The Node bridge now starts stdio before ``core.init()`` so host LLM
+        fallback can run during startup recovery. On a fast machine that
+        reverse request can arrive just before ``initialize()`` registers
+        ``host.llm.complete``. Waiting here turns that sub-millisecond race
+        into the intended handshake while still returning ``unknown_method``
+        for genuinely unsupported methods.
+        """
+        with self._host_handlers_cv:
+            self._host_handlers_cv.wait_for(
+                lambda: method in self._host_handlers or self._closed,
+                timeout=timeout,
+            )
+            return self._host_handlers.get(method)
 
     def _send_response(
         self,

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -89,7 +89,8 @@ async function main(): Promise<void> {
   // non-null bridge), but `stdio` itself doesn't exist until later
   // in this function. The trick: hand a placeholder closure to
   // bootstrap that defers actual stdio access to the time of the
-  // first fallback call. By then `stdio` has been assigned.
+  // first fallback call. In stdio mode we start the server before
+  // `core.init()` so startup recovery can also use host fallback.
   //
   // Routing through `bootstrapMemoryCoreFull({ hostLlmBridge })`
   // (instead of having `bridge.cts` call `registerHostLlmBridge`
@@ -153,15 +154,6 @@ async function main(): Promise<void> {
     hostLlmBridge: args.daemon ? null : lazyHostLlmBridge,
   });
 
-  const bridgeStatus =
-    args.agent === "hermes"
-      ? createBridgeStatusTracker(
-          path.join(home.root, BRIDGE_STATUS_FILE),
-          args.daemon,
-        )
-      : null;
-  await core.init();
-
   const telemetry = new Telemetry(
     config.telemetry ?? {},
     home.root,
@@ -171,6 +163,14 @@ async function main(): Promise<void> {
   );
   (core as { bindTelemetry?: (t: InstanceType<typeof Telemetry>) => void }).bindTelemetry?.(telemetry);
   telemetry.trackPluginStarted(args.agent);
+
+  const bridgeStatus =
+    args.agent === "hermes"
+      ? createBridgeStatusTracker(
+          path.join(home.root, BRIDGE_STATUS_FILE),
+          args.daemon,
+        )
+      : null;
 
   // Process-level error reporting. Without these handlers a crash in
   // a background task (capture / reward / L2 inducer) silently kills
@@ -213,6 +213,40 @@ async function main(): Promise<void> {
   // Per-agent fixed viewer port.
   const AGENT_DEFAULT_PORTS = { openclaw: 18799, hermes: 18800 } as const;
   const viewerPort = AGENT_DEFAULT_PORTS[args.agent];
+
+  let bridgeHeartbeat:
+    | ReturnType<NonNullable<typeof bridgeStatus>["startHeartbeat"]>
+    | undefined;
+
+  // In stdio mode the host fallback path is a reverse JSON-RPC request
+  // over the same pipe as normal bridge traffic. `core.init()` may
+  // recover dirty episodes and run reflection/reward/L2/skill work; if
+  // that work hits a broken primary skill-evolver model, the LLM facade
+  // can fall back to host before init returns. Start stdio first so that
+  // fallback has a transport instead of tripping the lazy bridge guard.
+  if (!args.daemon) {
+    stdio = startStdioServer({ core });
+    bridgeStatus?.markConnected();
+    bridgeHeartbeat = bridgeStatus?.startHeartbeat();
+    void stdio.done.then(() => {
+      bridgeHeartbeat?.stop();
+      bridgeStatus?.markDisconnected("Hermes chat disconnected");
+    });
+  }
+
+  try {
+    await core.init();
+  } catch (err) {
+    bridgeHeartbeat?.stop();
+    if (stdio) {
+      try {
+        await stdio.close();
+      } catch {
+        /* best-effort */
+      }
+    }
+    throw err;
+  }
 
   // ─── Daemon mode ──────────────────────────────────────────────
   // When started with `--daemon`, skip stdio and run as a pure HTTP
@@ -286,16 +320,12 @@ async function main(): Promise<void> {
   }
 
   // ─── Normal (stdio) mode ──────────────────────────────────────
-  // Assign the stdio handle into the closure variable so the host
-  // LLM bridge (registered earlier inside bootstrap) can dispatch
-  // reverse-direction requests to the adapter.
-  stdio = startStdioServer({ core });
-  bridgeStatus?.markConnected();
-  const bridgeHeartbeat = bridgeStatus?.startHeartbeat();
-  void stdio.done.then(() => {
-    bridgeHeartbeat?.stop();
-    bridgeStatus?.markDisconnected("Hermes chat disconnected");
-  });
+  // The stdio handle was started before `core.init()` above so host
+  // fallback is available during startup recovery.
+  const activeStdio = stdio;
+  if (!activeStdio) {
+    throw new Error("internal bridge error: stdio server was not started");
+  }
 
   // Try to bind the viewer port unless the caller requested a pure stdio
   // bridge. Hermes chat uses --no-viewer; the standalone --daemon process is
@@ -350,7 +380,7 @@ async function main(): Promise<void> {
         /* best-effort */
       }
     }
-    await waitForShutdown(core, stdio!);
+    await waitForShutdown(core, activeStdio);
     process.exit(0);
   };
 
@@ -358,7 +388,7 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
 
   // Keep the process alive until stdin ends (client disconnects).
-  await stdio.done;
+  await activeStdio.done;
 
   // If a viewer is running, keep the process alive as a daemon so the
   // memory panel stays accessible between `hermes chat` sessions.

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -15,6 +15,7 @@ import json
 import sys
 import tempfile
 import threading
+import time
 import unittest
 
 from pathlib import Path
@@ -42,6 +43,7 @@ class FakePopen:
 
     def __init__(self, *_args, **_kwargs) -> None:
         self.cmd = list(_args[0]) if _args else []
+        self.pid = 12345
         self.stdin = io.StringIO()
         self._stdin_lines: list[str] = []
         self.stdout = _ServerStream()
@@ -298,6 +300,47 @@ class BridgeClientTests(unittest.TestCase):
         cmd = getattr(self._fake, "cmd", [])
         self.assertIn("--no-viewer", cmd)
         client.close()
+
+    def test_reverse_request_waits_for_late_host_handler_registration(self) -> None:
+        client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+        assert self._fake is not None
+
+        self._fake.stdout._enqueue(
+            {
+                "jsonrpc": "2.0",
+                "id": "srv-1",
+                "method": "host.llm.complete",
+                "params": {"messages": [{"role": "user", "content": "ping"}]},
+            }
+        )
+        time.sleep(0.1)
+
+        client.register_host_handler(
+            "host.llm.complete",
+            lambda params: {
+                "text": f"host:{params['messages'][-1]['content']}",
+                "model": "host-test",
+            },
+        )
+
+        response = self._wait_for_client_write(lambda msg: msg.get("id") == "srv-1")
+        self.assertEqual(response["result"]["text"], "host:ping")
+        self.assertNotIn("error", response)
+        client.close()
+
+    def _wait_for_client_write(self, predicate, timeout: float = 2.0) -> dict:
+        assert self._fake is not None
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for raw in self._fake._stdin_lines:
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if predicate(msg):
+                    return msg
+            time.sleep(0.01)
+        self.fail("timed out waiting for client write")
 
 
 class MemTensorProviderTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- start the Hermes stdio bridge before core.init() so startup recovery can use host LLM fallback safely
- clean up stdio/heartbeat if core init fails
- make the Hermes Python bridge client wait briefly for late reverse-RPC host handler registration
- add regression coverage for delayed host.llm.complete handler registration

## Tests
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format adapters/hermes/memos_provider/bridge_client.py tests/python/test_bridge_client.py
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check adapters/hermes/memos_provider/bridge_client.py tests/python/test_bridge_client.py
- npm run lint
- npm test -- tests/unit/bridge/stdio.test.ts tests/unit/llm/client.test.ts
- python3 -m unittest tests.python.test_bridge_client.BridgeClientTests