### PR TITLE
Fix Hermes bridge packaged runtime startup

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
+++ b/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
@@ -36,7 +36,7 @@ if command -v npm >/dev/null 2>&1; then
     npm install --no-audit --no-fund --prefer-offline
   fi
 else
-  warn "npm not found on PATH; bridge.cts requires Node.js ≥ 20."
+  warn "npm not found on PATH; the bridge runtime requires Node.js ≥ 20."
 fi
 
 # ── 2. viewer bundle ──────────────────────────────────────────────────────────

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -4,7 +4,7 @@ Implements the ``agent.memory_provider.MemoryProvider`` interface exposed
 by the hermes-agent host (see
 ``hermes-agent/agent/memory_provider.py``). All heavy lifting lives in the
 Node.js ``memos-local-plugin`` core; this adapter is a thin Python client
-that speaks JSON-RPC 2.0 over stdio to ``bridge.cts``.
+that speaks JSON-RPC 2.0 over stdio to the packaged Node bridge.
 
 Discovery
 ---------
@@ -503,9 +503,7 @@ class MemTensorProvider(MemoryProvider):
         )
         if normalized.startswith(failure_prefixes):
             return True
-        if " traceback (most recent call last)" in normalized:
-            return True
-        return False
+        return " traceback (most recent call last)" in normalized
 
     def _on_post_tool_call(
         self,

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -1,9 +1,10 @@
 """JSON-RPC 2.0 over stdio client for the MemOS bridge.
 
-Spawns ``node bridge.cts --agent=hermes --no-viewer`` as a subprocess and
-communicates via line-delimited JSON messages on its stdin/stdout. Responses are
-matched by ``id``. Notifications (events + logs) are forwarded to
-registered callbacks on a reader thread.
+Spawns the packaged bridge subprocess (compiled ``dist/bridge.cjs`` when
+available, otherwise the source ``bridge.cts`` through ``tsx``) and communicates
+via line-delimited JSON messages on its stdin/stdout. Responses are matched by
+``id``. Notifications (events + logs) are forwarded to registered callbacks on a
+reader thread.
 
 The client is *blocking* by design — callers wanting async behaviour
 should wrap requests in a thread pool.
@@ -41,6 +42,13 @@ def _installed_node_binary(plugin_root: Path) -> str | None:
     if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
         return candidate
     return None
+
+
+def _bridge_script(plugin_root: Path) -> Path:
+    compiled = plugin_root / "dist" / "bridge.cjs"
+    if compiled.exists():
+        return compiled
+    return plugin_root / "bridge.cts"
 
 
 class BridgeError(RuntimeError):
@@ -99,25 +107,22 @@ class MemosBridgeClient:
             or shutil.which("node")
             or "node"
         )
-        script = bridge_path or str(plugin_root / "bridge.cts")
+        script_path = Path(bridge_path) if bridge_path else _bridge_script(plugin_root)
+        script = str(script_path)
         env = {**os.environ, **(extra_env or {})}
 
-        # The plugin ships raw TypeScript (no precompiled `dist/`). Node's
-        # own `--experimental-strip-types` strips type annotations but does
-        # not rewrite `.js` import specifiers to the corresponding `.ts`
-        # files on disk — and the source tree uses `.js` extensions in
-        # every import per the TSC / bundler convention. We therefore
-        # launch the bridge via the bundled `tsx` CLI, which handles
-        # both jobs (strip types + extension rewrite). On Windows the
-        # `.bin/tsx` file is a POSIX shell shim; invoking it as
-        # `node .bin/tsx` makes Node parse shell syntax as JavaScript.
-        # Use tsx's real JS entrypoint when we are launching through a
-        # specific Node binary.
+        # Prefer the compiled CommonJS bridge from packaged installs. The raw
+        # TypeScript entry remains as a development fallback and needs `tsx`
+        # for stripping types plus `.js` → `.ts` import resolution. On Windows
+        # the `.bin/tsx` file is a shell shim, so use tsx's real JS entrypoint
+        # whenever we have to launch the source entry through a specific Node.
         tsx_cli = plugin_root / "node_modules" / "tsx" / "dist" / "cli.mjs"
         bridge_args = [script, f"--agent={agent}"]
         if no_viewer:
             bridge_args.append("--no-viewer")
-        if tsx_cli.exists():
+        if script_path.suffix == ".cjs":
+            cmd = [node, *bridge_args]
+        elif tsx_cli.exists():
             cmd = [node, str(tsx_cli), *bridge_args]
         else:
             # Fallback path: `node --import tsx` reproduces the same loader

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -43,7 +43,18 @@ VIEWER_PROBE_TTL_SEC = 30.0
 
 
 def _bridge_script() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent / "bridge.cts"
+    plugin_root = _plugin_root()
+    compiled = plugin_root / "dist" / "bridge.cjs"
+    if compiled.exists():
+        return compiled
+    return plugin_root / "bridge.cts"
+
+
+def _plugin_root() -> Path:
+    plugin_root = Path(__file__).resolve().parent.parent.parent.parent
+    if plugin_root.name == "dist":
+        return plugin_root.parent
+    return plugin_root
 
 
 def _node_available() -> bool:
@@ -69,7 +80,7 @@ def _installed_node_binary(plugin_root: Path) -> str | None:
 
 
 def _node_binary() -> str | None:
-    plugin_root = _bridge_script().parent
+    plugin_root = _plugin_root()
     return (
         os.environ.get("MEMOS_NODE_BINARY")
         or _installed_node_binary(plugin_root)
@@ -78,15 +89,18 @@ def _node_binary() -> str | None:
 
 
 def _bridge_command(*, daemon: bool) -> list[str]:
-    plugin_root = _bridge_script().parent
+    plugin_root = _plugin_root()
     node = _node_binary()
     if not node:
         raise RuntimeError("Node.js not found on PATH")
-    script = str(_bridge_script())
+    script_path = _bridge_script()
+    script = str(script_path)
     tsx_cli = plugin_root / "node_modules" / "tsx" / "dist" / "cli.mjs"
     bridge_args = [script, "--agent=hermes"]
     if daemon:
         bridge_args.append("--daemon")
+    if script_path.suffix == ".cjs":
+        return [node, *bridge_args]
     if tsx_cli.exists():
         return [node, str(tsx_cli), *bridge_args]
     return [node, "--import", "tsx", *bridge_args]
@@ -208,7 +222,7 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
         if not ensure_bridge_running():
             return False
 
-        plugin_root = _bridge_script().parent
+        plugin_root = _plugin_root()
         logs_dir = plugin_root / "logs"
         logs_dir.mkdir(parents=True, exist_ok=True)
         log_file = logs_dir / "daemon-start.log"

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -30,6 +30,8 @@ const path = require("node:path") as typeof import("node:path");
 const fs = require("node:fs") as typeof import("node:fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const childProcess = require("node:child_process") as typeof import("node:child_process");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const url = require("node:url") as typeof import("node:url");
 
 const BRIDGE_STATUS_HEARTBEAT_MS = 5_000;
 const BRIDGE_STATUS_STALE_MS = 20_000;
@@ -68,20 +70,21 @@ async function main(): Promise<void> {
 
   // Lazy-import ESM core. Using dynamic import so this file remains
   // CommonJS and stays `require`-able.
-  const { bootstrapMemoryCoreFull } = (await import(
-    pathToEsmUrl(path.resolve(__dirname, "core/pipeline/index.ts"))
+  const { bootstrapMemoryCoreFull } = (await importEsm(
+    runtimeModule("core/pipeline/index.ts", "dist/core/pipeline/index.js")
   )) as typeof import("./core/pipeline/index.js");
-  const { startStdioServer, waitForShutdown } = (await import(
-    pathToEsmUrl(path.resolve(__dirname, "bridge/stdio.ts"))
+  const { startStdioServer, waitForShutdown } = (await importEsm(
+    runtimeModule("bridge/stdio.ts", "dist/bridge/stdio.js")
   )) as typeof import("./bridge/stdio.js");
-  const { memoryBuffer, rootLogger } = (await import(
-    pathToEsmUrl(path.resolve(__dirname, "core/logger/index.ts"))
+  const { memoryBuffer, rootLogger } = (await importEsm(
+    runtimeModule("core/logger/index.ts", "dist/core/logger/index.js")
   )) as typeof import("./core/logger/index.js");
-  const { startHttpServer } = (await import(
-    pathToEsmUrl(path.resolve(__dirname, "server/http.ts"))
+  const { startHttpServer } = (await importEsm(
+    runtimeModule("server/http.ts", "dist/server/http.js")
   )) as typeof import("./server/http.js");
 
-  const pkgVersion = require("./package.json").version;
+  const rootDir = pluginRoot();
+  const pkgVersion = require(path.join(rootDir, "package.json")).version;
 
   // ─── Host LLM bridge (reverse RPC, lazy-bound to stdio) ────────
   // We need to register the bridge BEFORE bootstrap creates the
@@ -143,8 +146,8 @@ async function main(): Promise<void> {
       },
     };
 
-  const { Telemetry } = (await import(
-    pathToEsmUrl(path.resolve(__dirname, "core/telemetry/index.ts"))
+  const { Telemetry } = (await importEsm(
+    runtimeModule("core/telemetry/index.ts", "dist/core/telemetry/index.js")
   )) as typeof import("./core/telemetry/index.js");
 
   const { core, config, home } = await bootstrapMemoryCoreFull({
@@ -159,7 +162,7 @@ async function main(): Promise<void> {
     home.root,
     pkgVersion,
     rootLogger.child({ channel: "core.telemetry" }),
-    __dirname,
+    rootDir,
   );
   (core as { bindTelemetry?: (t: InstanceType<typeof Telemetry>) => void }).bindTelemetry?.(telemetry);
   telemetry.trackPluginStarted(args.agent);
@@ -275,7 +278,7 @@ async function main(): Promise<void> {
           {
             port: viewerPort,
             host: config.viewer.bindHost,
-            staticRoot: path.resolve(__dirname, "viewer/dist"),
+            staticRoot: path.resolve(rootDir, "viewer/dist"),
             agent: args.agent,
           },
         );
@@ -348,7 +351,7 @@ async function main(): Promise<void> {
         {
           port: viewerPort,
           host: config.viewer.bindHost,
-          staticRoot: path.resolve(__dirname, "viewer/dist"),
+          staticRoot: path.resolve(rootDir, "viewer/dist"),
           agent: args.agent,
         },
       );
@@ -412,10 +415,29 @@ async function main(): Promise<void> {
   process.exit(0);
 }
 
-function pathToEsmUrl(abs: string): string {
-  const u = abs.startsWith("/") ? `file://${abs}` : `file:///${abs}`;
-  return u;
+function pluginRoot(): string {
+  // Source entry: <root>/bridge.cts. Built entry: <root>/dist/bridge.cjs.
+  if (fs.existsSync(path.join(__dirname, "package.json"))) return __dirname;
+  const parent = path.resolve(__dirname, "..");
+  if (fs.existsSync(path.join(parent, "package.json"))) return parent;
+  return __dirname;
 }
+
+function runtimeModule(sourceRel: string, distRel: string): string {
+  const root = pluginRoot();
+  const distAbs = path.resolve(root, distRel);
+  const sourceAbs = path.resolve(root, sourceRel);
+  return pathToEsmUrl(fs.existsSync(distAbs) ? distAbs : sourceAbs);
+}
+
+function pathToEsmUrl(abs: string): string {
+  return url.pathToFileURL(abs).href;
+}
+
+const importEsm = new Function(
+  "specifier",
+  "return import(specifier)",
+) as (specifier: string) => Promise<unknown>;
 
 /**
  * Best-effort error classification for ARMS `plugin_error.error_type`.
@@ -569,8 +591,9 @@ function isHermesChatRunning(): boolean {
 }
 
 void main().catch((err) => {
+  const detail = err instanceof Error ? err.stack ?? err.message : String(err);
   process.stderr.write(
-    `bridge: fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+    `bridge: fatal: ${detail}\n`,
   );
   process.exit(1);
 });

--- a/apps/memos-local-plugin/install.ps1
+++ b/apps/memos-local-plugin/install.ps1
@@ -406,13 +406,15 @@ function Install-Hermes {
     $ConfigFile = Join-Path $env:LOCALAPPDATA "hermes\config.yaml"
     $AdapterDir = Join-Path $Prefix "adapters\hermes"
     
-    Get-Process -Name "node" -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -match "bridge.cts" } | Stop-Process -Force -ErrorAction SilentlyContinue
+    Get-Process -Name "node" -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -match "bridge\.(cts|cjs)" } | Stop-Process -Force -ErrorAction SilentlyContinue
     Get-Process -Name "hermes" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
     
     Deploy-Tarball -Prefix $Prefix
     Ensure-RuntimeHome -Agent "hermes" -HomeDir $HomeDir -Prefix $Prefix
     
-    Set-Content -Path (Join-Path $AdapterDir "bridge_path.txt") -Value (Join-Path $Prefix "bridge.cts") -Encoding UTF8
+    $BridgeEntry = Join-Path $Prefix "dist\bridge.cjs"
+    if (-not (Test-Path $BridgeEntry)) { $BridgeEntry = Join-Path $Prefix "bridge.cts" }
+    Set-Content -Path (Join-Path $AdapterDir "bridge_path.txt") -Value $BridgeEntry -Encoding UTF8
     
     $PythonBin = ""
     $VenvPy = Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\venv\Scripts\python.exe"
@@ -472,13 +474,22 @@ memory:
     }
     
     Write-Info "Starting Memory Viewer daemon"
-    $TsxBin = Join-Path $Prefix "node_modules\.bin\tsx.cmd"
+    $NodeBin = Get-Content -Path (Join-Path $Prefix ".memos-node-bin") -ErrorAction SilentlyContinue
+    if (-not $NodeBin) { $NodeBin = (Get-Command "node.exe" -ErrorAction SilentlyContinue).Source }
+    $TsxBin = Join-Path $Prefix "node_modules\tsx\dist\cli.mjs"
     $BridgeCts = Join-Path $Prefix "bridge.cts"
+    $BridgeCjs = Join-Path $Prefix "dist\bridge.cjs"
+    $BridgeEntry = $BridgeCjs
+    if (-not (Test-Path $BridgeEntry)) { $BridgeEntry = $BridgeCts }
     
-    if ((Test-Path $TsxBin) -and (Test-Path $BridgeCts)) {
+    if ($NodeBin -and (Test-Path $BridgeEntry) -and ($BridgeEntry.EndsWith(".cjs") -or (Test-Path $TsxBin))) {
         $DaemonLog = Join-Path $Prefix "logs\daemon-start.log"
         $DaemonLogErr = Join-Path $Prefix "logs\daemon-start-err.log"
-        Start-Process -FilePath $TsxBin -ArgumentList "$BridgeCts --agent=hermes --daemon" -WindowStyle Hidden -RedirectStandardOutput $DaemonLog -RedirectStandardError $DaemonLogErr
+        if ($BridgeEntry.EndsWith(".cjs")) {
+            Start-Process -FilePath $NodeBin -ArgumentList "$BridgeEntry --agent=hermes --daemon" -WindowStyle Hidden -RedirectStandardOutput $DaemonLog -RedirectStandardError $DaemonLogErr
+        } else {
+            Start-Process -FilePath $NodeBin -ArgumentList "$TsxBin $BridgeEntry --agent=hermes --daemon" -WindowStyle Hidden -RedirectStandardOutput $DaemonLog -RedirectStandardError $DaemonLogErr
+        }
         
         if (Wait-ForViewer -Port $HermesPort -Timeout 120) {
             Write-Success "Memory Viewer daemon running"
@@ -486,7 +497,7 @@ memory:
             Write-Warn "Memory Viewer did not respond within 120s."
         }
     } else {
-        Write-Warn "tsx not found - skipping daemon start."
+        Write-Warn "node or bridge runtime not found - skipping daemon start."
     }
 }
 

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -654,15 +654,15 @@ install_hermes() {
 
   step "Stopping existing bridge daemon"
   local bridge_pids=""
-  bridge_pids="$(pgrep -f "bridge.cts" 2>/dev/null || true)"
+  bridge_pids="$(pgrep -f "bridge\\.(cts|cjs)" 2>/dev/null || true)"
   if [[ -n "${bridge_pids}" ]]; then
     kill ${bridge_pids} >/dev/null 2>&1 || true
     local i
     for i in {1..10}; do
       sleep 1
-      pgrep -f "bridge.cts" >/dev/null 2>&1 || break
+      pgrep -f "bridge\\.(cts|cjs)" >/dev/null 2>&1 || break
     done
-    bridge_pids="$(pgrep -f "bridge.cts" 2>/dev/null || true)"
+    bridge_pids="$(pgrep -f "bridge\\.(cts|cjs)" 2>/dev/null || true)"
     if [[ -n "${bridge_pids}" ]]; then
       kill -9 ${bridge_pids} >/dev/null 2>&1 || true
       sleep 1
@@ -695,7 +695,9 @@ install_hermes() {
   step "Configuring runtime environment"
   ensure_runtime_home "hermes" "${home}" "${prefix}"
 
-  echo "${prefix}/bridge.cts" > "${adapter_dir}/bridge_path.txt"
+  local bridge_entry="${prefix}/dist/bridge.cjs"
+  [[ -f "${bridge_entry}" ]] || bridge_entry="${prefix}/bridge.cts"
+  echo "${bridge_entry}" > "${adapter_dir}/bridge_path.txt"
   success "Bridge path recorded"
 
   step "Locating Hermes Python environment"
@@ -976,14 +978,21 @@ CFGEOF
     step "Starting Memory Viewer daemon"
     local node_bin
     node_bin="$(cat "${prefix}/.memos-node-bin" 2>/dev/null || command -v node || true)"
-    local tsx_bin="${prefix}/node_modules/.bin/tsx"
+    local tsx_bin="${prefix}/node_modules/tsx/dist/cli.mjs"
     local bridge_cts="${prefix}/bridge.cts"
-    if [[ -n "${node_bin}" && -x "${node_bin}" && -x "${tsx_bin}" && -f "${bridge_cts}" ]]; then
+    local bridge_cjs="${prefix}/dist/bridge.cjs"
+    local bridge_entry="${bridge_cjs}"
+    [[ -f "${bridge_entry}" ]] || bridge_entry="${bridge_cts}"
+    if [[ -n "${node_bin}" && -x "${node_bin}" && -f "${bridge_entry}" && ( "${bridge_entry}" == *.cjs || -f "${tsx_bin}" ) ]]; then
       local daemon_log="${prefix}/logs/daemon-start.log"
       mkdir -p "${prefix}/logs"
       # Launch bridge in --daemon mode (pure HTTP, no stdio).
       # The process stays alive to serve the Memory Viewer.
-      ( cd "${prefix}" && nohup "${node_bin}" "${tsx_bin}" "${bridge_cts}" --agent=hermes --daemon >"${daemon_log}" 2>&1 & )
+      if [[ "${bridge_entry}" == *.cjs ]]; then
+        ( cd "${prefix}" && nohup "${node_bin}" "${bridge_entry}" --agent=hermes --daemon >"${daemon_log}" 2>&1 & )
+      else
+        ( cd "${prefix}" && nohup "${node_bin}" "${tsx_bin}" "${bridge_entry}" --agent=hermes --daemon >"${daemon_log}" 2>&1 & )
+      fi
 
       if wait_for_viewer "${HERMES_PORT}" 120; then
         success "Memory Viewer daemon running"
@@ -993,7 +1002,7 @@ CFGEOF
         return 1
       fi
     else
-      warn "node or tsx not found — skipping daemon start."
+      warn "node or bridge runtime not found — skipping daemon start."
     fi
   fi
 


### PR DESCRIPTION
## Summary
- prefer the compiled dist/bridge.cjs runtime for packaged Hermes bridge launches
- resolve bridge runtime imports from compiled dist JS with source fallback
- print full fatal stack traces and update installers to use the packaged bridge entry

## Verification
- npm run build
- npm run lint
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format apps/memos-local-plugin/adapters/hermes/memos_provider
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check apps/memos-local-plugin/adapters/hermes/memos_provider
- bash -n apps/memos-local-plugin/install.sh
- node dist/bridge.cjs --agent=hermes --no-viewer
- npm pack --dry-run --json --ignore-scripts (confirmed dist/bridge.cjs, bridge.cts, dist/core/pipeline/index.js, viewer/dist/index.html)