### PR TITLE
refactor(mem-reader): remove dead remove_prompt_example branch in StrategyStructMemReader

### DIFF
--- a/src/memos/mem_reader/strategy_struct.py
+++ b/src/memos/mem_reader/strategy_struct.py
@@ -13,8 +13,6 @@ from memos.templates.mem_reader_prompts import (
     CUSTOM_TAGS_INSTRUCTION_ZH,
     SIMPLE_STRUCT_DOC_READER_PROMPT,
     SIMPLE_STRUCT_DOC_READER_PROMPT_ZH,
-    SIMPLE_STRUCT_MEM_READER_EXAMPLE,
-    SIMPLE_STRUCT_MEM_READER_EXAMPLE_ZH,
 )
 from memos.templates.mem_reader_strategy_prompts import (
     STRATEGY_STRUCT_MEM_READER_PROMPT,
@@ -27,8 +25,6 @@ STRATEGY_PROMPT_DICT = {
     "chat": {
         "en": STRATEGY_STRUCT_MEM_READER_PROMPT,
         "zh": STRATEGY_STRUCT_MEM_READER_PROMPT_ZH,
-        "en_example": SIMPLE_STRUCT_MEM_READER_EXAMPLE,
-        "zh_example": SIMPLE_STRUCT_MEM_READER_EXAMPLE_ZH,
     },
     "doc": {"en": SIMPLE_STRUCT_DOC_READER_PROMPT, "zh": SIMPLE_STRUCT_DOC_READER_PROMPT_ZH},
     "custom_tags": {"en": CUSTOM_TAGS_INSTRUCTION, "zh": CUSTOM_TAGS_INSTRUCTION_ZH},
@@ -45,7 +41,6 @@ class StrategyStructMemReader(SimpleStructMemReader, ABC):
     def _get_llm_response(self, mem_str: str, custom_tags: list[str] | None) -> dict:
         lang = detect_lang(mem_str)
         template = STRATEGY_PROMPT_DICT["chat"][lang]
-        examples = STRATEGY_PROMPT_DICT["chat"][f"{lang}_example"]
         prompt = template.replace("${conversation}", mem_str)
 
         custom_tags_prompt = (
@@ -54,9 +49,6 @@ class StrategyStructMemReader(SimpleStructMemReader, ABC):
             else ""
         )
         prompt = prompt.replace("${custom_tags_prompt}", custom_tags_prompt)
-
-        if self.config.remove_prompt_example:  # TODO unused
-            prompt = prompt.replace(examples, "")
         messages = [{"role": "user", "content": prompt}]
         try:
             response_text = self.llm.generate(messages)


### PR DESCRIPTION
## Description

In `StrategyStructMemReader._get_llm_response`, the `remove_prompt_example` flag had no effect: the strategy prompt template does not contain `SIMPLE_STRUCT_MEM_READER_EXAMPLE`, so `prompt.replace(examples, "")` was always a no-op.

Removed the dead branch and the now-unused `examples` variable. The `remove_prompt_example` config field is preserved — it is still used correctly in `SimpleStructMemReader` and `MultiModalStructMemReader`.

Related Issue (Required): Fixes #1792

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit Test

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人