### PR TITLE
fix: correct "monitering" typo in task_id field descriptions

### DIFF
--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -597,7 +597,7 @@ class APIADDRequest(BaseRequest):
         None,
         description="Session ID. If not provided, a default session will be used.",
     )
-    task_id: str | None = Field(None, description="Task ID for monitering async tasks")
+    task_id: str | None = Field(None, description="Task ID for monitoring async tasks")
     manager_user_id: str | None = Field(None, description="Manager User ID")
     project_id: str | None = Field(None, description="Project ID")
 
@@ -806,7 +806,7 @@ class APIFeedbackRequest(BaseRequest):
     session_id: str | None = Field(
         "default_session", description="Session ID for soft-filtering memories"
     )
-    task_id: str | None = Field(None, description="Task ID for monitering async tasks")
+    task_id: str | None = Field(None, description="Task ID for monitoring async tasks")
     history: MessageList | None = Field(..., description="Chat history")
     retrieved_memory_ids: list[str] | None = Field(
         None, description="Retrieved memory ids at last turn"


### PR DESCRIPTION
## Description

Two `task_id` field descriptions in `src/memos/api/product_models.py` contained a misspelling: `"monitering"` instead of `"monitoring"`. This fixes both occurrences in `APIADDRequest` and `APIFeedbackRequest`.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation update

## How Has This Been Tested?
- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

No tests needed — this is a typo fix in a field description string with no behavior change.

## Checklist
- [x] Self-review done
- [x] Issue linked