### PR TITLE
fix(bridge): derive profileId dynamically from MEMOS_HOME

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -246,9 +246,27 @@ async function main(): Promise<void> {
     ? resolveHome(args.agent, args.home)
     : undefined;
 
+  // Derive profileId dynamically from MEMOS_HOME.
+  // MEMOS_HOME points to <hermes-home>/memos-plugin, so parent dir is hermes-home.
+  // e.g. /root/.hermes/profiles/nova/memos-plugin → profile = "nova"
+  //      /root/.hermes/memos-plugin → profile = "default"
+  const deriveProfileId = (): string => {
+    const memosHome = process.env.MEMOS_HOME;
+    if (memosHome) {
+      const hermesHome = memosHome.replace(/memos-plugin\/?$/, "");
+      const match = /\/profiles\/([^/]+)\/?$/.exec(hermesHome);
+      if (match?.[1]) {
+        const cleaned = match[1].toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+        if (cleaned) return cleaned;
+      }
+      if (hermesHome.endsWith("/.hermes")) return "default";
+    }
+    return "default";
+  };
+  const resolvedProfileId = deriveProfileId();
   const { core, config, home } = await bootstrapMemoryCoreFull({
     agent: args.agent,
-    namespace: { agentKind: args.agent, profileId: "default" },
+    namespace: { agentKind: args.agent, profileId: resolvedProfileId },
     pkgVersion,
     hostLlmBridge: args.daemon ? null : lazyHostLlmBridge,
     home: resolvedHome,


### PR DESCRIPTION
---
name: Bug Fix
about: Create a report to help us improve
---

## Issue: dist/bridge.cjs missing dynamic profileId resolution from bridge.cts

### Problem
The `bridge.cts` source file hardcoded `profileId: "default"`, causing all profile-specific data to be invisible in the memOS web viewer when using multi-profile Hermes setups.

### Root Cause
- `bridge.cts` hardcoded `profileId: "default"` in `bootstrapMemoryCoreFull()` call
- The Python adapter already derives profileId correctly from `HERMES_HOME`
- This bug only affects the Node.js bridge process (HTTP viewer)

### Symptoms
- Web Viewer only shows data from `default` profile
- Database has thousands of records for other profiles (e.g., `nova`)
- Agent tool calls work correctly (Python adapter resolves profileId dynamically)
- Problem is ONLY in the standalone HTTP viewer bridge process

### Environment
- Hermes Agent v0.13+
- memos-local-plugin v2.0.19
- Profile: `nova` under multi-profile setup (`~/.hermes/profiles/nova/`)

### Expected Behavior
`bridge.cts` should derive `profileId` dynamically from `MEMOS_HOME` environment variable.

### Actual Behavior
`bridge.cts` hardcodes `profileId: "default"`, filtering out all profile-specific data.

### Fix
Added `deriveProfileId()` function that:
1. Reads `MEMOS_HOME` environment variable
2. Parses profile name from path pattern: `/profiles/<name>/`
3. Falls back to `"default"` if `MEMOS_HOME` is not set or path doesn't match

### Impact
- Zero for single-profile/default setups (still resolves to `"default"`)
- Fixes all multi-profile Hermes setups

### Testing
- Tested on Hermes v0.13+, memos-local-plugin v2.0.19, profile `nova` (~19K traces)
- All profile-specific data now visible in web viewer
- Database `owner_profile_id` values correctly resolved

### Workaround (for users who cannot upgrade)
Manually patch `dist/bridge.cjs` or update database `owner_profile_id` values to match the profile name.
