### PR TITLE
fix(memos-local-plugin): serialize Hermes viewer daemon startup

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -40,6 +40,47 @@ _viewer_process: subprocess.Popen | None = None
 
 HERMES_VIEWER_PORT = 18800
 VIEWER_PROBE_TTL_SEC = 30.0
+VIEWER_START_LOCK_TIMEOUT_SEC = 20.0
+VIEWER_START_LOCK_STALE_SEC = 60.0
+
+
+@contextlib.contextmanager
+def _viewer_start_lock(timeout: float = VIEWER_START_LOCK_TIMEOUT_SEC):
+    """Cross-process guard for the Hermes viewer daemon startup path."""
+    lock_dir = _plugin_root() / "daemon" / "viewer-start.lock"
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.time() + timeout
+    acquired = False
+
+    while True:
+        try:
+            lock_dir.mkdir()
+            acquired = True
+            with contextlib.suppress(Exception):
+                (lock_dir / "owner").write_text(
+                    f"pid={os.getpid()} started_at={time.time()}\n",
+                    encoding="utf-8",
+                )
+            break
+        except FileExistsError:
+            stale = False
+            with contextlib.suppress(Exception):
+                stale = time.time() - lock_dir.stat().st_mtime > VIEWER_START_LOCK_STALE_SEC
+            if stale:
+                with contextlib.suppress(Exception):
+                    shutil.rmtree(lock_dir)
+                continue
+            if time.time() >= deadline:
+                yield False
+                return
+            time.sleep(0.1)
+
+    try:
+        yield True
+    finally:
+        if acquired:
+            with contextlib.suppress(Exception):
+                shutil.rmtree(lock_dir)
 
 
 def _bridge_script() -> Path:
@@ -219,54 +260,73 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
             return False
         if probe_only:
             return False
-        if not ensure_bridge_running():
-            return False
-
-        plugin_root = _plugin_root()
-        logs_dir = plugin_root / "logs"
-        logs_dir.mkdir(parents=True, exist_ok=True)
-        log_file = logs_dir / "daemon-start.log"
-        try:
-            log_handle = log_file.open("a", encoding="utf-8")
-            _viewer_process = subprocess.Popen(
-                _bridge_command(daemon=True),
-                cwd=str(plugin_root),
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.DEVNULL,
-                text=True,
-                start_new_session=True,
-            )
-            log_handle.close()
-        except Exception as err:
-            with contextlib.suppress(Exception):
-                log_handle.close()  # type: ignore[possibly-undefined]
-            logger.warning("MemOS: failed to start viewer daemon — %s", err)
-            return False
-
-        deadline = time.time() + 15.0
-        while time.time() < deadline:
-            if _viewer_process.poll() is not None:
-                logger.warning(
-                    "MemOS: viewer daemon exited early with code %s",
-                    _viewer_process.returncode,
-                )
-                return False
+        with _viewer_start_lock() as lock_acquired:
             status = _probe_viewer()
             _viewer_status = status
             _viewer_last_probe_at = time.time()
             if status == "running_memos":
-                logger.info("MemOS: viewer daemon running on port %d", HERMES_VIEWER_PORT)
                 return True
             if status == "blocked":
                 logger.warning(
-                    "MemOS: viewer port %d became occupied by a non-MemOS service",
+                    "MemOS: viewer port %d is occupied by a non-MemOS service; "
+                    "memory capture will continue without the web panel",
                     HERMES_VIEWER_PORT,
                 )
                 return False
-            time.sleep(0.5)
-        logger.warning("MemOS: viewer daemon did not become healthy within 15s")
-        return False
+            if not lock_acquired:
+                logger.warning(
+                    "MemOS: timed out waiting for viewer daemon startup lock; "
+                    "memory capture will continue without the web panel",
+                )
+                return False
+            if not ensure_bridge_running():
+                return False
+
+            plugin_root = _plugin_root()
+            logs_dir = plugin_root / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            log_file = logs_dir / "daemon-start.log"
+            try:
+                log_handle = log_file.open("a", encoding="utf-8")
+                _viewer_process = subprocess.Popen(
+                    _bridge_command(daemon=True),
+                    cwd=str(plugin_root),
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    start_new_session=True,
+                )
+                log_handle.close()
+            except Exception as err:
+                with contextlib.suppress(Exception):
+                    log_handle.close()  # type: ignore[possibly-undefined]
+                logger.warning("MemOS: failed to start viewer daemon — %s", err)
+                return False
+
+            deadline = time.time() + 15.0
+            while time.time() < deadline:
+                if _viewer_process.poll() is not None:
+                    logger.warning(
+                        "MemOS: viewer daemon exited early with code %s",
+                        _viewer_process.returncode,
+                    )
+                    return False
+                status = _probe_viewer()
+                _viewer_status = status
+                _viewer_last_probe_at = time.time()
+                if status == "running_memos":
+                    logger.info("MemOS: viewer daemon running on port %d", HERMES_VIEWER_PORT)
+                    return True
+                if status == "blocked":
+                    logger.warning(
+                        "MemOS: viewer port %d became occupied by a non-MemOS service",
+                        HERMES_VIEWER_PORT,
+                    )
+                    return False
+                time.sleep(0.5)
+            logger.warning("MemOS: viewer daemon did not become healthy within 15s")
+            return False
 
 
 def shutdown_bridge() -> None:

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -68,8 +68,8 @@ function parseArgs(argv: readonly string[]): BridgeArgs {
 // ─── PID file singleton guard ───────────────────────────────────────────
 // Prevents bridge process accumulation: each new bridge that wants to
 // own the viewer port kills the previous holder via its PID file.
-// `--no-viewer` (headless) bridges skip the kill — they don't need the
-// port and should coexist with the daemon that owns it.
+// `--no-viewer` (headless) bridges skip this PID file entirely — they don't
+// need the port and should coexist with the daemon that owns it.
 
 const PID_FILENAME = "bridge.pid";
 
@@ -144,10 +144,14 @@ async function main(): Promise<void> {
 
   // ─── Singleton: kill previous bridge that owns the viewer port ───
   const pidPath = pidFilePath(args.agent);
-  if (!args.noViewer) {
+  const ownsViewerPort = args.daemon || !args.noViewer;
+  const removeOwnedPidFile = () => {
+    if (ownsViewerPort) removePidFile(pidPath);
+  };
+  if (ownsViewerPort) {
     killExistingBridge(pidPath);
+    writePidFile(pidPath);
   }
-  writePidFile(pidPath);
 
   // Lazy-import ESM core. Using dynamic import so this file remains
   // CommonJS and stays `require`-able.
@@ -393,7 +397,7 @@ async function main(): Promise<void> {
 
     const shutdownDaemon = async (sig: string) => {
       process.stderr.write(`bridge: daemon received ${sig}, shutting down\n`);
-      removePidFile(pidPath);
+      removeOwnedPidFile();
       try { await viewer!.close(); } catch { /* best-effort */ }
       await core.shutdown();
       process.exit(0);
@@ -458,7 +462,7 @@ async function main(): Promise<void> {
 
   const shutdown = async (sig: string) => {
     process.stderr.write(`bridge: received ${sig}, shutting down\n`);
-    removePidFile(pidPath);
+    removeOwnedPidFile();
     if (viewer) {
       try {
         await viewer.close();
@@ -486,7 +490,7 @@ async function main(): Promise<void> {
     const keepalive = setInterval(() => {
       if (viewer!.closed) {
         clearInterval(keepalive);
-        removePidFile(pidPath);
+        removeOwnedPidFile();
         void core.shutdown().then(() => process.exit(0));
       }
     }, 5_000);
@@ -495,7 +499,7 @@ async function main(): Promise<void> {
   }
 
   // No viewer (headless bridge) — clean exit.
-  removePidFile(pidPath);
+  removeOwnedPidFile();
   await core.shutdown();
   process.exit(0);
 }

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -10,6 +10,7 @@ Run:
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import sys
@@ -693,7 +694,7 @@ class ViewerDaemonTests(unittest.TestCase):
                 patch.object(
                     daemon_manager_mod,
                     "_probe_viewer",
-                    side_effect=["free", "running_memos"],
+                    side_effect=["free", "free", "running_memos"],
                 ),
                 patch.object(daemon_manager_mod, "_bridge_script", return_value=bridge_path),
                 patch.object(daemon_manager_mod, "ensure_bridge_running", return_value=True),
@@ -710,6 +711,36 @@ class ViewerDaemonTests(unittest.TestCase):
             ):
                 self.assertTrue(daemon_manager_mod.ensure_viewer_daemon())
                 popen.assert_called_once()
+
+    def test_start_lock_reprobes_before_spawning_daemon(self) -> None:
+        @contextlib.contextmanager
+        def acquired_lock():
+            yield True
+
+        with (
+            patch.object(
+                daemon_manager_mod,
+                "_probe_viewer",
+                side_effect=["free", "running_memos"],
+            ),
+            patch.object(daemon_manager_mod, "_viewer_start_lock", acquired_lock),
+            patch.object(daemon_manager_mod.subprocess, "Popen") as popen,
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_viewer_daemon())
+            popen.assert_not_called()
+
+    def test_start_lock_timeout_does_not_spawn_daemon(self) -> None:
+        @contextlib.contextmanager
+        def busy_lock():
+            yield False
+
+        with (
+            patch.object(daemon_manager_mod, "_probe_viewer", side_effect=["free", "free"]),
+            patch.object(daemon_manager_mod, "_viewer_start_lock", busy_lock),
+            patch.object(daemon_manager_mod.subprocess, "Popen") as popen,
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_viewer_daemon())
+            popen.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a cross-process startup lock around the Hermes viewer daemon launch path
- re-probe :18800 after acquiring the lock so concurrent no-viewer sessions reuse the daemon
- keep --no-viewer stdio bridges out of the viewer daemon pid file

## Tests
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff format apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py apps/memos-local-plugin/tests/python/test_bridge_client.py
- /Users/jiang/MyProject/MemOS-jiang/.venv/bin/ruff check apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py apps/memos-local-plugin/tests/python/test_bridge_client.py
- python3 -m unittest tests.python.test_bridge_client
- npm run lint
- npx vitest run tests/unit/bridge/methods.test.ts tests/unit/bridge/stdio.test.ts