### PR TITLE
fix: reward pipeline skips abandoned episodes (3 related fixes)

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -306,48 +306,14 @@ async function main(): Promise<void> {
     | ReturnType<NonNullable<typeof bridgeStatus>["startHeartbeat"]>
     | undefined;
 
-  // In stdio mode the host fallback path is a reverse JSON-RPC request
-  // over the same pipe as normal bridge traffic. `core.init()` may
-  // recover dirty episodes and run reflection/reward/L2/skill work; if
-  // that work hits a broken primary skill-evolver model, the LLM facade
-  // can fall back to host before init returns. Start stdio first so that
-  // fallback has a transport instead of tripping the lazy bridge guard.
-  if (!args.daemon) {
-    stdio = startStdioServer({ core });
-    bridgeStatus?.markConnected();
-    bridgeHeartbeat = bridgeStatus?.startHeartbeat();
-    void stdio.done.then(() => {
-      bridgeHeartbeat?.stop();
-      bridgeStatus?.markDisconnected("Hermes chat disconnected");
-    });
-  }
-
-  try {
-    await core.init();
-  } catch (err) {
-    bridgeHeartbeat?.stop();
-    if (stdio) {
-      try {
-        await stdio.close();
-      } catch {
-        /* best-effort */
-      }
-    }
-    throw err;
-  }
-
   // ─── Daemon mode ──────────────────────────────────────────────
-  // When started with `--daemon`, skip stdio and run as a pure HTTP
-  // viewer daemon. Used by install.sh (post-install) and admin/restart
-  // (self-restart) to keep the Memory Viewer always available.
+  // When started with `--daemon`, bind the viewer port BEFORE running
+  // core.init() so that ensure_viewer_daemon()'s 15-second health probe
+  // succeeds immediately. Without this, a lengthy dirty-episode rescore
+  // inside core.init() keeps the port unbound past the probe deadline,
+  // causing ensure_viewer_daemon() to give up and spawn a replacement
+  // daemon — which kills this one and restarts the cycle.
   if (args.daemon) {
-    // Daemon mode is the target of `POST /api/v1/admin/restart`,
-    // which re-spawns the bridge after a short sleep. On busy
-    // machines the previous bridge's listening socket can take a
-    // moment longer than expected to release, so we retry the bind
-    // a few times before giving up. Without this the user sees
-    // "重启超时" in the viewer because the new daemon raced its
-    // predecessor and lost.
     let viewer: import("./server/types.js").ServerHandle | null = null;
     const maxBindAttempts = 10;
     for (let attempt = 1; attempt <= maxBindAttempts; attempt++) {
@@ -404,8 +370,49 @@ async function main(): Promise<void> {
     };
     process.on("SIGINT", () => void shutdownDaemon("SIGINT"));
     process.on("SIGTERM", () => void shutdownDaemon("SIGTERM"));
+
+    // Run core.init() in the background. A dirty-episode rescore can
+    // take minutes; keeping it async lets the HTTP server stay responsive
+    // to health probes throughout and prevents ensure_viewer_daemon()
+    // from timing out and spawning a replacement daemon.
+    void core.init().catch((err) => {
+      process.stderr.write(
+        `bridge: daemon core.init error: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      );
+      void shutdownDaemon("init.error");
+    });
+
     // Process stays alive via the HTTP server's ref'd socket.
     return;
+  }
+
+  // ─── Non-daemon setup ─────────────────────────────────────────
+  // In stdio mode the host fallback path is a reverse JSON-RPC request
+  // over the same pipe as normal bridge traffic. `core.init()` may
+  // recover dirty episodes and run reflection/reward/L2/skill work; if
+  // that work hits a broken primary skill-evolver model, the LLM facade
+  // can fall back to host before init returns. Start stdio first so that
+  // fallback has a transport instead of tripping the lazy bridge guard.
+  stdio = startStdioServer({ core });
+  bridgeStatus?.markConnected();
+  bridgeHeartbeat = bridgeStatus?.startHeartbeat();
+  void stdio.done.then(() => {
+    bridgeHeartbeat?.stop();
+    bridgeStatus?.markDisconnected("Hermes chat disconnected");
+  });
+
+  try {
+    await core.init();
+  } catch (err) {
+    bridgeHeartbeat?.stop();
+    if (stdio) {
+      try {
+        await stdio.close();
+      } catch {
+        /* best-effort */
+      }
+    }
+    throw err;
   }
 
   // ─── Normal (stdio) mode ──────────────────────────────────────

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -926,6 +926,24 @@ export function createMemoryCore(
       });
     }
 
+    // Periodic rescore: the daemon bridge sits idle after bootstrap with no
+    // turn traffic to drive pipeline events. Any episodes closed (abandoned
+    // or finalized) by the --no-viewer JSON-RPC bridge after bootstrap will
+    // have their reward scored by that bridge's own pipeline — but episodes
+    // that were already closed before this init ran (and missed by the
+    // startup scan due to the abandoned-closeReason bug, or due to a crash
+    // mid-reward) need a periodic retry. 10-minute interval matches the
+    // `autoRescoreDirtyClosedEpisodes` 30 s guard so it's safe to call
+    // frequently; the guard prevents redundant DB scans.
+    const rescoreInterval = setInterval(() => {
+      void autoRescoreDirtyClosedEpisodes().catch((err) => {
+        log.debug("periodic_rescore.error", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, 10 * 60 * 1000);
+    (rescoreInterval as unknown as { unref?: () => void }).unref?.();
+
     // Wire `memory_add` into the api_logs table on EVERY turn so the
     // Logs viewer shows per-turn capture activity. `capture.lite.done`
     // fires once per `onTurnEnd` (the per-turn lite capture path);
@@ -1274,7 +1292,9 @@ export function createMemoryCore(
     if (
       ep.rTask == null &&
       (ep.traceIds?.length ?? 0) > 0 &&
-      (meta.closeReason === "finalized" || meta.recoveryReason === "missed_session_end")
+      (meta.closeReason === "finalized" ||
+        meta.closeReason === "abandoned" ||
+        meta.recoveryReason === "missed_session_end")
     ) {
       return true;
     }

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -1287,7 +1287,16 @@ export function createMemoryCore(
 
     const reward = meta.reward;
     if (reward && typeof reward === "object" && (reward as { skipped?: unknown }).skipped === true) {
-      return false;
+      // Abandoned episodes with no prior recovery attempt get one retry: the
+      // skip decision may have been made with incomplete data before the session
+      // ended. recoverDirtyClosedEpisodes() patches closeReason → "finalized"
+      // after processing, so if reward skips again the next check sees
+      // closeReason !== "abandoned" and stops retrying (no loop).
+      const isAbandonedNoRecovery =
+        meta.closeReason === "abandoned" && meta.recoveryReason == null;
+      if (!isAbandonedNoRecovery) {
+        return false;
+      }
     }
     if (
       ep.rTask == null &&


### PR DESCRIPTION
## Problem

The reward scoring pipeline processes only ~7 episodes on bootstrap and then goes permanently idle, leaving the vast majority of traces unscored. On a 43 MB database with 3,600 traces, only 45 (1.3%) had r_human scores before fixing.

## Root Cause & Fixes

Three interacting bugs, all in `apps/memos-local-plugin/`:

### Fix 1: `episodeRewardIsDirty()` excluded abandoned episodes
The dirty-check condition only matched `closeReason === "finalized"` or `recoveryReason === "missed_session_end"`. 219 of 224 closed episodes had `closeReason: "abandoned"`.

**Fix:** Add `closeReason === "abandoned"` to the rescore condition + a 10-minute periodic rescore timer.

### Fix 2: Daemon HTTP server must bind before `core.init()`
The daemon bridge started `core.init()` before `startHttpServer()`. When init rescores dirty episodes (5+ minutes of LLM calls), port 18800 stays free. The Python watchdog times out its 15-second health probe and spawns a new daemon — killing the in-progress one.

**Fix:** In daemon mode, bind HTTP server first, then run init asynchronously.

### Fix 3: `reward.skipped` blocked abandoned episodes from recovery
`episodeRewardIsDirty()` checked `reward.skipped === true` BEFORE `closeReason === "abandoned"`. The reward runner correctly skipped 173 one-turn episodes in a previous session, but that flag permanently excluded them from recovery.

**Fix:** `reward.skipped` is only honored if the episode is NOT (abandoned + no prior recovery). Abandoned episodes get one pass; after that, closeReason is patched to "finalized" and the normal skip guard works.

## Verification
- Daemon bridge: 7+ hours uptime, zero restart loops
- All 219 abandoned episodes processed
- r_human scores flowing for traces from May 9 onward
- Closes #1782
