### PR TITLE
chore: remove pending label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: "\U0001F41B Bug Report"
 description: Report a bug to help us improve MemOS | 报告错误以帮助我们改进 MemOS
 title: "fix: "
-labels: ["bug", "pending"]
+labels: ["bug"]
 body:
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: "\U0001F680 Feature request"
 description: Submit a request for a new feature | 申请添加新功能
 title: "feat: "
-labels: ["enhancement", "pending"]
+labels: ["enhancement"]
 body:
 
   - type: checkboxes


### PR DESCRIPTION
## Summary

- Remove `pending` label from bug report and feature request issue templates
- Labels are now auto-managed by the AutoDev scheduler webhook

## Test plan

- [x] Verify templates only apply `bug` / `enhancement` label on issue creation
- [x] Confirm `pending` label is no longer auto-applied