### PR TITLE
fix(memos-local-plugin): speed imports and stabilize overview

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -111,6 +111,7 @@ import type { UserFeedback } from "../reward/types.js";
 // ─── Public bootstrap helpers ───────────────────────────────────────────────
 
 const FINAL_HUB_LLM_FILTER_TIMEOUT_MS = 3_000;
+const IMPORT_WRITE_BATCH_SIZE = 500;
 
 export interface BootstrapOptions {
   agent: AgentKind;
@@ -3663,186 +3664,254 @@ export function createMemoryCore(
     // deterministic for the user — they opt in via a de-duplicating
     // pre-pass if they want merging.
     const traces = Array.isArray(bundle.traces) ? bundle.traces : [];
-
-    // Phase 0 — ensure every referenced (sessionId, episodeId) row
-    // exists before we try to `traces.insert`. Without this the FK
-    // constraint on `traces.episode_id REFERENCES episodes(id)` makes
-    // every legacy/external row bounce with "FOREIGN KEY constraint
-    // failed". This was the "Imported 0 traces, 0 skills, 0 tasks"
-    // bug the user reported on the legacy import button.
+    const defaultOwner = ownerFromNamespace(activeNamespace);
     const seenSessions = new Set<string>();
     const seenEpisodes = new Set<string>();
-    for (const raw of traces) {
-      const dto = raw as TraceDTO;
-      if (!dto?.id || !dto.episodeId || !dto.sessionId) continue;
-      if (!seenSessions.has(dto.sessionId)) {
-        try {
-          if (!handle.repos.sessions.getById(dto.sessionId)) {
-            handle.repos.sessions.upsert({
-              id: dto.sessionId,
-              agent: handle.agent,
-              startedAt: dto.ts ?? Date.now(),
-              lastSeenAt: dto.ts ?? Date.now(),
-              meta: { source: "import" },
-            } as never);
-          }
-        } catch {
-          // If the synthetic session row is rejected, the FK insert
-          // below will fail and be counted as `skipped`. Don't abort
-          // the entire import batch for one bad session.
-        }
-        seenSessions.add(dto.sessionId);
-      }
-      if (!seenEpisodes.has(dto.episodeId)) {
-        try {
-          if (!handle.repos.episodes.getById(dto.episodeId)) {
-            handle.repos.episodes.upsert({
-              id: dto.episodeId,
-              sessionId: dto.sessionId,
-              startedAt: dto.ts ?? Date.now(),
-              endedAt: dto.ts ?? Date.now(),
-              traceIds: [],
-              rTask: null,
-              status: "closed",
-              meta: { source: "import" },
-            } as never);
-          }
-        } catch {
-          /* see comment above */
-        }
-        seenEpisodes.add(dto.episodeId);
-      }
-    }
 
-    for (const raw of traces) {
-      try {
-        const dto = raw as TraceDTO;
-        if (!dto?.id) { skipped++; continue; }
-        const existing = handle.repos.traces.getById(dto.id);
-        if (existing) { skipped++; continue; }
-        // The trace table requires a fuller row shape than TraceDTO.
-        // We reconstitute a stub row. Vectors start null here; the
-        // embedding maintenance endpoint can backfill them with the
-        // currently configured embedding model after import.
-        handle.repos.traces.insert({
-          id: dto.id,
-          episodeId: dto.episodeId,
-          sessionId: dto.sessionId,
-          ts: dto.ts,
-          userText: dto.userText,
-          agentText: dto.agentText,
-          toolCalls: dto.toolCalls ?? [],
-          reflection: dto.reflection ?? null,
-          value: dto.value ?? 0,
-          alpha: dto.alpha ?? 0,
-          rHuman: dto.rHuman ?? null,
-          priority: dto.priority ?? 0,
-          tags: [],
-          vecSummary: null,
-          vecAction: null,
-          turnId: dto.turnId,
-          schemaVersion: 1,
-        } as TraceRow);
-        imported++;
-      } catch {
-        skipped++;
-      }
+    for (const batch of chunkArray(traces, IMPORT_WRITE_BATCH_SIZE)) {
+      const result = handle.db.tx(() => {
+        let batchImported = 0;
+        let batchSkipped = 0;
+        const valid = batch
+          .map((raw) => raw as TraceDTO)
+          .filter((dto) => dto?.id && dto.episodeId && dto.sessionId);
+        batchSkipped += batch.length - valid.length;
+
+        // Phase 0 — ensure every referenced (sessionId, episodeId) row
+        // exists before `traces.insert`, otherwise the FK constraint would
+        // bounce imported legacy/external rows.
+        for (const dto of valid) {
+          const owner = importOwnerFields(dto, defaultOwner);
+          const ts = Number.isFinite(dto.ts) ? dto.ts : Date.now();
+          if (!seenSessions.has(dto.sessionId)) {
+            try {
+              if (!handle.repos.sessions.getById(dto.sessionId)) {
+                handle.repos.sessions.upsert({
+                  id: dto.sessionId,
+                  agent: dto.ownerAgentKind ?? handle.agent,
+                  ...owner,
+                  startedAt: ts,
+                  lastSeenAt: ts,
+                  meta: { source: "import" },
+                } as never);
+              }
+            } catch {
+              // If the synthetic session row is rejected, the FK insert
+              // below will fail and be counted as `skipped`.
+            }
+            seenSessions.add(dto.sessionId);
+          }
+          if (!seenEpisodes.has(dto.episodeId)) {
+            try {
+              if (!handle.repos.episodes.getById(dto.episodeId)) {
+                handle.repos.episodes.upsert({
+                  id: dto.episodeId,
+                  sessionId: dto.sessionId,
+                  ...owner,
+                  share: dto.share ?? null,
+                  startedAt: ts,
+                  endedAt: ts,
+                  traceIds: [],
+                  rTask: null,
+                  status: "closed",
+                  meta: { source: "import" },
+                } as never);
+              }
+            } catch {
+              /* see comment above */
+            }
+            seenEpisodes.add(dto.episodeId);
+          }
+        }
+
+        const existingIds = new Set(
+          handle.repos.traces
+            .getManyByIds(valid.map((dto) => dto.id as TraceId))
+            .map((row) => row.id),
+        );
+        const addedByEpisode = new Map<EpisodeId, TraceId[]>();
+        for (const dto of valid) {
+          try {
+            if (existingIds.has(dto.id)) { batchSkipped++; continue; }
+            const owner = importOwnerFields(dto, defaultOwner);
+            const ts = Number.isFinite(dto.ts) ? dto.ts : Date.now();
+            const turnId = Number.isFinite(dto.turnId) ? dto.turnId : ts;
+            handle.repos.traces.insert({
+              ...owner,
+              id: dto.id,
+              episodeId: dto.episodeId,
+              sessionId: dto.sessionId,
+              ts,
+              userText: dto.userText ?? "",
+              agentText: dto.agentText ?? "",
+              summary: dto.summary ?? null,
+              share: dto.share ?? null,
+              toolCalls: dto.toolCalls ?? [],
+              agentThinking: dto.agentThinking ?? null,
+              reflection: dto.reflection ?? null,
+              value: dto.value ?? 0,
+              alpha: dto.alpha ?? 0,
+              rHuman: dto.rHuman ?? null,
+              priority: dto.priority ?? 0,
+              tags: dto.tags ?? [],
+              vecSummary: null,
+              vecAction: null,
+              turnId,
+              schemaVersion: 1,
+            } as TraceRow);
+            existingIds.add(dto.id);
+            if (!addedByEpisode.has(dto.episodeId)) addedByEpisode.set(dto.episodeId, []);
+            addedByEpisode.get(dto.episodeId)!.push(dto.id as TraceId);
+            batchImported++;
+          } catch {
+            batchSkipped++;
+          }
+        }
+        for (const [episodeId, ids] of addedByEpisode) {
+          const episode = handle.repos.episodes.getById(episodeId);
+          if (!episode) continue;
+          handle.repos.episodes.appendTrace(
+            episodeId,
+            dedupeTraceIds([...episode.traceIds, ...ids]) as string[],
+          );
+        }
+        return { imported: batchImported, skipped: batchSkipped };
+      });
+      imported += result.imported;
+      skipped += result.skipped;
+      await yieldToEventLoop();
     }
 
     // Policies / world models / skills use existing repo.insert shape.
-    for (const raw of bundle.policies ?? []) {
-      try {
-        const dto = raw as PolicyDTO;
-        if (!dto?.id || handle.repos.policies.getById(dto.id)) { skipped++; continue; }
-        handle.repos.policies.insert({
-          id: dto.id,
-          title: dto.title,
-          trigger: dto.trigger,
-          procedure: dto.procedure,
-          verification: dto.verification,
-          boundary: dto.boundary,
-          support: dto.support ?? 0,
-          gain: dto.gain ?? 0,
-          status: dto.status,
-          experienceType: dto.experienceType ?? "success_pattern",
-          evidencePolarity: dto.evidencePolarity ?? "positive",
-          salience: dto.salience ?? 0,
-          confidence: dto.confidence ?? 0.5,
-          skillEligible: dto.skillEligible !== false,
-          sourceEpisodeIds: dto.sourceEpisodeIds ?? [],
-          sourceFeedbackIds: dto.sourceFeedbackIds ?? [],
-          sourceTraceIds: dto.sourceTraceIds ?? [],
-          inducedBy: "import",
-          decisionGuidance: {
-            preference: [...(dto.preference ?? [])],
-            antiPattern: [...(dto.antiPattern ?? [])],
-          },
-          verifierMeta: dto.verifierMeta ?? null,
-          vec: null,
-          createdAt: dto.createdAt ?? Date.now(),
-          updatedAt: dto.updatedAt ?? Date.now(),
-        });
-        imported++;
-      } catch {
-        skipped++;
-      }
+    for (const batch of chunkArray(bundle.policies ?? [], IMPORT_WRITE_BATCH_SIZE)) {
+      const result = handle.db.tx(() => {
+        let batchImported = 0;
+        let batchSkipped = 0;
+        for (const raw of batch) {
+          try {
+            const dto = raw as PolicyDTO;
+            if (!dto?.id || handle.repos.policies.getById(dto.id)) { batchSkipped++; continue; }
+            handle.repos.policies.insert({
+              ...importOwnerFields(dto, defaultOwner),
+              id: dto.id,
+              title: dto.title,
+              trigger: dto.trigger,
+              procedure: dto.procedure,
+              verification: dto.verification,
+              boundary: dto.boundary,
+              support: dto.support ?? 0,
+              gain: dto.gain ?? 0,
+              status: dto.status,
+              experienceType: dto.experienceType ?? "success_pattern",
+              evidencePolarity: dto.evidencePolarity ?? "positive",
+              salience: dto.salience ?? 0,
+              confidence: dto.confidence ?? 0.5,
+              skillEligible: dto.skillEligible !== false,
+              sourceEpisodeIds: dto.sourceEpisodeIds ?? [],
+              sourceFeedbackIds: dto.sourceFeedbackIds ?? [],
+              sourceTraceIds: dto.sourceTraceIds ?? [],
+              inducedBy: "import",
+              decisionGuidance: {
+                preference: [...(dto.preference ?? [])],
+                antiPattern: [...(dto.antiPattern ?? [])],
+              },
+              verifierMeta: dto.verifierMeta ?? null,
+              share: dto.share ?? null,
+              vec: null,
+              createdAt: dto.createdAt ?? Date.now(),
+              updatedAt: dto.updatedAt ?? Date.now(),
+            });
+            batchImported++;
+          } catch {
+            batchSkipped++;
+          }
+        }
+        return { imported: batchImported, skipped: batchSkipped };
+      });
+      imported += result.imported;
+      skipped += result.skipped;
+      await yieldToEventLoop();
     }
 
-    for (const raw of bundle.skills ?? []) {
-      try {
-        const dto = raw as SkillDTO;
-        if (!dto?.id || handle.repos.skills.getById(dto.id)) { skipped++; continue; }
-        handle.repos.skills.insert({
-          id: dto.id,
-          name: dto.name,
-          status: dto.status,
-          invocationGuide: dto.invocationGuide,
-          eta: dto.eta ?? 0,
-          support: dto.support ?? 0,
-          gain: dto.gain ?? 0,
-          trialsAttempted: 0,
-          trialsPassed: 0,
-          sourcePolicyIds: dto.sourcePolicyIds ?? [],
-          sourceWorldModelIds: dto.sourceWorldModelIds ?? [],
-          evidenceAnchors: dto.evidenceAnchors ?? [],
-          procedureJson: {},
-          vec: null,
-          createdAt: dto.createdAt ?? Date.now(),
-          updatedAt: dto.updatedAt ?? Date.now(),
-          version: dto.version ?? 1,
-          usageCount: dto.usageCount ?? 0,
-          lastUsedAt: dto.lastUsedAt ?? null,
-        } as SkillRow);
-        imported++;
-      } catch {
-        skipped++;
-      }
+    for (const batch of chunkArray(bundle.skills ?? [], IMPORT_WRITE_BATCH_SIZE)) {
+      const result = handle.db.tx(() => {
+        let batchImported = 0;
+        let batchSkipped = 0;
+        for (const raw of batch) {
+          try {
+            const dto = raw as SkillDTO;
+            if (!dto?.id || handle.repos.skills.getById(dto.id)) { batchSkipped++; continue; }
+            handle.repos.skills.insert({
+              ...importOwnerFields(dto, defaultOwner),
+              id: dto.id,
+              name: dto.name,
+              status: dto.status,
+              invocationGuide: dto.invocationGuide,
+              eta: dto.eta ?? 0,
+              support: dto.support ?? 0,
+              gain: dto.gain ?? 0,
+              trialsAttempted: 0,
+              trialsPassed: 0,
+              sourcePolicyIds: dto.sourcePolicyIds ?? [],
+              sourceWorldModelIds: dto.sourceWorldModelIds ?? [],
+              evidenceAnchors: dto.evidenceAnchors ?? [],
+              procedureJson: {},
+              share: dto.share ?? null,
+              vec: null,
+              createdAt: dto.createdAt ?? Date.now(),
+              updatedAt: dto.updatedAt ?? Date.now(),
+              version: dto.version ?? 1,
+              usageCount: dto.usageCount ?? 0,
+              lastUsedAt: dto.lastUsedAt ?? null,
+            } as SkillRow);
+            batchImported++;
+          } catch {
+            batchSkipped++;
+          }
+        }
+        return { imported: batchImported, skipped: batchSkipped };
+      });
+      imported += result.imported;
+      skipped += result.skipped;
+      await yieldToEventLoop();
     }
 
-    for (const raw of bundle.worldModels ?? []) {
-      try {
-        const dto = raw as WorldModelDTO;
-        if (!dto?.id || handle.repos.worldModel.getById(dto.id)) { skipped++; continue; }
-        handle.repos.worldModel.insert({
-          id: dto.id,
-          title: dto.title,
-          body: dto.body,
-          structure: { environment: [], inference: [], constraints: [] },
-          domainTags: [],
-          confidence: 0.5,
-          policyIds: dto.policyIds ?? [],
-          sourceEpisodeIds: [],
-          inducedBy: "import",
-          vec: null,
-          createdAt: dto.createdAt ?? Date.now(),
-          updatedAt: dto.updatedAt ?? Date.now(),
-          version: dto.version ?? 1,
-          status: dto.status ?? "active",
-        } as WorldModelRow);
-        imported++;
-      } catch {
-        skipped++;
-      }
+    for (const batch of chunkArray(bundle.worldModels ?? [], IMPORT_WRITE_BATCH_SIZE)) {
+      const result = handle.db.tx(() => {
+        let batchImported = 0;
+        let batchSkipped = 0;
+        for (const raw of batch) {
+          try {
+            const dto = raw as WorldModelDTO;
+            if (!dto?.id || handle.repos.worldModel.getById(dto.id)) { batchSkipped++; continue; }
+            handle.repos.worldModel.insert({
+              ...importOwnerFields(dto, defaultOwner),
+              id: dto.id,
+              title: dto.title,
+              body: dto.body,
+              structure: { environment: [], inference: [], constraints: [] },
+              domainTags: [],
+              confidence: 0.5,
+              policyIds: dto.policyIds ?? [],
+              sourceEpisodeIds: [],
+              inducedBy: "import",
+              share: dto.share ?? null,
+              vec: null,
+              createdAt: dto.createdAt ?? Date.now(),
+              updatedAt: dto.updatedAt ?? Date.now(),
+              version: dto.version ?? 1,
+              status: dto.status ?? "active",
+            } as WorldModelRow);
+            batchImported++;
+          } catch {
+            batchSkipped++;
+          }
+        }
+        return { imported: batchImported, skipped: batchSkipped };
+      });
+      imported += result.imported;
+      skipped += result.skipped;
+      await yieldToEventLoop();
     }
 
     return { imported, skipped };
@@ -4742,6 +4811,48 @@ function compareTraceRowsForEpisodeOrder(
     }
   }
   return a.ts - b.ts;
+}
+
+function importOwnerFields(
+  row: {
+    ownerAgentKind?: AgentKind;
+    ownerProfileId?: string;
+    ownerWorkspaceId?: string | null;
+  },
+  fallback: ReturnType<typeof ownerFromNamespace>,
+): {
+  ownerAgentKind: AgentKind;
+  ownerProfileId: string;
+  ownerWorkspaceId: string | null;
+} {
+  return {
+    ownerAgentKind: row.ownerAgentKind ?? fallback.ownerAgentKind,
+    ownerProfileId: row.ownerProfileId ?? fallback.ownerProfileId,
+    ownerWorkspaceId: row.ownerWorkspaceId ?? fallback.ownerWorkspaceId ?? null,
+  };
+}
+
+function dedupeTraceIds(ids: readonly TraceId[]): TraceId[] {
+  const seen = new Set<TraceId>();
+  const out: TraceId[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 // ─── Row → DTO mappers ───────────────────────────────────────────────────────

--- a/apps/memos-local-plugin/core/storage/migrations/012-trace-turn-pagination-index.sql
+++ b/apps/memos-local-plugin/core/storage/migrations/012-trace-turn-pagination-index.sql
@@ -1,0 +1,12 @@
+-- Speed up Memories pagination after large imports.
+--
+-- The Memories page groups L1 traces by (episode_id, turn_id) and orders
+-- those groups by the newest trace timestamp. Large imports can push the
+-- trace table into the tens of thousands of rows, so keep a covering index
+-- for the grouped list path in addition to the episode-local ordering index.
+
+CREATE INDEX IF NOT EXISTS idx_traces_turn_page
+  ON traces(owner_agent_kind, owner_profile_id, episode_id, turn_id, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_traces_turn_recent
+  ON traces(episode_id, turn_id, ts DESC);

--- a/apps/memos-local-plugin/server/ALGORITHMS.md
+++ b/apps/memos-local-plugin/server/ALGORITHMS.md
@@ -78,10 +78,12 @@ The router is a `Map<"METHOD /path", handler>`. This is intentional:
 
 ## S7 — Request body is size-capped
 
-Default `maxBodyBytes = 1 MiB`. A stream overflowing this throws
-during `readBody`. The outer dispatch turns that into a 500, which is
-not strictly accurate but sufficient — 4xx vs 5xx coding here matters
-less than refusing the input.
+Default `maxBodyBytes = 1 MiB`; `/api/v1/import` is allowed up to
+64 MiB so exported memory bundles can round-trip through the viewer.
+A stream overflowing its route cap throws during `readBody`. The outer
+dispatch turns that into a 500, which is not strictly accurate but
+sufficient — 4xx vs 5xx coding here matters less than refusing the
+input.
 
 ## S8 — Static files are never cached permanently
 

--- a/apps/memos-local-plugin/server/http.ts
+++ b/apps/memos-local-plugin/server/http.ts
@@ -46,6 +46,8 @@ const AGENT_DEFAULT_PORTS: Record<AgentName, number> = {
   openclaw: 18799,
   hermes: 18800,
 };
+const DEFAULT_MAX_BODY_BYTES = 1_048_576;
+const IMPORT_MAX_BODY_BYTES = 64 * 1024 * 1024;
 
 export async function startHttpServer(
   deps: ServerDeps,
@@ -197,7 +199,7 @@ async function dispatch(
   const key = `${method} ${pathname}`;
   const exact = routes.getExact(key);
   if (exact) {
-    const body = await readBody(req, options.maxBodyBytes ?? 1_048_576);
+    const body = await readBody(req, bodyLimitForPath(pathname, options.maxBodyBytes));
     const result = await exact({ req, res, url, body, deps, params: {} });
     if (!res.headersSent && result !== undefined) {
       writeJson(res, 200, result);
@@ -208,7 +210,7 @@ async function dispatch(
   // Pattern-route fallback (e.g. `/api/v1/traces/:id`).
   const pattern = routes.matchPattern(method, pathname);
   if (pattern) {
-    const body = await readBody(req, options.maxBodyBytes ?? 1_048_576);
+    const body = await readBody(req, bodyLimitForPath(pathname, options.maxBodyBytes));
     const result = await pattern.handler({
       req,
       res,
@@ -234,3 +236,7 @@ async function dispatch(
   void deps;
 }
 
+function bodyLimitForPath(pathname: string, configured?: number): number {
+  if (configured !== undefined) return configured;
+  return pathname === "/api/v1/import" ? IMPORT_MAX_BODY_BYTES : DEFAULT_MAX_BODY_BYTES;
+}

--- a/apps/memos-local-plugin/server/routes/import-export.ts
+++ b/apps/memos-local-plugin/server/routes/import-export.ts
@@ -35,6 +35,22 @@ import { writeJson } from "../middleware/io.js";
 
 const NATIVE_IMPORT_DEFAULT_BATCH = 25;
 const NATIVE_IMPORT_MAX_BATCH = 200;
+const NATIVE_IMPORT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface HermesNativeSource {
+  memories: string[];
+  bytes: number;
+  mtimeMs: number;
+}
+
+interface OpenClawNativeSource {
+  messages: OpenClawNativeMessage[];
+  files: number;
+  sessions: number;
+}
+
+const hermesNativeCache = new Map<string, { source: HermesNativeSource }>();
+const openClawNativeCache = new Map<string, { source: OpenClawNativeSource; cachedAt: number }>();
 
 export function registerImportExportRoutes(
   routes: Routes,
@@ -143,7 +159,7 @@ export function registerImportExportRoutes(
     const limit = coerceBatchLimit(body.limit);
 
     try {
-      const source = await readHermesNativeMemories(path);
+      const source = await readHermesNativeMemories(path, { force: offset === 0 });
       const total = source.memories.length;
       const batch = source.memories.slice(offset, offset + limit);
       if (batch.length === 0) {
@@ -221,7 +237,7 @@ export function registerImportExportRoutes(
     const limit = coerceBatchLimit(body.limit);
 
     try {
-      const source = await readOpenClawNativeMessages(path);
+      const source = await readOpenClawNativeMessages(path, { force: offset === 0 });
       const total = source.messages.length;
       const batch = source.messages.slice(offset, offset + limit);
       if (batch.length === 0) {
@@ -340,7 +356,7 @@ interface HermesNativeScanResult {
 
 async function scanHermesNativeMemories(path: string): Promise<HermesNativeScanResult> {
   try {
-    const source = await readHermesNativeMemories(path);
+    const source = await readHermesNativeMemories(path, { force: true });
     return {
       found: true,
       agent: "hermes",
@@ -359,18 +375,28 @@ async function scanHermesNativeMemories(path: string): Promise<HermesNativeScanR
   }
 }
 
-async function readHermesNativeMemories(path: string): Promise<{
-  memories: string[];
-  bytes: number;
-  mtimeMs: number;
-}> {
+async function readHermesNativeMemories(
+  path: string,
+  opts: { force?: boolean } = {},
+): Promise<HermesNativeSource> {
   const info = await stat(path);
+  const cached = hermesNativeCache.get(path);
+  if (
+    !opts.force &&
+    cached &&
+    cached.source.bytes === info.size &&
+    cached.source.mtimeMs === info.mtimeMs
+  ) {
+    return cached.source;
+  }
   const raw = await readFile(path, "utf8");
-  return {
+  const source = {
     memories: splitHermesNativeMemories(raw),
     bytes: info.size,
     mtimeMs: info.mtimeMs,
   };
+  hermesNativeCache.set(path, { source });
+  return source;
 }
 
 function splitHermesNativeMemories(raw: string): string[] {
@@ -446,7 +472,7 @@ interface OpenClawNativeScanResult {
 
 async function scanOpenClawNativeSessions(path: string): Promise<OpenClawNativeScanResult> {
   try {
-    const source = await readOpenClawNativeMessages(path);
+    const source = await readOpenClawNativeMessages(path, { force: true });
     return {
       found: true,
       agent: "openclaw",
@@ -468,11 +494,14 @@ async function scanOpenClawNativeSessions(path: string): Promise<OpenClawNativeS
   }
 }
 
-async function readOpenClawNativeMessages(path: string): Promise<{
-  messages: OpenClawNativeMessage[];
-  files: number;
-  sessions: number;
-}> {
+async function readOpenClawNativeMessages(
+  path: string,
+  opts: { force?: boolean } = {},
+): Promise<OpenClawNativeSource> {
+  const cached = openClawNativeCache.get(path);
+  if (!opts.force && cached && Date.now() - cached.cachedAt < NATIVE_IMPORT_CACHE_TTL_MS) {
+    return cached.source;
+  }
   const agentEntries = await readdir(path, { withFileTypes: true });
   const messages: OpenClawNativeMessage[] = [];
   let files = 0;
@@ -549,7 +578,9 @@ async function readOpenClawNativeMessages(path: string): Promise<{
     if (af !== bf) return af.localeCompare(bf);
     return a.lineNo - b.lineNo;
   });
-  return { messages, files, sessions };
+  const source = { messages, files, sessions };
+  openClawNativeCache.set(path, { source, cachedAt: Date.now() });
+  return source;
 }
 
 function buildOpenClawNativeTraces(messages: readonly OpenClawNativeMessage[]): TraceDTO[] {

--- a/apps/memos-local-plugin/server/routes/trace.ts
+++ b/apps/memos-local-plugin/server/routes/trace.ts
@@ -7,7 +7,7 @@
  * The unparameterised endpoints `/api/v1/memory/trace?id=…` live on
  * for backward compatibility.
  */
-import type { EpisodeId, SessionId } from "../../agent-contract/dto.js";
+import type { EpisodeId, SessionId, TraceDTO } from "../../agent-contract/dto.js";
 import type { ServerDeps } from "../types.js";
 import { parseJson, writeError, type Routes } from "./registry.js";
 
@@ -42,8 +42,10 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
     // pair as one "memory" — matching the viewer's grouped display where
     // a user query + its tool steps + final reply collapse into one card.
     const groupByTurn = params.get("groupByTurn") === "true";
-    const traces = await deps.core.listTraces({
-      limit,
+    const includeTotal = params.get("includeTotal") !== "false";
+    const listLimit = includeTotal ? limit : limit + 1;
+    const rawTraces = await deps.core.listTraces({
+      limit: listLimit,
       offset,
       sessionId: sessionId as SessionId | undefined,
       ownerAgentKind,
@@ -51,19 +53,24 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       q,
       groupByTurn,
     });
-    const total = await deps.core.countTraces({
-      sessionId: sessionId as SessionId | undefined,
-      ownerAgentKind,
-      ownerProfileId,
-      q,
-      groupByTurn,
-    });
+    const { traces, hasMore } = trimTracePage(rawTraces, limit, groupByTurn);
+    const total = includeTotal
+      ? await deps.core.countTraces({
+          sessionId: sessionId as SessionId | undefined,
+          ownerAgentKind,
+          ownerProfileId,
+          q,
+          groupByTurn,
+        })
+      : undefined;
     // When grouping, `traces.length === limit` is no longer a reliable
     // "has more" signal (a single turn can yield many traces). Use the
     // total count instead to detect a next page.
-    const nextOffset = groupByTurn
-      ? offset + limit < total ? offset + limit : undefined
-      : traces.length === limit ? offset + limit : undefined;
+    const nextOffset = includeTotal
+      ? groupByTurn
+        ? offset + limit < (total ?? 0) ? offset + limit : undefined
+        : traces.length === limit ? offset + limit : undefined
+      : hasMore ? offset + limit : undefined;
     return {
       traces,
       limit,
@@ -181,6 +188,34 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
     const traces = await deps.core.timeline({ episodeId: id });
     return { episodeId: id, traces };
   });
+}
+
+function trimTracePage(
+  traces: TraceDTO[],
+  limit: number,
+  groupByTurn: boolean,
+): { traces: TraceDTO[]; hasMore: boolean } {
+  if (!groupByTurn) {
+    return {
+      traces: traces.slice(0, limit),
+      hasMore: traces.length > limit,
+    };
+  }
+  const turnOrder = new Map<string, number>();
+  const kept: TraceDTO[] = [];
+  for (const trace of traces) {
+    const key = `${trace.episodeId ?? "_"}:${trace.turnId}`;
+    let index = turnOrder.get(key);
+    if (index === undefined) {
+      index = turnOrder.size;
+      turnOrder.set(key, index);
+    }
+    if (index < limit) kept.push(trace);
+  }
+  return {
+    traces: kept,
+    hasMore: turnOrder.size > limit,
+  };
 }
 
 function parseNamespace(value: string | null): { ownerAgentKind: string; ownerProfileId: string } | null {

--- a/apps/memos-local-plugin/tests/unit/viewer/overview-model-status.test.ts
+++ b/apps/memos-local-plugin/tests/unit/viewer/overview-model-status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatModelStatusLine,
+  modelStatusFromInfo,
+} from "../../../viewer/src/views/overview/model-status";
+
+describe("overview model status", () => {
+  it("renders a healthy model as Connected, not the status object", () => {
+    const status = modelStatusFromInfo({
+      available: true,
+      provider: "openai_compatible",
+      model: "gpt-4o-mini",
+      lastOkAt: 1_700_000_000_000,
+    });
+
+    expect(status.label).toBe("Connected");
+    expect(formatModelStatusLine(status.label)).toBe("Connected");
+  });
+
+  it("never falls back to browser object stringification in the status line", () => {
+    const status = modelStatusFromInfo({
+      available: true,
+      provider: { name: "openai_compatible" },
+      model: "gpt-4o-mini",
+      lastFallbackAt: 1_700_000_000_000,
+      lastError: {
+        at: 1_700_000_000_000,
+        message: { code: "bad_model", reason: "missing" },
+      },
+    });
+    const line = formatModelStatusLine(status.label, { inherited: true }, { name: "x" });
+
+    expect(status.label).not.toContain("[object Object]");
+    expect(line).not.toContain("[object Object]");
+    expect(line).toContain("bad_model");
+  });
+});

--- a/apps/memos-local-plugin/viewer/src/components/Header.tsx
+++ b/apps/memos-local-plugin/viewer/src/components/Header.tsx
@@ -57,7 +57,7 @@ export function Header() {
     const fetchers = [
       api
         .get<{ traces: { id: string; summary?: string; userText?: string }[] }>(
-          `/api/v1/traces?q=${encodeURIComponent(q)}&limit=${limit}`,
+          `/api/v1/traces?q=${encodeURIComponent(q)}&limit=${limit}&includeTotal=false`,
           { signal },
         )
         .then((r) =>

--- a/apps/memos-local-plugin/viewer/src/views/ImportView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/ImportView.tsx
@@ -297,7 +297,7 @@ function NativeImportCard({ kind }: { kind: NativeImportKind }) {
       while (offset < knownScan.total && !stopRef.current) {
         const r = await api.post<NativeImportBatchResult>(
           `${cfg.endpoint}/run`,
-          { offset, limit: 25 },
+          { offset, limit: 100 },
         );
         imported += r.imported;
         skipped += r.skipped;

--- a/apps/memos-local-plugin/viewer/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/MemoriesView.tsx
@@ -113,6 +113,7 @@ export function MemoriesView() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [traces, setTraces] = useState<TraceDTO[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [total, setTotal] = useState(0);
@@ -139,17 +140,26 @@ export function MemoriesView() {
       qs.set("limit", String(roleFilterActive ? ROLE_FILTER_FETCH_LIMIT : pageSize));
       qs.set("offset", String(roleFilterActive ? 0 : opts.page * pageSize));
       qs.set("groupByTurn", "true");
+      qs.set("includeTotal", "false");
       if (opts.q) qs.set("q", opts.q);
       appendNamespaceParams(qs, namespaceFilter);
       const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`);
+      const pageGroupCount = buildGroups(res.traces ?? []).length;
       setTraces(res.traces);
       setHasMore(roleFilterActive ? false : res.nextOffset != null);
-      setTotal(res.total ?? 0);
+      setTotal(
+        res.total ??
+          opts.page * pageSize +
+            pageGroupCount +
+            (res.nextOffset != null ? pageSize : 0),
+      );
       setPage(opts.page);
-    } catch {
+      setLoadError(null);
+    } catch (err) {
       setTraces([]);
       setHasMore(false);
       setTotal(0);
+      setLoadError((err as Error).message || "Failed to load memories");
     } finally {
       setLoading(false);
     }
@@ -437,6 +447,7 @@ export function MemoriesView() {
               setQuery("");
               setNamespaceFilter("");
               setSelected(new Set());
+              setLoadError(null);
               void loadPage({ q: "", page: 0 });
             }}
           >
@@ -523,7 +534,17 @@ export function MemoriesView() {
         </div>
       )}
 
-      {loading && groups.length === 0 && (
+      {!loading && loadError && (
+        <div class="empty">
+          <div class="empty__icon">
+            <Icon name="circle-alert" size={22} />
+          </div>
+          <div class="empty__title">Failed to load memories</div>
+          <div class="empty__hint">{loadError}</div>
+        </div>
+      )}
+
+      {loading && groups.length === 0 && !loadError && (
         <div class="list">
           {[0, 1, 2, 3, 4].map((i) => (
             <div key={i} class="skeleton" style="height:82px" />
@@ -531,7 +552,7 @@ export function MemoriesView() {
         </div>
       )}
 
-      {!loading && groups.length === 0 && (
+      {!loading && !loadError && groups.length === 0 && (
         <div class="empty">
           <div class="empty__icon">
             <Icon name="brain-circuit" size={22} />

--- a/apps/memos-local-plugin/viewer/src/views/OverviewView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/OverviewView.tsx
@@ -29,6 +29,12 @@ import { t } from "../stores/i18n";
 import { navigate } from "../stores/router";
 import type { ApiLogDTO, CoreEvent, CoreEventType } from "../api/types";
 import { ActivityDashboard } from "./overview/ActivityDashboard";
+import {
+  formatModelStatusLine,
+  modelScalarText,
+  modelStatusFromInfo,
+  type ModelInfo,
+} from "./overview/model-status";
 
 interface SkillStats {
   total: number;
@@ -41,22 +47,6 @@ interface PolicyStats {
   active: number;
   candidate: number;
   archived: number;
-}
-interface ModelInfo {
-  available?: boolean;
-  provider: string;
-  model: string;
-  dim?: number;
-  inherited?: boolean;
-  /** Epoch ms of most recent direct primary-provider success. */
-  lastOkAt?: number | null;
-  /**
-   * Epoch ms of most recent rescued-by-host-fallback call. Populates
-   * the "yellow" overview state.
-   */
-  lastFallbackAt?: number | null;
-  /** Most recent failure (sticky — see ModelHealth comment). */
-  lastError?: { at: number; message: string } | null;
 }
 interface OverviewSummary {
   ok?: boolean;
@@ -444,96 +434,6 @@ function QuantityCard({
   );
 }
 
-type ModelDotKind = "ok" | "fallback" | "err" | "idle" | "off";
-
-/**
- * Derive the overview card status from a {@link ModelInfo}.
- *
- * The card is painted by picking the most-recent of three timestamps
- * — `lastOkAt`, `lastFallbackAt`, `lastError.at` — and mapping that
- * winner to a colour:
- *
- *   - `ok` (green)        — primary provider answered directly.
- *   - `fallback` (yellow) — primary failed but host LLM bridge
- *                           rescued the call. The card surfaces the
- *                           original error so users know *why* it
- *                           degraded.
- *   - `err` (red)         — primary failed and either there was no
- *                           fallback or the fallback also failed.
- *
- * `lastError` is sticky on the backend so it can sit alongside a
- * fresher `lastOkAt` after recovery — comparing timestamps lets the
- * UI naturally "go green again" without having to clear the message.
- */
-function modelStatusFromInfo(info: ModelInfo | undefined): {
-  kind: ModelDotKind;
-  label: string;
-  tooltip?: string;
-} {
-  if (!info || info.available === false) {
-    return { kind: "off", label: t("overview.metric.model.unconfigured") };
-  }
-
-  const okAt = info.lastOkAt ?? 0;
-  const fbAt = info.lastFallbackAt ?? 0;
-  const errAt = info.lastError?.at ?? 0;
-  const max = Math.max(okAt, fbAt, errAt);
-
-  // Nothing has happened yet — fresh process, no calls landed.
-  if (max === 0) {
-    return { kind: "idle", label: t("overview.metric.model.idle") };
-  }
-
-  // Priority order matters when timestamps tie.
-  //
-  // The backend stamps `lastFallbackAt` and `lastError.at` with the
-  // SAME `Date.now()` inside `markFallback` (the upstream error is
-  // kept on `lastError` so the viewer can show *why* fallback
-  // engaged). When that happens, a strict "errAt === max ⇒ red"
-  // check would always win over the fallback branch and the slot
-  // would never go yellow. The current call succeeded — through the
-  // host bridge — so semantically it is the fallback state, with
-  // the error only providing context. Hence: fallback wins ties
-  // against err.
-  //
-  // We also let fallback win ties against ok for the rare case where
-  // a successful primary call and a fallback rescue happen in the
-  // same millisecond — yellow is the most informative state.
-  if (fbAt > 0 && fbAt >= errAt && fbAt >= okAt) {
-    const raw = (info.lastError?.message ?? "").trim();
-    const head = t("overview.metric.model.fallback");
-    const tail = raw ? `: ${raw.length > 60 ? raw.slice(0, 59) + "…" : raw}` : "";
-    return {
-      kind: "fallback",
-      label: head + tail,
-      tooltip: raw
-        ? t("overview.metric.model.fallback.tooltip", { msg: raw })
-        : head,
-    };
-  }
-
-  // Most recent event was a terminal failure.
-  if (errAt > 0 && errAt >= okAt) {
-    const raw = (info.lastError?.message ?? "").trim();
-    const short =
-      raw.length > 80 ? raw.slice(0, 79) + "…" : raw || t("overview.metric.model.failed");
-    return {
-      kind: "err",
-      label: short,
-      tooltip: raw || t("overview.metric.model.failed"),
-    };
-  }
-
-  // okAt is the largest — primary provider is working directly.
-  return {
-    kind: "ok",
-    label: t("overview.metric.model.connected"),
-    tooltip: t("overview.metric.model.connectedAt", {
-      ts: new Date(okAt).toLocaleTimeString(),
-    }),
-  };
-}
-
 function ModelCard({
   label,
   info,
@@ -545,7 +445,7 @@ function ModelCard({
   hint?: string;
   onClick?: () => void;
 }) {
-  const model = (info?.model ?? "").trim();
+  const model = modelScalarText(info?.model).trim();
   const display = model ? model : t("overview.metric.model.unconfigured");
   const status = modelStatusFromInfo(info);
   const titleAttr = status.tooltip
@@ -574,7 +474,7 @@ function ModelCard({
         {display}
       </div>
       <div class="metric__delta">
-        {[status.label, hint].filter(Boolean).join(" · ") || info?.provider || "—"}
+        {formatModelStatusLine(status.label, hint, info?.provider)}
       </div>
     </button>
   );

--- a/apps/memos-local-plugin/viewer/src/views/overview/model-status.ts
+++ b/apps/memos-local-plugin/viewer/src/views/overview/model-status.ts
@@ -1,0 +1,125 @@
+import { t } from "../../stores/i18n";
+
+export interface ModelInfo {
+  available?: boolean;
+  provider?: unknown;
+  model?: unknown;
+  dim?: number;
+  inherited?: boolean;
+  /** Epoch ms of most recent direct primary-provider success. */
+  lastOkAt?: unknown;
+  /**
+   * Epoch ms of most recent rescued-by-host-fallback call. Populates
+   * the "yellow" overview state.
+   */
+  lastFallbackAt?: unknown;
+  /** Most recent failure (sticky — see ModelHealth comment). */
+  lastError?: { at?: unknown; message?: unknown } | null;
+}
+
+export type ModelDotKind = "ok" | "fallback" | "err" | "idle" | "off";
+
+/**
+ * Derive the overview card status from a model health payload.
+ *
+ * The card is painted by picking the most-recent of three timestamps
+ * — `lastOkAt`, `lastFallbackAt`, `lastError.at` — and mapping that
+ * winner to a colour:
+ *
+ *   - `ok` (green)        — primary provider answered directly.
+ *   - `fallback` (yellow) — primary failed but host LLM bridge
+ *                           rescued the call.
+ *   - `err` (red)         — primary failed and either there was no
+ *                           fallback or the fallback also failed.
+ */
+export function modelStatusFromInfo(info: ModelInfo | undefined): {
+  kind: ModelDotKind;
+  label: string;
+  tooltip?: string;
+} {
+  if (!info || info.available === false) {
+    return { kind: "off", label: t("overview.metric.model.unconfigured") };
+  }
+
+  const okAt = timestampMs(info.lastOkAt);
+  const fbAt = timestampMs(info.lastFallbackAt);
+  const errAt = timestampMs(info.lastError?.at);
+  const max = Math.max(okAt, fbAt, errAt);
+
+  if (max === 0) {
+    return { kind: "idle", label: t("overview.metric.model.idle") };
+  }
+
+  // Fallback wins ties against errors because the backend stamps
+  // `lastFallbackAt` and `lastError.at` at the same instant when the
+  // host bridge rescued the call.
+  if (fbAt > 0 && fbAt >= errAt && fbAt >= okAt) {
+    const raw = statusText(info.lastError?.message).trim();
+    const head = t("overview.metric.model.fallback");
+    const tail = raw ? `: ${raw.length > 60 ? raw.slice(0, 59) + "…" : raw}` : "";
+    return {
+      kind: "fallback",
+      label: head + tail,
+      tooltip: raw
+        ? t("overview.metric.model.fallback.tooltip", { msg: raw })
+        : head,
+    };
+  }
+
+  if (errAt > 0 && errAt >= okAt) {
+    const raw = statusText(info.lastError?.message).trim();
+    const short =
+      raw.length > 80 ? raw.slice(0, 79) + "…" : raw || t("overview.metric.model.failed");
+    return {
+      kind: "err",
+      label: short,
+      tooltip: raw || t("overview.metric.model.failed"),
+    };
+  }
+
+  return {
+    kind: "ok",
+    label: t("overview.metric.model.connected"),
+    tooltip: t("overview.metric.model.connectedAt", {
+      ts: new Date(okAt).toLocaleTimeString(),
+    }),
+  };
+}
+
+export function modelScalarText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+export function formatModelStatusLine(
+  statusLabel: string,
+  hint?: unknown,
+  provider?: unknown,
+): string {
+  const parts = [statusLabel, modelScalarText(hint).trim()].filter(Boolean);
+  return parts.join(" · ") || modelScalarText(provider).trim() || "—";
+}
+
+function timestampMs(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+function statusText(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  const scalar = modelScalarText(value);
+  if (scalar) return scalar;
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary
- batch memory bundle import writes and cache native import scans to reduce UI stalls during large imports
- make memories pagination avoid expensive total counts while preserving navigation
- fix overview model cards so connected status cannot render as [object Object]

## Tests
- npm run lint
- npm run build:viewer
- npx vitest run tests/unit/viewer/overview-model-status.test.ts
- npx vitest run tests/unit/server/http.test.ts
- npx vitest run tests/unit/pipeline/memory-core.test.ts -t "repairs missing and wrong-dimension imported trace embeddings"

No Python files changed, so ruff was not applicable.