### PR TITLE
fix(hermes-adapter): kill old bridge process on reconnect to prevent zombie accumulation

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -1641,6 +1641,11 @@ class MemTensorProvider(MemoryProvider):
         if old_bridge:
             with contextlib.suppress(Exception):
                 old_bridge.close()
+            # Kill the old process to prevent zombie accumulation.
+            # close() alone only closes stdin — headless bridges may
+            # not notice and keep running forever.
+            with contextlib.suppress(Exception):
+                old_bridge.terminate()
         ensure_bridge_running()
         self._bridge = MemosBridgeClient()
         self._bridge.register_host_handler(

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -218,6 +218,18 @@ class MemosBridgeClient:
         """
         self._host_handlers[method] = handler
 
+    def terminate(self) -> None:
+        """Kill the bridge subprocess (SIGKILL). Use when the bridge is
+        stuck/unresponsive and must be forcefully cleaned up before
+        starting a new one."""
+        self._closed = True
+        with contextlib.suppress(Exception):
+            self._proc.stdin.close()
+        with contextlib.suppress(Exception):
+            self._proc.kill()
+        with contextlib.suppress(Exception):
+            self._proc.wait(timeout=5)
+
     def close(self) -> None:
         if self._closed:
             return


### PR DESCRIPTION
## Summary

Fixes a critical process leak in the Hermes Python adapter that causes the bridge subprocess to accumulate zombies, eventually invoking the OOM killer.

## Root Cause

When the MemOS bridge fails to initialize (e.g., stuck on orphan recovery due to external API rate limiting), `_reconnect_bridge()` would call `close()` on the old bridge — which only closes stdin without killing the process. The old process, stuck in its init loop, never reads stdin EOF and lives forever.

Each failed reconnect cycle spawned new node processes, accumulating zombies until the system OOM killer was invoked — making the VPS completely unreachable via SSH.

## Changes

- **bridge_client.py**: add `terminate()` method that sends SIGKILL and waits up to 5s
- **__init__.py**: call `old_bridge.terminate()` during reconnect to clean up the old process

## Verification

- Before fix: 90+ zombie bridge processes, 5.1GB memory, new zombies spawning every ~15s
- After fix: stable at 2 bridge processes, 721MB memory, zero reconnect failure logs

## Related

- The orphan recovery blocking issue (bridge init stuck on LLM calls during dirty episode rescore) is a separate concern tracked in the TypeScript core
- This Python-side fix is a safety net: even if the bridge hangs, it won't leak processes