### PR TITLE
Fix #1782: Reward pipeline skips abandoned episodes — 98% of closed episodes never scored

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -924,6 +924,19 @@ export function createMemoryCore(
       });
     }
 
+    // Periodic rescore timer for episodes that miss the startup scan or
+    // retry of failed reward runs. 10-minute interval is safe because
+    // autoRescoreDirtyClosedEpisodes has its own 30-second dedup guard.
+    const rescoreInterval = setInterval(() => {
+      void autoRescoreDirtyClosedEpisodes().catch((err) => {
+        log.debug("periodic_rescore.error", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, 10 * 60 * 1000);
+    // Mark as unref so the timer doesn't block shutdown
+    (rescoreInterval as unknown as { unref?: () => void }).unref?.();
+
     // Wire `memory_add` into the api_logs table on EVERY turn so the
     // Logs viewer shows per-turn capture activity. `capture.lite.done`
     // fires once per `onTurnEnd` (the per-turn lite capture path);
@@ -1272,7 +1285,9 @@ export function createMemoryCore(
     if (
       ep.rTask == null &&
       (ep.traceIds?.length ?? 0) > 0 &&
-      (meta.closeReason === "finalized" || meta.recoveryReason === "missed_session_end")
+      (meta.closeReason === "finalized" ||
+        meta.closeReason === "abandoned" ||
+        meta.recoveryReason === "missed_session_end")
     ) {
       return true;
     }


### PR DESCRIPTION
## Description

Fixed reward pipeline bug that caused 98% of closed episodes to be skipped for scoring. The issue was caused by two interacting bugs in memory-core.ts:

1. **episodeRewardIsDirty() excluded abandoned episodes**: The function only matched closeReason === "finalized" or recoveryReason === "missed_session_end", but 219 of 224 closed episodes had closeReason === "abandoned". Added the abandoned check to line 1287.

2. **No polling fallback after bootstrap**: autoRescoreDirtyClosedEpisodes() was called once during init() with no retry mechanism. Added a 10-minute periodic timer (lines 927-937) with unref() to prevent blocking shutdown. The timer safely overlaps with the existing 30-second dedup guard in autoRescoreDirtyClosedEpisodes.

**Impact**: Before the fix, only 7 episodes were scored (stale open episodes recovered at startup). After the fix, all 219 abandoned episodes become eligible for scoring. The issue reporter confirmed that within 3 minutes of restart with this fix, scoring increased from 45 traces to 257 traces (212 freshly scored).

**Changes**: Single file modified (apps/memos-local-plugin/core/pipeline/memory-core.ts), 16 insertions, 1 deletion. The fix precisely matches the solution proposed in the issue description with exact code snippets verified.

Related Issue (Required):  Fixes #1782

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Executor did not report tests.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1782
- [ ] Made sure Checks passed
- [ ] Tests have been provided
