### PR TITLE
Mem agent 0611 merge

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -17,8 +17,10 @@ import json
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import threading
+import time
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -31,6 +33,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 HOST_HANDLER_WAIT_SECONDS = 5.0
+HEADLESS_REGISTRY_FILENAME = "headless-bridges.json"
+HEADLESS_STALE_SECONDS = float(os.environ.get("MEMOS_HEADLESS_BRIDGE_STALE_SEC", "1800"))
+HEADLESS_TERMINATE_TIMEOUT_SECONDS = 2.0
+HEADLESS_REGISTRY_LOCK_TIMEOUT_SECONDS = 2.0
+HEADLESS_REGISTRY_LOCK_STALE_SECONDS = 30.0
 
 
 def _installed_node_binary(plugin_root: Path) -> str | None:
@@ -49,6 +56,237 @@ def _bridge_script(plugin_root: Path) -> Path:
     if compiled.exists():
         return compiled
     return plugin_root / "bridge.cts"
+
+
+def _headless_registry_path(plugin_root: Path) -> Path:
+    return plugin_root / "daemon" / HEADLESS_REGISTRY_FILENAME
+
+
+def _read_headless_registry(path: Path) -> list[dict[str, Any]]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    bridges = raw.get("bridges") if isinstance(raw, dict) else raw
+    if not isinstance(bridges, list):
+        return []
+    return [entry for entry in bridges if isinstance(entry, dict)]
+
+
+def _write_headless_registry(path: Path, bridges: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(
+        f".{path.name}.{os.getpid()}.{threading.get_ident()}.{time.monotonic_ns()}.tmp"
+    )
+    tmp.write_text(
+        json.dumps({"bridges": bridges}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+@contextlib.contextmanager
+def _headless_registry_lock(
+    path: Path,
+    timeout: float = HEADLESS_REGISTRY_LOCK_TIMEOUT_SECONDS,
+):
+    lock_dir = path.with_suffix(path.suffix + ".lock")
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout
+    acquired = False
+
+    while True:
+        try:
+            lock_dir.mkdir()
+            acquired = True
+            with contextlib.suppress(Exception):
+                (lock_dir / "owner").write_text(
+                    f"pid={os.getpid()} started_at={time.time()}\n",
+                    encoding="utf-8",
+                )
+            break
+        except FileExistsError:
+            stale = False
+            with contextlib.suppress(Exception):
+                stale = time.time() - lock_dir.stat().st_mtime > HEADLESS_REGISTRY_LOCK_STALE_SECONDS
+            if stale:
+                with contextlib.suppress(Exception):
+                    shutil.rmtree(lock_dir)
+                continue
+            if time.monotonic() >= deadline:
+                yield False
+                return
+            time.sleep(0.05)
+
+    try:
+        yield True
+    finally:
+        if acquired:
+            with contextlib.suppress(Exception):
+                shutil.rmtree(lock_dir)
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _pid_command(pid: int) -> str:
+    try:
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=1.0,
+        )
+    except Exception:
+        return ""
+    return out.strip()
+
+
+def _is_headless_bridge_command(command: str, agent: str) -> bool:
+    if not command:
+        return False
+    return (
+        ("bridge.cjs" in command or "bridge.cts" in command)
+        and "--no-viewer" in command
+        and f"--agent={agent}" in command
+    )
+
+
+def _terminate_pid(pid: int, timeout: float = HEADLESS_TERMINATE_TIMEOUT_SECONDS) -> None:
+    if not _pid_alive(pid):
+        return
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.05)
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGKILL)
+
+
+def _entry_pid(entry: dict[str, Any]) -> int:
+    try:
+        return int(entry.get("pid") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _entry_parent_pid(entry: dict[str, Any]) -> int:
+    try:
+        return int(entry.get("parentPid") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _entry_started_at(entry: dict[str, Any]) -> float:
+    try:
+        return float(entry.get("startedAt") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _reap_stale_headless_bridges(plugin_root: Path, agent: str) -> None:
+    registry_path = _headless_registry_path(plugin_root)
+    with _headless_registry_lock(registry_path) as locked:
+        if not locked:
+            logger.warning("MemOS: headless bridge registry lock timed out during reap")
+            return
+        _reap_stale_headless_bridges_locked(registry_path, agent)
+
+
+def _reap_stale_headless_bridges_locked(registry_path: Path, agent: str) -> None:
+    now = time.time()
+    keep: list[dict[str, Any]] = []
+    changed = False
+
+    for entry in _read_headless_registry(registry_path):
+        if entry.get("agent") not in (None, agent):
+            keep.append(entry)
+            continue
+
+        pid = _entry_pid(entry)
+        if not _pid_alive(pid):
+            changed = True
+            continue
+
+        parent_pid = _entry_parent_pid(entry)
+        parent_dead = parent_pid > 0 and not _pid_alive(parent_pid)
+        legacy_stale = parent_pid <= 0 and now - _entry_started_at(entry) > HEADLESS_STALE_SECONDS
+        if parent_dead or legacy_stale:
+            if not _is_headless_bridge_command(_pid_command(pid), agent):
+                logger.warning(
+                    "MemOS: dropping stale headless bridge registry entry for non-bridge pid=%s",
+                    pid,
+                )
+                changed = True
+                continue
+            logger.warning("MemOS: reaping stale headless bridge pid=%s", pid)
+            _terminate_pid(pid)
+            changed = True
+            continue
+
+        keep.append(entry)
+
+    if changed:
+        _write_headless_registry(registry_path, keep)
+
+
+def _register_headless_bridge(plugin_root: Path, *, pid: int, agent: str) -> None:
+    registry_path = _headless_registry_path(plugin_root)
+    with _headless_registry_lock(registry_path) as locked:
+        if not locked:
+            logger.warning("MemOS: headless bridge registry lock timed out during register")
+            return
+        _register_headless_bridge_locked(registry_path, pid=pid, agent=agent)
+
+
+def _register_headless_bridge_locked(registry_path: Path, *, pid: int, agent: str) -> None:
+    bridges = [
+        entry
+        for entry in _read_headless_registry(registry_path)
+        if _entry_pid(entry) != pid
+    ]
+    bridges.append(
+        {
+            "pid": pid,
+            "parentPid": os.getpid(),
+            "startedAt": time.time(),
+            "agent": agent,
+        }
+    )
+    _write_headless_registry(registry_path, bridges)
+
+
+def _unregister_headless_bridge(plugin_root: Path, pid: int) -> None:
+    registry_path = _headless_registry_path(plugin_root)
+    with _headless_registry_lock(registry_path) as locked:
+        if not locked:
+            logger.warning("MemOS: headless bridge registry lock timed out during unregister")
+            return
+        _unregister_headless_bridge_locked(registry_path, pid)
+
+
+def _unregister_headless_bridge_locked(registry_path: Path, pid: int) -> None:
+    bridges = _read_headless_registry(registry_path)
+    next_bridges = [entry for entry in bridges if _entry_pid(entry) != pid]
+    if len(next_bridges) != len(bridges):
+        _write_headless_registry(registry_path, next_bridges)
+
+
+def _best_effort_registry_step(label: str, fn: Callable[[], None]) -> None:
+    try:
+        fn()
+    except Exception as err:
+        logger.warning("MemOS: headless bridge registry %s failed: %s", label, err)
 
 
 class BridgeError(RuntimeError):
@@ -100,6 +338,8 @@ class MemosBridgeClient:
         self._closed = False
 
         plugin_root = Path(__file__).resolve().parent.parent.parent.parent
+        self._plugin_root = plugin_root
+        self._no_viewer = no_viewer
         node = (
             node_binary
             or os.environ.get("MEMOS_NODE_BINARY")
@@ -110,6 +350,11 @@ class MemosBridgeClient:
         script_path = Path(bridge_path) if bridge_path else _bridge_script(plugin_root)
         script = str(script_path)
         env = {**os.environ, **(extra_env or {})}
+        if no_viewer:
+            _best_effort_registry_step(
+                "reap",
+                lambda: _reap_stale_headless_bridges(plugin_root, agent),
+            )
 
         # Prefer the compiled CommonJS bridge from packaged installs. The raw
         # TypeScript entry remains as a development fallback and needs `tsx`
@@ -143,6 +388,11 @@ class MemosBridgeClient:
             env=env,
             cwd=str(plugin_root),
         )
+        if no_viewer:
+            _best_effort_registry_step(
+                "register",
+                lambda: _register_headless_bridge(plugin_root, pid=self.pid, agent=agent),
+            )
         self._reader = threading.Thread(
             target=self._read_loop,
             daemon=True,
@@ -284,6 +534,12 @@ class MemosBridgeClient:
                 }
                 entry["event"].set()
             self._pending.clear()
+
+        if self._no_viewer:
+            _best_effort_registry_step(
+                "unregister",
+                lambda: _unregister_headless_bridge(self._plugin_root, pid),
+            )
 
     # ─── Internals ──
 

--- a/apps/memos-local-plugin/agent-contract/memory-core.ts
+++ b/apps/memos-local-plugin/agent-contract/memory-core.ts
@@ -217,7 +217,7 @@ export interface MemoryCore {
 
   // ── memory queries ──
   searchMemory(query: RetrievalQueryDTO): Promise<RetrievalResultDTO>;
-  getTrace(id: string, namespace?: RuntimeNamespace): Promise<TraceDTO | null>;
+  getTrace(id: string, namespace?: RuntimeNamespace, opts?: { includeAllNamespaces?: boolean }): Promise<TraceDTO | null>;
   /**
    * Mutate a single trace's user-facing fields (role / summary /
    * body). Never touches algorithmic signals. Returns the updated
@@ -231,14 +231,15 @@ export interface MemoryCore {
       agentText?: string;
       tags?: readonly string[];
     },
+    opts?: { includeAllNamespaces?: boolean },
   ): Promise<TraceDTO | null>;
   /** Delete a trace by id (idempotent). Hard delete. */
-  deleteTrace(id: string): Promise<{ deleted: boolean }>;
+  deleteTrace(id: string, opts?: { includeAllNamespaces?: boolean }): Promise<{ deleted: boolean }>;
   /**
    * Bulk delete — takes an id list and returns how many rows were
    * actually removed. The viewer's "批量删除" uses this.
    */
-  deleteTraces(ids: readonly string[]): Promise<{ deleted: number }>;
+  deleteTraces(ids: readonly string[], opts?: { includeAllNamespaces?: boolean }): Promise<{ deleted: number }>;
   /**
    * Update the sharing state for a trace. `scope = null` clears the
    * share. The core never talks to the Hub itself; the adapter /
@@ -252,6 +253,7 @@ export interface MemoryCore {
       target?: string | null;
       sharedAt?: number | null;
     },
+    opts?: { includeAllNamespaces?: boolean },
   ): Promise<TraceDTO | null>;
   getPolicy(id: string, namespace?: RuntimeNamespace, opts?: { includeAllNamespaces?: boolean }): Promise<PolicyDTO | null>;
   getWorldModel(id: string, namespace?: RuntimeNamespace, opts?: { includeAllNamespaces?: boolean }): Promise<WorldModelDTO | null>;

--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -36,6 +36,7 @@ const url = require("node:url") as typeof import("node:url");
 const BRIDGE_STATUS_HEARTBEAT_MS = 5_000;
 const BRIDGE_STATUS_STALE_MS = 20_000;
 const BRIDGE_STATUS_FILE = "bridge-status.json";
+const HEADLESS_BRIDGE_IDLE_TTL_MS = 30 * 60 * 1000;
 
 interface BridgeArgs {
   daemon: boolean;
@@ -108,6 +109,43 @@ function removePidFile(pidPath: string): void {
   } catch {
     /* best-effort; another bridge may have overwritten */
   }
+}
+
+function headlessRegistryPath(agent: string): string {
+  const agentHome = agent === "hermes" ? ".hermes" : ".openclaw";
+  return path.join(
+    process.env.HOME ?? "/tmp",
+    agentHome,
+    "memos-plugin",
+    "daemon",
+    "headless-bridges.json",
+  );
+}
+
+function removeHeadlessRegistryEntry(agent: string): void {
+  const registryPath = headlessRegistryPath(agent);
+  try {
+    const raw = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+    const bridges = Array.isArray(raw?.bridges) ? raw.bridges : [];
+    const next = bridges.filter((entry: unknown) => {
+      if (!entry || typeof entry !== "object") return false;
+      return Number((entry as { pid?: unknown }).pid) !== process.pid;
+    });
+    if (next.length === bridges.length) return;
+    const tmp = `${registryPath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify({ bridges: next }, null, 2) + "\n", "utf8");
+    fs.renameSync(tmp, registryPath);
+  } catch {
+    /* best-effort; Python reaper will clean dead entries on next start */
+  }
+}
+
+function headlessIdleTimeoutMs(): number {
+  const raw = process.env.MEMOS_HEADLESS_BRIDGE_IDLE_TTL_SEC;
+  if (!raw) return HEADLESS_BRIDGE_IDLE_TTL_MS;
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+  return Math.floor(seconds * 1000);
 }
 
 function killExistingBridge(pidPath: string, timeoutMs = 5000): void {
@@ -313,7 +351,10 @@ async function main(): Promise<void> {
   // can fall back to host before init returns. Start stdio first so that
   // fallback has a transport instead of tripping the lazy bridge guard.
   if (!args.daemon) {
-    stdio = startStdioServer({ core });
+    stdio = startStdioServer({
+      core,
+      idleTimeoutMs: args.noViewer ? headlessIdleTimeoutMs() : undefined,
+    });
     bridgeStatus?.markConnected();
     bridgeHeartbeat = bridgeStatus?.startHeartbeat();
     void stdio.done.then(() => {
@@ -463,6 +504,7 @@ async function main(): Promise<void> {
   const shutdown = async (sig: string) => {
     process.stderr.write(`bridge: received ${sig}, shutting down\n`);
     removeOwnedPidFile();
+    if (args.noViewer) removeHeadlessRegistryEntry(args.agent);
     if (viewer) {
       try {
         await viewer.close();
@@ -500,6 +542,7 @@ async function main(): Promise<void> {
 
   // No viewer (headless bridge) — clean exit.
   removeOwnedPidFile();
+  if (args.noViewer) removeHeadlessRegistryEntry(args.agent);
   await core.shutdown();
   process.exit(0);
 }

--- a/apps/memos-local-plugin/bridge/stdio.ts
+++ b/apps/memos-local-plugin/bridge/stdio.ts
@@ -44,6 +44,8 @@ export interface StdioServerOptions {
   logToStderr?: boolean;
   /** Enable strict param validation. */
   strict?: boolean;
+  /** Close the stdio transport after this many milliseconds without input. */
+  idleTimeoutMs?: number;
 }
 
 export interface StdioServerHandle {
@@ -74,9 +76,13 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
   const stdin = options.stdin ?? process.stdin;
   const stdout = options.stdout ?? process.stdout;
   const logToStderr = options.logToStderr ?? true;
+  const idleTimeoutMs = options.idleTimeoutMs;
   const dispatch = makeDispatcher(options.core, { strict: !!options.strict });
 
   let closed = false;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  let resolveDone: (() => void) | null = null;
+  let activeDispatches = 0;
   const eventsHandlers = new Set<symbol>();
   const logsHandlers = new Set<symbol>();
 
@@ -104,6 +110,10 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
   function finishTransport(err?: Error): void {
     if (closed) return;
     closed = true;
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
     try {
       eventsUnsubscribe();
     } catch {
@@ -119,6 +129,24 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
       entry.reject(err ?? new Error("stdio bridge closed"));
       serverPending.delete(id);
     }
+    resolveDone?.();
+  }
+
+  function armIdleTimer(): void {
+    if (!idleTimeoutMs || idleTimeoutMs <= 0 || closed) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      if (serverPending.size > 0 || activeDispatches > 0) {
+        armIdleTimer();
+        return;
+      }
+      if (logToStderr) {
+        process.stderr.write(`bridge.stdio.idle: closing after ${idleTimeoutMs}ms without input\n`);
+      }
+      finishTransport(new Error("stdio bridge idle timeout"));
+      stdin.pause?.();
+    }, idleTimeoutMs);
+    (idleTimer as unknown as { unref?: () => void }).unref?.();
   }
 
   function writeLine(obj: unknown): void {
@@ -154,6 +182,7 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
     if (closed) return;
     const trimmed = line.trim();
     if (trimmed.length === 0) return;
+    armIdleTimer();
 
     let msg: JsonRpcRequest | null = null;
     try {
@@ -198,6 +227,7 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
     }
 
     try {
+      activeDispatches++;
       const result = await dispatch(msg.method, msg.params);
       if (msg.id !== undefined && msg.id !== null) {
         const ok: JsonRpcSuccess = {
@@ -221,6 +251,9 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
           `bridge.stdio.dispatch.err ${msg.method}: ${mErr.message}\n`,
         );
       }
+    } finally {
+      activeDispatches = Math.max(0, activeDispatches - 1);
+      armIdleTimer();
     }
   }
 
@@ -229,6 +262,8 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
   stdin.setEncoding?.("utf8");
 
   const donePromise = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+    armIdleTimer();
     stdin.on("data", (chunk) => {
       if (closed) return;
       buffer += String(chunk);
@@ -246,14 +281,12 @@ export function startStdioServer(options: StdioServerOptions): StdioServerHandle
         buffer = "";
       }
       finishTransport();
-      resolve();
     });
     stdin.on("error", (err) => {
       if (logToStderr) {
         process.stderr.write(`bridge.stdio.read.err: ${err.message}\n`);
       }
       finishTransport(err);
-      resolve();
     });
   });
 

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -2580,11 +2580,17 @@ export function createMemoryCore(
     }
   }
 
-  async function getTrace(id: string, namespace?: RuntimeNamespace): Promise<TraceDTO | null> {
+  async function getTrace(
+    id: string,
+    namespace?: RuntimeNamespace,
+    opts?: { includeAllNamespaces?: boolean },
+  ): Promise<TraceDTO | null> {
     ensureLive();
     if (namespace) activeNamespace = namespace;
     const row = handle.repos.traces.getById(id);
-    return row && visibleToCurrent(row) ? traceRowToDTO(row, handle.repos.episodes.getById(row.episodeId)) : null;
+    return row && (opts?.includeAllNamespaces || visibleToCurrent(row))
+      ? traceRowToDTO(row, handle.repos.episodes.getById(row.episodeId))
+      : null;
   }
 
   async function updateTrace(
@@ -2595,10 +2601,11 @@ export function createMemoryCore(
       agentText?: string;
       tags?: readonly string[];
     },
+    opts?: { includeAllNamespaces?: boolean },
   ): Promise<TraceDTO | null> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing || !ownedByCurrent(existing)) return null;
+    if (!existing || (!opts?.includeAllNamespaces && !ownedByCurrent(existing))) return null;
     handle.repos.traces.updateBody(id, patch);
     const updated = handle.repos.traces.getById(id);
     return updated
@@ -2606,10 +2613,13 @@ export function createMemoryCore(
       : null;
   }
 
-  async function deleteTrace(id: string): Promise<{ deleted: boolean }> {
+  async function deleteTrace(
+    id: string,
+    opts?: { includeAllNamespaces?: boolean },
+  ): Promise<{ deleted: boolean }> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing || !ownedByCurrent(existing)) return { deleted: false };
+    if (!existing || (!opts?.includeAllNamespaces && !ownedByCurrent(existing))) return { deleted: false };
     const wasHubShared = existing.share?.scope === "hub";
     handle.db.tx(() => {
       handle.repos.episodes.removeTraceIds(existing.episodeId, [id]);
@@ -2621,14 +2631,17 @@ export function createMemoryCore(
     return { deleted: true };
   }
 
-  async function deleteTraces(ids: readonly string[]): Promise<{ deleted: number }> {
+  async function deleteTraces(
+    ids: readonly string[],
+    opts?: { includeAllNamespaces?: boolean },
+  ): Promise<{ deleted: number }> {
     ensureLive();
     let deleted = 0;
     // Process one-by-one so a bad id doesn't poison the whole batch.
     // The viewer's bulk delete is low-frequency (dozens at a time).
     for (const id of ids) {
       const existing = handle.repos.traces.getById(id);
-      if (!existing || !ownedByCurrent(existing)) continue;
+      if (!existing || (!opts?.includeAllNamespaces && !ownedByCurrent(existing))) continue;
       const wasHubShared = existing.share?.scope === "hub";
       handle.db.tx(() => {
         handle.repos.episodes.removeTraceIds(existing.episodeId, [id]);
@@ -2649,10 +2662,11 @@ export function createMemoryCore(
       target?: string | null;
       sharedAt?: number | null;
     },
+    opts?: { includeAllNamespaces?: boolean },
   ): Promise<TraceDTO | null> {
     ensureLive();
     const existing = handle.repos.traces.getById(id);
-    if (!existing || !ownedByCurrent(existing)) return null;
+    if (!existing || (!opts?.includeAllNamespaces && !ownedByCurrent(existing))) return null;
     handle.repos.traces.updateShare(id, share);
     const updated = handle.repos.traces.getById(id);
     if (updated) {

--- a/apps/memos-local-plugin/server/routes/memory.ts
+++ b/apps/memos-local-plugin/server/routes/memory.ts
@@ -64,7 +64,7 @@ export function registerMemoryRoutes(
       writeError(ctx, 400, "invalid_argument", "id is required");
       return;
     }
-    const trace = await deps.core.getTrace(id);
+    const trace = await deps.core.getTrace(id, undefined, { includeAllNamespaces: true });
     if (trace === null) {
       writeError(ctx, 404, "not_found", `trace not found: ${id}`);
       return;

--- a/apps/memos-local-plugin/server/routes/trace.ts
+++ b/apps/memos-local-plugin/server/routes/trace.ts
@@ -38,6 +38,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
     const ownerAgentKind = parseOwnerFilter(params.get("ownerAgentKind")) || namespace?.ownerAgentKind || undefined;
     const ownerProfileId = parseOwnerFilter(params.get("ownerProfileId")) || namespace?.ownerProfileId || undefined;
     const q = params.get("q") || undefined;
+    const includeAllNamespaces = params.get("includeAllNamespaces") === "true";
     // When `groupByTurn=true`, pagination treats each (episodeId, turnId)
     // pair as one "memory" — matching the viewer's grouped display where
     // a user query + its tool steps + final reply collapse into one card.
@@ -52,6 +53,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       ownerProfileId,
       q,
       groupByTurn,
+      includeAllNamespaces,
     });
     const { traces, hasMore } = trimTracePage(rawTraces, limit, groupByTurn);
     const total = includeTotal
@@ -61,6 +63,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
           ownerProfileId,
           q,
           groupByTurn,
+          includeAllNamespaces,
         })
       : undefined;
     // When grouping, `traces.length === limit` is no longer a reliable
@@ -86,7 +89,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "id is required");
       return;
     }
-    const trace = await deps.core.getTrace(id);
+    const trace = await deps.core.getTrace(id, undefined, { includeAllNamespaces: true });
     if (!trace) {
       writeError(ctx, 404, "not_found", `trace not found: ${id}`);
       return;
@@ -110,7 +113,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       agentText?: string;
       tags?: string[];
     }>(ctx);
-    const updated = await deps.core.updateTrace(id, body);
+    const updated = await deps.core.updateTrace(id, body, { includeAllNamespaces: true });
     if (!updated) {
       writeError(ctx, 404, "not_found", `trace not found: ${id}`);
       return;
@@ -128,7 +131,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "id is required");
       return;
     }
-    return await deps.core.deleteTrace(id);
+    return await deps.core.deleteTrace(id, { includeAllNamespaces: true });
   });
 
   /**
@@ -145,7 +148,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "ids[] is required");
       return;
     }
-    return await deps.core.deleteTraces(ids);
+    return await deps.core.deleteTraces(ids, { includeAllNamespaces: true });
   });
 
   /**
@@ -171,7 +174,7 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       scope: scope ?? null,
       target: body.target ?? null,
       sharedAt: scope ? Date.now() : null,
-    });
+    }, { includeAllNamespaces: true });
     if (!updated) {
       writeError(ctx, 404, "not_found", `trace not found: ${id}`);
       return;
@@ -185,7 +188,10 @@ export function registerTraceRoutes(routes: Routes, deps: ServerDeps): void {
       writeError(ctx, 400, "invalid_argument", "id is required");
       return;
     }
-    const traces = await deps.core.timeline({ episodeId: id });
+    const traces = await deps.core.timeline({
+      episodeId: id,
+      includeAllNamespaces: true,
+    });
     return { episodeId: id, traces };
   });
 }

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -245,6 +245,14 @@ class RecordingBridge:
 class BridgeClientTests(unittest.TestCase):
     def setUp(self) -> None:
         self._fake: FakePopen | None = None
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._registry_path = (
+            Path(self._tmpdir.name)
+            / ".hermes"
+            / "memos-plugin"
+            / "daemon"
+            / "headless-bridges.json"
+        )
 
         def _factory(*args, **kwargs):
             self._fake = FakePopen(*args, **kwargs)
@@ -254,14 +262,22 @@ class BridgeClientTests(unittest.TestCase):
         self._which_patch = patch.object(
             bridge_client_mod.shutil, "which", return_value="/usr/bin/node"
         )
+        self._registry_patch = patch.object(
+            bridge_client_mod,
+            "_headless_registry_path",
+            return_value=self._registry_path,
+        )
         self._popen_patch.start()
         self._which_patch.start()
+        self._registry_patch.start()
 
     def tearDown(self) -> None:
         if self._fake is not None:
             self._fake.stdout._done = True
+        self._registry_patch.stop()
         self._popen_patch.stop()
         self._which_patch.stop()
+        self._tmpdir.cleanup()
 
     def test_request_returns_result_on_success(self) -> None:
         client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
@@ -301,6 +317,90 @@ class BridgeClientTests(unittest.TestCase):
         cmd = getattr(self._fake, "cmd", [])
         self.assertIn("--no-viewer", cmd)
         client.close()
+
+    def test_new_headless_bridge_reaps_previous_registered_headless_bridge(self) -> None:
+        stale_pid = 424242
+        self._registry_path.parent.mkdir(parents=True)
+        self._registry_path.write_text(
+            json.dumps(
+                {
+                    "bridges": [
+                        {
+                            "pid": stale_pid,
+                            "startedAt": time.time() - 3600,
+                            "agent": "hermes",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        killed: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            killed.append((pid, sig))
+
+        with patch.object(bridge_client_mod.os, "kill", fake_kill), patch.object(
+            bridge_client_mod,
+            "_pid_command",
+            return_value="/opt/homebrew/bin/node /Users/niu/.hermes/memos-plugin/dist/bridge.cjs --agent=hermes --no-viewer",
+        ):
+            client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+            client.close()
+
+        self.assertTrue(
+            any(pid == stale_pid for pid, _sig in killed),
+            "starting a new --no-viewer bridge should reap stale registered headless bridges",
+        )
+
+    def test_headless_reaper_does_not_kill_non_bridge_pid(self) -> None:
+        stale_pid = 424243
+        self._registry_path.parent.mkdir(parents=True)
+        self._registry_path.write_text(
+            json.dumps(
+                {
+                    "bridges": [
+                        {
+                            "pid": stale_pid,
+                            "parentPid": 99978,
+                            "startedAt": time.time() - 3600,
+                            "agent": "hermes",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        killed: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            killed.append((pid, sig))
+
+        with patch.object(bridge_client_mod.os, "kill", fake_kill), patch.object(
+            bridge_client_mod,
+            "_pid_command",
+            return_value="/usr/bin/sleep 600",
+        ):
+            client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+            client.close()
+
+        self.assertFalse(
+            any(pid == stale_pid and sig != 0 for pid, sig in killed),
+            "registry cleanup must not signal a PID unless it is a Hermes headless bridge",
+        )
+
+    def test_registry_write_failure_does_not_block_bridge_start(self) -> None:
+        with patch.object(
+            bridge_client_mod,
+            "_write_headless_registry",
+            side_effect=OSError("readonly registry"),
+        ):
+            client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+            res = client.request("core.health")
+            self.assertEqual(res, {"ok": True, "version": "test"})
+            client.close()
 
     def test_reverse_request_waits_for_late_host_handler_registration(self) -> None:
         client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
@@ -353,10 +453,23 @@ class MemTensorProviderTests(unittest.TestCase):
         import memos_provider
 
         self._provider_mod = memos_provider
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._registry_path = (
+            Path(self._tmpdir.name)
+            / ".hermes"
+            / "memos-plugin"
+            / "daemon"
+            / "headless-bridges.json"
+        )
 
         self._patches = [
             patch("memos_provider.ensure_bridge_running", return_value=True),
             patch("memos_provider.ensure_viewer_daemon", return_value=True),
+            patch.object(
+                bridge_client_mod,
+                "_headless_registry_path",
+                return_value=self._registry_path,
+            ),
         ]
         for p in self._patches:
             p.start()
@@ -364,6 +477,7 @@ class MemTensorProviderTests(unittest.TestCase):
     def tearDown(self) -> None:
         for p in self._patches:
             p.stop()
+        self._tmpdir.cleanup()
 
     def test_is_available_returns_true_when_bridge_ok(self) -> None:
         p = self._provider_mod.MemTensorProvider()

--- a/apps/memos-local-plugin/tests/unit/bridge/stdio.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/stdio.test.ts
@@ -159,4 +159,63 @@ describe("stdio transport", () => {
     expect(server.connected).toBe(false);
     expect(core.shutdown).toHaveBeenCalled();
   });
+
+  it("closes the stdio transport after an idle timeout", async () => {
+    const clientOut = new PassThrough();
+    const serverOut = new PassThrough();
+    const core = stubCore();
+    const server = startStdioServer({
+      core,
+      stdin: clientOut,
+      stdout: serverOut,
+      logToStderr: false,
+      idleTimeoutMs: 20,
+    });
+
+    const finished = await Promise.race([
+      server.done.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 200)),
+    ]);
+
+    expect(finished).toBe(true);
+    expect(server.connected).toBe(false);
+    expect(core.shutdown).not.toHaveBeenCalled();
+  });
+
+  it("does not close the stdio transport while a request is in flight", async () => {
+    const clientOut = new PassThrough();
+    const serverOut = new PassThrough();
+    const core = stubCore();
+    (core.health as any).mockImplementation(
+      async () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                version: "slow",
+                uptimeMs: 1,
+                agent: "openclaw",
+                paths: { home: "", config: "", db: "", skills: "", logs: "" },
+                llm: { available: false, provider: "" },
+                embedder: { available: false, provider: "", dim: 0 },
+              }),
+            60,
+          ),
+        ),
+    );
+    const server = startStdioServer({
+      core,
+      stdin: clientOut,
+      stdout: serverOut,
+      logToStderr: false,
+      idleTimeoutMs: 20,
+    });
+    const client = createStdioClient(serverOut, clientOut);
+
+    const response = client.request<{ version: string }>("core.health", {});
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(server.connected).toBe(true);
+    await expect(response).resolves.toMatchObject({ version: "slow" });
+  });
 });

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -536,6 +536,100 @@ describe("MemoryCore façade", () => {
     expect(await core.listTraces({ limit: 10, groupByTurn: true })).toHaveLength(1);
   });
 
+  it("lets the viewer browse private Hermes instance memories without sharing them", async () => {
+    pipeline = createPipeline(buildDeps(db!));
+    core = createMemoryCore(
+      pipeline,
+      resolveHome("openclaw", "/tmp/memos-mc-test"),
+      "test",
+    );
+    await core.init();
+
+    const agentANs = { agentKind: "hermes", profileId: "agent-a" };
+    const agentBNs = { agentKind: "hermes", profileId: "agent-b" };
+
+    const aStart = await core.onTurnStart({
+      agent: "hermes",
+      namespace: agentANs,
+      sessionId: "s-agent-a",
+      userText: "remember private agent a trace",
+      ts: 1_700_000_000_101,
+    });
+    await core.onTurnEnd({
+      agent: "hermes",
+      namespace: agentANs,
+      sessionId: "s-agent-a",
+      episodeId: aStart.query.episodeId!,
+      agentText: "stored for agent a",
+      toolCalls: [],
+      ts: 1_700_000_000_102,
+    });
+
+    const bStart = await core.onTurnStart({
+      agent: "hermes",
+      namespace: agentBNs,
+      sessionId: "s-agent-b",
+      userText: "remember private agent b trace",
+      ts: 1_700_000_000_201,
+    });
+    await core.onTurnEnd({
+      agent: "hermes",
+      namespace: agentBNs,
+      sessionId: "s-agent-b",
+      episodeId: bStart.query.episodeId!,
+      agentText: "stored for agent b",
+      toolCalls: [],
+      ts: 1_700_000_000_202,
+    });
+
+    await core.openSession({ agent: "hermes", sessionId: "s-agent-a", namespace: agentANs });
+
+    const runtimeRows = await core.listTraces({
+      limit: 10,
+      ownerAgentKind: "hermes",
+      ownerProfileId: "agent-b",
+    });
+    expect(runtimeRows).toHaveLength(0);
+
+    const viewerRows = await core.listTraces({
+      limit: 10,
+      ownerAgentKind: "hermes",
+      ownerProfileId: "agent-b",
+      includeAllNamespaces: true,
+    });
+    expect(viewerRows).toHaveLength(1);
+    expect(viewerRows[0]?.ownerProfileId).toBe("agent-b");
+    expect(viewerRows[0]?.share?.scope).toBe("private");
+
+    const allViewerRows = await core.listTraces({ limit: 10, includeAllNamespaces: true });
+    expect(allViewerRows.map((row) => row.ownerProfileId).sort()).toEqual([
+      "agent-a",
+      "agent-b",
+    ]);
+
+    const agentBTraceId = viewerRows[0]!.id;
+    expect(await core.updateTrace(agentBTraceId, { summary: "edited from viewer" })).toBeNull();
+    const updated = await core.updateTrace(
+      agentBTraceId,
+      { summary: "edited from viewer" },
+      { includeAllNamespaces: true },
+    );
+    expect(updated?.summary).toBe("edited from viewer");
+
+    expect(await core.shareTrace(agentBTraceId, { scope: "public" })).toBeNull();
+    const shared = await core.shareTrace(
+      agentBTraceId,
+      { scope: "public" },
+      { includeAllNamespaces: true },
+    );
+    expect(shared?.share?.scope).toBe("public");
+
+    expect(await core.deleteTrace(agentBTraceId)).toEqual({ deleted: false });
+    expect(await core.deleteTrace(agentBTraceId, { includeAllNamespaces: true })).toEqual({
+      deleted: true,
+    });
+  });
+
   it("records visible subagent task and result in the parent episode", async () => {
     pipeline = createPipeline(buildDeps(db!));
     core = createMemoryCore(

--- a/apps/memos-local-plugin/tests/unit/server/http.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/http.test.ts
@@ -327,7 +327,9 @@ describe("HTTP server — REST routes", () => {
   it("GET /api/v1/memory/trace?id=t1 returns the trace", async () => {
     const r = await fetch(`${handle.url}/api/v1/memory/trace?id=t1`);
     expect(r.status).toBe(200);
-    expect(core.getTrace).toHaveBeenCalledWith("t1");
+    expect(core.getTrace).toHaveBeenCalledWith("t1", undefined, {
+      includeAllNamespaces: true,
+    });
   });
 
   it("GET /api/v1/memory/trace returns 404 for unknown ids", async () => {
@@ -472,6 +474,32 @@ describe("HTTP server — REST routes", () => {
       groupByTurn: false,
       ownerAgentKind: undefined,
       ownerProfileId: undefined,
+      includeAllNamespaces: false,
+    });
+  });
+
+  it("GET /api/v1/traces forwards includeAllNamespaces for viewer-wide browsing", async () => {
+    const r = await fetch(
+      `${handle.url}/api/v1/traces?ownerAgentKind=hermes&ownerProfileId=coder10&includeAllNamespaces=true`,
+    );
+    expect(r.status).toBe(200);
+    expect(core.listTraces).toHaveBeenCalledWith({
+      limit: 50,
+      offset: 0,
+      sessionId: undefined,
+      q: undefined,
+      groupByTurn: false,
+      ownerAgentKind: "hermes",
+      ownerProfileId: "coder10",
+      includeAllNamespaces: true,
+    });
+    expect(core.countTraces).toHaveBeenCalledWith({
+      sessionId: undefined,
+      q: undefined,
+      groupByTurn: false,
+      ownerAgentKind: "hermes",
+      ownerProfileId: "coder10",
+      includeAllNamespaces: true,
     });
   });
 
@@ -481,7 +509,53 @@ describe("HTTP server — REST routes", () => {
     const body = (await r.json()) as { id: string };
     expect(body.id).toBe("t-42");
     // Dispatcher strips route prefix and passes `t-42` to core.getTrace.
-    expect(core.getTrace).toHaveBeenCalledWith("t-42");
+    expect(core.getTrace).toHaveBeenCalledWith("t-42", undefined, {
+      includeAllNamespaces: true,
+    });
+  });
+
+  it("trace mutations use viewer-wide admin scope", async () => {
+    const patch = await fetch(`${handle.url}/api/v1/traces/t-42`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ summary: "edited" }),
+    });
+    expect(patch.status).toBe(200);
+    expect(core.updateTrace).toHaveBeenCalledWith(
+      "t-42",
+      { summary: "edited" },
+      { includeAllNamespaces: true },
+    );
+
+    const share = await fetch(`${handle.url}/api/v1/traces/t-42/share`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "public" }),
+    });
+    expect(share.status).toBe(200);
+    expect(core.shareTrace).toHaveBeenCalledWith(
+      "t-42",
+      expect.objectContaining({ scope: "public" }),
+      { includeAllNamespaces: true },
+    );
+
+    const del = await fetch(`${handle.url}/api/v1/traces/t-42`, {
+      method: "DELETE",
+    });
+    expect(del.status).toBe(200);
+    expect(core.deleteTrace).toHaveBeenCalledWith("t-42", {
+      includeAllNamespaces: true,
+    });
+
+    const bulk = await fetch(`${handle.url}/api/v1/traces/delete`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: ["t-1", "t-2"] }),
+    });
+    expect(bulk.status).toBe(200);
+    expect(core.deleteTraces).toHaveBeenCalledWith(["t-1", "t-2"], {
+      includeAllNamespaces: true,
+    });
   });
 
   it("GET /api/v1/api-logs supports multi-tool filtering", async () => {
@@ -503,6 +577,10 @@ describe("HTTP server — REST routes", () => {
     const body = (await r.json()) as { episodeId: string; traces: unknown[] };
     expect(body.episodeId).toBe("e1");
     expect(Array.isArray(body.traces)).toBe(true);
+    expect(core.timeline).toHaveBeenCalledWith({
+      episodeId: "e1",
+      includeAllNamespaces: true,
+    });
   });
 
   it("GET /api/v1/metrics returns aggregate counts", async () => {

--- a/apps/memos-local-plugin/viewer/src/views/MemoriesView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/MemoriesView.tsx
@@ -141,6 +141,7 @@ export function MemoriesView() {
       qs.set("offset", String(roleFilterActive ? 0 : opts.page * pageSize));
       qs.set("groupByTurn", "true");
       qs.set("includeTotal", "false");
+      qs.set("includeAllNamespaces", "true");
       if (opts.q) qs.set("q", opts.q);
       appendNamespaceParams(qs, namespaceFilter);
       const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`);
@@ -199,6 +200,7 @@ export function MemoriesView() {
       qs.set("limit", String(pageSize));
       qs.set("offset", String(targetPage * pageSize));
       qs.set("groupByTurn", "true");
+      qs.set("includeAllNamespaces", "true");
       const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`, {
         signal,
       });
@@ -755,6 +757,7 @@ async function findTracePage(
     qs.set("limit", String(scanLimit));
     qs.set("offset", String(offset));
     qs.set("groupByTurn", "true");
+    qs.set("includeAllNamespaces", "true");
     const res = await api.get<ListResponse>(`/api/v1/traces?${qs.toString()}`, {
       signal,
     });


### PR DESCRIPTION
# Description
This PR adds an IR readonly evaluation path to memos-local-plugin, gated on domain=ir, so information-retrieval benchmarks can inject skills/playbook without affecting normal OpenClaw sessions.

## Problem

- IR readonly eval needs turn-start memory injection (searchMemory), skill filtering.
- The previous LLM filter could fall back to mechanical top-K injection when the model rejected all candidates, polluting prompts with irrelevant skills.

## Implementation

- core/domain.ts: domain=ir gating for skill mode, readonly injection profile.
- OpenClaw bridge: readonly mode (OPENCLAW_MEMOS_READONLY=1) routes onTurnStart through searchMemory with configurable readOnlyInjectionProfile.
- llm-filter.ts: empty LLM selection → no injection (llm_rejected_all); errors → llm_filter_error (no mechanical safe-cutoff fallback).
- injection-profile.ts / task-focus.ts / retrieve.ts: injection profile plans and IR query focus.
- LogsView.tsx: align retrieval funnel outcomes with new filter enum values.
