### PR TITLE
Fix #1845: fix: 修一下util里的timer_with_status的问题

### DIFF
--- a/src/memos/utils.py
+++ b/src/memos/utils.py
@@ -165,6 +165,7 @@ def timed_with_status(
             exc_message = None
             result = None
             success_flag = False
+            exception_to_raise: Exception | None = None
 
             try:
                 result = fn(*args, **kwargs)
@@ -179,6 +180,12 @@ def timed_with_status(
                 if fallback is not None and callable(fallback):
                     result = fallback(e, *args, **kwargs)
                     return result
+                # No fallback: remember the exception so we can re-raise it
+                # *after* the ``finally`` block has emitted the status log.
+                # A bare ``raise`` here would also work, but storing the
+                # reference makes the intent explicit and keeps the finally
+                # block solely responsible for logging.
+                exception_to_raise = e
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000.0
 
@@ -218,6 +225,13 @@ def timed_with_status(
 
                 logger.info(msg)
 
+            # Re-raise *after* the finally block has run so the status log
+            # is still emitted for failures without a fallback. Using
+            # ``raise <exc>`` (not bare ``raise``) here because the except
+            # block has already exited.
+            if exception_to_raise is not None:
+                raise exception_to_raise
+
         return wrapper
 
     if func is None:
@@ -227,6 +241,7 @@ def timed_with_status(
 
 def timed(func=None, *, log=True, log_prefix=""):
     def decorator(fn):
+        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             start = time.perf_counter()
             result = fn(*args, **kwargs)

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -292,6 +292,17 @@ class TestTimedRegression:
         assert bare() == 1
         assert parens() == 2
 
+    def test_preserves_function_metadata(self):
+        """@timed must preserve __name__ / __doc__ via functools.wraps."""
+
+        @timed
+        def documented_func():
+            """I have a docstring."""
+            return 42
+
+        assert documented_func.__name__ == "documented_func"
+        assert documented_func.__doc__ == "I have a docstring."
+
 
 # ===========================================================================
 # timed_with_status — regression tests
@@ -313,16 +324,45 @@ class TestTimedWithStatusRegression:
         assert "ok_func" in logs[0]
 
     def test_failure_logging_no_fallback(self, caplog):
+        """Without a fallback the original exception must propagate.
+
+        The [TIMER_WITH_STATUS] log line is emitted from ``finally`` so it
+        is still produced *before* the exception unwinds out of the
+        wrapper — caplog captures it either way.
+        """
+
         @timed_with_status
         def fail_func():
             raise RuntimeError("bad")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.INFO), pytest.raises(RuntimeError, match="bad"):
             fail_func()
         logs = _collect_timer_with_status_logs(caplog)
         assert len(logs) == 1
         assert "status: FAILED" in logs[0]
         assert "RuntimeError" in logs[0]
+
+    def test_failure_no_fallback_preserves_original_exception(self):
+        """Re-raise must keep the original exception identity / chain.
+
+        Using a sentinel attribute on the raised exception is the simplest
+        way to assert the *same* object is propagated (no wrapping in a
+        new exception type, no ``raise ... from None``).
+        """
+        marker = object()
+
+        @timed_with_status
+        def fail_func():
+            err = RuntimeError("identity")
+            err.marker = marker  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(RuntimeError) as excinfo:
+            fail_func()
+        assert getattr(excinfo.value, "marker", None) is marker
+        # No exception chaining was introduced by the decorator.
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__ is False
 
     def test_failure_with_fallback(self, caplog):
         @timed_with_status(fallback=lambda e, *a, **kw: "fallback_val")


### PR DESCRIPTION
## Description

修复 `src/memos/utils.py::timed_with_status` 的静默吞异常 bug。原行为：当未传 `fallback` 时，被装饰函数抛出的异常会被 `except` 捕获后丢失，包装器返回 `None`——这正是 `format_utils.py:1410-1415` 里那条"clean_json_response received None — upstream LLM call likely failed silently"防御注释指控的源头。新行为：未传 `fallback` 时，先在 `finally` 内照常打 `[TIMER_WITH_STATUS] ... status: FAILED` 日志，再把原异常重新抛出，traceback / `__cause__` / `__context__` 保持不变；传了 `fallback` 时路径完全不变。顺手给 `timed` 装饰器补了 `functools.wraps`，停止把 `__name__` / `__doc__` 弄丢。

生产侧受影响的两个调用点 `OpenAILLM.generate` / `generate_stream` 函数体内本来就有 `raise`，装饰器现在终于把这个意图传到上层；另外三个用了 `fallback` 的调用点 (`UniversalAPIEmbedder.get_embeddings`、`HttpBGEReranker.rerank`) 行为零变化。

测试改动：把原 `test_failure_logging_no_fallback`（之前以"应静默"为契约）改成断言异常需向上传播且 FAILED 日志仍要打；新增 `test_failure_no_fallback_preserves_original_exception`（同对象身份 + 无合成链）和 `test_preserves_function_metadata` (`@timed` 元数据)。沙箱内无法跑 `make test`（缺 `transformers` 等大依赖），用最小化 `memos` 命名空间桩跑 `pytest tests/test_utils_timing.py` 得 `33 passed`；并把修复回滚为旧实现重跑两条新用例，两条均按预期 `DID NOT RAISE` 红——TDD 证据完整。`ruff check` / `ruff format --check` 在改动文件上均通过；本地分支已 push 到 `origin/autodev/MemOS-1845`。specs 仓库归档了 `00-decision.md` / `01-clarification.md` / `03-fix.md` / `04-integration-report.md`。

Related Issue (Required):  Fixes #1845

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Executor did not report tests.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

@CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1845
- [ ] Made sure Checks passed
- [ ] Tests have been provided


## 📋 opsp 产物

本任务的设计文档、澄清记录、集成报告归档在 specs 仓库：
https://github.com/MemTensor/memos-autodev-specs/tree/main/2026-06-01-1845-fix-修一下util里的timerwithstatus的问题/

（异步推送，短时间内访问可能 404，稍候再试。）
