### PR TITLE
docs: clarify API search filter description

### DIFF
--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -400,18 +400,13 @@ class APISearchRequest(BaseRequest):
     )
 
     # ==== Filter conditions ====
-    # TODO: maybe add detailed description later
     filter: dict[str, Any] | None = Field(
         None,
-        description="""
-        Filter for the memory, example:
-        {
-            "`and` or `or`": [
-                {"id": "uuid-xxx"},
-                {"created_at": {"gt": "2024-01-01"}},
-            ]
-        }
-        """,
+        description=(
+            "Optional structured metadata filter for narrowing memory search results. "
+            "Supports logical operators such as `and` and `or`, and field conditions "
+            "such as id and created_at ranges. None means no metadata filter is applied."
+        ),
     )
 
     # ==== Extended capabilities ====

--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -404,8 +404,10 @@ class APISearchRequest(BaseRequest):
         None,
         description=(
             "Optional structured metadata filter for narrowing memory search results. "
-            "Supports logical operators such as `and` and `or`, and field conditions "
-            "such as id and created_at ranges. None means no metadata filter is applied."
+            "Supports logical operators such as `and` and `or`, plus field-level "
+            "operator objects. Example: "
+            '`{"and": [{"field_name": {"eq": "value"}}, {"other_field": {"gte": 10}}]}`. '
+            "None means no metadata filter is applied."
         ),
     )
 


### PR DESCRIPTION
## Summary

- Removed the TODO above `APISearchRequest.filter`
- Clarified how the structured metadata filter is used for memory search
- Kept the field type, default value, and validation behavior unchanged

## Testing

- `python3 -m compileall src/memos/api/product_models.py`