### PR TITLE
fix(scheduler): report total working memory count in log_working_memory_replacement

### DIFF
--- a/src/memos/mem_scheduler/general_modules/scheduler_logger.py
+++ b/src/memos/mem_scheduler/general_modules/scheduler_logger.py
@@ -166,7 +166,6 @@ class SchedulerLoggerModule(BaseSchedulerModule):
             return "PublicMemCube"
         return "UserMemCube"
 
-    # TODO: Log output count is incorrect
     @log_exceptions(logger=logger)
     def log_working_memory_replacement(
         self,
@@ -226,7 +225,7 @@ class SchedulerLoggerModule(BaseSchedulerModule):
                 mem_cube=mem_cube,
                 memcube_log_content=memcube_content,
                 metadata=meta,
-                memory_len=len(memcube_content),
+                memory_len=len(new_memory),
                 memcube_name=self._map_memcube_name(mem_cube_id),
             )
             log_func_callback([ev])

--- a/tests/mem_scheduler/test_scheduler_logger.py
+++ b/tests/mem_scheduler/test_scheduler_logger.py
@@ -59,11 +59,11 @@ class TestSchedulerLogger(unittest.TestCase):
             _make_memory_item("id2", "memory two"),
         ]
         new_memory = [
-            _make_memory_item("id1", "memory one"),    # carried over
-            _make_memory_item("id2", "memory two"),    # carried over
+            _make_memory_item("id1", "memory one"),  # carried over
+            _make_memory_item("id2", "memory two"),  # carried over
             _make_memory_item("id3", "memory three"),  # new
-            _make_memory_item("id4", "memory four"),   # new
-            _make_memory_item("id5", "memory five"),   # new
+            _make_memory_item("id4", "memory four"),  # new
+            _make_memory_item("id5", "memory five"),  # new
         ]
 
         captured_events = []

--- a/tests/mem_scheduler/test_scheduler_logger.py
+++ b/tests/mem_scheduler/test_scheduler_logger.py
@@ -1,0 +1,90 @@
+import sys
+import unittest
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from memos.mem_cube.general import GeneralMemCube
+from memos.mem_scheduler.general_modules.scheduler_logger import SchedulerLoggerModule
+from memos.memories.textual.tree import TextualMemoryItem
+
+
+FILE_PATH = Path(__file__).absolute()
+BASE_DIR = FILE_PATH.parent.parent.parent
+sys.path.insert(0, str(BASE_DIR))  # Enable execution from any working directory
+
+
+def _make_memory_item(memory_id, memory_text, memory_type="LongTermMemory"):
+    item = MagicMock(spec=TextualMemoryItem)
+    item.id = memory_id
+    item.memory = memory_text
+    item.metadata = MagicMock()
+    item.metadata.key = memory_text
+    item.metadata.memory_type = memory_type
+    item.metadata.status = "active"
+    item.metadata.confidence = 1.0
+    item.metadata.tags = []
+    item.metadata.updated_at = None
+    item.metadata.update_at = None
+    return item
+
+
+def _make_mem_cube():
+    mem_cube = MagicMock(spec=GeneralMemCube)
+    mem_cube.text_mem = MagicMock()
+    mem_cube.text_mem.memory_manager = MagicMock()
+    mem_cube.text_mem.memory_manager.memory_size = {
+        "LongTermMemory": 10000,
+        "UserMemory": 10000,
+        "WorkingMemory": 20,
+    }
+    mem_cube.text_mem.get_current_memory_size.return_value = {
+        "LongTermMemory": 100,
+        "UserMemory": 50,
+        "WorkingMemory": 10,
+    }
+    return mem_cube
+
+
+class TestSchedulerLogger(unittest.TestCase):
+    def setUp(self):
+        self.logger_module = SchedulerLoggerModule()
+        self.mem_cube = _make_mem_cube()
+
+    def test_log_working_memory_replacement_memory_len_equals_new_memory(self):
+        """memory_len in the logged event should equal len(new_memory), not len(added items)."""
+        # original has 2 items; new_memory has 5 items (2 carried over + 3 new)
+        original_memory = [
+            _make_memory_item("id1", "memory one"),
+            _make_memory_item("id2", "memory two"),
+        ]
+        new_memory = [
+            _make_memory_item("id1", "memory one"),    # carried over
+            _make_memory_item("id2", "memory two"),    # carried over
+            _make_memory_item("id3", "memory three"),  # new
+            _make_memory_item("id4", "memory four"),   # new
+            _make_memory_item("id5", "memory five"),   # new
+        ]
+
+        captured_events = []
+
+        self.logger_module.log_working_memory_replacement(
+            original_memory=original_memory,
+            new_memory=new_memory,
+            user_id="test_user",
+            mem_cube_id="test_cube",
+            mem_cube=self.mem_cube,
+            log_func_callback=lambda evts: captured_events.extend(evts),
+        )
+
+        self.assertTrue(len(captured_events) > 0, "Expected at least one log event")
+        event = captured_events[0]
+        self.assertEqual(
+            event.memory_len,
+            len(new_memory),
+            f"memory_len should be {len(new_memory)} (total new_memory size), got {event.memory_len}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

`log_working_memory_replacement` was passing `memory_len=len(memcube_content)` where `memcube_content` only contains newly added memories. This caused the scheduler UI to show the delta count instead of the total working memory size after replacement.

Fix: use `len(new_memory)` to report the actual output count.

Related Issue (Required): Fixes #1790

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit Test

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人