### PR TITLE
fix(neo4j): cascade delete vectors from Qdrant when deleting memory nodes

### DIFF
--- a/src/memos/graph_dbs/neo4j_community.py
+++ b/src/memos/graph_dbs/neo4j_community.py
@@ -1038,31 +1038,44 @@ class Neo4jCommunityGraphDB(Neo4jGraphDB):
             f"[delete_node_by_prams] Deleting nodes - memory_ids: {memory_ids}, file_ids: {file_ids}, filter: {filter}"
         )
 
-        # First count matching nodes to get accurate count
-        count_query = f"MATCH (n:Memory) WHERE {ids_where} RETURN count(n) AS node_count"
-        logger.info(f"[delete_node_by_prams] count_query: {count_query}")
-        print(f"[delete_node_by_prams] count_query: {count_query}")
+        # First collect IDs of matching nodes (for both Neo4j deletion and Qdrant cleanup)
+        ids_query = f"MATCH (n:Memory) WHERE {ids_where} RETURN n.id AS node_id"
+        logger.info(f"[delete_node_by_prams] ids_query: {ids_query}")
+        print(f"[delete_node_by_prams] ids_query: {ids_query}")
 
-        # Then delete nodes
+        # Then delete nodes from Neo4j
         delete_query = f"MATCH (n:Memory) WHERE {ids_where} DETACH DELETE n"
         logger.info(f"[delete_node_by_prams] delete_query: {delete_query}")
         print(f"[delete_node_by_prams] delete_query: {delete_query}")
         print(f"[delete_node_by_prams] params: {params}")
 
         deleted_count = 0
+        deleted_ids: list[str] = []
         try:
             with self.driver.session(database=self.db_name) as session:
-                # Count nodes before deletion
-                count_result = session.run(count_query, **params)
-                count_record = count_result.single()
-                expected_count = 0
-                if count_record:
-                    expected_count = count_record["node_count"] or 0
+                # Collect IDs before deletion
+                ids_result = session.run(ids_query, **params)
+                for rec in ids_result:
+                    node_id = rec.get("node_id")
+                    if node_id:
+                        deleted_ids.append(str(node_id))
+                expected_count = len(deleted_ids)
 
-                # Delete nodes
+                # Delete nodes from Neo4j
                 session.run(delete_query, **params)
-                # Use the count from before deletion as the actual deleted count
                 deleted_count = expected_count
+
+            # After successful Neo4j deletion, clean up Qdrant vectors
+            if deleted_ids:
+                try:
+                    self.vec_db.delete(deleted_ids)
+                    logger.info(
+                        f"[delete_node_by_prams] Deleted {len(deleted_ids)} vectors from Qdrant"
+                    )
+                except Exception as vec_err:
+                    logger.warning(
+                        f"[delete_node_by_prams] Failed to delete vectors from Qdrant: {vec_err}"
+                    )
 
         except Exception as e:
             logger.error(f"[delete_node_by_prams] Failed to delete nodes: {e}", exc_info=True)


### PR DESCRIPTION
## Description

`delete_node_by_prams()` only ran `DETACH DELETE` on Neo4j, leaving orphan vectors behind in Qdrant. Every memory deletion via the API created a leaked vector in Qdrant with no corresponding Neo4j node.

## Root Cause

The write path (`add_node` / `add_nodes_batch`) is symmetric — it writes to both Neo4j and Qdrant in the same method. But the delete path only touched Neo4j:

```python
# Before: count then delete Neo4j only
count_query = f"MATCH (n:Memory) WHERE ... RETURN count(n) AS node_count"
...
session.run("MATCH (n:Memory) WHERE ... DETACH DELETE n", **params)
# ← No vec_db.delete() call
```

Note that `clear()` and the newer `delete_node_by_mem_cube_id()` both correctly call `vec_db.delete()` — this was simply an omission in `delete_node_by_prams`.

## Fix

1. Replace `count_query` with an `ids_query` that collects node IDs
2. Delete from Neo4j (same as before)
3. Call `self.vec_db.delete(deleted_ids)` after successful Neo4j deletion

## Verification

- `BaseVecDB.delete(ids)` is an abstract method with working implementations in both QdrantVecDB and MilvusVecDB
- `self.vec_db` is initialized in the constructor and used elsewhere in the same class
- The fix gracefully falls back with a warning log if Qdrant cleanup fails