### PR TITLE
fix(memos-local-plugin): detect Hermes chat with global flags

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -679,9 +679,11 @@ function createBridgeStatusTracker(statusFile: string, daemon: boolean): {
   };
 }
 
+const HERMES_CHAT_PROCESS_PATTERN = "hermes(?:\\s+\\S+)*\\s+chat\\b";
+
 function isHermesChatRunning(): boolean {
   try {
-    const out = childProcess.execFileSync("pgrep", ["-f", "hermes chat"], {
+    const out = childProcess.execFileSync("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
       encoding: "utf8",
       timeout: 1000,
     });

--- a/apps/memos-local-plugin/tests/unit/bridge-status.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge-status.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function matchesHermesChatProcess(command: string): boolean {
+  const bridgePath = path.resolve(__dirname, "../../bridge.cts");
+  const bridgeSource = fs.readFileSync(bridgePath, "utf8");
+  const match = bridgeSource.match(
+    /const HERMES_CHAT_PROCESS_PATTERN = "(?<pattern>.*)";/,
+  );
+  expect(match?.groups?.pattern).toBeTruthy();
+  const escapedPattern = match!.groups!.pattern;
+  const pattern = escapedPattern.replaceAll("\\\\", "\\");
+  return new RegExp(pattern).test(command);
+}
+
+describe("Hermes chat process detection", () => {
+  it("matches the standard Hermes chat command", () => {
+    expect(matchesHermesChatProcess("hermes chat")).toBe(true);
+    expect(matchesHermesChatProcess("/usr/local/bin/hermes chat")).toBe(true);
+  });
+
+  it("matches global flags before the chat subcommand", () => {
+    expect(
+      matchesHermesChatProcess(
+        "/usr/local/lib/hermes-agent/venv/bin/hermes --skills memory-routing chat",
+      ),
+    ).toBe(true);
+    expect(
+      matchesHermesChatProcess(
+        "hermes -m gpt-4.1 --provider openai chat --skills memory-routing",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match non-chat Hermes commands", () => {
+    expect(matchesHermesChatProcess("hermes dashboard")).toBe(false);
+    expect(matchesHermesChatProcess("hermes --skills memory-routing gateway")).toBe(false);
+  });
+});

--- a/apps/memos-local-plugin/tests/unit/bridge-status.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge-status.test.ts
@@ -1,40 +1,28 @@
-import fs from "node:fs";
-import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-function matchesHermesChatProcess(command: string): boolean {
-  const bridgePath = path.resolve(__dirname, "../../bridge.cts");
-  const bridgeSource = fs.readFileSync(bridgePath, "utf8");
-  const match = bridgeSource.match(
-    /const HERMES_CHAT_PROCESS_PATTERN = "(?<pattern>.*)";/,
-  );
-  expect(match?.groups?.pattern).toBeTruthy();
-  const escapedPattern = match!.groups!.pattern;
-  const pattern = escapedPattern.replaceAll("\\\\", "\\");
-  return new RegExp(pattern).test(command);
-}
+import { matchesHermesChatCommandLine } from "../../bridge/hermes-process.js";
 
 describe("Hermes chat process detection", () => {
   it("matches the standard Hermes chat command", () => {
-    expect(matchesHermesChatProcess("hermes chat")).toBe(true);
-    expect(matchesHermesChatProcess("/usr/local/bin/hermes chat")).toBe(true);
+    expect(matchesHermesChatCommandLine("hermes chat")).toBe(true);
+    expect(matchesHermesChatCommandLine("/usr/local/bin/hermes chat")).toBe(true);
   });
 
   it("matches global flags before the chat subcommand", () => {
     expect(
-      matchesHermesChatProcess(
+      matchesHermesChatCommandLine(
         "/usr/local/lib/hermes-agent/venv/bin/hermes --skills memory-routing chat",
       ),
     ).toBe(true);
     expect(
-      matchesHermesChatProcess(
+      matchesHermesChatCommandLine(
         "hermes -m gpt-4.1 --provider openai chat --skills memory-routing",
       ),
     ).toBe(true);
   });
 
   it("does not match non-chat Hermes commands", () => {
-    expect(matchesHermesChatProcess("hermes dashboard")).toBe(false);
-    expect(matchesHermesChatProcess("hermes --skills memory-routing gateway")).toBe(false);
+    expect(matchesHermesChatCommandLine("hermes dashboard")).toBe(false);
+    expect(matchesHermesChatCommandLine("hermes --skills memory-routing gateway")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- update bridge status detection to match Hermes chat processes when global flags appear before the chat subcommand
- add a focused unit test covering standard chat, global flags before chat, and non-chat commands

Fixes #1915.

## Verification
- npm test -- --run tests/unit/bridge-status.test.ts
- npm run lint