### PR TITLE
Fix #1915: fix(memos-local-plugin): bridge status detection misses hermes chat with global 

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -169,6 +169,9 @@ async function main(): Promise<void> {
   const { startHttpServer } = (await importEsm(
     runtimeModule("server/http.ts", "dist/server/http.js")
   )) as typeof import("./server/http.js");
+  const { isHermesChatRunning } = (await importEsm(
+    runtimeModule("bridge/hermes-process.ts", "dist/bridge/hermes-process.js")
+  )) as typeof import("./bridge/hermes-process.js");
 
   const rootDir = pluginRoot();
   const pkgVersion = require(path.join(rootDir, "package.json")).version;
@@ -269,6 +272,7 @@ async function main(): Promise<void> {
       ? createBridgeStatusTracker(
           path.join(home.root, BRIDGE_STATUS_FILE),
           args.daemon,
+          isHermesChatRunning,
         )
       : null;
 
@@ -565,7 +569,11 @@ function classifyErrorCode(err: unknown): string {
   return "unknown";
 }
 
-function createBridgeStatusTracker(statusFile: string, daemon: boolean): {
+function createBridgeStatusTracker(
+  statusFile: string,
+  daemon: boolean,
+  isHermesChatRunning: () => boolean,
+): {
   snapshot(): BridgeStatusSnapshot;
   markConnected(): void;
   markDisconnected(message: string): void;
@@ -677,18 +685,6 @@ function createBridgeStatusTracker(statusFile: string, daemon: boolean): {
       };
     },
   };
-}
-
-function isHermesChatRunning(): boolean {
-  try {
-    const out = childProcess.execFileSync("pgrep", ["-f", "hermes chat"], {
-      encoding: "utf8",
-      timeout: 1000,
-    });
-    return out.trim().length > 0;
-  } catch {
-    return false;
-  }
 }
 
 void main().catch((err) => {

--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -1,0 +1,108 @@
+/**
+ * Hermes chat process detection.
+ *
+ * The viewer daemon (`bridge.cts --daemon`) wants to know whether the
+ * user has a `hermes chat` session attached to *some* bridge stdio
+ * process so it can upgrade its own `"disconnected"` status to
+ * `"reconnecting"` instead of leaving the viewer permanently red.
+ *
+ * Implementation: shell out to `pgrep -f <regex>`. The regex has to
+ * cover all three CLI invocation shapes the Hermes CLI supports:
+ *
+ *   • no flags                    — `hermes chat`
+ *   • flags after the subcommand  — `hermes chat --skills memory-routing`
+ *   • global flags before it      — `hermes --skills memory-routing chat`
+ *
+ * The third shape is the bug reported in #1915: the previous literal
+ * pattern `"hermes chat"` requires the two tokens to be contiguous and
+ * therefore misses any invocation with a global flag (`--skills`,
+ * `-m`, `--provider`, …) between them.
+ *
+ * The current pattern is `hermes\s.*chat\b`:
+ *
+ *   • `hermes\s`  — the binary basename followed by whitespace (the
+ *     separator that always sits between the binary and either the
+ *     first flag or the subcommand). Anchoring on whitespace stops it
+ *     from matching `hermesctl`, `hermes-helper`, etc.
+ *   • `.*`        — any flags between the binary and the subcommand
+ *     (empty in the no-flags case).
+ *   • `chat\b`    — `chat` ending at a word boundary, so it does *not*
+ *     match `chatter`, `chat-server`, or a flag value like
+ *     `--profile=chats`.
+ *
+ * `pgrep -f` on Linux uses glibc's ERE engine, which supports
+ * `\s`/`\b` as GNU extensions. JavaScript's `RegExp` supports the same
+ * tokens natively, so this module also exports
+ * `matchesHermesChatCommandLine()` for unit tests — exercising the
+ * pattern as a JS regex is a faithful proxy for the pgrep-side
+ * behaviour without requiring a real Hermes binary or a fork of the
+ * pgrep process in CI.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import * as childProcess from "node:child_process";
+
+/**
+ * pgrep `-f` pattern used by `isHermesChatRunning`.
+ *
+ * Exported separately so callers — and tests — can introspect the exact
+ * string we hand to `pgrep` and confirm we have not silently regressed
+ * back to a literal substring match.
+ */
+export const HERMES_CHAT_PROCESS_PATTERN = "hermes\\s.*chat\\b";
+
+/**
+ * JS-side equivalent of `pgrep -f HERMES_CHAT_PROCESS_PATTERN`.
+ *
+ * Used by unit tests to verify the regex matches every documented
+ * Hermes invocation shape and rejects unrelated command lines. Kept
+ * deliberately stateless — callers should pass the full
+ * `/proc/<pid>/cmdline`-style command-line string.
+ */
+export function matchesHermesChatCommandLine(commandLine: string): boolean {
+  return new RegExp(HERMES_CHAT_PROCESS_PATTERN).test(commandLine);
+}
+
+/**
+ * Shape of the `execFileSync`-compatible helper that
+ * `isHermesChatRunning` shells out through. Carved out as a named type
+ * so tests can pass a `vi.fn()` without depending on Node's overloaded
+ * `ExecFileSyncOptions` union.
+ */
+export type ExecFileSyncLike = (
+  file: string,
+  args: readonly string[],
+  options: { encoding: "utf8"; timeout: number },
+) => string;
+
+const defaultExecFileSync: ExecFileSyncLike = (file, args, options) =>
+  childProcess.execFileSync(file, [...args], options) as unknown as string;
+
+/**
+ * Returns `true` when `pgrep -f` finds at least one process whose full
+ * command line matches `HERMES_CHAT_PROCESS_PATTERN`.
+ *
+ * `pgrep` exits non-zero when there is no match, when it cannot be
+ * found, or on permission errors — all of which we collapse into
+ * `false` because the caller only uses the boolean to decide whether
+ * to upgrade `"disconnected"` to `"reconnecting"`. Surfacing the
+ * difference would just turn a UI hint into a noisy crash path.
+ *
+ * `execFile` is overridable so the unit test can inject a stub instead
+ * of mocking `node:child_process` globally — a Node ESM namespace is
+ * frozen at import time, so spy-based mocking is brittle. Injection is
+ * the same dependency pattern the rest of the bridge uses (see
+ * `startStdioServer`'s `stdin` / `stdout` options).
+ */
+export function isHermesChatRunning(
+  execFile: ExecFileSyncLike = defaultExecFileSync,
+): boolean {
+  try {
+    const out = execFile("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
+      encoding: "utf8",
+      timeout: 1000,
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Hermes chat process detection — regex + pgrep wrapper.
+ *
+ * Regression for #1915: the daemon-mode bridge's `applyStaleRule()`
+ * used `pgrep -f "hermes chat"` as a literal substring, so any
+ * invocation with a global flag between the binary and the
+ * subcommand (`hermes --skills memory-routing chat`) was silently
+ * missed and the viewer was stuck on `"disconnected"`.
+ *
+ * The pattern under test is `hermes\s.*chat\b` — these cases lock in
+ * the exact shape of the fix.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  HERMES_CHAT_PROCESS_PATTERN,
+  isHermesChatRunning,
+  matchesHermesChatCommandLine,
+} from "../../../bridge/hermes-process.js";
+
+describe("HERMES_CHAT_PROCESS_PATTERN", () => {
+  it("is the documented #1915 regex (locks in the wire format pgrep sees)", () => {
+    // If this string ever changes, audit `bridge.cts` callers and the
+    // issue description before adjusting — the constant is the only
+    // surface that fixes the substring-detection bug.
+    expect(HERMES_CHAT_PROCESS_PATTERN).toBe("hermes\\s.*chat\\b");
+  });
+});
+
+describe("matchesHermesChatCommandLine", () => {
+  // ─── positive cases (must match) ───────────────────────────────
+  it("matches plain `hermes chat` with no flags", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes chat"),
+    ).toBe(true);
+  });
+
+  it("matches `hermes chat --skills …` (chat-level flags, the old happy path)", () => {
+    expect(
+      matchesHermesChatCommandLine(
+        "/usr/local/bin/hermes chat --skills memory-routing",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches `hermes --skills … chat` (global long flag before subcommand) — #1915", () => {
+    expect(
+      matchesHermesChatCommandLine(
+        "/usr/local/lib/hermes-agent/venv/bin/hermes --skills memory-routing chat",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches `hermes -m gpt-4 chat` (global short flag before subcommand) — #1915", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes -m gpt-4 chat"),
+    ).toBe(true);
+  });
+
+  it("matches `hermes --provider openai --skills mem chat` (multiple global flags) — #1915", () => {
+    expect(
+      matchesHermesChatCommandLine(
+        "/usr/local/bin/hermes --provider openai --skills mem chat",
+      ),
+    ).toBe(true);
+  });
+
+  // ─── negative cases (must NOT match) ───────────────────────────
+  it("does not match `hermes status` (different subcommand)", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes status"),
+    ).toBe(false);
+  });
+
+  it("does not match `hermes chatter` (chat must end at a word boundary)", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes chatter"),
+    ).toBe(false);
+  });
+
+  it("does not match a process with neither `hermes` nor `chat`", () => {
+    expect(matchesHermesChatCommandLine("/bin/bash -c sleep 5")).toBe(false);
+  });
+
+  it("does not match `hermesctl …` (binary name needs a whitespace separator)", () => {
+    // Catches the foot-gun of dropping the `\s` anchor and matching
+    // `hermesctl --chat-log=...` against the pattern.
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermesctl --chat-log=foo"),
+    ).toBe(false);
+  });
+});
+
+describe("isHermesChatRunning", () => {
+  it("calls pgrep with the documented #1915 regex pattern", () => {
+    const spy = vi.fn().mockReturnValue("12345\n");
+    expect(isHermesChatRunning(spy)).toBe(true);
+    expect(spy).toHaveBeenCalledWith(
+      "pgrep",
+      ["-f", HERMES_CHAT_PROCESS_PATTERN],
+      { encoding: "utf8", timeout: 1000 },
+    );
+  });
+
+  it("returns false when pgrep prints only whitespace (no match)", () => {
+    const spy = vi.fn().mockReturnValue("\n");
+    expect(isHermesChatRunning(spy)).toBe(false);
+  });
+
+  it("returns false when pgrep throws (e.g. exit 1 on no match, binary missing)", () => {
+    const spy = vi.fn().mockImplementation(() => {
+      throw new Error("Command failed with exit code 1");
+    });
+    expect(isHermesChatRunning(spy)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1915. `isHermesChatRunning()` in `apps/memos-local-plugin/bridge.cts` was using `pgrep -f "hermes chat"` as a literal substring, so it silently missed any session launched with global flags before the subcommand (e.g. `hermes --skills memory-routing chat`). In daemon mode this left `applyStaleRule()` permanently stuck on `"disconnected"` instead of upgrading to `"reconnecting"`. Stdio mode was unaffected (it manages its own status via `markConnected` / `markDisconnected`).

The pattern + helper were extracted into a new ESM module `apps/memos-local-plugin/bridge/hermes-process.ts`, exporting `HERMES_CHAT_PROCESS_PATTERN = "hermes\\s.*chat\\b"`, a JS-side `matchesHermesChatCommandLine(cmd)` predicate, and an `isHermesChatRunning(execFile?)` wrapper with injectable `execFile` for testing. `bridge.cts` now loads the helper via the same `runtimeModule()` / `importEsm()` machinery as its other dependencies and threads it into `createBridgeStatusTracker` via DI. The new regex covers `hermes chat`, `hermes chat --…`, and `hermes --… chat` while still rejecting `hermesctl`, `hermes status`, and unrelated processes thanks to the `\s` anchor and the `\b` word boundary.

Verification: `pnpm exec vitest run tests/unit/bridge/` → 28 passed (13 new regex / pgrep-wrapper assertions + 15 existing methods/stdio); `pnpm run lint` (tsc --noEmit) → exit 0; live-fire on Linux spawned a fake `/usr/local/bin/hermes --skills memory-routing chat` process and confirmed the old literal pattern missed it while the new regex matched it. Two unit failures in `tests/unit/storage/{migrator,traces-count}.test.ts` were confirmed pre-existing on the base branch (stashed this diff and re-ran) and are unrelated.

Branch `bugfix/autodev-1915` pushed to origin at commit `ccb369da`. Reviewers @MatthewZhuang @CarltonXiang @syzsunshine219.

Related Issue (Required):  Fixes #1915

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219 please review this PR.

## Reviewer Checklist
- [x] closes #1915
- [ ] Made sure Checks passed
- [ ] Tests have been provided
