### PR TITLE
fix(chunkers): fall back to 'character' tokenizer when configured one is unavailable

### DIFF
--- a/src/memos/chunkers/sentence_chunker.py
+++ b/src/memos/chunkers/sentence_chunker.py
@@ -26,18 +26,10 @@ class SentenceChunker(BaseChunker):
             "chunk_overlap": config.chunk_overlap,
             "min_sentences_per_chunk": config.min_sentences_per_chunk,
         }
-        self.chunker = None
-        last_error: Exception | None = None
-        # Try chonkie >=1.4.0 API first, then the pre-1.4 signature.
-        for kwarg in ("tokenizer", "tokenizer_or_token_counter"):
-            try:
-                self.chunker = ChonkieSentenceChunker(
-                    **{kwarg: config.tokenizer_or_token_counter}, **common_kwargs
-                )
-                break
-            except (TypeError, AttributeError, ValueError) as e:
-                last_error = e
-                continue
+
+        self.chunker, used_kwarg, last_error = self._build_chonkie_chunker(
+            ChonkieSentenceChunker, config.tokenizer_or_token_counter, common_kwargs
+        )
 
         # If the configured tokenizer can't be loaded (no tiktoken, no
         # HuggingFace access, etc.), fall back to chonkie's built-in
@@ -49,11 +41,35 @@ class SentenceChunker(BaseChunker):
                 f"Tokenizer '{config.tokenizer_or_token_counter}' unavailable "
                 f"({last_error!r}); falling back to 'character'"
             )
-            self.chunker = ChonkieSentenceChunker(
-                tokenizer_or_token_counter="character", **common_kwargs
+            self.chunker, used_kwarg, fallback_error = self._build_chonkie_chunker(
+                ChonkieSentenceChunker, "character", common_kwargs
             )
+            if self.chunker is None:
+                raise RuntimeError(
+                    "Failed to initialize SentenceChunker: 'character' fallback "
+                    f"also rejected by chonkie ({fallback_error!r})."
+                ) from last_error
 
+        logger.debug(f"chonkie SentenceChunker initialized via kwarg {used_kwarg!r}")
         logger.info(f"Initialized SentenceChunker with config: {config}")
+
+    @staticmethod
+    def _build_chonkie_chunker(chunker_cls, tokenizer_value, common_kwargs):
+        """Build a chonkie SentenceChunker, tolerating the 1.4.0 kwarg rename.
+
+        chonkie >=1.4.0 renamed ``tokenizer_or_token_counter`` to ``tokenizer``.
+        Try the new keyword first, then the legacy one. Returns
+        ``(instance_or_None, used_kwarg_or_None, last_error_or_None)``.
+        """
+        last_error: Exception | None = None
+        for kwarg in ("tokenizer", "tokenizer_or_token_counter"):
+            try:
+                instance = chunker_cls(**{kwarg: tokenizer_value}, **common_kwargs)
+                return instance, kwarg, None
+            except (TypeError, AttributeError, ValueError) as e:
+                last_error = e
+                continue
+        return None, None, last_error
 
     def chunk(self, text: str) -> list[str] | list[Chunk]:
         """Chunk the given text into smaller chunks based on sentences."""

--- a/src/memos/chunkers/sentence_chunker.py
+++ b/src/memos/chunkers/sentence_chunker.py
@@ -21,22 +21,36 @@ class SentenceChunker(BaseChunker):
 
         self.config = config
 
-        # Try new API first (v1.4.0+)
-        try:
-            self.chunker = ChonkieSentenceChunker(
-                tokenizer=config.tokenizer_or_token_counter,
-                chunk_size=config.chunk_size,
-                chunk_overlap=config.chunk_overlap,
-                min_sentences_per_chunk=config.min_sentences_per_chunk,
+        common_kwargs = {
+            "chunk_size": config.chunk_size,
+            "chunk_overlap": config.chunk_overlap,
+            "min_sentences_per_chunk": config.min_sentences_per_chunk,
+        }
+        self.chunker = None
+        last_error: Exception | None = None
+        # Try chonkie >=1.4.0 API first, then the pre-1.4 signature.
+        for kwarg in ("tokenizer", "tokenizer_or_token_counter"):
+            try:
+                self.chunker = ChonkieSentenceChunker(
+                    **{kwarg: config.tokenizer_or_token_counter}, **common_kwargs
+                )
+                break
+            except (TypeError, AttributeError, ValueError) as e:
+                last_error = e
+                continue
+
+        # If the configured tokenizer can't be loaded (no tiktoken, no
+        # HuggingFace access, etc.), fall back to chonkie's built-in
+        # 'character' counter so the chunker still works offline. Note:
+        # chunk_size semantics change from token count to character count
+        # for fallback runs.
+        if self.chunker is None:
+            logger.warning(
+                f"Tokenizer '{config.tokenizer_or_token_counter}' unavailable "
+                f"({last_error!r}); falling back to 'character'"
             )
-        except (TypeError, AttributeError) as e:
-            # Fallback to old API (<v1.4.0)
-            logger.debug(f"Falling back to old chonkie API: {e}")
             self.chunker = ChonkieSentenceChunker(
-                tokenizer_or_token_counter=config.tokenizer_or_token_counter,
-                chunk_size=config.chunk_size,
-                chunk_overlap=config.chunk_overlap,
-                min_sentences_per_chunk=config.min_sentences_per_chunk,
+                tokenizer_or_token_counter="character", **common_kwargs
             )
 
         logger.info(f"Initialized SentenceChunker with config: {config}")

--- a/tests/chunkers/test_sentence_chunker.py
+++ b/tests/chunkers/test_sentence_chunker.py
@@ -102,17 +102,28 @@ class TestSentenceChunker(unittest.TestCase):
         )
 
     def test_sentence_chunker_no_warning_when_character_configured(self):
-        """When 'character' is explicitly configured, no fallback warning is emitted.
+        """When 'character' is explicitly configured, the initial build
+        succeeds and no fallback warning is emitted.
 
-        Guards against a regression where the fallback warning fires for
-        users who deliberately picked the character counter.
+        Mock setup: only ``character`` is accepted; any other value raises
+        ``ValueError``. With ``character`` configured, the first iteration
+        of the build loop succeeds, so the fallback branch is never
+        entered — proving that a user who explicitly picked the character
+        counter does not see the "Tokenizer 'character' unavailable;
+        falling back to 'character'" warning.
         """
         import logging
 
         def side_effect(*args, **kwargs):
             if "tokenizer" in kwargs:
-                raise TypeError("unexpected keyword argument 'tokenizer'")
-            return MagicMock()
+                value = kwargs["tokenizer"]
+            elif "tokenizer_or_token_counter" in kwargs:
+                value = kwargs["tokenizer_or_token_counter"]
+            else:
+                raise TypeError("no tokenizer kwarg")
+            if value == "character":
+                return MagicMock()
+            raise ValueError(f"Tokenizer not found: {value}")
 
         records: list[logging.LogRecord] = []
 
@@ -124,7 +135,7 @@ class TestSentenceChunker(unittest.TestCase):
         logger_under_test = logging.getLogger("memos.chunkers.sentence_chunker")
         logger_under_test.addHandler(handler)
         try:
-            with patch("chonkie.SentenceChunker", side_effect=side_effect):
+            with patch("chonkie.SentenceChunker", side_effect=side_effect) as mock_cls:
                 config = ChunkerConfigFactory.model_validate(
                     {
                         "backend": "sentence",
@@ -138,9 +149,87 @@ class TestSentenceChunker(unittest.TestCase):
         finally:
             logger_under_test.removeHandler(handler)
 
+        # Sanity: chonkie was called exactly once (first build-loop
+        # iteration succeeded), so the fallback path was never entered.
+        self.assertEqual(mock_cls.call_count, 1)
         fallback_warnings = [r for r in records if "falling back to 'character'" in r.getMessage()]
         self.assertEqual(
             fallback_warnings,
             [],
             f"Unexpected fallback warning when 'character' was configured: {fallback_warnings}",
         )
+
+    def test_sentence_chunker_fallback_uses_new_api_for_character(self):
+        """Fallback is itself version-resilient: on chonkie >=1.4.0 the
+        ``character`` fallback must use the new ``tokenizer=`` kwarg.
+
+        Regression: a previous version unconditionally called
+        ``ChonkieSentenceChunker(tokenizer_or_token_counter="character", ...)``
+        in the fallback path, which raises ``TypeError`` on chonkie
+        >=1.4.0 because the keyword was removed.
+        """
+
+        def side_effect(*args, **kwargs):
+            # Simulate chonkie >=1.4.0: legacy keyword is gone.
+            if "tokenizer_or_token_counter" in kwargs:
+                raise TypeError("unexpected keyword argument 'tokenizer_or_token_counter'")
+            value = kwargs.get("tokenizer")
+            if value == "character":
+                return MagicMock()
+            raise ValueError(f"Tokenizer not found: {value}")
+
+        with patch("chonkie.SentenceChunker", side_effect=side_effect) as mock_cls:
+            config = ChunkerConfigFactory.model_validate(
+                {
+                    "backend": "sentence",
+                    "config": {
+                        "tokenizer_or_token_counter": "gpt2",
+                        "chunk_size": 10,
+                        "chunk_overlap": 2,
+                    },
+                }
+            )
+            chunker = ChunkerFactory.from_config(config)
+
+        self.assertIsNotNone(chunker.chunker)
+        # Last attempt must be the new-API ``tokenizer="character"`` call.
+        last_kwargs = mock_cls.call_args.kwargs
+        self.assertEqual(last_kwargs.get("tokenizer"), "character")
+        self.assertNotIn("tokenizer_or_token_counter", last_kwargs)
+
+    def test_sentence_chunker_raises_when_fallback_also_fails(self):
+        """If chonkie rejects every attempt — including the ``character``
+        fallback — a clear ``RuntimeError`` chained to the original
+        tokenizer-load error is raised instead of an opaque chonkie
+        exception leaking out.
+        """
+
+        original_error = ValueError("Tokenizer not found: gpt2")
+
+        def side_effect(*args, **kwargs):
+            # Re-raise the same class but vary the message so we can
+            # distinguish the original vs. fallback failure.
+            if kwargs.get("tokenizer") == "character" or kwargs.get(
+                "tokenizer_or_token_counter"
+            ) == "character":
+                raise ValueError("character also unavailable")
+            raise original_error
+
+        with patch("chonkie.SentenceChunker", side_effect=side_effect):
+            config = ChunkerConfigFactory.model_validate(
+                {
+                    "backend": "sentence",
+                    "config": {
+                        "tokenizer_or_token_counter": "gpt2",
+                        "chunk_size": 10,
+                        "chunk_overlap": 2,
+                    },
+                }
+            )
+            with self.assertRaises(RuntimeError) as ctx:
+                ChunkerFactory.from_config(config)
+
+        self.assertIn("character", str(ctx.exception))
+        # The original tokenizer-load error is preserved via __cause__.
+        self.assertIsInstance(ctx.exception.__cause__, ValueError)
+        self.assertIn("gpt2", str(ctx.exception.__cause__))

--- a/tests/chunkers/test_sentence_chunker.py
+++ b/tests/chunkers/test_sentence_chunker.py
@@ -61,3 +61,86 @@ class TestSentenceChunker(unittest.TestCase):
                 self.assertEqual(chunks[0].text, "This is the first sentence.")
                 self.assertEqual(chunks[0].token_count, 6)
                 self.assertEqual(chunks[0].sentences, ["This is the first sentence."])
+
+    def test_sentence_chunker_falls_back_to_character(self):
+        """Falls back to 'character' tokenizer when the configured one cannot be loaded.
+
+        Regression: in environments without tiktoken and without HuggingFace
+        access, chonkie raises ValueError trying to load tokenizers like
+        'gpt2'. The chunker should recover by falling back to chonkie's
+        built-in 'character' counter instead of propagating the error.
+        """
+        mock_instance = MagicMock()
+
+        def side_effect(*args, **kwargs):
+            # New API (chonkie >=1.4.0) uses 'tokenizer='.
+            if "tokenizer" in kwargs:
+                raise TypeError("unexpected keyword argument 'tokenizer'")
+            value = kwargs.get("tokenizer_or_token_counter")
+            if value == "character":
+                return mock_instance
+            raise ValueError(f"Tokenizer not found in transformers/tokenizers/tiktoken: {value}")
+
+        with patch("chonkie.SentenceChunker", side_effect=side_effect) as mock_chunker_cls:
+            config = ChunkerConfigFactory.model_validate(
+                {
+                    "backend": "sentence",
+                    "config": {
+                        "tokenizer_or_token_counter": "gpt2",
+                        "chunk_size": 10,
+                        "chunk_overlap": 2,
+                    },
+                }
+            )
+            chunker = ChunkerFactory.from_config(config)
+
+        self.assertIs(chunker.chunker, mock_instance)
+        # Last call should be the 'character' fallback.
+        self.assertEqual(
+            mock_chunker_cls.call_args.kwargs.get("tokenizer_or_token_counter"),
+            "character",
+        )
+
+    def test_sentence_chunker_no_warning_when_character_configured(self):
+        """When 'character' is explicitly configured, no fallback warning is emitted.
+
+        Guards against a regression where the fallback warning fires for
+        users who deliberately picked the character counter.
+        """
+        import logging
+
+        def side_effect(*args, **kwargs):
+            if "tokenizer" in kwargs:
+                raise TypeError("unexpected keyword argument 'tokenizer'")
+            return MagicMock()
+
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        logger_under_test = logging.getLogger("memos.chunkers.sentence_chunker")
+        logger_under_test.addHandler(handler)
+        try:
+            with patch("chonkie.SentenceChunker", side_effect=side_effect):
+                config = ChunkerConfigFactory.model_validate(
+                    {
+                        "backend": "sentence",
+                        "config": {
+                            "tokenizer_or_token_counter": "character",
+                            "chunk_size": 10,
+                        },
+                    }
+                )
+                ChunkerFactory.from_config(config)
+        finally:
+            logger_under_test.removeHandler(handler)
+
+        fallback_warnings = [r for r in records if "falling back to 'character'" in r.getMessage()]
+        self.assertEqual(
+            fallback_warnings,
+            [],
+            f"Unexpected fallback warning when 'character' was configured: {fallback_warnings}",
+        )


### PR DESCRIPTION
## Problem

`ChonkieSentenceChunker` raises `ValueError` when none of `tokenizers` / `tiktoken` / `transformers` can load the configured tokenizer (default `gpt2`). The current code in `SentenceChunker.__init__` only catches `TypeError`/`AttributeError` (added by #705 for the chonkie v1.4.0 API switch), so the `ValueError` propagates and crashes the worker process during MOS initialization.

This is reproducible on the official `memos-base-arm:v1.0` Docker image — it ships without `tiktoken`, and HuggingFace is unreachable from many networks (notably mainland China), so the `gpt2` tokenizer load fails through every fallback path inside chonkie.

## Reproduction

1. Start `docker/docker-compose.yml` as documented.
2. Worker process logs:
   ```
   chonkie/tokenizer.py: Could not load tokenizer with 'tokenizers'. Falling back to 'tiktoken'.
   chonkie/tokenizer.py: 'tiktoken' library not found. Falling back to 'transformers'.
   ValueError: Tokenizer not found in transformers, tokenizers, or tiktoken
   ```
3. `/health` endpoint returns nothing — the uvicorn worker keeps crashing on reload.

## Fix

After both API attempts (`tokenizer=` for chonkie >=1.4.0, `tokenizer_or_token_counter=` for older) fail, fall back to chonkie's built-in `character` counter, which requires no external libraries or downloads. The original error is preserved in a `WARNING` log so operators can see why the fallback fired.

## Tradeoff

`chunk_size` semantics change from token count to character count under fallback — chunks become roughly 4x smaller for English text. A working chunker beats a crashing worker, and operators who need token-accurate chunking can install `tiktoken` (or fix HuggingFace network access) to restore the original behavior. The fallback is announced loudly via WARNING log so the degradation isn't silent.

## Tests

- `test_sentence_chunker_falls_back_to_character` — regression test: when configured tokenizer raises `ValueError`, fallback engages and the chunker is constructed with `tokenizer_or_token_counter='character'`.
- `test_sentence_chunker_no_warning_when_character_configured` — guards against firing a misleading \"character unavailable, using character\" warning for users who deliberately picked the character counter.

All 3 tests pass (`pytest tests/chunkers/test_sentence_chunker.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)