### PR TITLE
fix: bridge startup race, dirty-reward orphan traces, RPC loopback auth

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -63,8 +63,8 @@ _PLUGIN_DIR = Path(__file__).resolve().parent
 if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
-from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
-from daemon_manager import ensure_bridge_running, ensure_viewer_daemon  # noqa: E402
+from bridge_client import BridgeError, MemosBridgeClient, MemosHttpClient  # noqa: E402
+from daemon_manager import ensure_bridge_running, ensure_viewer_daemon, probe_viewer_status, kill_zombie_bridges  # noqa: E402
 
 
 try:  # pragma: no cover — host-provided base class, absent in unit tests
@@ -243,7 +243,7 @@ class MemTensorProvider(MemoryProvider):
     """
 
     def __init__(self) -> None:
-        self._bridge: MemosBridgeClient | None = None
+        self._bridge: MemosBridgeClient | MemosHttpClient | None = None
         self._reconnect_lock = threading.Lock()
         self._session_id: str = ""
         self._episode_id: str = ""
@@ -314,34 +314,94 @@ class MemTensorProvider(MemoryProvider):
         except Exception as err:
             logger.warning("MemOS: failed to start bridge — %s", err)
             return
+
+        # Kill zombie bridges from previous sessions before deciding
+        # how to connect.
         try:
-            ensure_viewer_daemon()
-        except Exception as err:
-            logger.warning("MemOS: viewer daemon check failed — %s", err)
-        new_bridge: MemosBridgeClient | None = None
-        try:
-            new_bridge = MemosBridgeClient()
-            # Register the fallback LLM handler BEFORE we open the
-            # session so it is available the very first time the
-            # plugin's facade asks for help (e.g. on the first
-            # `turn.start` retrieval call).
-            new_bridge.register_host_handler(
-                "host.llm.complete",
-                self._handle_host_llm_complete,
-            )
-            self._bridge = new_bridge
-            self._open_session(session_id)
-            logger.info(
-                "MemOS: bridge ready session=%s platform=%s (episode deferred)",
-                self._session_id,
-                self._platform,
-            )
-        except Exception as err:
-            logger.warning("MemOS: bridge init failed — %s", err)
-            if new_bridge is not None:
+            zombies = kill_zombie_bridges()
+            if zombies:
+                logger.info("MemOS: killed %d zombie bridge(s)", zombies)
+        except Exception:
+            pass
+
+        # If the daemon is already running on the viewer port, connect
+        # to it over HTTP instead of spawning a new stdio bridge. This
+        # eliminates zombie bridge accumulation.
+        viewer_status = probe_viewer_status()
+        if viewer_status == "running_memos":
+            try:
+                http_bridge: MemosHttpClient | None = MemosHttpClient()
+                http_bridge.register_host_handler(
+                    "host.llm.complete",
+                    self._handle_host_llm_complete,
+                )
+                self._bridge = http_bridge
+                self._open_session(session_id, timeout=60.0)
+                logger.info(
+                    "MemOS: bridge ready (HTTP) session=%s platform=%s (episode deferred)",
+                    self._session_id,
+                    self._platform,
+                )
+            except Exception as err:
+                logger.warning("MemOS: HTTP bridge failed, falling back to stdio — %s", err)
                 with contextlib.suppress(Exception):
-                    new_bridge.close()
-            self._bridge = None
+                    http_bridge.close()  # type: ignore[union-attr]
+                self._bridge = None
+                viewer_status = "free"  # force stdio fallback below
+        elif viewer_status == "free":
+            # The daemon might be mid-startup from a concurrent session.
+            # Wait briefly and re-probe before spawning a second daemon.
+            time.sleep(1.0)
+            viewer_status = probe_viewer_status()
+            if viewer_status == "running_memos":
+                try:
+                    http_bridge_late: MemosHttpClient | None = MemosHttpClient()
+                    http_bridge_late.register_host_handler(
+                        "host.llm.complete",
+                        self._handle_host_llm_complete,
+                    )
+                    self._bridge = http_bridge_late
+                    self._open_session(session_id, timeout=60.0)
+                    logger.info(
+                        "MemOS: bridge ready (HTTP, late probe) session=%s platform=%s (episode deferred)",
+                        self._session_id,
+                        self._platform,
+                    )
+                except Exception as err:
+                    logger.warning("MemOS: HTTP bridge (late probe) failed, falling back to stdio — %s", err)
+                    with contextlib.suppress(Exception):
+                        http_bridge_late.close()  # type: ignore[union-attr]
+                    self._bridge = None
+
+        if self._bridge is None:
+            try:
+                ensure_viewer_daemon()
+            except Exception as err:
+                logger.warning("MemOS: viewer daemon check failed — %s", err)
+            new_bridge: MemosBridgeClient | None = None
+            try:
+                new_bridge = MemosBridgeClient()
+                # Register the fallback LLM handler BEFORE we open the
+                # session so it is available the very first time the
+                # plugin's facade asks for help (e.g. on the first
+                # `turn.start` retrieval call).
+                new_bridge.register_host_handler(
+                    "host.llm.complete",
+                    self._handle_host_llm_complete,
+                )
+                self._bridge = new_bridge
+                self._open_session(session_id, timeout=60.0)
+                logger.info(
+                    "MemOS: bridge ready (stdio) session=%s platform=%s (episode deferred)",
+                    self._session_id,
+                    self._platform,
+                )
+            except Exception as err:
+                logger.warning("MemOS: bridge init failed — %s", err)
+                if new_bridge is not None:
+                    with contextlib.suppress(Exception):
+                        new_bridge.close()
+                self._bridge = None
         # Register a Hermes plugin hook to capture tool calls as they
         # happen. The `post_tool_call` hook fires after every tool
         # dispatch (write_file, terminal, search_files, etc.) with the
@@ -1746,6 +1806,25 @@ class MemTensorProvider(MemoryProvider):
                 logger.info("MemOS: old bridge closed (pid=%s)", old_pid)
 
             ensure_bridge_running()
+            # Try HTTP first if daemon is running
+            viewer_status = probe_viewer_status()
+            if viewer_status == "running_memos":
+                try:
+                    http_bridge: MemosHttpClient | None = MemosHttpClient()
+                    http_bridge.register_host_handler(
+                        "host.llm.complete",
+                        self._handle_host_llm_complete,
+                    )
+                    self._bridge = http_bridge
+                    self._open_session(session_id, timeout=timeout)
+                    logger.info("MemOS: reconnected via HTTP")
+                    return
+                except Exception as err:
+                    logger.warning("MemOS: HTTP reconnect failed, falling back to stdio — %s", err)
+                    with contextlib.suppress(Exception):
+                        http_bridge.close()  # type: ignore[union-attr]
+                    self._bridge = None
+
             try:
                 ensure_viewer_daemon()
             except Exception as err:

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -304,7 +304,10 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
                 logger.warning("MemOS: failed to start viewer daemon — %s", err)
                 return False
 
-            deadline = time.time() + 15.0
+            # 45s is generous for cold Node.js starts (tsx compile + SQLite
+            # open + FTS warmup). Fast probes for the first 15s, then back
+            # off to 2s to avoid hammering a slow-starting daemon.
+            deadline = time.time() + 45.0
             while time.time() < deadline:
                 if _viewer_process.poll() is not None:
                     logger.warning(
@@ -324,8 +327,8 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
                         HERMES_VIEWER_PORT,
                     )
                     return False
-                time.sleep(0.5)
-            logger.warning("MemOS: viewer daemon did not become healthy within 15s")
+                time.sleep(0.5 if (deadline - time.time()) > 30 else 2.0)
+            logger.warning("MemOS: viewer daemon did not become healthy within 45s")
             return False
 
 

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -396,33 +396,47 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     for (const tr of existing) traceByTs.set(tr.ts, tr);
     const orphan = normalized.filter((s) => !traceByTs.has(s.ts));
     if (orphan.length > 0) {
-      log.warn("reflect.orphan_steps", {
-        episodeId: input.episode.id,
-        count: orphan.length,
-        action: "fallback_insert",
-      });
-      // These steps never went through runLite (likely a test path or a
-      // dropped event). Insert them now with reflection=null so the
-      // batch pass below can patch them like the rest.
-      const summStart = now();
-      const { summaries } = await runSummarize(
-        orphan.map((s) => ({
+      // During dirty-reward recovery (recoverDirtyClosedEpisodes), the episode
+      // snapshot is rebuilt from trace_ids_json. Any "orphan" steps here are
+      // artifact mismatches between snapshot timestamps and DB rows — NOT
+      // genuinely missing traces. Inserting them would grow trace_ids_json,
+      // keep reward.traceCount !== traceIds.length, and restart the recovery
+      // loop on every bridge start.
+      if (input.episode.meta?.recoveryReason === "dirty_reward_rescore") {
+        log.warn("reflect.orphan_steps_skipped_recovery", {
+          episodeId: input.episode.id,
+          count: orphan.length,
+          reason: "dirty_reward_rescore — skipping insert to break recovery loop",
+        });
+      } else {
+        log.warn("reflect.orphan_steps", {
+          episodeId: input.episode.id,
+          count: orphan.length,
+          action: "fallback_insert",
+        });
+        // These steps never went through runLite (likely a test path or a
+        // dropped event). Insert them now with reflection=null so the
+        // batch pass below can patch them like the rest.
+        const summStart = now();
+        const { summaries } = await runSummarize(
+          orphan.map((s) => ({
+            ...s,
+            reflection: { text: null, alpha: 0, usable: false, source: "none" },
+          })),
+          summStart,
+          llmCalls,
+          warnings,
+          { episodeId: input.episode.id, phase: "reflect" },
+        );
+        const orphanScored: ScoredStep[] = orphan.map((s) => ({
           ...s,
           reflection: { text: null, alpha: 0, usable: false, source: "none" },
-        })),
-        summStart,
-        llmCalls,
-        warnings,
-        { episodeId: input.episode.id, phase: "reflect" },
-      );
-      const orphanScored: ScoredStep[] = orphan.map((s) => ({
-        ...s,
-        reflection: { text: null, alpha: 0, usable: false, source: "none" },
-      }));
-      const { vecs } = await runEmbed(orphanScored, summaries, warnings);
-      const orphanRows = buildRows(orphanScored, summaries, vecs, input.episode);
-      await persistRows(orphanRows, input, warnings);
-      for (const r of orphanRows) traceByTs.set(r.ts, r);
+        }));
+        const { vecs } = await runEmbed(orphanScored, summaries, warnings);
+        const orphanRows = buildRows(orphanScored, summaries, vecs, input.episode);
+        await persistRows(orphanRows, input, warnings);
+        for (const r of orphanRows) traceByTs.set(r.ts, r);
+      }
     }
 
     if (normalized.length === 0) {

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -410,10 +410,22 @@ export function requireSession(
   agent?: string | null,
 ): boolean {
   // Public: auth endpoints + health (so the viewer can tell whether
-  // the backend is up BEFORE unlocking). Other API routes, including
-  // ping, fall through and are only open when no password is configured.
+  // the backend is up BEFORE unlocking). RPC endpoint is exempt for
+  // loopback callers only (local Python adapter, same machine, no
+  // browser session). Remote callers on the hub's 0.0.0.0 binding
+  // must still hold a valid session cookie.
   if (pathname.startsWith("/api/v1/auth/")) return true;
   if (pathname === "/api/v1/health") return true;
+  if (pathname === "/api/v1/rpc") {
+    const remote =
+      (req as unknown as { socket?: { remoteAddress?: string } }).socket
+        ?.remoteAddress ?? "";
+    const isLoopback =
+      remote === "127.0.0.1" ||
+      remote === "::1" ||
+      remote === "::ffff:127.0.0.1";
+    if (isLoopback) return true;
+  }
 
   const state = readAuthState(homeDir);
   if (!state) return true; // password protection off → open


### PR DESCRIPTION
Three fixes from companion-stable, tested on three Hermes instances.

### 1. Skip orphan trace insert during dirty-reward recovery
capture.ts — stops empty trace generation from dirty-reward loop (saved 44K traces / 268MB on one instance).

### 2. Bridge startup race fix
daemon_manager.py + __init__.py — 45s poll deadline with backoff, 60s session.open timeout, double-spawn prevention.

### 3. RPC loopback auth restriction
auth.ts — /api/v1/rpc now requires session cookie from non-loopback callers.