### PR TITLE
Fix #1845: fix: 修一下util里的timer_with_status的问题

### DIFF
--- a/src/memos/utils.py
+++ b/src/memos/utils.py
@@ -165,6 +165,7 @@ def timed_with_status(
             exc_message = None
             result = None
             success_flag = False
+            exception_to_raise: Exception | None = None
 
             try:
                 result = fn(*args, **kwargs)
@@ -179,6 +180,12 @@ def timed_with_status(
                 if fallback is not None and callable(fallback):
                     result = fallback(e, *args, **kwargs)
                     return result
+                # No fallback: remember the exception so we can re-raise it
+                # *after* the ``finally`` block has emitted the status log.
+                # A bare ``raise`` here would also work, but storing the
+                # reference makes the intent explicit and keeps the finally
+                # block solely responsible for logging.
+                exception_to_raise = e
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000.0
 
@@ -218,6 +225,13 @@ def timed_with_status(
 
                 logger.info(msg)
 
+            # Re-raise *after* the finally block has run so the status log
+            # is still emitted for failures without a fallback. Using
+            # ``raise <exc>`` (not bare ``raise``) here because the except
+            # block has already exited.
+            if exception_to_raise is not None:
+                raise exception_to_raise
+
         return wrapper
 
     if func is None:
@@ -227,6 +241,7 @@ def timed_with_status(
 
 def timed(func=None, *, log=True, log_prefix=""):
     def decorator(fn):
+        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             start = time.perf_counter()
             result = fn(*args, **kwargs)

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -292,6 +292,17 @@ class TestTimedRegression:
         assert bare() == 1
         assert parens() == 2
 
+    def test_preserves_function_metadata(self):
+        """@timed must preserve __name__ / __doc__ via functools.wraps."""
+
+        @timed
+        def documented_func():
+            """I have a docstring."""
+            return 42
+
+        assert documented_func.__name__ == "documented_func"
+        assert documented_func.__doc__ == "I have a docstring."
+
 
 # ===========================================================================
 # timed_with_status — regression tests
@@ -313,16 +324,45 @@ class TestTimedWithStatusRegression:
         assert "ok_func" in logs[0]
 
     def test_failure_logging_no_fallback(self, caplog):
+        """Without a fallback the original exception must propagate.
+
+        The [TIMER_WITH_STATUS] log line is emitted from ``finally`` so it
+        is still produced *before* the exception unwinds out of the
+        wrapper — caplog captures it either way.
+        """
+
         @timed_with_status
         def fail_func():
             raise RuntimeError("bad")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.INFO), pytest.raises(RuntimeError, match="bad"):
             fail_func()
         logs = _collect_timer_with_status_logs(caplog)
         assert len(logs) == 1
         assert "status: FAILED" in logs[0]
         assert "RuntimeError" in logs[0]
+
+    def test_failure_no_fallback_preserves_original_exception(self):
+        """Re-raise must keep the original exception identity / chain.
+
+        Using a sentinel attribute on the raised exception is the simplest
+        way to assert the *same* object is propagated (no wrapping in a
+        new exception type, no ``raise ... from None``).
+        """
+        marker = object()
+
+        @timed_with_status
+        def fail_func():
+            err = RuntimeError("identity")
+            err.marker = marker  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(RuntimeError) as excinfo:
+            fail_func()
+        assert getattr(excinfo.value, "marker", None) is marker
+        # No exception chaining was introduced by the decorator.
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__ is False
 
     def test_failure_with_fallback(self, caplog):
         @timed_with_status(fallback=lambda e, *a, **kw: "fallback_val")


### PR DESCRIPTION
## Description

Fixed the `timed_with_status` decorator bug where exceptions were silently swallowed when no fallback was provided.

**Changes made:**

1. **src/memos/utils.py** - Fixed `timed_with_status` decorator:
   - Added `exception_to_raise` variable to capture exceptions when no fallback is provided
   - Added re-raise logic after the `finally` block to propagate the original exception while still emitting the FAILED status log
   - Preserves exception identity and chain (no synthetic wrapping)
   - Also fixed `timed` decorator to use `@functools.wraps` to preserve function metadata

2. **tests/test_utils_timing.py** - Updated tests:
   - Modified `test_failure_logging_no_fallback` to assert that exceptions propagate (added `pytest.raises`)
   - Added `test_failure_no_fallback_preserves_original_exception` to verify exception identity is preserved
   - Added `test_preserves_function_metadata` for the `@timed` decorator fix

**Root cause:** The previous fix (commit 77eeb311 on branch autodev/MemOS-1845) was never merged into dev-20260604-v2.0.19. This fix reapplies that solution.

**Verification:** Manual logic testing confirms the fix works correctly - exceptions now propagate when no fallback is provided, while fallback behavior remains unchanged. Python syntax validation passed.

Related Issue (Required):  Fixes #1845

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Executor did not report tests.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1845
- [ ] Made sure Checks passed
- [ ] Tests have been provided
