### PR TITLE
Fix #1612: [Bug] memos-local-openclaw-plugin: ctx.registerTools() never called in QClaw des

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -2382,6 +2382,29 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
 
     let serviceStarted = false;
 
+    // Hub client connection is split out from startServiceCore so it can be
+    // attempted eagerly at plugin-load time, regardless of how the host
+    // chooses to launch the plugin. Some hosts (notably the QClaw desktop
+    // app) load the plugin without calling service.start(), which used to
+    // mean Hub connection never happened (see GitHub issue #1612).
+    //
+    // The guard makes this safe to call from multiple entry points: the
+    // service.start() callback (gateway CLI path) and the eager fire at the
+    // end of register() (QClaw desktop path) both funnel through here and
+    // only one attempt actually runs.
+    let hubClientConnectAttempted = false;
+    const connectClientToHubIfNeeded = async () => {
+      if (hubClientConnectAttempted) return;
+      if (!ctx.config.sharing?.enabled || ctx.config.sharing.role !== "client") return;
+      hubClientConnectAttempted = true;
+      try {
+        const session = await connectToHub(store, ctx.config, ctx.log);
+        api.logger.info(`memos-local: connected to Hub as "${session.username}" (${session.userId})`);
+      } catch (err) {
+        api.logger.warn(`memos-local: Hub connection failed: ${err}`);
+      }
+    };
+
     const startServiceCore = async () => {
       if (serviceStarted) return;
       serviceStarted = true;
@@ -2391,14 +2414,7 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
         api.logger.info(`memos-local: hub started at ${hubUrl}`);
       }
 
-      if (ctx.config.sharing?.enabled && ctx.config.sharing.role === "client") {
-        try {
-          const session = await connectToHub(store, ctx.config, ctx.log);
-          api.logger.info(`memos-local: connected to Hub as "${session.username}" (${session.userId})`);
-        } catch (err) {
-          api.logger.warn(`memos-local: Hub connection failed: ${err}`);
-        }
-      }
+      await connectClientToHubIfNeeded();
 
       try {
         const viewerUrl = await viewer.start();
@@ -2436,6 +2452,16 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
         store.close();
         api.logger.info("memos-local: stopped");
       },
+    });
+
+    // Eager Hub client connection: kick off the Hub login as soon as the
+    // plugin is registered, independent of the host's service lifecycle.
+    // This guarantees team sharing works in hosts that load the plugin
+    // without calling service.start() (e.g. the QClaw desktop app — see
+    // GitHub issue #1612). The setTimeout(0) fallback below still handles
+    // viewer startup; this fire-and-forget call does not block register().
+    connectClientToHubIfNeeded().catch((err) => {
+      api.logger.warn(`memos-local: eager Hub connection failed: ${err}`);
     });
 
     // Fallback: OpenClaw may load this plugin via deferred reload after

--- a/apps/memos-local-openclaw/tests/hub-eager-connect.test.ts
+++ b/apps/memos-local-openclaw/tests/hub-eager-connect.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const noopLog = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+/**
+ * Regression coverage for GitHub issue #1612:
+ * "memos-local-openclaw-plugin: ctx.registerTools() never called in QClaw
+ * desktop app context"
+ *
+ * Hosts such as the QClaw desktop app load the plugin without calling
+ * `service.start()` and may not reliably tick `setTimeout(0)`. The plugin
+ * must still attempt the Hub client connection so team sharing works.
+ *
+ * These tests verify:
+ *   1. When `service.start()` is never called, `connectToHub` is still
+ *      invoked (eager hub connect).
+ *   2. When sharing is disabled or the role is not "client", no connection
+ *      attempt is made.
+ *   3. When both `service.start()` and the eager path run, the connection
+ *      is attempted exactly once (idempotency guard).
+ */
+async function loadPluginWithMocks(opts: {
+  sharingConfig: any;
+  connectToHubImpl?: (...args: unknown[]) => Promise<unknown>;
+  captureService?: (service: any) => void;
+}): Promise<{ connectSpy: ReturnType<typeof vi.fn> }> {
+  const connectSpy = vi.fn(opts.connectToHubImpl ?? (async () => ({ userId: "u1", username: "tester" })));
+
+  vi.doMock("../src/config", () => ({
+    buildContext: () => ({
+      stateDir: "/tmp/memos-eager-hub",
+      workspaceDir: "/tmp/memos-eager-hub/workspace",
+      log: noopLog,
+      openclawAPI: undefined,
+      config: {
+        storage: { dbPath: "/tmp/memos-eager-hub/memos.db" },
+        capture: { evidenceWrapperTag: "STORED_MEMORY" },
+        telemetry: {},
+        sharing: opts.sharingConfig,
+      },
+    }),
+  }));
+
+  vi.doMock("../src/storage/sqlite", () => ({
+    SqliteStore: class {
+      recordToolCall() {}
+      recordApiLog() {}
+      close() {}
+    },
+  }));
+
+  vi.doMock("../src/embedding", () => ({
+    Embedder: class { provider = "mock"; },
+  }));
+
+  vi.doMock("../src/ingest/worker", () => ({
+    IngestWorker: class {
+      getTaskProcessor() { return { onTaskCompleted() {} }; }
+      enqueue() {}
+      async flush() {}
+    },
+  }));
+
+  vi.doMock("../src/recall/engine", () => ({
+    RecallEngine: class {
+      async search() { return { hits: [], meta: {} }; }
+      async searchSkills() { return []; }
+    },
+  }));
+
+  vi.doMock("../src/ingest/providers", () => ({
+    Summarizer: class { async filterRelevant() { return null; } },
+  }));
+
+  vi.doMock("../src/viewer/server", () => ({
+    ViewerServer: class {
+      async start() { return "http://127.0.0.1:18799"; }
+      stop() {}
+      getResetToken() { return "token"; }
+    },
+  }));
+
+  vi.doMock("../src/hub/server", () => ({
+    HubServer: class {
+      async start() { return "http://127.0.0.1:18800"; }
+      async stop() {}
+    },
+  }));
+
+  vi.doMock("../src/client/hub", () => ({
+    hubGetMemoryDetail: async () => ({}),
+    hubRequestJson: async () => ({}),
+    hubSearchMemories: async () => ({ hits: [], meta: {} }),
+    hubSearchSkills: async () => ({ hits: [] }),
+    resolveHubClient: async () => ({ hubUrl: "", userToken: "", userId: "" }),
+  }));
+
+  vi.doMock("../src/client/connector", () => ({
+    connectToHub: connectSpy,
+    getHubStatus: async () => ({ connected: false }),
+  }));
+
+  vi.doMock("../src/client/skill-sync", () => ({
+    fetchHubSkillBundle: async () => ({}),
+    publishSkillBundleToHub: async () => ({}),
+    restoreSkillBundleFromHub: () => ({}),
+    unpublishSkillBundleFromHub: async () => ({}),
+  }));
+
+  vi.doMock("../src/skill/evolver", () => ({
+    SkillEvolver: class { async onTaskCompleted() {} async recoverOrphanedTasks() { return 0; } },
+  }));
+
+  vi.doMock("../src/skill/installer", () => ({ SkillInstaller: class {} }));
+  vi.doMock("../src/skill/bundled-memory-guide", () => ({ MEMORY_GUIDE_SKILL_MD: "# mock" }));
+
+  vi.doMock("../src/telemetry", () => ({
+    Telemetry: class {
+      trackToolCalled() {}
+      trackAutoRecall() {}
+      trackMemoryIngested() {}
+      trackSkillInstalled() {}
+      trackPluginStarted() {}
+      trackViewerOpened() {}
+      trackSkillEvolved() {}
+      async shutdown() {}
+    },
+  }));
+
+  const pluginModule = await import("../plugin-impl");
+  pluginModule.default.register({
+    pluginConfig: {},
+    config: {},
+    resolvePath: () => "/tmp/memos-eager-hub",
+    logger: { info() {}, warn() {} },
+    registerTool: () => {},
+    registerMemoryCapability: () => {},
+    registerService: (service: any) => { opts.captureService?.(service); },
+    on: () => {},
+  } as any);
+
+  return { connectSpy };
+}
+
+describe("eager hub connection (GitHub #1612)", () => {
+  it("attempts to connect to the hub at register-time when sharing is enabled in client role, even if service.start() is never called", async () => {
+    const { connectSpy } = await loadPluginWithMocks({
+      sharingConfig: {
+        enabled: true,
+        role: "client",
+        client: { hubAddress: "127.0.0.1:18912", userToken: "tk" },
+      },
+    });
+
+    // Allow the fire-and-forget eager connectToHub() promise to settle
+    // without depending on setTimeout — the eager call runs as part of
+    // register(), so the next microtask flush is enough.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attempt to connect when sharing is disabled", async () => {
+    const { connectSpy } = await loadPluginWithMocks({
+      sharingConfig: {
+        enabled: false,
+        role: "client",
+        client: { hubAddress: "127.0.0.1:18912", userToken: "tk" },
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt to connect when running in hub role", async () => {
+    const { connectSpy } = await loadPluginWithMocks({
+      sharingConfig: {
+        enabled: true,
+        role: "hub",
+        hub: { port: 18912, teamName: "T", teamToken: "tk" },
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("only attempts the hub connection once when both the eager path and service.start() run", async () => {
+    let capturedService: any;
+    const { connectSpy } = await loadPluginWithMocks({
+      sharingConfig: {
+        enabled: true,
+        role: "client",
+        client: { hubAddress: "127.0.0.1:18912", userToken: "tk" },
+      },
+      captureService: (s) => { capturedService = s; },
+    });
+
+    // Eager connect runs first (already initiated at register-time).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturedService).toBeDefined();
+    await capturedService.start();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Successfully fixed bug #1612: QClaw desktop app Hub connection issue in memos-local-openclaw plugin.

**Root Cause:**
The QClaw desktop app loads the memos-local-openclaw plugin without calling `service.start()`, which meant `connectToHub()` inside `startServiceCore()` never ran. This caused the Hub Server to see zero incoming connections from QClaw desktop users, making team sharing completely non-functional even though local memory worked fine.

**Solution Implemented:**
Cherry-picked and applied fix from commit a645ddd0 that splits the Hub client connection logic out of `startServiceCore()` into an idempotent helper function `connectClientToHubIfNeeded()`. This helper is now called eagerly at the end of the `register()` function, independent of the host's service lifecycle.

**Key Changes:**
1. Created `connectClientToHubIfNeeded()` function with idempotency guard to prevent duplicate connection attempts
2. Replaced inline Hub connection logic in `startServiceCore()` with call to the helper
3. Added eager Hub connection call at end of `register()` function to handle QClaw desktop app case
4. Added comprehensive test coverage in `tests/hub-eager-connect.test.ts` with 224 lines of regression tests

**Files Modified:**
- `apps/memos-local-openclaw/index.ts` (42 line changes: +34 insertions, -8 deletions)
- `apps/memos-local-openclaw/tests/hub-eager-connect.test.ts` (224 lines, new file)

**Note on Issue Title:**
The issue title mentions "ctx.registerTools() never called" but this was a misnomer. The actual problem was Hub client connection initialization, not tool registration. The plugin correctly uses OpenClaw Plugin SDK's `api.registerTool()` pattern throughout.

Related Issue (Required):  Fixes #1612

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Executor did not report tests.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1612
- [ ] Made sure Checks passed
- [ ] Tests have been provided
