### PR TITLE
fix(memos): address review feedback on PRs #1813 and #1817

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,18 @@ outputs
 evaluation/data/
 test_add_pipeline.py
 test_file_pipeline.py
+data/
+config.yaml
+
+# ── Runtime / ephemeral (Violet addition 2026-05-27) ──
+daemon/bridge.pid
+memos-local/
+bridge-status.json
+apps/memos-local-plugin/daemon/
+apps/memos-local-plugin/memos-local/
+apps/memos-local-plugin/.memos-node-bin
+apps/memos-local-plugin/bridge-status.json
+apps/memos-local-plugin/prod_check.cjs
+data.stale-backup/
+scripts/trigger-scoring.py
+data

--- a/.gitignore
+++ b/.gitignore
@@ -253,4 +253,3 @@ apps/memos-local-plugin/bridge-status.json
 apps/memos-local-plugin/prod_check.cjs
 data.stale-backup/
 scripts/trigger-scoring.py
-data

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -64,7 +64,7 @@ if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
 from bridge_client import BridgeError, MemosBridgeClient, MemosHttpClient  # noqa: E402
-from daemon_manager import ensure_bridge_running, ensure_viewer_daemon, probe_viewer_status, kill_zombie_bridges  # noqa: E402
+from daemon_manager import ensure_bridge_running, ensure_viewer_daemon, probe_viewer_status, kill_zombie_bridges, startup_lock_active  # noqa: E402
 
 
 try:  # pragma: no cover — host-provided base class, absent in unit tests
@@ -293,6 +293,23 @@ class MemTensorProvider(MemoryProvider):
 
     # ─── Lifecycle ────────────────────────────────────────────────────────
 
+    def _connect_http_bridge(self, session_id: str, *, timeout: float = 60.0) -> bool:
+        """Try to connect via HTTP bridge. Sets self._bridge on success."""
+        http_bridge: MemosHttpClient | None = None
+        try:
+            http_bridge = MemosHttpClient()
+            http_bridge.register_host_handler("host.llm.complete", self._handle_host_llm_complete)
+            self._bridge = http_bridge
+            self._open_session(session_id, timeout=timeout)
+            return True
+        except Exception as err:
+            logger.warning("MemOS: HTTP bridge failed, falling back to stdio — %s", err)
+            if http_bridge is not None:
+                with contextlib.suppress(Exception):
+                    http_bridge.close()
+            self._bridge = None
+            return False
+
     def initialize(self, session_id: str, **kwargs: Any) -> None:  # type: ignore[override]
         """Called once at agent startup.
 
@@ -329,49 +346,28 @@ class MemTensorProvider(MemoryProvider):
         # eliminates zombie bridge accumulation.
         viewer_status = probe_viewer_status()
         if viewer_status == "running_memos":
-            try:
-                http_bridge: MemosHttpClient | None = MemosHttpClient()
-                http_bridge.register_host_handler(
-                    "host.llm.complete",
-                    self._handle_host_llm_complete,
-                )
-                self._bridge = http_bridge
-                self._open_session(session_id, timeout=60.0)
+            if self._connect_http_bridge(session_id):
                 logger.info(
                     "MemOS: bridge ready (HTTP) session=%s platform=%s (episode deferred)",
                     self._session_id,
                     self._platform,
                 )
-            except Exception as err:
-                logger.warning("MemOS: HTTP bridge failed, falling back to stdio — %s", err)
-                with contextlib.suppress(Exception):
-                    http_bridge.close()  # type: ignore[union-attr]
-                self._bridge = None
+            else:
                 viewer_status = "free"  # force stdio fallback below
         elif viewer_status == "free":
-            # The daemon might be mid-startup from a concurrent session.
-            # Wait briefly and re-probe before spawning a second daemon.
-            time.sleep(1.0)
-            viewer_status = probe_viewer_status()
+            # Re-probe after a short wait only when another process may be
+            # mid-startup (startup lock is held). On a cold first-launch the
+            # lock doesn't exist, so we skip the delay entirely.
+            if startup_lock_active():
+                time.sleep(1.0)
+                viewer_status = probe_viewer_status()
             if viewer_status == "running_memos":
-                try:
-                    http_bridge_late: MemosHttpClient | None = MemosHttpClient()
-                    http_bridge_late.register_host_handler(
-                        "host.llm.complete",
-                        self._handle_host_llm_complete,
-                    )
-                    self._bridge = http_bridge_late
-                    self._open_session(session_id, timeout=60.0)
+                if self._connect_http_bridge(session_id):
                     logger.info(
                         "MemOS: bridge ready (HTTP, late probe) session=%s platform=%s (episode deferred)",
                         self._session_id,
                         self._platform,
                     )
-                except Exception as err:
-                    logger.warning("MemOS: HTTP bridge (late probe) failed, falling back to stdio — %s", err)
-                    with contextlib.suppress(Exception):
-                        http_bridge_late.close()  # type: ignore[union-attr]
-                    self._bridge = None
 
         if self._bridge is None:
             try:
@@ -1809,21 +1805,9 @@ class MemTensorProvider(MemoryProvider):
             # Try HTTP first if daemon is running
             viewer_status = probe_viewer_status()
             if viewer_status == "running_memos":
-                try:
-                    http_bridge: MemosHttpClient | None = MemosHttpClient()
-                    http_bridge.register_host_handler(
-                        "host.llm.complete",
-                        self._handle_host_llm_complete,
-                    )
-                    self._bridge = http_bridge
-                    self._open_session(session_id, timeout=timeout)
+                if self._connect_http_bridge(session_id, timeout=timeout):
                     logger.info("MemOS: reconnected via HTTP")
                     return
-                except Exception as err:
-                    logger.warning("MemOS: HTTP reconnect failed, falling back to stdio — %s", err)
-                    with contextlib.suppress(Exception):
-                        http_bridge.close()  # type: ignore[union-attr]
-                    self._bridge = None
 
             try:
                 ensure_viewer_daemon()

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -63,8 +63,8 @@ _PLUGIN_DIR = Path(__file__).resolve().parent
 if str(_PLUGIN_DIR) not in sys.path:
     sys.path.insert(0, str(_PLUGIN_DIR))
 
-from bridge_client import BridgeError, MemosBridgeClient  # noqa: E402
-from daemon_manager import ensure_bridge_running, ensure_viewer_daemon  # noqa: E402
+from bridge_client import BridgeError, MemosBridgeClient, MemosHttpClient  # noqa: E402
+from daemon_manager import ensure_bridge_running, ensure_viewer_daemon, probe_viewer_status, kill_zombie_bridges  # noqa: E402
 
 
 try:  # pragma: no cover — host-provided base class, absent in unit tests
@@ -243,7 +243,7 @@ class MemTensorProvider(MemoryProvider):
     """
 
     def __init__(self) -> None:
-        self._bridge: MemosBridgeClient | None = None
+        self._bridge: MemosBridgeClient | MemosHttpClient | None = None
         self._reconnect_lock = threading.Lock()
         self._session_id: str = ""
         self._episode_id: str = ""
@@ -314,34 +314,70 @@ class MemTensorProvider(MemoryProvider):
         except Exception as err:
             logger.warning("MemOS: failed to start bridge — %s", err)
             return
+
+        # Kill zombie bridges from previous sessions before deciding
+        # how to connect.
         try:
-            ensure_viewer_daemon()
-        except Exception as err:
-            logger.warning("MemOS: viewer daemon check failed — %s", err)
-        new_bridge: MemosBridgeClient | None = None
-        try:
-            new_bridge = MemosBridgeClient()
-            # Register the fallback LLM handler BEFORE we open the
-            # session so it is available the very first time the
-            # plugin's facade asks for help (e.g. on the first
-            # `turn.start` retrieval call).
-            new_bridge.register_host_handler(
-                "host.llm.complete",
-                self._handle_host_llm_complete,
-            )
-            self._bridge = new_bridge
-            self._open_session(session_id)
-            logger.info(
-                "MemOS: bridge ready session=%s platform=%s (episode deferred)",
-                self._session_id,
-                self._platform,
-            )
-        except Exception as err:
-            logger.warning("MemOS: bridge init failed — %s", err)
-            if new_bridge is not None:
+            zombies = kill_zombie_bridges()
+            if zombies:
+                logger.info("MemOS: killed %d zombie bridge(s)", zombies)
+        except Exception:
+            pass
+
+        # If the daemon is already running on the viewer port, connect
+        # to it over HTTP instead of spawning a new stdio bridge. This
+        # eliminates zombie bridge accumulation.
+        viewer_status = probe_viewer_status()
+        if viewer_status == "running_memos":
+            try:
+                http_bridge: MemosHttpClient | None = MemosHttpClient()
+                http_bridge.register_host_handler(
+                    "host.llm.complete",
+                    self._handle_host_llm_complete,
+                )
+                self._bridge = http_bridge
+                self._open_session(session_id)
+                logger.info(
+                    "MemOS: bridge ready (HTTP) session=%s platform=%s (episode deferred)",
+                    self._session_id,
+                    self._platform,
+                )
+            except Exception as err:
+                logger.warning("MemOS: HTTP bridge failed, falling back to stdio — %s", err)
                 with contextlib.suppress(Exception):
-                    new_bridge.close()
-            self._bridge = None
+                    http_bridge.close()  # type: ignore[union-attr]
+                self._bridge = None
+                viewer_status = "free"  # force stdio fallback below
+
+        if self._bridge is None:
+            try:
+                ensure_viewer_daemon()
+            except Exception as err:
+                logger.warning("MemOS: viewer daemon check failed — %s", err)
+            new_bridge: MemosBridgeClient | None = None
+            try:
+                new_bridge = MemosBridgeClient()
+                # Register the fallback LLM handler BEFORE we open the
+                # session so it is available the very first time the
+                # plugin's facade asks for help (e.g. on the first
+                # `turn.start` retrieval call).
+                new_bridge.register_host_handler(
+                    "host.llm.complete",
+                    self._handle_host_llm_complete,
+                )
+                self._bridge = new_bridge
+                self._open_session(session_id)
+                logger.info(
+                    "MemOS: bridge ready (stdio) session=%s platform=%s (episode deferred)",
+                    self._session_id,
+                    self._platform,
+                )
+            except Exception as err:
+                logger.warning("MemOS: bridge init failed — %s", err)
+                if new_bridge is not None:
+                    with contextlib.suppress(Exception):
+                        new_bridge.close()
+                self._bridge = None
         # Register a Hermes plugin hook to capture tool calls as they
         # happen. The `post_tool_call` hook fires after every tool
         # dispatch (write_file, terminal, search_files, etc.) with the
@@ -1746,6 +1782,25 @@ class MemTensorProvider(MemoryProvider):
                 logger.info("MemOS: old bridge closed (pid=%s)", old_pid)
 
             ensure_bridge_running()
+            # Try HTTP first if daemon is running
+            viewer_status = probe_viewer_status()
+            if viewer_status == "running_memos":
+                try:
+                    http_bridge: MemosHttpClient | None = MemosHttpClient()
+                    http_bridge.register_host_handler(
+                        "host.llm.complete",
+                        self._handle_host_llm_complete,
+                    )
+                    self._bridge = http_bridge
+                    self._open_session(session_id, timeout=timeout)
+                    logger.info("MemOS: reconnected via HTTP")
+                    return
+                except Exception as err:
+                    logger.warning("MemOS: HTTP reconnect failed, falling back to stdio — %s", err)
+                    with contextlib.suppress(Exception):
+                        http_bridge.close()  # type: ignore[union-attr]
+                    self._bridge = None
+
             try:
                 ensure_viewer_daemon()
             except Exception as err:

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -336,7 +336,7 @@ class MemTensorProvider(MemoryProvider):
                     self._handle_host_llm_complete,
                 )
                 self._bridge = http_bridge
-                self._open_session(session_id)
+                self._open_session(session_id, timeout=60.0)
                 logger.info(
                     "MemOS: bridge ready (HTTP) session=%s platform=%s (episode deferred)",
                     self._session_id,
@@ -348,6 +348,30 @@ class MemTensorProvider(MemoryProvider):
                     http_bridge.close()  # type: ignore[union-attr]
                 self._bridge = None
                 viewer_status = "free"  # force stdio fallback below
+        elif viewer_status == "free":
+            # The daemon might be mid-startup from a concurrent session.
+            # Wait briefly and re-probe before spawning a second daemon.
+            time.sleep(1.0)
+            viewer_status = probe_viewer_status()
+            if viewer_status == "running_memos":
+                try:
+                    http_bridge_late: MemosHttpClient | None = MemosHttpClient()
+                    http_bridge_late.register_host_handler(
+                        "host.llm.complete",
+                        self._handle_host_llm_complete,
+                    )
+                    self._bridge = http_bridge_late
+                    self._open_session(session_id, timeout=60.0)
+                    logger.info(
+                        "MemOS: bridge ready (HTTP, late probe) session=%s platform=%s (episode deferred)",
+                        self._session_id,
+                        self._platform,
+                    )
+                except Exception as err:
+                    logger.warning("MemOS: HTTP bridge (late probe) failed, falling back to stdio — %s", err)
+                    with contextlib.suppress(Exception):
+                        http_bridge_late.close()  # type: ignore[union-attr]
+                    self._bridge = None
 
         if self._bridge is None:
             try:
@@ -366,7 +390,7 @@ class MemTensorProvider(MemoryProvider):
                     self._handle_host_llm_complete,
                 )
                 self._bridge = new_bridge
-                self._open_session(session_id)
+                self._open_session(session_id, timeout=60.0)
                 logger.info(
                     "MemOS: bridge ready (stdio) session=%s platform=%s (episode deferred)",
                     self._session_id,

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -19,6 +19,9 @@ import os
 import shutil
 import subprocess
 import threading
+import time
+import urllib.error
+import urllib.request
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -419,4 +422,123 @@ class MemosBridgeClient:
             entry["error"] = msg["error"]
         else:
             entry["result"] = msg.get("result")
-        entry["event"].set()
+
+
+class MemosHttpClient:
+    """JSON-RPC 2.0 client that talks to the daemon bridge over HTTP.
+
+    Drop-in replacement for ``MemosBridgeClient`` when a daemon is already
+    running on the viewer port. Instead of spawning a new subprocess, this
+    client POSTs JSON-RPC envelopes to ``/api/v1/rpc`` on the daemon's HTTP
+    server. This eliminates zombie bridge accumulation.
+
+    Limitations vs. stdio client:
+    - No reverse-direction RPC (``host.llm.complete``). The daemon's own
+      stdio bridge handles host LLM fallback internally.
+    - No ``notify()`` (notifications have no response; use ``request()``
+      for all calls — the daemon handles both).
+    """
+
+    def __init__(
+        self,
+        *,
+        port: int = 18800,
+        host: str = "127.0.0.1",
+        api_key: str | None = None,
+    ) -> None:
+        self._base_url = f"http://{host}:{port}/api/v1/rpc"
+        self._lock = threading.Lock()
+        self._next_id = 1
+        self._closed = False
+        self._api_key = api_key
+        self._host_handlers: dict[str, Callable[[dict[str, Any]], Any]] = {}
+
+    @property
+    def pid(self) -> int:
+        """Return 0 — HTTP client has no subprocess."""
+        return 0
+
+    # ─── Public API (matches MemosBridgeClient) ──
+
+    def request(
+        self,
+        method: str,
+        params: Any = None,
+        *,
+        timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        if self._closed:
+            raise BridgeError("transport_closed", "HTTP client is closed")
+        with self._lock:
+            rpc_id = self._next_id
+            self._next_id += 1
+
+        envelope = {
+            "jsonrpc": "2.0",
+            "id": rpc_id,
+            "method": method,
+            "params": params,
+        }
+        payload = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+
+        req = urllib.request.Request(
+            self._base_url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        if self._api_key:
+            req.add_header("Authorization", f"Bearer {self._api_key}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = resp.read(4_194_304)  # 4 MiB safety cap
+        except urllib.error.HTTPError as exc:
+            # Try to read the JSON-RPC error body
+            try:
+                err_body = exc.read(4_194_304)
+                err_json = json.loads(err_body.decode("utf-8", errors="replace"))
+                err_obj = err_json.get("error") or {}
+                raise BridgeError(
+                    err_obj.get("data", {}).get("code") or str(err_obj.get("code", "internal")),
+                    err_obj.get("message", f"HTTP {exc.code}"),
+                    err_obj.get("data"),
+                ) from exc
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                raise BridgeError("internal", f"HTTP {exc.code}: {exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            raise BridgeError("transport_closed", str(exc)) from exc
+
+        result = json.loads(body.decode("utf-8", errors="replace"))
+        if "error" in result:
+            e = result["error"]
+            raise BridgeError(
+                (e.get("data") or {}).get("code") or str(e.get("code", "internal")),
+                e.get("message", "unknown error"),
+                e.get("data"),
+            )
+        return result.get("result") or {}
+
+    def notify(self, method: str, params: Any = None) -> None:
+        """No-op for HTTP — use request() for all calls."""
+        try:
+            self.request(method, params, timeout=5.0)
+        except Exception:
+            pass
+
+    def on_event(self, cb: Callable[[dict[str, Any]], None]) -> None:
+        """No-op — SSE events not supported over HTTP transport."""
+
+    def on_log(self, cb: Callable[[dict[str, Any]], None]) -> None:
+        """No-op — SSE logs not supported over HTTP transport."""
+
+    def register_host_handler(
+        self,
+        method: str,
+        handler: Callable[[dict[str, Any]], Any],
+    ) -> None:
+        """Store the handler but it won't be called (daemon handles host LLM internally)."""
+        self._host_handlers[method] = handler
+
+    def close(self) -> None:
+        self._closed = True

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -349,6 +350,15 @@ def probe_viewer_status() -> str:
     return _probe_viewer()
 
 
+def startup_lock_active() -> bool:
+    """Return True when the viewer-start.lock directory exists.
+
+    Used by the provider to skip the cold-start sleep when there is no
+    concurrent daemon launch in progress.
+    """
+    return (_plugin_root() / "daemon" / "viewer-start.lock").exists()
+
+
 def kill_zombie_bridges() -> int:
     """Kill all bridge.cjs processes that are NOT the daemon on port 18800.
 
@@ -356,12 +366,11 @@ def kill_zombie_bridges() -> int:
     owns port 18800) is left alone. This should be called early in the
     provider's lifecycle to clean up leftovers from crashed sessions.
     """
-    import subprocess as sp
-
-    # Find the PID that owns port 18800 (the real daemon)
+    # Find the PID that owns port 18800 (the real daemon).
+    # ss(8) is Linux-only; fall back to lsof on macOS.
     daemon_pid: int | None = None
     try:
-        ss_out = sp.check_output(
+        ss_out = subprocess.check_output(
             ["ss", "-tlnp"],
             timeout=2.0,
             text=True,
@@ -369,7 +378,6 @@ def kill_zombie_bridges() -> int:
         for line in ss_out.splitlines():
             if ":18800" in line:
                 # ss output: users:(("node",pid=21246,fd=24))
-                import re
                 m = re.search(r"pid=(\d+)", line)
                 if m:
                     daemon_pid = int(m.group(1))
@@ -377,10 +385,35 @@ def kill_zombie_bridges() -> int:
     except Exception:
         pass
 
+    if daemon_pid is None:
+        # macOS fallback — lsof is available on both Linux and macOS.
+        try:
+            lsof_out = subprocess.check_output(
+                ["lsof", "-iTCP:18800", "-sTCP:LISTEN", "-n", "-P"],
+                timeout=2.0,
+                text=True,
+            )
+            for line in lsof_out.splitlines()[1:]:  # skip header
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        daemon_pid = int(parts[1])
+                        break
+                    except ValueError:
+                        continue
+        except Exception:
+            pass
+
+    # If we still can't identify the daemon PID, skip killing entirely to
+    # avoid terminating the daemon itself.
+    if daemon_pid is None:
+        logger.debug("MemOS: zombie scan skipped — could not identify daemon PID on port 18800")
+        return 0
+
     # Find all bridge.cjs processes
     killed = 0
     try:
-        ps_out = sp.check_output(
+        ps_out = subprocess.check_output(
             ["ps", "aux"],
             timeout=2.0,
             text=True,
@@ -395,9 +428,8 @@ def kill_zombie_bridges() -> int:
                 pid = int(parts[1])
             except ValueError:
                 continue
-            if daemon_pid is not None and pid == daemon_pid:
+            if pid == daemon_pid:
                 continue
-            # This is a zombie — kill it
             try:
                 os.kill(pid, signal.SIGTERM)
                 killed += 1

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -304,7 +304,10 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
                 logger.warning("MemOS: failed to start viewer daemon — %s", err)
                 return False
 
-            deadline = time.time() + 15.0
+            # 45s is generous for cold Node.js starts (tsx compile + SQLite
+            # open + FTS warmup). Fast probes for the first 15s, then back
+            # off to 2s to avoid hammering a slow-starting daemon.
+            deadline = time.time() + 45.0
             while time.time() < deadline:
                 if _viewer_process.poll() is not None:
                     logger.warning(
@@ -324,8 +327,8 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
                         HERMES_VIEWER_PORT,
                     )
                     return False
-                time.sleep(0.5)
-            logger.warning("MemOS: viewer daemon did not become healthy within 15s")
+                time.sleep(0.5 if (deadline - time.time()) > 30 else 2.0)
+            logger.warning("MemOS: viewer daemon did not become healthy within 45s")
             return False
 
 

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -336,6 +336,77 @@ def shutdown_bridge() -> None:
         _bridge_ok = None
 
 
+def probe_viewer_status() -> str:
+    """Return the current viewer daemon status without side effects.
+
+    Returns one of: ``"running_memos"``, ``"free"``, ``"blocked"``.
+    This is a cheap, lock-free probe suitable for deciding whether to
+    spawn a new stdio bridge or connect to the existing daemon over HTTP.
+    """
+    return _probe_viewer()
+
+
+def kill_zombie_bridges() -> int:
+    """Kill all bridge.cjs processes that are NOT the daemon on port 18800.
+
+    Returns the number of zombies killed. The daemon (the process that
+    owns port 18800) is left alone. This should be called early in the
+    provider's lifecycle to clean up leftovers from crashed sessions.
+    """
+    import subprocess as sp
+
+    # Find the PID that owns port 18800 (the real daemon)
+    daemon_pid: int | None = None
+    try:
+        ss_out = sp.check_output(
+            ["ss", "-tlnp"],
+            timeout=2.0,
+            text=True,
+        )
+        for line in ss_out.splitlines():
+            if ":18800" in line:
+                # ss output: users:(("node",pid=21246,fd=24))
+                import re
+                m = re.search(r"pid=(\d+)", line)
+                if m:
+                    daemon_pid = int(m.group(1))
+                    break
+    except Exception:
+        pass
+
+    # Find all bridge.cjs processes
+    killed = 0
+    try:
+        ps_out = sp.check_output(
+            ["ps", "aux"],
+            timeout=2.0,
+            text=True,
+        )
+        for line in ps_out.splitlines():
+            if "bridge.cjs" not in line or "grep" in line:
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            try:
+                pid = int(parts[1])
+            except ValueError:
+                continue
+            if daemon_pid is not None and pid == daemon_pid:
+                continue
+            # This is a zombie — kill it
+            try:
+                os.kill(pid, signal.SIGTERM)
+                killed += 1
+                logger.info("MemOS: killed zombie bridge pid=%d", pid)
+            except (OSError, ProcessLookupError):
+                pass
+    except Exception as err:
+        logger.debug("MemOS: zombie scan failed — %s", err)
+
+    return killed
+
+
 def wait_for_process_exit(pid: int, timeout: float = 5.0) -> bool:
     """Wait for a process to exit.
 

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -33,6 +33,7 @@ import { extractSteps } from "./step-extractor.js";
 import { createSummarizer, type Summarizer } from "./summarizer.js";
 import { tagsForStep } from "./tagger.js";
 import { extractErrorSignatures } from "./error-signature.js";
+import { RECOVERY_REASONS } from "../pipeline/recovery-constants.js";
 import type {
   CaptureConfig,
   CaptureEvent,
@@ -402,7 +403,7 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
       // genuinely missing traces. Inserting them would grow trace_ids_json,
       // keep reward.traceCount !== traceIds.length, and restart the recovery
       // loop on every bridge start.
-      if (input.episode.meta?.recoveryReason === "dirty_reward_rescore") {
+      if (input.episode.meta?.recoveryReason === RECOVERY_REASONS.DIRTY_REWARD_RESCORE) {
         log.warn("reflect.orphan_steps_skipped_recovery", {
           episodeId: input.episode.id,
           count: orphan.length,

--- a/apps/memos-local-plugin/core/capture/capture.ts
+++ b/apps/memos-local-plugin/core/capture/capture.ts
@@ -396,33 +396,47 @@ export function createCaptureRunner(deps: CaptureDeps): CaptureRunner {
     for (const tr of existing) traceByTs.set(tr.ts, tr);
     const orphan = normalized.filter((s) => !traceByTs.has(s.ts));
     if (orphan.length > 0) {
-      log.warn("reflect.orphan_steps", {
-        episodeId: input.episode.id,
-        count: orphan.length,
-        action: "fallback_insert",
-      });
-      // These steps never went through runLite (likely a test path or a
-      // dropped event). Insert them now with reflection=null so the
-      // batch pass below can patch them like the rest.
-      const summStart = now();
-      const { summaries } = await runSummarize(
-        orphan.map((s) => ({
+      // During dirty-reward recovery (recoverDirtyClosedEpisodes), the episode
+      // snapshot is rebuilt from trace_ids_json. Any "orphan" steps here are
+      // artifact mismatches between snapshot timestamps and DB rows — NOT
+      // genuinely missing traces. Inserting them would grow trace_ids_json,
+      // keep reward.traceCount !== traceIds.length, and restart the recovery
+      // loop on every bridge start.
+      if (input.episode.meta?.recoveryReason === "dirty_reward_rescore") {
+        log.warn("reflect.orphan_steps_skipped_recovery", {
+          episodeId: input.episode.id,
+          count: orphan.length,
+          reason: "dirty_reward_rescore — skipping insert to break recovery loop",
+        });
+      } else {
+        log.warn("reflect.orphan_steps", {
+          episodeId: input.episode.id,
+          count: orphan.length,
+          action: "fallback_insert",
+        });
+        // These steps never went through runLite (likely a test path or a
+        // dropped event). Insert them now with reflection=null so the
+        // batch pass below can patch them like the rest.
+        const summStart = now();
+        const { summaries } = await runSummarize(
+          orphan.map((s) => ({
+            ...s,
+            reflection: { text: null, alpha: 0, usable: false, source: "none" },
+          })),
+          summStart,
+          llmCalls,
+          warnings,
+          { episodeId: input.episode.id, phase: "reflect" },
+        );
+        const orphanScored: ScoredStep[] = orphan.map((s) => ({
           ...s,
           reflection: { text: null, alpha: 0, usable: false, source: "none" },
-        })),
-        summStart,
-        llmCalls,
-        warnings,
-        { episodeId: input.episode.id, phase: "reflect" },
-      );
-      const orphanScored: ScoredStep[] = orphan.map((s) => ({
-        ...s,
-        reflection: { text: null, alpha: 0, usable: false, source: "none" },
-      }));
-      const { vecs } = await runEmbed(orphanScored, summaries, warnings);
-      const orphanRows = buildRows(orphanScored, summaries, vecs, input.episode);
-      await persistRows(orphanRows, input, warnings);
-      for (const r of orphanRows) traceByTs.set(r.ts, r);
+        }));
+        const { vecs } = await runEmbed(orphanScored, summaries, warnings);
+        const orphanRows = buildRows(orphanScored, summaries, vecs, input.episode);
+        await persistRows(orphanRows, input, warnings);
+        for (const r of orphanRows) traceByTs.set(r.ts, r);
+      }
     }
 
     if (normalized.length === 0) {

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -89,6 +89,7 @@ import {
 } from "../llm/host-bridge.js";
 
 import { createPipeline } from "./orchestrator.js";
+import { RECOVERY_REASONS } from "./recovery-constants.js";
 import { wrapRetrievalRepos } from "./retrieval-repos.js";
 import type { PipelineDeps, PipelineHandle } from "./types.js";
 import {
@@ -1248,10 +1249,10 @@ export function createMemoryCore(
       handle.repos.episodes.updateMeta(episodeId, {
         closeReason: "finalized",
         recoveredAtStartup: endedAt,
-        recoveryReason: "dirty_reward_rescore",
+        recoveryReason: RECOVERY_REASONS.DIRTY_REWARD_RESCORE,
       });
       const snapshot = snapshotFromRecoveredEpisode(ep, endedAt, {
-        recoveryReason: "dirty_reward_rescore",
+        recoveryReason: RECOVERY_REASONS.DIRTY_REWARD_RESCORE,
       });
       handle.buses.session.emit({
         kind: "episode.finalized",

--- a/apps/memos-local-plugin/core/pipeline/recovery-constants.ts
+++ b/apps/memos-local-plugin/core/pipeline/recovery-constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared string constants for episode recovery reasons.
+ *
+ * Both `memory-core.ts` (which sets recoveryReason) and `capture.ts`
+ * (which checks it) import from here so a rename can't silently
+ * break the orphan-skip guard.
+ */
+export const RECOVERY_REASONS = {
+  DIRTY_REWARD_RESCORE: "dirty_reward_rescore",
+} as const;
+
+export type RecoveryReason = (typeof RECOVERY_REASONS)[keyof typeof RECOVERY_REASONS];

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -410,13 +410,22 @@ export function requireSession(
   agent?: string | null,
 ): boolean {
   // Public: auth endpoints + health (so the viewer can tell whether
-  // the backend is up BEFORE unlocking). RPC endpoint is exempt
-  // because it's used by the local Python adapter (same machine, no
-  // browser session). Other API routes, including ping, fall through
-  // and are only open when no password is configured.
+  // the backend is up BEFORE unlocking). RPC endpoint is exempt for
+  // loopback callers only (local Python adapter, same machine, no
+  // browser session). Remote callers on the hub's 0.0.0.0 binding
+  // must still hold a valid session cookie.
   if (pathname.startsWith("/api/v1/auth/")) return true;
   if (pathname === "/api/v1/health") return true;
-  if (pathname === "/api/v1/rpc") return true;
+  if (pathname === "/api/v1/rpc") {
+    const remote =
+      (req as unknown as { socket?: { remoteAddress?: string } }).socket
+        ?.remoteAddress ?? "";
+    const isLoopback =
+      remote === "127.0.0.1" ||
+      remote === "::1" ||
+      remote === "::ffff:127.0.0.1";
+    if (isLoopback) return true;
+  }
 
   const state = readAuthState(homeDir);
   if (!state) return true; // password protection off → open

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -414,6 +414,11 @@ export function requireSession(
   // loopback callers only (local Python adapter, same machine, no
   // browser session). Remote callers on the hub's 0.0.0.0 binding
   // must still hold a valid session cookie.
+  //
+  // ASSUMPTION: the server binds directly (no reverse proxy). If a
+  // reverse proxy is ever added, socket.remoteAddress will be the
+  // proxy address and X-Forwarded-For must be consulted instead, or
+  // this loopback exemption will bypass auth for all proxy traffic.
   if (pathname.startsWith("/api/v1/auth/")) return true;
   if (pathname === "/api/v1/health") return true;
   if (pathname === "/api/v1/rpc") {

--- a/apps/memos-local-plugin/server/routes/auth.ts
+++ b/apps/memos-local-plugin/server/routes/auth.ts
@@ -410,10 +410,13 @@ export function requireSession(
   agent?: string | null,
 ): boolean {
   // Public: auth endpoints + health (so the viewer can tell whether
-  // the backend is up BEFORE unlocking). Other API routes, including
-  // ping, fall through and are only open when no password is configured.
+  // the backend is up BEFORE unlocking). RPC endpoint is exempt
+  // because it's used by the local Python adapter (same machine, no
+  // browser session). Other API routes, including ping, fall through
+  // and are only open when no password is configured.
   if (pathname.startsWith("/api/v1/auth/")) return true;
   if (pathname === "/api/v1/health") return true;
+  if (pathname === "/api/v1/rpc") return true;
 
   const state = readAuthState(homeDir);
   if (!state) return true; // password protection off → open

--- a/apps/memos-local-plugin/server/routes/registry.ts
+++ b/apps/memos-local-plugin/server/routes/registry.ts
@@ -46,6 +46,7 @@ import { registerApiLogsRoutes } from "./api-logs.js";
 import { registerDiagRoutes } from "./diag.js";
 import { registerEmbeddingRoutes } from "./embeddings.js";
 import { registerTelemetryRoutes } from "./telemetry.js";
+import { registerRpcRoutes } from "./rpc.js";
 
 export interface RouteContext {
   req: IncomingMessage;
@@ -183,6 +184,7 @@ export function buildRoutes(
   registerApiLogsRoutes(routes, deps);
   registerDiagRoutes(routes, deps);
   registerTelemetryRoutes(routes, deps);
+  registerRpcRoutes(routes, deps);
   return routes;
 }
 

--- a/apps/memos-local-plugin/server/routes/rpc.ts
+++ b/apps/memos-local-plugin/server/routes/rpc.ts
@@ -1,0 +1,138 @@
+/**
+ * JSON-RPC-over-HTTP route — `/api/v1/rpc`.
+ *
+ * Accepts a single JSON-RPC 2.0 request envelope (or a batch) and
+ * dispatches via the same `makeDispatcher` the stdio bridge uses.
+ * This allows the Python adapter to talk to an already-running daemon
+ * over HTTP instead of spawning a new stdio bridge subprocess, which
+ * eliminates zombie bridge accumulation.
+ *
+ * ## Protocol
+ *
+ * `POST /api/v1/rpc` accepts:
+ * - A single JSON-RPC request: `{"jsonrpc":"2.0","id":1,"method":"turn.start","params":{...}}`
+ * - A batch: `[{...}, {...}]`
+ *
+ * Notifications (no `id`) are accepted and return 204.
+ * Responses follow JSON-RPC 2.0 spec.
+ *
+ * ## Security
+ *
+ * Inherit the same auth gating as all `/api/*` routes:
+ * loopback default + optional API key + session cookie.
+ */
+
+import type { Routes } from "./registry.js";
+import type { ServerDeps } from "../types.js";
+import { makeDispatcher, errorCodeOf } from "../../bridge/methods.js";
+import { MemosError } from "../../agent-contract/errors.js";
+import type { ErrorCode } from "../../agent-contract/errors.js";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number | string | null;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: { code: ErrorCode };
+  };
+}
+
+const JSONRPC_INVALID_REQUEST = -32600;
+const JSONRPC_METHOD_NOT_FOUND = -32601;
+const JSONRPC_INVALID_PARAMS = -32602;
+const JSONRPC_INTERNAL_ERROR = -32603;
+
+function memosErrorCodeToJsonRpc(code: ErrorCode): number {
+  switch (code) {
+    case "unknown_method": return JSONRPC_METHOD_NOT_FOUND;
+    case "invalid_argument": return JSONRPC_INVALID_PARAMS;
+    default: return JSONRPC_INTERNAL_ERROR;
+  }
+}
+
+export function registerRpcRoutes(routes: Routes, deps: ServerDeps): void {
+  const dispatch = makeDispatcher(deps.core, { strict: false });
+
+  routes.set("POST /api/v1/rpc", async (ctx) => {
+    let parsed: unknown;
+    try {
+      const text = ctx.body.toString("utf-8");
+      parsed = JSON.parse(text);
+    } catch {
+      return {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: JSONRPC_INVALID_REQUEST, message: "Parse error" },
+      } satisfies JsonRpcResponse;
+    }
+
+    // Batch support
+    if (Array.isArray(parsed)) {
+      const results = await Promise.all(
+        parsed.map((item) => handleSingle(item, dispatch)),
+      );
+      return results;
+    }
+
+    return await handleSingle(parsed, dispatch);
+  });
+}
+
+async function handleSingle(
+  raw: unknown,
+  dispatch: ReturnType<typeof makeDispatcher>,
+): Promise<JsonRpcResponse> {
+  if (!isRpcRequest(raw)) {
+    return {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: JSONRPC_INVALID_REQUEST, message: "Invalid Request" },
+    };
+  }
+
+  // Notification — fire and forget
+  if (raw.id === undefined || raw.id === null) {
+    try {
+      await dispatch(raw.method, raw.params);
+    } catch {
+      // Notifications must not return errors per spec
+    }
+    return undefined as unknown as JsonRpcResponse; // 204 handled by caller
+  }
+
+  try {
+    const result = await dispatch(raw.method, raw.params);
+    return { jsonrpc: "2.0", id: raw.id, result };
+  } catch (err) {
+    const code = errorCodeOf(err);
+    const message =
+      err instanceof MemosError ? err.message : String(err);
+    return {
+      jsonrpc: "2.0",
+      id: raw.id,
+      error: {
+        code: memosErrorCodeToJsonRpc(code),
+        message,
+        data: { code },
+      },
+    };
+  }
+}
+
+function isRpcRequest(v: unknown): v is JsonRpcRequest {
+  if (typeof v !== "object" || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    obj.jsonrpc === "2.0" &&
+    typeof obj.method === "string"
+  );
+}

--- a/apps/memos-local-plugin/server/routes/rpc.ts
+++ b/apps/memos-local-plugin/server/routes/rpc.ts
@@ -77,10 +77,15 @@ export function registerRpcRoutes(routes: Routes, deps: ServerDeps): void {
 
     // Batch support
     if (Array.isArray(parsed)) {
-      const results = await Promise.all(
+      const all = await Promise.all(
         parsed.map((item) => handleSingle(item, dispatch)),
       );
-      return results;
+      // Per JSON-RPC 2.0 §6: notifications produce no response object.
+      // Filter out undefined so they don't serialize as null.
+      const results = all.filter((r): r is JsonRpcResponse => r !== undefined);
+      // If every item was a notification, return nothing (204).
+      if (results.length === 0) return undefined as unknown as JsonRpcResponse;
+      return results as unknown as JsonRpcResponse;
     }
 
     return await handleSingle(parsed, dispatch);

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -26,6 +26,7 @@ import {
   __resetHostLlmBridgeForTests,
   type HostLlmBridge,
 } from "../../../core/llm/index.js";
+import { RECOVERY_REASONS } from "../../../core/pipeline/recovery-constants.js";
 import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
 import { makeTmpHome, type TmpHomeContext } from "../../helpers/tmp-home.js";
 import { fakeEmbedder } from "../../helpers/fake-embedder.js";
@@ -1363,7 +1364,7 @@ algorithm:
       reward?: { traceCount?: number; traceIds?: string[] };
     };
     expect(meta.rewardDirty).toBeUndefined();
-    expect(meta.recoveryReason).toBe("dirty_reward_rescore");
+    expect(meta.recoveryReason).toBe(RECOVERY_REASONS.DIRTY_REWARD_RESCORE);
     expect(meta.reward?.traceCount).toBe(1);
     expect(meta.reward?.traceIds).toEqual(["tr_dirty"]);
   });
@@ -1452,7 +1453,7 @@ algorithm:
       recoveryReason?: string;
       reward?: { traceCount?: number; traceIds?: string[] };
     };
-    expect(meta.recoveryReason).toBe("dirty_reward_rescore");
+    expect(meta.recoveryReason).toBe(RECOVERY_REASONS.DIRTY_REWARD_RESCORE);
     expect(meta.reward?.traceCount).toBe(1);
     expect(meta.reward?.traceIds).toEqual(["tr_missing_reward"]);
   });


### PR DESCRIPTION
## Summary

Addresses all feedback from the Memtensor-AI reviews on PRs #1813 (HTTP transport + JSON-RPC endpoint) and #1817 (bridge startup race, orphan trace fix, RPC loopback auth). This branch consolidates both PRs plus the review fixes.

## Changes

**Ship-stoppers**

- **`auth.ts`**: Added comment documenting the direct-bind assumption on the loopback RPC exemption. If a reverse proxy is ever introduced, `socket.remoteAddress` reflects the proxy IP and `X-Forwarded-For` must be consulted instead — auth will bypass silently without this documented.

- **`__init__.py`**: Fixed unbound `http_bridge` / `http_bridge_late` — the type annotation and constructor were on the same line, so a constructor exception left the variable unbound when the `except` block called `.close()`. Extracted `_connect_http_bridge()` helper which deduplicates the three identical connect-and-register sites and correctly initializes to `None` before constructing.

- **`capture.ts` + `memory-core.ts`**: Extracted `"dirty_reward_rescore"` to `core/pipeline/recovery-constants.ts` as `RECOVERY_REASONS.DIRTY_REWARD_RESCORE`; both files and the test now import the shared constant. A rename in the recovery path no longer silently breaks the orphan-skip guard in `capture.ts`.

**Bugs**

- **`rpc.ts`**: Batch notifications were serializing as `null` (JSON-RPC 2.0 §6 violation). Added type-predicate filter to strip `undefined` results; all-notifications batch now returns 204 instead of an empty array (also forbidden by §6).

- **`daemon_manager.py`**: `ss -tlnp` is Linux-only — on macOS `daemon_pid` was always `None`, causing `kill_zombie_bridges` to kill every `bridge.cjs` process including the daemon itself. Added `lsof -iTCP:18800 -sTCP:LISTEN` macOS fallback; skips killing entirely if PID still cannot be identified.

**Should-fix / nits**

- **`daemon_manager.py`**: `import re` moved to module level; added `startup_lock_active()` helper.
- **`__init__.py`**: Cold-start re-probe delay is now conditional on `startup_lock_active()` — skipped on first cold launch.
- **`.gitignore`**: Removed redundant bare `data` entry.
- **`memory-core.test.ts`**: Updated assertions to use `RECOVERY_REASONS.DIRTY_REWARD_RESCORE`.

## Related

Addresses review feedback on #1813 and #1817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)