### PR TITLE
Fix #1518: (capture) Internal "Review the conversation above" prompts stored as user chunks

### DIFF
--- a/apps/memos-local-openclaw/src/capture/index.ts
+++ b/apps/memos-local-openclaw/src/capture/index.ts
@@ -7,6 +7,11 @@ const SYSTEM_BOILERPLATE_RE = /^A new session was started via \/new or \/reset\b
 // Boot-check / memory-system injection patterns that should never be stored.
 const BOOT_CHECK_RE = /^(?:You are running a boot check|Read HEARTBEAT\.md if it exists|## Memory system — ACTION REQUIRED)/;
 
+// Agent-framework self-instruction prompts (e.g. Hermes Agent's "Review the
+// conversation above, consider saving..."). These arrive with role="user"
+// but are not user content and must never be stored as memory.
+const REVIEW_CONVERSATION_RE = /^Review the conversation above/i;
+
 /**
  * Returns true for sentinel reply values that carry no user-facing content.
  */
@@ -79,6 +84,10 @@ export function captureMessages(
     }
     if (BOOT_CHECK_RE.test(msg.content.trim())) {
       log.debug(`Skipping boot-check injection: ${msg.content.slice(0, 60)}...`);
+      continue;
+    }
+    if (role === "user" && REVIEW_CONVERSATION_RE.test(msg.content.trim())) {
+      log.debug(`Skipping review-conversation injection: ${msg.content.slice(0, 60)}...`);
       continue;
     }
 

--- a/apps/memos-local-openclaw/tests/capture.test.ts
+++ b/apps/memos-local-openclaw/tests/capture.test.ts
@@ -148,4 +148,43 @@ describe("captureMessages", () => {
     const result = captureMessages(msgs, "s1", "t1", "STORED_MEMORY", noopLog);
     expect(result[0].content).toBe("普通的用户消息");
   });
+
+  it("should skip Hermes 'Review the conversation above' injected user prompts", () => {
+    const msgs = [
+      {
+        role: "user",
+        content:
+          "Review the conversation above, consider saving any durable facts to long-term memory.",
+      },
+      { role: "user", content: "Real user message" },
+    ];
+    const result = captureMessages(msgs, "s1", "t1", "STORED_MEMORY", noopLog);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("Real user message");
+  });
+
+  it("should skip 'Review the conversation above' regardless of case and trim whitespace", () => {
+    const msgs = [
+      {
+        role: "user",
+        content: "   review THE conversation above and decide what to keep.   ",
+      },
+    ];
+    const result = captureMessages(msgs, "s1", "t1", "STORED_MEMORY", noopLog);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should not skip 'Review the conversation above' when sent by assistant", () => {
+    // Assistant-generated text that happens to start with the same phrase
+    // is real assistant content, not an injected self-instruction. Keep it.
+    const msgs = [
+      {
+        role: "assistant",
+        content: "Review the conversation above to find the answer.",
+      },
+    ];
+    const result = captureMessages(msgs, "s1", "t1", "STORED_MEMORY", noopLog);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("assistant");
+  });
 });


### PR DESCRIPTION
## Description

Fixed #1518 by adding a REVIEW_CONVERSATION_RE filter to captureMessages() in apps/memos-local-openclaw/src/capture/index.ts that drops Hermes-style "Review the conversation above..." self-instruction prompts arriving with role="user", mirroring the existing BOOT_CHECK_RE pattern. Added 3 unit tests in tests/capture.test.ts covering the typical injection, case/whitespace variants, and the negative case (assistant-authored text starting with the same phrase is preserved). All 14 capture tests pass and `tsc --noEmit` is clean. Branch pushed; no gh CLI available in this environment, so scheduler should open the PR.

Related Issue (Required):  Fixes #1518

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Executor did not report tests.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

@CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1518
- [ ] Made sure Checks passed
- [ ] Tests have been provided
