### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/examples/basic_modules/llm.py
+++ b/examples/basic_modules/llm.py
@@ -167,14 +167,14 @@ print("Scenario 6:", resp)
 # Scenario 7: Using LLMFactory with MiniMax (OpenAI-compatible API)
 # Prerequisites:
 # 1. Get your API key from the MiniMax platform.
-# 2. Available models: MiniMax-M2.7 (flagship), MiniMax-M2.7-highspeed (low-latency),
-#    MiniMax-M2.5, MiniMax-M2.5-highspeed.
+# 2. Available models: MiniMax-M3 (flagship, default), MiniMax-M2.7,
+#    MiniMax-M2.7-highspeed (low-latency).
 
 cfg_mm = LLMConfigFactory.model_validate(
     {
         "backend": "minimax",
         "config": {
-            "model_name_or_path": "MiniMax-M2.7",
+            "model_name_or_path": "MiniMax-M3",
             "api_key": "your-minimax-api-key",
             "api_base": "https://api.minimax.io/v1",
             "temperature": 0.7,

--- a/src/memos/api/config.py
+++ b/src/memos/api/config.py
@@ -288,7 +288,7 @@ class APIConfig:
     def minimax_config() -> dict[str, Any]:
         """Get MiniMax configuration."""
         return {
-            "model_name_or_path": os.getenv("MOS_CHAT_MODEL", "MiniMax-M2.7"),
+            "model_name_or_path": os.getenv("MOS_CHAT_MODEL", "MiniMax-M3"),
             "temperature": float(os.getenv("MOS_CHAT_TEMPERATURE", "0.8")),
             "max_tokens": int(os.getenv("MOS_MAX_TOKENS", "8000")),
             "top_p": float(os.getenv("MOS_TOP_P", "0.9")),


### PR DESCRIPTION
## Summary

Upgrades the MiniMax default chat model from M2.7 to M3 in MemOS, following the established pattern from the merged PR #1291 (M2.6 -> M2.7).

M3 is the new MiniMax flagship: 512K context window, 128K max output tokens, and image input support across both the OpenAI-compatible and Anthropic-compatible interfaces exposed by `https://api.minimax.io`.

## Changes

- `src/memos/api/config.py`: Default `MOS_CHAT_MODEL` fallback switched from `MiniMax-M2.7` to `MiniMax-M3` in `APIConfig.minimax_config()`.
- `examples/basic_modules/llm.py`: Scenario 7 example updated to use `MiniMax-M3`, and the "Available models" comment refreshed to list the current supported set.

## Model support matrix

| Model | Status |
|---|---|
| `MiniMax-M3` | **New default (flagship)** |
| `MiniMax-M2.7` | Retained (still supported) |
| `MiniMax-M2.7-highspeed` | Retained (low-latency) |
| `MiniMax-M2.5` | Dropped from example list (deprecated upstream) |
| `MiniMax-M2.5-highspeed` | Dropped from example list (deprecated upstream) |

`M2.7` and `M2.7-highspeed` are intentionally kept: the change only flips the default when `MOS_CHAT_MODEL` is unset; users who pin a specific model via env var are unaffected. The `MinimaxLLM` and `MinimaxLLMConfig` classes are untouched, and no API URL or provider wiring changes are introduced.

## Scope

- Pure config/default change.
- No dependency bumps, no API URL changes, no new provider wiring.
- Test pinning (`tests/llms/test_minimax.py`, `tests/configs/test_llm.py`) continues to exercise M2.7 / M2.7-highspeed and is unchanged.

## Verification

- `python -m pytest tests/llms/test_minimax.py tests/configs/test_llm.py` continues to pass (existing tests pin M2.7 / M2.7-highspeed, both still valid).
- Confirmed `MiniMax-M3` is reachable via the OpenAI-compatible endpoint at `https://api.minimax.io/v1`.