### PR TITLE
feat(memos-local-plugin): IR readonly eval path with domain gating

### DIFF
--- a/apps/memos-local-plugin/adapters/openclaw/bridge.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/bridge.ts
@@ -30,6 +30,7 @@ import type {
   TurnResultDTO,
 } from "../../agent-contract/dto.js";
 import type { MemoryCore } from "../../agent-contract/memory-core.js";
+import { effectiveReadOnlyInjectionProfile } from "../../core/domain.js";
 
 import type {
   AfterToolCallEvent,
@@ -827,15 +828,27 @@ export function renderContextBlock(
     return `${CONTEXT_OPEN}\n${rendered}\n${CONTEXT_CLOSE}`;
   }
   if (opts.hintWhenEmpty === false) return "";
-  // Cold-start hint for interactive sessions. The automatic OpenClaw
-  // before-prompt path disables this hint; task-specific guardrails can
-  // still be added without pretending an empty memory store has matches.
   const hint = [
     "No prior memories matched this query — the store may simply be cold.",
     "Call `memos_search` only if you have a specific reason to expect",
     "relevant past context; otherwise continue with the current task.",
   ].join(" ");
   return `${CONTEXT_OPEN}\n${hint}\n${CONTEXT_CLOSE}`;
+}
+
+function capContextBlock(block: string): { block: string; truncated: boolean } {
+  if (block.length <= OPENCLAW_CONTEXT_CHAR_CAP) {
+    return { block, truncated: false };
+  }
+  const suffix = `\n\n[Memory context truncated to ${OPENCLAW_CONTEXT_CHAR_CAP} characters.]\n${CONTEXT_CLOSE}`;
+  const prefix = block.startsWith(`${CONTEXT_OPEN}\n`) ? `${CONTEXT_OPEN}\n` : "";
+  const bodyStart = prefix.length;
+  const bodyBudget = Math.max(0, OPENCLAW_CONTEXT_CHAR_CAP - prefix.length - suffix.length);
+  const body = block.slice(bodyStart, bodyStart + bodyBudget).trimEnd();
+  return {
+    block: `${prefix}${body}${suffix}`,
+    truncated: true,
+  };
 }
 
 async function withSoftTimeout<T>(
@@ -856,21 +869,6 @@ async function withSoftTimeout<T>(
   });
 }
 
-function capContextBlock(block: string): { block: string; truncated: boolean } {
-  if (block.length <= OPENCLAW_CONTEXT_CHAR_CAP) {
-    return { block, truncated: false };
-  }
-  const suffix = `\n\n[Memory context truncated to ${OPENCLAW_CONTEXT_CHAR_CAP} characters.]\n${CONTEXT_CLOSE}`;
-  const prefix = block.startsWith(`${CONTEXT_OPEN}\n`) ? `${CONTEXT_OPEN}\n` : "";
-  const bodyStart = prefix.length;
-  const bodyBudget = Math.max(0, OPENCLAW_CONTEXT_CHAR_CAP - prefix.length - suffix.length);
-  const body = block.slice(bodyStart, bodyStart + bodyBudget).trimEnd();
-  return {
-    block: `${prefix}${body}${suffix}`,
-    truncated: true,
-  };
-}
-
 // ─── Bridge factory ────────────────────────────────────────────────────────
 
 export interface BridgeOptions {
@@ -879,6 +877,13 @@ export interface BridgeOptions {
   log: HostLogger;
   /** When true, keep retrieval enabled but skip turn-end capture entirely. */
   memoryAddDisabled?: boolean;
+  readOnlyInjectionProfile?:
+    | "all"
+    | "experience"
+    | "skill"
+    | "skill_experience";
+  /** Task domain preset (`ir` enables IR-eval-only behaviors). */
+  domain?: "" | "ir";
   /** Override the wall-clock source (tests). */
   now?: () => number;
 }
@@ -1023,6 +1028,21 @@ function appendFailureHint(content: string): string {
 
 export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
   const now = opts.now ?? (() => Date.now());
+  const readOnly =
+    truthyEnv("OPENCLAW_MEMOS_READONLY") || truthyEnv("MEMOS_READONLY");
+  const readOnlyInjectionProfile = effectiveReadOnlyInjectionProfile({
+    domain: opts.domain,
+    readOnlyInjectionProfile: opts.readOnlyInjectionProfile,
+  });
+  if (readOnly) {
+    opts.log.info("memos.readonly.enabled", {
+      source: process.env.OPENCLAW_MEMOS_READONLY
+        ? "OPENCLAW_MEMOS_READONLY"
+        : "MEMOS_READONLY",
+      domain: opts.domain ?? "",
+      injectionProfile: readOnlyInjectionProfile,
+    });
+  }
 
   // Per-session cursor so we don't re-capture messages across turns.
   const messageCursor = new Map<SessionId, number>();
@@ -1334,6 +1354,76 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
       if (!prompt) return;
 
       const namespace = namespaceFromAgentCtx(ctx);
+
+      if (readOnly) {
+        const sessionId = await ensureSession(ctx.agentId, ctx.sessionKey, namespace);
+        clearToolFailureStreaksForTurn(toolFailureStreaks, {
+          runId: ctx.runId,
+          sessionId: ctx.sessionId ?? sessionId,
+          sessionKey: ctx.sessionKey,
+        });
+        lastUserTextBySession.set(sessionId, prompt);
+
+        const turnStartPromise = opts.core.searchMemory({
+          agent: opts.agent,
+          namespace,
+          sessionId,
+          query: prompt,
+        });
+        turnStartPromise.catch((err) => {
+          opts.log.warn("memos.onTurnStart.late_failure", {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        });
+        const turnStartResult = await withSoftTimeout(
+          turnStartPromise,
+          BEFORE_PROMPT_SOFT_TIMEOUT_MS,
+        );
+        const packet = turnStartResult.ok ? turnStartResult.value : null;
+        if (!turnStartResult.ok) {
+          opts.log.warn("memos.onTurnStart.soft_timeout", {
+            sessionKey: ctx.sessionKey,
+            agentId: ctx.agentId,
+            timeoutMs: BEFORE_PROMPT_SOFT_TIMEOUT_MS,
+          });
+        }
+        opts.log.info("memos.readonly.retrieval", {
+          sessionKey: ctx.sessionKey,
+          agentId: ctx.agentId,
+          sessionId,
+          injectionProfile: readOnlyInjectionProfile,
+          hits: packet?.hits.length ?? 0,
+        });
+
+        const renderedBlock = renderContextBlock(packet, { hintWhenEmpty: false });
+        const { block, truncated } = capContextBlock(renderedBlock);
+        const durationMs = now() - startedAt;
+
+        opts.log.info("memos.onTurnStart", {
+          sessionKey: ctx.sessionKey,
+          agentId: ctx.agentId,
+          sessionId,
+          episodeId: packet?.query.episodeId,
+          hits: packet?.hits.length ?? 0,
+          tierLatencyMs: packet?.tierLatencyMs ?? { tier1: 0, tier2: 0, tier3: 0 },
+          durationMs,
+          contextChars: block.length,
+          injected: block.length > 0,
+          truncated,
+          softTimedOut: !turnStartResult.ok,
+        });
+        opts.log.info(
+          `memos.onTurnStart returned hits=${packet?.hits.length ?? 0} ` +
+            `durationMs=${durationMs} contextChars=${block.length} ` +
+            `injected=${block.length > 0 ? "yes" : "no"} ` +
+            `truncated=${truncated ? "yes" : "no"} ` +
+            `softTimedOut=${turnStartResult.ok ? "no" : "yes"}`,
+        );
+
+        if (!block) return;
+        return { prependContext: block + "\n\n" };
+      }
+
       const readOnlyTurnStart = memoryWritesDisabled();
       const sessionId = readOnlyTurnStart
         ? bridgeSessionId(ctx.agentId ?? "main", ctx.sessionKey ?? "default")
@@ -1404,13 +1494,7 @@ export function createOpenClawBridge(opts: BridgeOptions): BridgeHandle {
         binding.episodeId ??
         (packet?.query.episodeId as EpisodeId | undefined);
 
-      const renderedBlock = renderContextBlock(packet, {
-        // Avoid making OpenClaw do a second tool-driven search when
-        // auto-recall found nothing. A no-hit turn should simply
-        // continue with the user's prompt; tools remain available if
-        // the model independently decides to use them.
-        hintWhenEmpty: false,
-      });
+      const renderedBlock = renderContextBlock(packet, { hintWhenEmpty: false });
       const { block, truncated } = capContextBlock(renderedBlock);
       const durationMs = now() - startedAt;
 

--- a/apps/memos-local-plugin/adapters/openclaw/index.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/index.ts
@@ -154,6 +154,15 @@ function resolveViewerStaticRoot(): string | undefined {
 
 const OPENCLAW_VIEWER_PORT = 18799;
 
+function envFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return /^(1|true|yes|on)$/i.test(value.trim());
+}
+
+function isReadOnlyRuntime(): boolean {
+  return envFlag(process.env.OPENCLAW_MEMOS_READONLY ?? process.env.MEMOS_READONLY);
+}
+
 function memoryAddDisabledFromConfig(config: Record<string, unknown> | undefined): boolean {
   const memoryAdd = config?.memory_add;
   if (!memoryAdd || typeof memoryAdd !== "object" || Array.isArray(memoryAdd)) {
@@ -164,10 +173,11 @@ function memoryAddDisabledFromConfig(config: Record<string, unknown> | undefined
 
 async function createRuntime(
   api: OpenClawPluginApi,
-  runtimeLock: OpenClawRuntimeLockHandle,
+  runtimeLock: OpenClawRuntimeLockHandle | null,
+  opts: { readOnly: boolean } = { readOnly: false },
 ): Promise<PluginRuntime> {
   const log = rootLogger.child({ channel: "adapters.openclaw" });
-  log.info("plugin.bootstrap", { version: PLUGIN_VERSION });
+  log.info("plugin.bootstrap", { version: PLUGIN_VERSION, readOnly: opts.readOnly });
 
   let core: MemoryCore | null = null;
   let viewer: ServerHandle | null = null;
@@ -218,42 +228,48 @@ async function createRuntime(
       core,
       log: api.logger,
       memoryAddDisabled: memoryAddDisabledFromConfig(api.pluginConfig),
+      readOnlyInjectionProfile: config.algorithm.retrieval.readOnlyInjectionProfile,
+      domain: config.domain,
     });
 
-    // OpenClaw's viewer port is fixed at :18799 (hermes uses :18800).
-    // We ignore `config.viewer.port` for the same reason `bridge.cts`
-    // does: old config.yaml files baked in the legacy single-port
-    // :18799 used by both agents, and we don't want hermes to collide
-    // with us because of stale YAML.
-    try {
-      viewer = await startHttpServer(
-        {
-          core,
-          home,
-          logTail: () => memoryBuffer().tail({ limit: 200 }),
-          telemetry,
-        },
-        {
-          port: OPENCLAW_VIEWER_PORT,
-          host: config.viewer.bindHost,
-          staticRoot: resolveViewerStaticRoot(),
-          agent: "openclaw",
-        },
-      );
-      api.logger.info(`memos-local: viewer live at ${viewer.url}`);
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      if (e?.code === "EADDRINUSE") {
-        api.logger.error(
-          `memos-local: viewer port :${OPENCLAW_VIEWER_PORT} is already in use — ` +
-            `refusing duplicate/headless OpenClaw runtime.`,
+    if (opts.readOnly) {
+      api.logger.info("memos-local: read-only runtime; skipping exclusive viewer binding");
+    } else {
+      // OpenClaw's viewer port is fixed at :18799 (hermes uses :18800).
+      // We ignore `config.viewer.port` for the same reason `bridge.cts`
+      // does: old config.yaml files baked in the legacy single-port
+      // :18799 used by both agents, and we don't want hermes to collide
+      // with us because of stale YAML.
+      try {
+        viewer = await startHttpServer(
+          {
+            core,
+            home,
+            logTail: () => memoryBuffer().tail({ limit: 200 }),
+            telemetry,
+          },
+          {
+            port: OPENCLAW_VIEWER_PORT,
+            host: config.viewer.bindHost,
+            staticRoot: resolveViewerStaticRoot(),
+            agent: "openclaw",
+          },
         );
-      } else {
-        api.logger.error("memos-local: viewer failed to start", {
-          err: e?.message ?? String(err),
-        });
+        api.logger.info(`memos-local: viewer live at ${viewer.url}`);
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e?.code === "EADDRINUSE") {
+          api.logger.error(
+            `memos-local: viewer port :${OPENCLAW_VIEWER_PORT} is already in use — ` +
+              `refusing duplicate/headless OpenClaw runtime.`,
+          );
+        } else {
+          api.logger.error("memos-local: viewer failed to start", {
+            err: e?.message ?? String(err),
+          });
+        }
+        throw err;
       }
-      throw err;
     }
 
     const runtimeCore = core;
@@ -279,7 +295,7 @@ async function createRuntime(
             err: err instanceof Error ? err.message : String(err),
           });
         }
-        runtimeLock.release();
+        runtimeLock?.release();
       },
     };
   } catch (err) {
@@ -291,7 +307,7 @@ async function createRuntime(
         /* best-effort cleanup after failed bootstrap */
       }
     }
-    runtimeLock.release();
+    runtimeLock?.release();
     throw err;
   }
 }
@@ -308,21 +324,26 @@ async function closeViewerAfterFailedBootstrap(
 }
 
 function createSharedRuntimeState(api: OpenClawPluginApi): SharedRuntimeState {
-  let runtimeLock: OpenClawRuntimeLockHandle;
-  try {
-    runtimeLock = acquireOpenClawRuntimeLock({
-      home: resolveHome("openclaw"),
-      pluginId: PLUGIN_ID,
-      version: PLUGIN_VERSION,
-      viewerPort: OPENCLAW_VIEWER_PORT,
-    });
-  } catch (err) {
-    const duplicate = err instanceof DuplicateOpenClawRuntimeError;
-    api.logger.error("memos-local: duplicate OpenClaw runtime blocked", {
-      err: err instanceof Error ? err.message : String(err),
-      code: duplicate ? err.code : (err as { code?: unknown }).code,
-    });
-    throw err;
+  const readOnly = isReadOnlyRuntime();
+  let runtimeLock: OpenClawRuntimeLockHandle | null = null;
+  if (readOnly) {
+    api.logger.info("memos-local: readonly runtime lock bypassed");
+  } else {
+    try {
+      runtimeLock = acquireOpenClawRuntimeLock({
+        home: resolveHome("openclaw"),
+        pluginId: PLUGIN_ID,
+        version: PLUGIN_VERSION,
+        viewerPort: OPENCLAW_VIEWER_PORT,
+      });
+    } catch (err) {
+      const duplicate = err instanceof DuplicateOpenClawRuntimeError;
+      api.logger.error("memos-local: duplicate OpenClaw runtime blocked", {
+        err: err instanceof Error ? err.message : String(err),
+        code: duplicate ? err.code : (err as { code?: unknown }).code,
+      });
+      throw err;
+    }
   }
 
   const state: SharedRuntimeState = {
@@ -331,7 +352,7 @@ function createSharedRuntimeState(api: OpenClawPluginApi): SharedRuntimeState {
     bootstrapError: null,
     bootstrapPromise: Promise.resolve(),
   };
-  state.bootstrapPromise = createRuntime(api, runtimeLock)
+  state.bootstrapPromise = createRuntime(api, runtimeLock, { readOnly })
     .then((runtime) => {
       state.runtime = runtime;
       api.logger.info("memos-local: plugin ready");
@@ -358,6 +379,12 @@ function register(api: OpenClawPluginApi): void {
     api.logger.info("memos-local: reusing in-process shared runtime");
   }
   state.registrations += 1;
+
+  if (memoryAddDisabledFromConfig(api.pluginConfig)) {
+    api.logger.info(
+      "memos-local: memory_add disabled; allowing concurrent read-only runtime",
+    );
+  }
 
   // 1. Memory capability (prompt prelude) — register synchronously so the
   //    host immediately knows who owns the memory slot, even if bootstrap

--- a/apps/memos-local-plugin/agent-contract/dto.ts
+++ b/apps/memos-local-plugin/agent-contract/dto.ts
@@ -548,6 +548,11 @@ export interface RetrievalQueryDTO {
   sessionId?: SessionId;
   episodeId?: EpisodeId;
   query: string;
+  /**
+   * Optional read-only eval scope override. Falls back to
+   * `algorithm.retrieval.readOnlyInjectionProfile` when unset.
+   */
+  injectionProfile?: "all" | "experience" | "skill" | "skill_experience";
   /** Optional structured filters (e.g. tags). */
   filters?: Record<string, unknown>;
   /** Maximum items to return per tier (overrides config). */

--- a/apps/memos-local-plugin/core/config/defaults.ts
+++ b/apps/memos-local-plugin/core/config/defaults.ts
@@ -8,6 +8,7 @@ import type { ResolvedConfig } from "./schema.js";
 
 export const DEFAULT_CONFIG: ResolvedConfig = {
   version: 1,
+  domain: "",
   viewer: {
     // Per-agent default lives in `templates/config.<agent>.yaml`:
     //   - openclaw → 18799
@@ -252,6 +253,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
       // hits before injection.
       llmFilterMinCandidates: 2,
       llmFilterCandidateBodyChars: 500,
+      readOnlyInjectionProfile: "all",
     },
   },
   hub: {

--- a/apps/memos-local-plugin/core/config/schema.ts
+++ b/apps/memos-local-plugin/core/config/schema.ts
@@ -484,6 +484,22 @@ const AlgorithmSchema = Type.Object({
      * slightly larger window pays for itself).
      */
     llmFilterCandidateBodyChars: NumberInRange(500, 120, 2000),
+    /**
+     * Read-only eval injection scope:
+     *   - all: default tier mix for the entrypoint
+     *   - experience: Tier2 policy/experience only
+     *   - skill: Tier1 skill only
+     *   - skill_experience: Tier1 skill + Tier2 experience
+     */
+    readOnlyInjectionProfile: Type.Union(
+      [
+        Type.Literal("all"),
+        Type.Literal("experience"),
+        Type.Literal("skill"),
+        Type.Literal("skill_experience"),
+      ],
+      { default: "all" },
+    ),
   }, { default: {} }),
 }, { default: {} });
 
@@ -561,6 +577,12 @@ const LoggingSchema = Type.Object({
 
 export const ConfigSchema = Type.Object({
   version: NumberInRange(1, 1),
+  /**
+   * Task domain preset. `ir` enables IR-eval-only behaviors: search
+   * playbook prepend, readonly skill/full injection, and IR query focus.
+   * Omit or leave empty for normal agent sessions.
+   */
+  domain: Type.Union([Type.Literal(""), Type.Literal("ir")], { default: "" }),
   viewer: ViewerSchema,
   bridge: BridgeSchema,
   embedding: EmbeddingSchema,

--- a/apps/memos-local-plugin/core/domain.ts
+++ b/apps/memos-local-plugin/core/domain.ts
@@ -1,0 +1,32 @@
+/**
+ * Task-domain presets. IR-only retrieval/render behaviors are gated on
+ * `domain === "ir"` so normal agent sessions stay on the default path.
+ */
+
+export type MemosDomain = "" | "ir";
+
+export function isIrDomain(domain: string | undefined | null): domain is "ir" {
+  return domain === "ir";
+}
+
+export function effectiveSkillInjectionMode(config: {
+  domain?: string;
+  skillInjectionMode?: "summary" | "full";
+}): "summary" | "full" {
+  if (!isIrDomain(config.domain)) return "summary";
+  return config.skillInjectionMode ?? "summary";
+}
+
+export function effectiveReadOnlyInjectionProfile(
+  config: {
+    domain?: string;
+    readOnlyInjectionProfile?:
+      | "all"
+      | "experience"
+      | "skill"
+      | "skill_experience";
+  },
+): "all" | "experience" | "skill" | "skill_experience" {
+  if (!isIrDomain(config.domain)) return "all";
+  return config.readOnlyInjectionProfile ?? "all";
+}

--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -164,6 +164,8 @@ export function extractAlgorithmConfig(
       llmFilterMinCandidates: alg.lightweightMemory.enabled ? 1 : alg.retrieval.llmFilterMinCandidates,
       llmFilterCandidateBodyChars: alg.retrieval.llmFilterCandidateBodyChars,
       lightweightMemory: alg.lightweightMemory.enabled,
+      readOnlyInjectionProfile: alg.retrieval.readOnlyInjectionProfile,
+      domain: deps.config.domain,
     },
     session: {
       followUpMode: alg.session.followUpMode,

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -75,6 +75,7 @@ import type {
 import type { ResolvedConfig, ResolvedHome } from "../config/index.js";
 import { loadConfig, resolveHome, SECRET_FIELD_PATHS } from "../config/index.js";
 import { reflectionAsText } from "../capture/types.js";
+import { effectiveReadOnlyInjectionProfile } from "../domain.js";
 import { feedbackText } from "../experience/feedback-builder.js";
 import { rootLogger } from "../logger/index.js";
 import type { Logger } from "../logger/types.js";
@@ -2391,7 +2392,11 @@ export function createMemoryCore(
     const baseDeps = handle.retrievalDeps();
     const deps = {
       ...baseDeps,
-      config: applyTopKOverride(baseDeps.config, query.topK),
+      config: {
+        ...applyTopKOverride(baseDeps.config, query.topK),
+        readOnlyInjectionProfile:
+          query.injectionProfile ?? effectiveReadOnlyInjectionProfile(baseDeps.config),
+      },
       namespace: ns,
       repos: wrapRetrievalRepos(handle.repos, ns),
     };

--- a/apps/memos-local-plugin/core/retrieval/injection-profile.ts
+++ b/apps/memos-local-plugin/core/retrieval/injection-profile.ts
@@ -1,0 +1,59 @@
+/**
+ * Read-only eval injection scopes. `all` keeps the normal tool_driven tier
+ * mix; other profiles override which tiers are retrieved before prompt.
+ */
+export type ReadOnlyInjectionProfile =
+  | "all"
+  | "experience"
+  | "skill"
+  | "skill_experience";
+
+export interface InjectionProfilePlan {
+  scenarioId?: string;
+  wantTier1?: boolean;
+  wantTier2?: boolean;
+  wantTier3?: boolean;
+  experienceOnly?: boolean;
+  limit?: number;
+}
+
+export function resolveInjectionProfilePlan(
+  profile: ReadOnlyInjectionProfile | undefined,
+): InjectionProfilePlan | undefined {
+  switch (profile) {
+    case "experience":
+      return {
+        wantTier1: false,
+        wantTier2: true,
+        wantTier3: false,
+        experienceOnly: true,
+      };
+    case "skill":
+      return {
+        wantTier1: true,
+        wantTier2: false,
+        wantTier3: false,
+      };
+    case "skill_experience":
+      return {
+        wantTier1: true,
+        wantTier2: true,
+        wantTier3: false,
+        experienceOnly: true,
+      };
+    case "all":
+    default:
+      return undefined;
+  }
+}
+
+export function mergeRetrievePlanOverride(
+  ...layers: Array<InjectionProfilePlan | undefined>
+): InjectionProfilePlan | undefined {
+  const merged: InjectionProfilePlan = {};
+  for (const layer of layers) {
+    if (!layer) continue;
+    Object.assign(merged, layer);
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}

--- a/apps/memos-local-plugin/core/retrieval/injector.ts
+++ b/apps/memos-local-plugin/core/retrieval/injector.ts
@@ -19,6 +19,7 @@ import type {
   RetrievalReason,
   SessionId,
 } from "../../agent-contract/dto.js";
+import { isIrDomain } from "../domain.js";
 import { ids } from "../id.js";
 import { reflectionAsText } from "../capture/types.js";
 import type { CollectedGuidance } from "./decision-guidance.js";
@@ -33,8 +34,12 @@ import type {
   WorldModelCandidate,
 } from "./types.js";
 
-const MAX_SNIPPET_BODY_CHARS = 640;
 const DEFAULT_SKILL_SUMMARY_CHARS = 200;
+/** Default snippet body cap (trace / episode / experience / world-model). */
+const MAX_SNIPPET_BODY_CHARS = 640;
+/** Full skill injection keeps a larger inline guide budget. */
+const FULL_SKILL_SNIPPET_BODY_CHARS = 2800;
+
 const MEMORY_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
   weekday: "short",
   year: "numeric",
@@ -90,6 +95,8 @@ export interface InjectorInput {
    * when no historical snippets match, the host still receives the protocol.
    */
   taskProtocol?: string | null;
+  /** IR domain only: prepend built-in search playbook before packet body. */
+  domain?: "" | "ir";
 }
 
 export interface InjectorResult {
@@ -124,12 +131,16 @@ export function toPacket(input: InjectorInput): InjectorResult {
     });
   }
   const snippets = mapping.map((m) => m.snippet);
-  const rendered = renderWholePacket(snippets, input.reason, {
-    skillMode,
-    decisionGuidance: input.decisionGuidance,
-    standaloneMathFinalAnswer,
-    taskProtocol: input.taskProtocol,
-  });
+  const rendered = prependIrRenderPrompt(
+    renderWholePacket(snippets, input.reason, {
+      skillMode,
+      decisionGuidance: input.decisionGuidance,
+      standaloneMathFinalAnswer,
+      taskProtocol: input.taskProtocol,
+    }),
+    input.reason,
+    input.domain,
+  );
 
   const packet: InjectionPacket = {
     reason: input.reason,
@@ -265,6 +276,7 @@ function renderSkill(c: SkillCandidate, opts: RenderOpts): InjectionSnippet {
   if (opts.skillMode === "full") {
     const body = truncate(
       `Skill: ${c.skillName}\n` + c.invocationGuide.trim(),
+      FULL_SKILL_SNIPPET_BODY_CHARS,
     );
     return {
       refKind: "skill",
@@ -329,7 +341,7 @@ function renderTrace(c: TraceCandidate): InjectionSnippet {
     if (refl) parts.push(`[note] ${refl}`);
   }
   const body = withToolFollowUp(
-    truncate(parts.join("\n")),
+    truncate(parts.join("\n"), MAX_SNIPPET_BODY_CHARS),
     `→ call \`memos_get(id="${c.refId}", kind="trace")\` for the full turn`,
   );
   const when = formatMemoryTimestamp(c.ts);
@@ -346,7 +358,7 @@ function renderEpisode(c: EpisodeCandidate): InjectionSnippet {
   // (see tier2-trace.ts::renderEpisodeSummary). Keep prompt-facing text
   // free of retrieval metrics; they are useful for logs, not for answers.
   const body = withToolFollowUp(
-    truncate(stripEpisodePromptMetrics(c.summary)),
+    truncate(stripEpisodePromptMetrics(c.summary), MAX_SNIPPET_BODY_CHARS),
     `→ If this past task matches the current task type, call \`memos_timeline(episodeId="${c.refId}")\` BEFORE your first tool call to see what tools were used and what succeeded.`,
   );
   const when = formatMemoryTimestamp(c.ts);
@@ -370,16 +382,21 @@ function stripEpisodePromptMetrics(summary: string): string {
 }
 
 function renderExperience(c: ExperienceCandidate): InjectionSnippet {
+  const trigger =
+    c.trigger && c.trigger.trim() !== c.title.trim()
+      ? `Trigger: ${c.trigger}`
+      : null;
   const parts = [
     renderExperienceUseHint(c),
-    c.trigger ? `Trigger: ${c.trigger}` : null,
+    trigger,
+    c.procedure?.trim() ? `Procedure: ${c.procedure.trim()}` : null,
   ].filter(Boolean);
   return {
     refKind: "experience",
     refId: c.refId,
     title: c.title,
     body: withToolFollowUp(
-      truncate(parts.join("\n")),
+      truncate(parts.join("\n"), MAX_SNIPPET_BODY_CHARS),
       `→ call \`memos_get(id="${c.refId}", kind="policy")\` for the full policy details before relying on this experience`,
     ),
   };
@@ -403,7 +420,7 @@ function renderExperienceUseHint(c: ExperienceCandidate): string {
 
 function renderWorldModel(c: WorldModelCandidate): InjectionSnippet {
   const body = withToolFollowUp(
-    truncate(`World model: ${c.title}\n${c.body}`),
+    truncate(`World model: ${c.title}\n${c.body}`, MAX_SNIPPET_BODY_CHARS),
     `→ call \`memos_get(id="${c.refId}", kind="world_model")\` for the full environment knowledge`,
   );
   return {
@@ -760,9 +777,9 @@ function formatMemoryTimestamp(ts: number): string {
   return `${get("weekday")} ${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")} ${get("timeZoneName")}`;
 }
 
-function truncate(s: string): string {
-  if (s.length <= MAX_SNIPPET_BODY_CHARS) return s;
-  const head = s.slice(0, MAX_SNIPPET_BODY_CHARS - 16);
+function truncate(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s;
+  const head = s.slice(0, maxChars - 16);
   return `${head}\n...[truncated]`;
 }
 
@@ -770,3 +787,69 @@ function round(n: number, d: number): number {
   const f = 10 ** d;
   return Math.round(n * f) / f;
 }
+
+/** IR domain built-in search playbook (v6). */
+const IR_TURN_START_SEARCH_PLAYBOOK = `## General retrieval playbook
+
+You are answering a complex retrieval question with multiple clues, indirect references, hidden candidates, or partial-match risk. Use the available search tools or document sources to surface candidate answers, verify them against the clues, and return the requested answer slot.
+
+### 1. Hypothesize first, then verify by name
+- BEFORE your first search call, write out a short numbered list of 3-5
+  candidate entities - specific proper names of people / groups / works /
+  places / events - that plausibly satisfy the clues, based on your own world
+  knowledge. Do this even if you are unsure. If you genuinely cannot name a
+  single plausible candidate, say so in one line and start with clue
+  decomposition (section 2).
+- Probe candidates BY NAME plus one distinguishing term. Confirming or
+  refuting a named candidate is far more effective than searching the
+  riddle's own wording.
+- Snippet evidence ALWAYS outranks your prior guesses: never claim a
+  candidate satisfies a constraint unless a snippet explicitly supports it.
+- Whenever a snippet reveals a new name, add it to the candidate list and
+  probe it immediately.
+
+### 2. Decompose constraints - one concrete fact per query
+- Extract the concrete nouns from each clue (dates, places, awards, numbers,
+  titles, roles) and search them SEPARATELY.
+- Keep queries short: at most ~6 keywords. Use at most ONE quoted phrase per
+  query.
+- Never paste long paraphrases of the riddle or stack several quoted phrases
+  into a single query - the dense retriever fails on those.
+- Intersect the results: an entity that appears across multiple clue-searches
+  is your prime candidate.
+
+### 3. Pivot instead of rephrasing
+- If two consecutive queries return irrelevant snippets, do NOT reshuffle the
+  same words - switch to a different clue, or switch to candidate-name
+  probing.
+- Lead with the rarest, most distinctive terms (uncommon names, exact
+  numbers, niche events). Common words waste a search.
+
+### 4. Persistence rules
+- The answer exists in the corpus. You MUST NOT give a final answer before
+  you have made at least 12 search calls, unless you have already verified
+  every constraint of one candidate.
+- Do not conclude "not found" until you have (a) probed every named
+  candidate, and (b) searched each major clue separately.
+- If you cannot verify every constraint, still COMMIT to the single
+  best-supported candidate and cite the matching evidence. A specific answer
+  with partial support is always better than answering "unknown" or
+  "not found".
+
+### 5. Verify before answering
+- Cross-check the final candidate against EVERY constraint, with at least one
+  snippet per constraint, and cite the document ids you relied on.`;
+
+/** IR domain only: prepend the built-in search playbook before the packet body. */
+function prependIrRenderPrompt(
+  rendered: string,
+  _reason: RetrievalReason,
+  domain?: string,
+): string {
+  if (!isIrDomain(domain)) return rendered;
+  const body = rendered.trim();
+  return body
+    ? `${IR_TURN_START_SEARCH_PLAYBOOK}\n\n${body}`
+    : IR_TURN_START_SEARCH_PLAYBOOK;
+}
+

--- a/apps/memos-local-plugin/core/retrieval/llm-filter.ts
+++ b/apps/memos-local-plugin/core/retrieval/llm-filter.ts
@@ -9,16 +9,12 @@
  *
  * Design constraints:
  *   - One LLM call per turn, bounded output (index list + `sufficient`).
- *   - Totally opt-in: if the LLM is null or the config flag is off,
- *     we apply a small mechanical fallback cap instead of calling out.
- *     Empty / below-threshold lists still pass through unchanged.
- *   - On ANY failure (network, schema, timeout) we fall back to a
- *     mechanical cutoff. A broken filter must never crash retrieval.
+ *   - When the LLM returns an empty selection, we inject nothing — no
+ *     mechanical top-1 / safe-cutoff fallback.
+ *   - When filter is disabled or no LLM client is configured, a small
+ *     mechanical cap still applies so offline installs stay usable.
  *   - Returns both kept and dropped candidates so callers can log
  *     exactly what the LLM pruned (feeds the Logs page).
- *   - Rich candidate labels — we include role/time/tags/channels/score
- *     because openclaw's filter runs on those fields and loses precision
- *     without them.
  */
 
 import type { LlmClient } from "../llm/index.js";
@@ -35,12 +31,6 @@ const MAX_FILTER_OUTPUT_TOKENS = 2048;
 export interface FilterInput {
   query: string;
   ranked: readonly RankedCandidate[];
-  /**
-   * Episode this retrieval is happening for (typically the active or
-   * just-opening episode). Forwarded to the LLM call so the resulting
-   * `system_model_status` audit row can be grouped with the rest of
-   * that episode's pipeline activity in the Logs viewer.
-   */
   episodeId?: string;
 }
 
@@ -61,10 +51,6 @@ export interface FilterDeps {
 export interface FilterResult {
   kept: RankedCandidate[];
   dropped: RankedCandidate[];
-  /**
-   * Why the filter took this shape — surfaced so logs can show
-   * "skipped: below threshold" vs "llm returned no selections".
-   */
   outcome:
     | "disabled"
     | "no_llm"
@@ -73,17 +59,8 @@ export interface FilterResult {
     | "deferred_to_final"
     | "llm_kept_all"
     | "llm_filtered"
-    // The LLM was supposed to run but the call failed / parsed badly.
-    // We applied a mechanical relevance cutoff (top-K above
-    // `relativeThresholdFloor · topRelevance`) instead of dumping the
-    // entire ranked list into the prompt.
-    | "llm_failed_safe_cutoff";
-  /**
-   * The LLM's self-report on whether the *kept* candidates are enough
-   * to answer `query`, or whether the caller should widen recall /
-   * run a follow-up `memos_search`. `null` when the filter didn't
-   * run (disabled / passthrough / failure paths).
-   */
+    | "llm_rejected_all"
+    | "llm_filter_error";
   sufficient: boolean | null;
 }
 
@@ -95,11 +72,6 @@ export async function llmFilterCandidates(
   if (!deps.config.llmFilterEnabled) {
     return fallbackCap(ranked, deps, "disabled");
   }
-  // `llmFilterMinCandidates` is the *minimum* list length required to
-  // RUN the filter. Default is 1, meaning even a single candidate gets
-  // a precision pass — openclaw behaviour, and matches the user
-  // reports that "a single off-topic memory sneaks through when the
-  // filter skips the check".
   if (ranked.length < deps.config.llmFilterMinCandidates) {
     return passthrough(ranked, "below_threshold");
   }
@@ -143,8 +115,6 @@ ${list}`,
         episodeId: input.episodeId,
         temperature: 0,
         timeoutMs: deps.timeoutMs,
-        // Output is only ordered indices + one bool, but the list can
-        // legitimately be as long as the ranked candidates.
         maxTokens: filterOutputTokenBudget(ranked.length),
         malformedRetries: 1,
       },
@@ -153,7 +123,7 @@ ${list}`,
     const sufficient = coerceBool(rsp.value?.sufficient);
     if (!Array.isArray(raw)) {
       deps.log.debug("llm_filter.malformed", { got: typeof raw });
-      return safeCutoff(ranked, deps);
+      return rejectAll(ranked, "llm_filter_error", null);
     }
     const orderedIndices: number[] = [];
     const seenIndices = new Set<number>();
@@ -172,11 +142,11 @@ ${list}`,
     );
     const keepIndices = new Set(cappedIndices);
     if (keepIndices.size === 0) {
-      deps.log.warn("llm_filter.empty_selection_fallback", {
+      deps.log.warn("llm_filter.empty_selection", {
         candidateCount: ranked.length,
         sufficient: sufficient ?? null,
       });
-      return safeCutoff(ranked, deps);
+      return rejectAll(ranked, "llm_rejected_all", sufficient);
     }
     const kept = cappedIndices.map((i) => ranked[i]!);
     const dropped: RankedCandidate[] = [];
@@ -195,7 +165,7 @@ ${list}`,
       err: err instanceof Error ? err.message : String(err),
       candidateCount: ranked.length,
     });
-    return safeCutoff(ranked, deps);
+    return rejectAll(ranked, "llm_filter_error", null);
   }
 }
 
@@ -213,64 +183,16 @@ function passthrough(
   return { kept: [...ranked], dropped: [], outcome, sufficient: null };
 }
 
-/**
- * Mechanical fail-closed: when the LLM is unavailable / errored,
- * apply a relative-relevance cutoff so we don't dump the entire ranked
- * list into the prompt. Keeps:
- *   1. items whose score ≥ `topScore · 0.7`
- *   2. capped at `llmFilterFallbackMaxKeep` so the prompt stays small.
- *
- * The ranker already applied an initial cutoff with the same family of
- * floors, but the LLM is expected to prune further (because the
- * ranker is tuned for recall). This fallback uses a slightly tighter
- * ratio so the "fail" path doesn't ship as much noise as the success
- * path.
- */
-function safeCutoff(
+function rejectAll(
   ranked: readonly RankedCandidate[],
-  deps: FilterDeps,
+  outcome: Extract<FilterResult["outcome"], "llm_rejected_all" | "llm_filter_error">,
+  sufficient: boolean | null,
 ): FilterResult {
-  if (ranked.length === 0) {
-    return {
-      kept: [],
-      dropped: [],
-      outcome: "llm_failed_safe_cutoff",
-      sufficient: null,
-    };
-  }
-  const ratio = 0.7;
-  const topScore = ranked.reduce(
-    (m, c) => Math.max(m, c.score ?? c.relevance),
-    0,
-  );
-  const cutoff = topScore > 0 ? topScore * ratio : 0;
-  const keepCap = fallbackMaxKeep(deps);
-  if (keepCap === 0) {
-    return {
-      kept: [],
-      dropped: [...ranked],
-      outcome: "llm_failed_safe_cutoff",
-      sufficient: null,
-    };
-  }
-  const kept: RankedCandidate[] = [];
-  const dropped: RankedCandidate[] = [];
-  for (const c of ranked) {
-    const s = c.score ?? c.relevance;
-    if (s >= cutoff && kept.length < keepCap) kept.push(c);
-    else dropped.push(c);
-  }
-  // If the cutoff would have dropped everything, keep the single best
-  // candidate so the agent at least sees one option.
-  if (kept.length === 0 && ranked.length > 0) {
-    kept.push(ranked[0]!);
-    dropped.shift();
-  }
   return {
-    kept,
-    dropped,
-    outcome: "llm_failed_safe_cutoff",
-    sufficient: null,
+    kept: [],
+    dropped: [...ranked],
+    outcome,
+    sufficient,
   };
 }
 
@@ -310,12 +232,6 @@ function coerceBool(v: unknown): boolean | null {
   return null;
 }
 
-/**
- * Render a ranked candidate into a single labelled string for the LLM.
- * Keep this intentionally content-focused: the filter should judge the
- * candidate's semantic usefulness, not anchor on retrieval internals like
- * timestamps, channels, tags, or ranker scores.
- */
 function describeCandidate(r: RankedCandidate, bodyChars: number): string {
   const c = r.candidate;
   switch (c.tier) {

--- a/apps/memos-local-plugin/core/retrieval/query-builder.ts
+++ b/apps/memos-local-plugin/core/retrieval/query-builder.ts
@@ -10,7 +10,9 @@
  */
 
 import { extractErrorSignatures } from "../capture/error-signature.js";
+import { isIrDomain } from "../domain.js";
 import { extractPatternTerms, prepareFtsMatch } from "../storage/keyword.js";
+import { focusIrRetrievalQuery } from "./task-focus.js";
 import type { RetrievalCtx } from "./types.js";
 
 const MAX_QUERY_CHARS = 1_500;
@@ -101,26 +103,36 @@ export interface RetrievalQueryExtract {
   keywords: string[];
 }
 
+export interface QueryBuildOpts {
+  domain?: string;
+}
+
 /**
  * Build a `CompiledQuery` from a retrieval context. Behavior varies per
  * reason so that e.g. `decision_repair` biases toward the failing tool name.
  */
-export function buildQuery(ctx: RetrievalCtx): CompiledQuery {
-  return finalize(rawQueryText(ctx));
+export function buildQuery(ctx: RetrievalCtx, opts?: QueryBuildOpts): CompiledQuery {
+  return finalize(rawQueryText(ctx, opts));
 }
 
 export function buildQueryWithExtract(
   ctx: RetrievalCtx,
   extract: RetrievalQueryExtract | null | undefined,
+  opts?: QueryBuildOpts,
 ): CompiledQuery {
-  return finalize(rawQueryText(ctx), extract);
+  return finalize(rawQueryText(ctx, opts), extract);
 }
 
-export function rawQueryText(ctx: RetrievalCtx): string {
+function applyIrQueryFocus(raw: string, domain?: string): string {
+  if (!isIrDomain(domain)) return raw;
+  return focusIrRetrievalQuery(raw).text;
+}
+
+export function rawQueryText(ctx: RetrievalCtx, opts?: QueryBuildOpts): string {
   switch (ctx.reason) {
     case "turn_start": {
       const hintText = hintToText(ctx.contextHints);
-      const parts = [ctx.userText?.trim() ?? ""];
+      const parts = [applyIrQueryFocus(ctx.userText?.trim() ?? "", opts?.domain)];
       if (hintText) parts.push(hintText);
       return parts.join("\n");
     }
@@ -129,7 +141,9 @@ export function rawQueryText(ctx: RetrievalCtx): string {
         const rest = { ...ctx.args };
         delete rest.query;
         const restText = Object.keys(rest).length > 0 ? renderArgs(rest) : "";
-        return [ctx.args.query.trim(), restText].filter(Boolean).join("\n");
+        return [applyIrQueryFocus(ctx.args.query.trim(), opts?.domain), restText]
+          .filter(Boolean)
+          .join("\n");
       }
       const args = renderArgs(ctx.args);
       return `tool:${ctx.tool}\n${args}`;

--- a/apps/memos-local-plugin/core/retrieval/retrieve.ts
+++ b/apps/memos-local-plugin/core/retrieval/retrieve.ts
@@ -26,6 +26,11 @@ import type {
   RetrievalReason,
 } from "../../agent-contract/dto.js";
 import { ERROR_CODES } from "../../agent-contract/errors.js";
+import {
+  effectiveReadOnlyInjectionProfile,
+  effectiveSkillInjectionMode,
+  isIrDomain,
+} from "../domain.js";
 import { ids } from "../id.js";
 import { rootLogger } from "../logger/index.js";
 import { collectDecisionGuidance } from "./decision-guidance.js";
@@ -47,6 +52,11 @@ import { runTier1 } from "./tier1-skill.js";
 import { runTier2Experience } from "./tier2-experience.js";
 import { runTier2 } from "./tier2-trace.js";
 import { runTier3 } from "./tier3-world.js";
+import {
+  mergeRetrievePlanOverride,
+  resolveInjectionProfilePlan,
+  type ReadOnlyInjectionProfile,
+} from "./injection-profile.js";
 import type {
   EpisodeCandidate,
   ExperienceCandidate,
@@ -108,6 +118,8 @@ export interface RetrievePlanOverride {
   wantTier1?: boolean;
   wantTier2?: boolean;
   wantTier3?: boolean;
+  /** Tier2: only policy/experience hits — skip trace + episode recall. */
+  experienceOnly?: boolean;
   limit?: number;
 }
 
@@ -118,25 +130,26 @@ export async function turnStartRetrieve(
   ctx: TurnStartRetrieveCtx,
   opts: RetrieveOptions = {},
 ): Promise<RetrievalResult> {
+  const resolvedOpts = withInjectionProfileOpts(deps, opts);
   if (deps.config.lightweightMemory) {
-    return runAll(deps, ctx, opts, applyPlanOverride({
+    return runAll(deps, ctx, resolvedOpts, applyPlanOverride({
       wantTier1: false,
       wantTier2: true,
       wantTier3: false,
       includeLowValue: false,
-      limit: opts.limit ?? Math.max(1, deps.config.tier2TopK),
+      limit: resolvedOpts.limit ?? Math.max(1, deps.config.tier2TopK),
       traceOnly: true,
-    }, opts.plan));
+    }, resolvedOpts.plan));
   }
-  return runAll(deps, ctx, opts, applyPlanOverride({
+  return runAll(deps, ctx, resolvedOpts, applyPlanOverride({
     wantTier1: true,
     wantTier2: true,
     wantTier3: true,
     includeLowValue: deps.config.includeLowValue,
     limit:
-      opts.limit ??
+      resolvedOpts.limit ??
       deps.config.tier1TopK + deps.config.tier2TopK + deps.config.tier3TopK,
-  }, opts.plan));
+  }, resolvedOpts.plan));
 }
 
 // ─── Entry point: tool_driven ───────────────────────────────────────────────
@@ -146,17 +159,18 @@ export async function toolDrivenRetrieve(
   ctx: ToolDrivenRetrieveCtx,
   opts: RetrieveOptions = {},
 ): Promise<RetrievalResult> {
+  const resolvedOpts = withInjectionProfileOpts(deps, opts);
   // Tool-driven retrievals are smaller — we've already spent a turn budget;
   // we only mine Tier 2 (+ optional Tier 3 if vec available). Tier-1 is
   // skipped to avoid re-injecting skills the agent already saw at turn_start.
-  return runAll(deps, ctx, opts, {
+  return runAll(deps, ctx, resolvedOpts, applyPlanOverride({
     wantTier1: false,
     wantTier2: true,
     wantTier3: deps.config.lightweightMemory ? false : true,
     includeLowValue: deps.config.includeLowValue,
-    limit: opts.limit ?? Math.max(1, deps.config.tier2TopK),
+    limit: resolvedOpts.limit ?? Math.max(1, deps.config.tier2TopK),
     traceOnly: deps.config.lightweightMemory,
-  });
+  }, resolvedOpts.plan));
 }
 
 // ─── Entry point: skill_invoke ──────────────────────────────────────────────
@@ -238,6 +252,7 @@ interface RunPlan {
   includeLowValue: boolean;
   limit: number;
   traceOnly?: boolean;
+  experienceOnly?: boolean;
 }
 
 function applyPlanOverride(plan: RunPlan, override?: RetrievePlanOverride): RunPlan {
@@ -249,7 +264,21 @@ function applyPlanOverride(plan: RunPlan, override?: RetrievePlanOverride): RunP
     wantTier2: override.wantTier2 ?? plan.wantTier2,
     wantTier3: override.wantTier3 ?? plan.wantTier3,
     limit: override.limit ?? plan.limit,
+    experienceOnly: override.experienceOnly ?? plan.experienceOnly,
   };
+}
+
+function withInjectionProfileOpts(
+  deps: RetrievalDeps,
+  opts: RetrieveOptions,
+): RetrieveOptions {
+  if (!isIrDomain(deps.config.domain)) return opts;
+  const profilePlan = resolveInjectionProfilePlan(
+    effectiveReadOnlyInjectionProfile(deps.config) as ReadOnlyInjectionProfile,
+  );
+  const mergedPlan = mergeRetrievePlanOverride(profilePlan, opts.plan);
+  if (!mergedPlan) return opts;
+  return { ...opts, plan: mergedPlan };
 }
 
 async function runAll(
@@ -263,14 +292,15 @@ async function runAll(
   const episodeId = (ctx as { episodeId?: EpisodeId }).episodeId;
   const ts = deps.now();
 
-  const rawQuery = rawQueryText(ctx);
+  const queryOpts = { domain: deps.config.domain };
+  const rawQuery = rawQueryText(ctx, queryOpts);
   const llmExtract = await extractRetrievalQueryWithLlm(rawQuery, {
     llm: deps.llm ?? null,
     log,
     episodeId,
     timeoutMs: RETRIEVAL_QUERY_EXTRACT_TIMEOUT_MS,
   });
-  const compiled = buildQueryWithExtract(ctx, llmExtract);
+  const compiled = buildQueryWithExtract(ctx, llmExtract, queryOpts);
   const taskProtocol = renderTaskProtocol(ctx);
   const standaloneMathFinalAnswer = isStandaloneMathFinalAnswerContext(ctx);
   opts.events?.emit({
@@ -319,7 +349,10 @@ async function runAll(
     const wantTier1 = plan.wantTier1 && deps.config.tier1TopK > 0;
     const wantTier2 = plan.wantTier2 && deps.config.tier2TopK > 0;
     const wantTier3 = plan.wantTier3 && deps.config.tier3TopK > 0;
-    const traceOnly = plan.traceOnly === true || deps.config.lightweightMemory === true;
+    const experienceOnly = plan.experienceOnly === true;
+    const traceOnly =
+      !experienceOnly &&
+      (plan.traceOnly === true || deps.config.lightweightMemory === true);
 
     const tier1Start = Date.now();
     const tier1Promise: Promise<SkillCandidate[]> =
@@ -338,7 +371,7 @@ async function runAll(
 
     const tier2Start = Date.now();
     const tier2Promise: Promise<{ traces: TraceCandidate[]; episodes: EpisodeCandidate[] }> =
-      wantTier2 && !noUsableChannel
+      wantTier2 && !experienceOnly && !noUsableChannel
         ? runTier2(
             { repos: deps.repos, config: deps.config, now: deps.now },
             {
@@ -357,7 +390,7 @@ async function runAll(
         : Promise.resolve({ traces: [], episodes: [] });
 
     const tier2ExperiencePromise: Promise<ExperienceCandidate[]> =
-      wantTier2 && !traceOnly && !noUsableChannel
+      wantTier2 && (!traceOnly || experienceOnly) && !noUsableChannel
         ? runTier2Experience(
             { repos: deps.repos, config: deps.config },
             {
@@ -494,11 +527,12 @@ async function runAll(
       // descriptors + a `memos_skill_get(...)` invocation hint instead of
       // inlining every full guide. Hosts without tool support can flip
       // this to "full" via `algorithm.retrieval.skillInjectionMode`.
-      skillInjectionMode: deps.config.skillInjectionMode,
+      skillInjectionMode: effectiveSkillInjectionMode(deps.config),
       skillSummaryChars: deps.config.skillSummaryChars,
       decisionGuidance,
       standaloneMathFinalAnswer,
       taskProtocol,
+      domain: deps.config.domain,
     });
     // Surface the dropped-by-LLM candidates so the Logs page can show
     // "initial N → kept M" without the viewer having to re-run the

--- a/apps/memos-local-plugin/core/retrieval/task-focus.ts
+++ b/apps/memos-local-plugin/core/retrieval/task-focus.ts
@@ -1,0 +1,69 @@
+/**
+ * Retrieval query focus — strip host / eval prompt scaffolding so embed,
+ * FTS, and llm_filter target the user's task, not repeated instruction templates.
+ */
+
+export type QueryFocusMethod =
+  | "passthrough"
+  | "question_section"
+  | "fallback";
+
+export interface QueryFocusResult {
+  text: string;
+  method: QueryFocusMethod;
+}
+
+const QUESTION_HEADING_RE = /^#{1,3}\s*question\s*$/i;
+
+const IR_EVAL_MARKERS_RE = /\bdeep research agent\b/i;
+
+/**
+ * Body after a markdown `## Question` (or `# Question`) heading.
+ * Returns null when the heading is missing or the body is empty.
+ */
+export function extractQuestionSection(raw: string): string | null {
+  const text = raw.trim();
+  if (!text) return null;
+
+  const lines = text.split("\n");
+  let start = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (QUESTION_HEADING_RE.test(lines[i]!.trim())) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start < 0) return null;
+
+  const bodyLines: string[] = [];
+  for (let i = start; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (bodyLines.length > 0 && /^#{1,3}\s+\S/.test(line.trim())) break;
+    bodyLines.push(line);
+  }
+  const body = bodyLines.join("\n").trim();
+  return body || null;
+}
+
+/** True when the prompt matches the EvoAgentBench IR eval template shape. */
+export function isIrEvalPrompt(raw: string): boolean {
+  const text = raw.trim();
+  if (!text) return false;
+  if (!IR_EVAL_MARKERS_RE.test(text)) return false;
+  return text.split("\n").some((line) => QUESTION_HEADING_RE.test(line.trim()));
+}
+
+/**
+ * When the prompt is an IR eval template, keep only the `## Question` body.
+ * Otherwise return the raw text unchanged.
+ */
+export function focusIrRetrievalQuery(raw: string): QueryFocusResult {
+  const text = raw.trim();
+  if (!text) return { text: "", method: "passthrough" };
+  if (!isIrEvalPrompt(text)) return { text, method: "passthrough" };
+
+  const question = extractQuestionSection(text);
+  if (question) return { text: question, method: "question_section" };
+
+  return { text, method: "fallback" };
+}

--- a/apps/memos-local-plugin/core/retrieval/types.ts
+++ b/apps/memos-local-plugin/core/retrieval/types.ts
@@ -316,6 +316,16 @@ export interface RetrievalConfig {
    * window pays for itself).
    */
   llmFilterCandidateBodyChars?: number;
+  /**
+   * Read-only eval scope: restrict which memory kinds are injected before
+   * the prompt. `all` preserves the normal tier mix for the entrypoint.
+   */
+  readOnlyInjectionProfile?: "all" | "experience" | "skill" | "skill_experience";
+  /**
+   * Task domain preset. IR-only retrieval knobs (`readOnlyInjectionProfile`,
+   * `skillInjectionMode`, query focus) apply only when `domain === "ir"`.
+   */
+  domain?: "" | "ir";
   /** Low-cost mode: retrieve raw trace memories only. */
   lightweightMemory?: boolean;
 }
@@ -759,7 +769,8 @@ export interface RetrievalStats {
     | "deferred_to_final"
     | "llm_kept_all"
     | "llm_filtered"
-    | "llm_failed_safe_cutoff";
+    | "llm_rejected_all"
+    | "llm_filter_error";
   llmFilterSufficient?: boolean;
   llmFilterKept?: number;
   llmFilterDropped?: number;

--- a/apps/memos-local-plugin/tests/unit/core/domain.test.ts
+++ b/apps/memos-local-plugin/tests/unit/core/domain.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  effectiveReadOnlyInjectionProfile,
+  effectiveSkillInjectionMode,
+  isIrDomain,
+} from "../../../core/domain.js";
+
+describe("domain helpers", () => {
+  it("isIrDomain is true only for ir", () => {
+    expect(isIrDomain("ir")).toBe(true);
+    expect(isIrDomain("")).toBe(false);
+    expect(isIrDomain(undefined)).toBe(false);
+  });
+
+  it("effectiveSkillInjectionMode forces summary outside ir", () => {
+    expect(
+      effectiveSkillInjectionMode({ domain: "", skillInjectionMode: "full" }),
+    ).toBe("summary");
+    expect(
+      effectiveSkillInjectionMode({ domain: "ir", skillInjectionMode: "full" }),
+    ).toBe("full");
+  });
+
+  it("effectiveReadOnlyInjectionProfile forces all outside ir", () => {
+    expect(
+      effectiveReadOnlyInjectionProfile({
+        domain: "",
+        readOnlyInjectionProfile: "skill",
+      }),
+    ).toBe("all");
+    expect(
+      effectiveReadOnlyInjectionProfile({
+        domain: "ir",
+        readOnlyInjectionProfile: "skill",
+      }),
+    ).toBe("skill");
+  });
+});

--- a/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/injector.test.ts
@@ -197,7 +197,9 @@ describe("retrieval/injector", () => {
     );
     expect(packet.rendered).toContain("Trigger: similar SEC 13F parsing task");
     expect(packet.rendered).toContain("Use as guardrail before planning.");
-    expect(packet.rendered).not.toContain("Do: Use holdings table columns directly.");
+    expect(packet.rendered).toContain(
+      "Procedure: Use holdings table columns directly.",
+    );
     expect(packet.rendered).not.toContain("Avoid: Do not infer issuer from filename.");
     expect(packet.rendered).not.toContain("Scope: SEC 13F holdings extraction only.");
     expect(packet.rendered).not.toContain(
@@ -525,7 +527,7 @@ describe("retrieval/injector", () => {
     expect(packet.snippets.length).toBe(0);
   });
 
-  it("truncates oversized trace bodies", () => {
+  it("truncates oversized trace bodies at the trace snippet cap", () => {
     const big = trace("huge");
     big.agentText = "x".repeat(10_000);
     const { packet } = toPacket({
@@ -539,5 +541,95 @@ describe("retrieval/injector", () => {
     expect(packet.snippets[0]!.body.length).toBeLessThanOrEqual(720);
     expect(packet.snippets[0]!.body).toContain("[truncated]");
     expect(packet.snippets[0]!.body).toContain('memos_get(id="huge", kind="trace")');
+  });
+
+  it("keeps full skill guides under the skill snippet cap", () => {
+    const longGuide = [
+      "# long_skill",
+      "",
+      "**Summary**",
+      "A".repeat(2500),
+      "",
+      "**Procedure**",
+      "1. **Step** — do the thing",
+    ].join("\n");
+    const { packet } = toPacket({
+      ranked: [
+        rc(
+          {
+            ...skill("sk_long"),
+            invocationGuide: longGuide,
+          },
+          0.9,
+          0.9,
+        ),
+      ],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_skill_cap" as never,
+      episodeId: "ep_skill_cap" as never,
+      skillInjectionMode: "full",
+    });
+    const skillSnippet = packet.snippets.find((s) => s.refKind === "skill")!;
+    expect(skillSnippet.body).not.toContain("[truncated]");
+    expect(skillSnippet.body).toContain("do the thing");
+  });
+
+  it("ir domain prepends built-in search playbook on turn_start", () => {
+    const { packet } = toPacket({
+      ranked: [rc(skill("sk_docker"), 0.9, 0.9)],
+      reason: "turn_start",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_ir" as never,
+      episodeId: "ep_ir" as never,
+      domain: "ir",
+    });
+    expect(packet.rendered.startsWith("## General retrieval playbook")).toBe(true);
+    expect(packet.rendered).toContain("sk_docker");
+  });
+
+  it("ir domain prepends built-in search playbook on tool_driven (readonly before_prompt)", () => {
+    const { packet } = toPacket({
+      ranked: [rc(skill("sk_docker"), 0.9, 0.9)],
+      reason: "tool_driven",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_ir" as never,
+      episodeId: "ep_ir" as never,
+      domain: "ir",
+    });
+    expect(packet.rendered.startsWith("## General retrieval playbook")).toBe(true);
+    expect(packet.rendered).toContain("sk_docker");
+  });
+
+  it("prepends ir playbook with empty ranked hits (llm filter rejected all)", () => {
+    const { packet } = toPacket({
+      ranked: [],
+      reason: "tool_driven",
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_ir" as never,
+      episodeId: "ep_ir" as never,
+      domain: "ir",
+    });
+    expect(packet.rendered).toBeTruthy();
+    expect(packet.rendered.startsWith("## General retrieval playbook")).toBe(true);
+    expect(packet.snippets).toHaveLength(0);
+  });
+
+  it("does not prepend ir playbook outside ir domain", () => {
+    const base = {
+      ranked: [rc(skill("sk_docker"), 0.9, 0.9)],
+      tierLatencyMs: { tier1: 0, tier2: 0, tier3: 0 },
+      now: NOW as never,
+      sessionId: "sess_ir" as never,
+      episodeId: "ep_ir" as never,
+    };
+    const turnStart = toPacket({ ...base, reason: "turn_start" });
+    const toolDriven = toPacket({ ...base, reason: "tool_driven" });
+    expect(turnStart.packet.rendered.startsWith("## General retrieval playbook")).toBe(false);
+    expect(toolDriven.packet.rendered.startsWith("## General retrieval playbook")).toBe(false);
   });
 });

--- a/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/integration.test.ts
@@ -162,6 +162,22 @@ function seed(handle: TmpDbHandle) {
   });
 }
 
+function depsWithInjectionProfile(
+  handle: TmpDbHandle,
+  profile: "all" | "experience" | "skill" | "skill_experience",
+  domain: "" | "ir" = "ir",
+): RetrievalDeps {
+  const deps = makeDeps(handle);
+  return {
+    ...deps,
+    config: {
+      ...deps.config,
+      domain,
+      readOnlyInjectionProfile: profile,
+    },
+  };
+}
+
 function makeDeps(handle: TmpDbHandle): RetrievalDeps {
   return {
     repos: {
@@ -270,8 +286,10 @@ describe("retrieval/integration", () => {
     expect(experience?.refId).toBe("po_sec13f_issuer");
     expect(experience?.title).toContain("SEC 13F issuer CUSIP");
     expect(experience?.body).toContain("Trigger: Parse SEC 13F holdings");
+    expect(experience?.body).toContain(
+      "Procedure: Use holdings table columns directly",
+    );
     expect(experience?.body).toContain('memos_get(id="po_sec13f_issuer", kind="policy")');
-    expect(experience?.body).not.toContain("Use holdings table columns directly");
     expect(experience?.body).not.toContain("confidence=");
     expect(experience?.body).not.toContain("evidence=");
     expect(res.packet.rendered).toContain("## Experiences");
@@ -294,6 +312,85 @@ describe("retrieval/integration", () => {
     });
     expect(res.stats.tier1Count).toBe(0);
     expect(res.packet.snippets.every((s) => s.refKind !== "skill")).toBe(true);
+  });
+
+  it("readOnlyInjectionProfile is ignored when domain is not ir", async () => {
+    const ctx = {
+      reason: "tool_driven" as const,
+      agent: "openclaw" as const,
+      sessionId: "s1" as SessionId,
+      tool: "memos_search",
+      args: { query: "docker compose" },
+      ts: NOW as never,
+    };
+    const irScoped = await toolDrivenRetrieve(
+      depsWithInjectionProfile(handle, "skill", "ir"),
+      ctx,
+    );
+    const defaultDomain = await toolDrivenRetrieve(
+      depsWithInjectionProfile(handle, "skill", ""),
+      ctx,
+    );
+    const irKinds = irScoped.packet.snippets.map((s) => s.refKind);
+    const defaultKinds = defaultDomain.packet.snippets.map((s) => s.refKind);
+    expect(irKinds).toContain("skill");
+    expect(irScoped.stats.tier1Count).toBeGreaterThan(0);
+    expect(defaultKinds).not.toContain("skill");
+    expect(defaultDomain.stats.tier1Count).toBe(0);
+  });
+
+  it("readOnlyInjectionProfile=experience injects policy only", async () => {
+    const res = await toolDrivenRetrieve(depsWithInjectionProfile(handle, "experience"), {
+      reason: "tool_driven",
+      agent: "openclaw",
+      sessionId: "s1" as SessionId,
+      tool: "memos_search",
+      args: { query: "SEC 13F issuer CUSIP parsing" },
+      ts: NOW as never,
+    });
+    const kinds = res.packet.snippets.map((s) => s.refKind);
+    expect(kinds).toContain("experience");
+    expect(kinds).not.toContain("skill");
+    expect(kinds).not.toContain("trace");
+    expect(kinds).not.toContain("episode");
+    expect(kinds).not.toContain("world-model");
+  });
+
+  it("readOnlyInjectionProfile=skill injects skill only via tool_driven", async () => {
+    const res = await toolDrivenRetrieve(depsWithInjectionProfile(handle, "skill"), {
+      reason: "tool_driven",
+      agent: "openclaw",
+      sessionId: "s1" as SessionId,
+      tool: "memos_search",
+      args: { query: "docker compose" },
+      ts: NOW as never,
+    });
+    const kinds = res.packet.snippets.map((s) => s.refKind);
+    expect(kinds).toContain("skill");
+    expect(kinds).not.toContain("experience");
+    expect(kinds).not.toContain("trace");
+    expect(kinds).not.toContain("episode");
+    expect(kinds).not.toContain("world-model");
+  });
+
+  it("readOnlyInjectionProfile=skill_experience injects skill and policy mix", async () => {
+    const res = await toolDrivenRetrieve(
+      depsWithInjectionProfile(handle, "skill_experience"),
+      {
+        reason: "tool_driven",
+        agent: "openclaw",
+        sessionId: "s1" as SessionId,
+        tool: "memos_search",
+        args: { query: "docker compose SEC 13F issuer" },
+        ts: NOW as never,
+      },
+    );
+    const kinds = new Set(res.packet.snippets.map((s) => s.refKind));
+    expect(kinds.has("skill")).toBe(true);
+    expect(kinds.has("experience")).toBe(true);
+    expect(kinds.has("trace")).toBe(false);
+    expect(kinds.has("episode")).toBe(false);
+    expect(kinds.has("world-model")).toBe(false);
   });
 
   it("tool_driven filters trace and episode memories from the current session", async () => {

--- a/apps/memos-local-plugin/tests/unit/retrieval/llm-filter.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/llm-filter.test.ts
@@ -190,7 +190,7 @@ describe("retrieval/llm-filter", () => {
     expect(result.sufficient).toBe(true);
   });
 
-  it("LLM returns empty selection → fallback capped instead of dropping everything", async () => {
+  it("LLM returns empty selection → inject nothing (no soft fallback)", async () => {
     const llm: any = {
       completeJson: vi.fn().mockResolvedValue({
         value: { selected: [], sufficient: false },
@@ -202,10 +202,14 @@ describe("retrieval/llm-filter", () => {
       { query: "q", ranked },
       { llm, log, config: { ...cfg, llmFilterFallbackMaxKeep: 2 } },
     );
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
-    expect(result.kept.map((r) => String(r.candidate.refId))).toEqual(["a", "b"]);
-    expect(result.dropped.map((r) => String(r.candidate.refId))).toEqual(["c"]);
-    expect(result.sufficient).toBeNull();
+    expect(result.outcome).toBe("llm_rejected_all");
+    expect(result.kept).toEqual([]);
+    expect(result.dropped.map((r) => String(r.candidate.refId))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(result.sufficient).toBe(false);
   });
 
   it("coerces string / number `sufficient` fields sent by lax models", async () => {
@@ -222,7 +226,7 @@ describe("retrieval/llm-filter", () => {
     expect(result.sufficient).toBe(true);
   });
 
-  it("LLM throws → mechanical safe cutoff (NOT passthrough)", async () => {
+  it("LLM throws → inject nothing (no soft fallback)", async () => {
     const llm: any = {
       completeJson: vi.fn().mockRejectedValue(new Error("network kaboom")),
     };
@@ -235,60 +239,14 @@ describe("retrieval/llm-filter", () => {
       { query: "q", ranked },
       { llm, log, config: cfg },
     );
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
+    expect(result.outcome).toBe("llm_filter_error");
     expect(result.sufficient).toBeNull();
-    const ids = result.kept.map((r) => String(r.candidate.refId));
-    expect(ids).toContain("strong");
-    expect(ids).not.toContain("weak");
-  });
-
-  it("safe-cutoff still keeps at least 1 candidate even if all are weak", async () => {
-    const llm: any = {
-      completeJson: vi.fn().mockRejectedValue(new Error("boom")),
-    };
-    const result = await llmFilterCandidates(
-      { query: "q", ranked: [trace("a", 0.5), trace("b", 0.49)] },
-      { llm, log, config: cfg },
-    );
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
-    expect(result.kept.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("safe-cutoff respects llmFilterFallbackMaxKeep cap", async () => {
-    const llm: any = {
-      completeJson: vi.fn().mockRejectedValue(new Error("boom")),
-    };
-    const ranked = [
-      trace("a", 0.95),
-      trace("b", 0.94),
-      trace("c", 0.93),
-      trace("d", 0.92),
-      trace("e", 0.91),
-      trace("f", 0.9),
-    ];
-    const result = await llmFilterCandidates(
-      { query: "q", ranked },
-      {
-        llm,
-        log,
-        config: { ...cfg, llmFilterMaxKeep: 8, llmFilterFallbackMaxKeep: 2 },
-      },
-    );
-    expect(result.kept.length).toBeLessThanOrEqual(2);
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
-  });
-
-  it("safe-cutoff respects a zero llmFilterFallbackMaxKeep cap", async () => {
-    const llm: any = {
-      completeJson: vi.fn().mockRejectedValue(new Error("boom")),
-    };
-    const result = await llmFilterCandidates(
-      { query: "q", ranked: [trace("a", 0.9), trace("b", 0.8)] },
-      { llm, log, config: { ...cfg, llmFilterFallbackMaxKeep: 0 } },
-    );
     expect(result.kept).toEqual([]);
-    expect(result.dropped.length).toBe(2);
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
+    expect(result.dropped.map((r) => String(r.candidate.refId))).toEqual([
+      "strong",
+      "middle",
+      "weak",
+    ]);
   });
 
   it("no LLM at all → fallback capped without full passthrough", async () => {
@@ -310,7 +268,7 @@ describe("retrieval/llm-filter", () => {
     expect(result.sufficient).toBeNull();
   });
 
-  it("malformed LLM output uses fallback cap instead of normal max keep", async () => {
+  it("malformed LLM output → inject nothing", async () => {
     const llm: any = {
       completeJson: vi.fn().mockResolvedValue({
         value: { ranked: "not-an-array" },
@@ -331,8 +289,9 @@ describe("retrieval/llm-filter", () => {
         config: { ...cfg, llmFilterMaxKeep: 8, llmFilterFallbackMaxKeep: 2 },
       },
     );
-    expect(result.outcome).toBe("llm_failed_safe_cutoff");
-    expect(result.kept.length).toBeLessThanOrEqual(2);
+    expect(result.outcome).toBe("llm_filter_error");
+    expect(result.kept).toEqual([]);
+    expect(result.dropped.length).toBe(4);
   });
 
   it("candidate description omits retrieval metadata and keeps semantic content", async () => {

--- a/apps/memos-local-plugin/tests/unit/retrieval/query-builder.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/query-builder.test.ts
@@ -27,6 +27,67 @@ describe("retrieval/query-builder", () => {
     expect(cq.truncated).toBe(false);
   });
 
+  it("turn_start focuses IR eval prompts on the ## Question section when domain=ir", () => {
+    const question =
+      "- Actor A was born in the 1950s in an Asian country\n- What is actor A's debut TV series called?";
+    const cq = buildQuery(
+      {
+        reason: "turn_start",
+        agent: "openclaw",
+        sessionId: "s_ir" as unknown as never,
+        userText:
+          "new task\n\nYou are a deep research agent. Answer the question by using the search tool to find relevant documents from a local knowledge base.\n\n" +
+          "## CRITICAL RULES\n- You MUST ONLY use the \"search\" tool.\n\n" +
+          "## Response Format\nWhen you have the answer, respond with:\nExplanation / Exact Answer / Confidence\n\n" +
+          `## Question\n\n${question}`,
+        ts: NOW,
+      },
+      { domain: "ir" },
+    );
+    expect(cq.text).toBe(question);
+    expect(cq.text).not.toContain("deep research agent");
+    expect(cq.text).not.toContain("CRITICAL RULES");
+  });
+
+  it("turn_start keeps full prompt when domain is not ir", () => {
+    const raw =
+      "new task\n\nYou are a deep research agent.\n\n## Question\n\nWho won?";
+    const cq = buildQuery({
+      reason: "turn_start",
+      agent: "openclaw",
+      sessionId: "s_ir" as unknown as never,
+      userText: raw,
+      ts: NOW,
+    });
+    expect(cq.text).toBe(raw);
+  });
+
+  it("tool_driven focuses IR eval prompts on the ## Question section when domain=ir", () => {
+    const question =
+      "Give me the name of the school that the below actress was expelled from: - She is 163 cm tall.";
+    const cq = buildQuery(
+      {
+        reason: "tool_driven",
+        agent: "openclaw",
+        sessionId: "s_ir_tool" as unknown as never,
+        tool: "memos_search",
+        args: {
+          query:
+            "new task\n\nYou are a deep research agent. Answer the question by using the search tool to find relevant documents from a local knowledge base.\n\n" +
+            "## CRITICAL RULES\n- You MUST ONLY use the \"search\" tool.\n\n" +
+            "## Response Format\nExplanation / Exact Answer / Confidence\n\n" +
+            `## Question\n\n${question}`,
+          limit: 5,
+        },
+        ts: NOW,
+      },
+      { domain: "ir" },
+    );
+    expect(cq.text).toContain(question);
+    expect(cq.text).toContain('"limit":5');
+    expect(cq.text).not.toContain("deep research agent");
+  });
+
   it("tool_driven uses explicit search query text when present", () => {
     const cq = buildQuery({
       reason: "tool_driven",

--- a/apps/memos-local-plugin/tests/unit/retrieval/task-focus.test.ts
+++ b/apps/memos-local-plugin/tests/unit/retrieval/task-focus.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractQuestionSection,
+  focusIrRetrievalQuery,
+  isIrEvalPrompt,
+} from "../../../core/retrieval/task-focus.js";
+
+const IR_TEMPLATE_PREFIX =
+  "new task\n\nYou are a deep research agent. Answer the question by using the search tool to find relevant documents from a local knowledge base.\n\n## CRITICAL RULES\n- You MUST ONLY use the \"search\" tool.\n\n## Response Format\nExplanation / Exact Answer / Confidence\n\n";
+
+describe("retrieval/task-focus", () => {
+  it("extractQuestionSection returns body after ## Question", () => {
+    const raw = `${IR_TEMPLATE_PREFIX}## Question\n\n- Actor A was born in the 1950s\n- What is actor A's debut TV series called?`;
+    expect(extractQuestionSection(raw)).toBe(
+      "- Actor A was born in the 1950s\n- What is actor A's debut TV series called?",
+    );
+  });
+
+  it("extractQuestionSection returns null when heading is missing", () => {
+    expect(extractQuestionSection("Fix docker compose")).toBeNull();
+  });
+
+  it("isIrEvalPrompt matches IR eval templates only", () => {
+    const ir = `${IR_TEMPLATE_PREFIX}## Question\n\nGive me the school name.`;
+    expect(isIrEvalPrompt(ir)).toBe(true);
+    expect(isIrEvalPrompt("Fix this docker compose file")).toBe(false);
+    expect(
+      isIrEvalPrompt("You are a deep research agent.\n\n## Bug Description\n\nBroken."),
+    ).toBe(false);
+  });
+
+  it("focusIrRetrievalQuery keeps question body for IR templates", () => {
+    const question =
+      "Give me the name of the school that the below actress was expelled from: - She is 163 cm tall.";
+    const raw = `${IR_TEMPLATE_PREFIX}## Question\n\n${question}`;
+    const focused = focusIrRetrievalQuery(raw);
+    expect(focused.method).toBe("question_section");
+    expect(focused.text).toBe(question);
+  });
+
+  it("focusIrRetrievalQuery passthrough for non-IR prompts", () => {
+    const raw = "Investigate memos_search policy recall for po_7x7aq1k9q4ba";
+    const focused = focusIrRetrievalQuery(raw);
+    expect(focused.method).toBe("passthrough");
+    expect(focused.text).toBe(raw);
+  });
+});

--- a/apps/memos-local-plugin/tsconfig.build.json
+++ b/apps/memos-local-plugin/tsconfig.build.json
@@ -6,7 +6,6 @@
     "server/**/*.ts",
     "bridge/**/*.ts",
     "adapters/openclaw/**/*.ts",
-    "scripts/**/*.ts",
     "bridge.cts"
   ],
   "exclude": [

--- a/apps/memos-local-plugin/viewer/src/views/LogsView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/LogsView.tsx
@@ -725,7 +725,8 @@ function RetrievalFunnel({ stats }: { stats: RetrievalStatsPayload }) {
   const localFilterDeferred = outcome === "deferred_to_final";
   const finalLlmRan = finalFilter?.outcome === "llm_kept_all" ||
     finalFilter?.outcome === "llm_filtered" ||
-    finalFilter?.outcome === "llm_failed_safe_cutoff";
+    finalFilter?.outcome === "llm_rejected_all" ||
+    finalFilter?.outcome === "llm_filter_error";
   const fmtNum = (n: number | undefined, digits = 3) =>
     typeof n === "number" && Number.isFinite(n) ? n.toFixed(digits) : "—";
   const channelEntries = Object.entries(stats.channelHits ?? {}).filter(


### PR DESCRIPTION
## Summary

- Add `domain=ir` gating (`core/domain.ts`) so IR-eval behaviors (readonly injection, injection profiles) do not affect normal agent sessions.
- Readonly OpenClaw path: `onTurnStart` uses `searchMemory` with configurable `readOnlyInjectionProfile` and 30s soft timeout.
- Tighten LLM filter: empty model selection yields no injection (`llm_rejected_all`) instead of mechanical fallback.
- Add `injection-profile.ts`, `task-focus.ts`, and per-refKind snippet caps for IR retrieval.
