### PR TITLE
Fix #1311: bug(openclaw-plugin): auto-recall contaminates cron runs with prior meta-discuss

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -18,6 +18,7 @@ import { SqliteStore } from "./src/storage/sqlite";
 import { Embedder } from "./src/embedding";
 import { IngestWorker } from "./src/ingest/worker";
 import { RecallEngine } from "./src/recall/engine";
+import { shouldSkipAutoRecallForSession } from "./src/recall/session-policy";
 import { captureMessages, stripInboundMetadata } from "./src/capture";
 import { DEFAULTS } from "./src/types";
 import type { SearchHit } from "./src/types";
@@ -1866,6 +1867,16 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
     api.on("before_prompt_build", async (event: { prompt?: string; messages?: unknown[] }, hookCtx?: { agentId?: string; sessionKey?: string }) => {
       if (!allowPromptInjection) return {};
       if (!event.prompt || event.prompt.length < 3) return;
+
+      // ─── Cron / excluded-session gate (GitHub #1311) ───────────────
+      // Skip auto-recall (and skill auto-recall) entirely for OpenClaw
+      // cron sessions by default. The cron prompt is the spec — recalling
+      // prior meta-discussion about the cron contaminates the next run.
+      const recallSessionKey = hookCtx?.sessionKey ?? (event as any)?.sessionKey;
+      if (shouldSkipAutoRecallForSession(recallSessionKey, ctx.config.autoRecall)) {
+        ctx.log.info(`auto-recall: skipping (cron/excluded session: "${recallSessionKey}")`);
+        return;
+      }
 
       const recallAgentId = hookCtx?.agentId ?? (event as any)?.agentId ?? (event as any)?.profileId ?? "main";
       currentAgentId = recallAgentId;

--- a/apps/memos-local-openclaw/src/config.ts
+++ b/apps/memos-local-openclaw/src/config.ts
@@ -57,6 +57,10 @@ export function resolveConfig(raw: Partial<MemosLocalConfig> | undefined, stateD
     storage: {
       dbPath: cfg.storage?.dbPath ?? path.join(stateDir, "memos-local", "memos.db"),
     },
+    autoRecall: {
+      excludeCron: cfg.autoRecall?.excludeCron ?? true,
+      excludeSessionKeyPatterns: cfg.autoRecall?.excludeSessionKeyPatterns ?? [],
+    },
     recall: {
       maxResultsDefault: cfg.recall?.maxResultsDefault ?? DEFAULTS.maxResultsDefault,
       maxResultsMax: cfg.recall?.maxResultsMax ?? DEFAULTS.maxResultsMax,

--- a/apps/memos-local-openclaw/src/recall/session-policy.ts
+++ b/apps/memos-local-openclaw/src/recall/session-policy.ts
@@ -1,0 +1,66 @@
+/**
+ * Auto-recall session-key policy.
+ *
+ * Decides whether the `before_prompt_build` auto-recall hook should
+ * short-circuit for the current OpenClaw session.
+ *
+ * Background: OpenClaw cron jobs use stable session keys of the form
+ * `agent:<agentId>:cron:<jobId>`. Auto-recall has historically used the
+ * cron prompt itself as the recall query, which means prior meta-discussion
+ * about the cron (prompt tuning, debugging, rerun requests) was injected
+ * back into the next scheduled run and contaminated its output. See
+ * GitHub issue MemTensor/MemOS#1311.
+ *
+ * The helper is intentionally pure and lives outside the plugin entry so
+ * it can be unit tested without spinning up the full plugin context.
+ */
+
+export interface AutoRecallExclusionConfig {
+  /**
+   * When true (default), skip auto-recall for any session whose key
+   * contains a `cron` segment (`/(^|:)cron(:|$)/i`). Operators who rely on
+   * cron-cross-turn memory recall can flip this to `false` to restore the
+   * pre-1311 behaviour.
+   */
+  excludeCron?: boolean;
+  /**
+   * Optional list of additional regex strings tested against the raw
+   * session key. Any match wins (OR semantics with `excludeCron`).
+   * Invalid regex strings are ignored.
+   */
+  excludeSessionKeyPatterns?: string[];
+}
+
+const CRON_SEGMENT_RE = /(?:^|:)cron(?::|$)/i;
+
+/**
+ * Return `true` when the auto-recall hook should not run for this session.
+ *
+ * - Empty / missing `sessionKey` → returns `false` (no opinion; preserves
+ *   behaviour for hosts that do not pass a session key).
+ * - Cron session keys are skipped when `cfg?.excludeCron !== false`.
+ *   The default behaviour (no config) is to skip.
+ * - Any user-supplied regex in `cfg?.excludeSessionKeyPatterns` that
+ *   matches the session key also forces a skip.
+ */
+export function shouldSkipAutoRecallForSession(
+  sessionKey: string | undefined,
+  cfg: AutoRecallExclusionConfig | undefined,
+): boolean {
+  if (!sessionKey) return false;
+
+  const excludeCron = cfg?.excludeCron ?? true;
+  if (excludeCron && CRON_SEGMENT_RE.test(sessionKey)) return true;
+
+  const patterns = cfg?.excludeSessionKeyPatterns ?? [];
+  for (const raw of patterns) {
+    try {
+      if (new RegExp(raw).test(sessionKey)) return true;
+    } catch {
+      // Invalid regex — silently ignore. Callers may log this at config
+      // resolution time but the hook must not throw.
+    }
+  }
+
+  return false;
+}

--- a/apps/memos-local-openclaw/src/types.ts
+++ b/apps/memos-local-openclaw/src/types.ts
@@ -296,12 +296,28 @@ export interface SharingConfig {
   capabilities?: SharingCapabilities;
 }
 
+export interface AutoRecallConfig {
+  /**
+   * When true (default), skip auto-recall for OpenClaw cron session keys
+   * (any session whose path contains a `cron` segment, e.g.
+   * `agent:main:cron:<jobId>`). Set to false to restore the pre-1311
+   * behaviour where cron sessions also got recall-injected context.
+   */
+  excludeCron?: boolean;
+  /**
+   * Optional regex strings tested against the raw session key in addition
+   * to the cron rule above. Any match wins. Invalid patterns are ignored.
+   */
+  excludeSessionKeyPatterns?: string[];
+}
+
 export interface MemosLocalConfig {
   summarizer?: SummarizerConfig;
   embedding?: EmbeddingConfig;
   storage?: {
     dbPath?: string;
   };
+  autoRecall?: AutoRecallConfig;
   recall?: {
     maxResultsDefault?: number;
     maxResultsMax?: number;

--- a/apps/memos-local-openclaw/tests/auto-recall-cron-gate.test.ts
+++ b/apps/memos-local-openclaw/tests/auto-recall-cron-gate.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+interface HarnessResult {
+  recallSearchCalls: Array<{ query: string }>;
+  hookHandler: ((event: unknown, ctx: unknown) => Promise<unknown> | unknown) | null;
+}
+
+async function buildPlugin(autoRecall: Record<string, unknown> | undefined): Promise<HarnessResult> {
+  const recallSearchCalls: Array<{ query: string }> = [];
+
+  vi.doMock("../src/config", () => ({
+    buildContext: () => ({
+      stateDir: "/tmp/memos-cron-gate",
+      workspaceDir: "/tmp/memos-cron-gate/workspace",
+      log: { debug() {}, info() {}, warn() {}, error() {} },
+      openclawAPI: undefined,
+      config: {
+        storage: { dbPath: "/tmp/memos-cron-gate/memos.db" },
+        capture: { evidenceWrapperTag: "STORED_MEMORY" },
+        telemetry: {},
+        sharing: { enabled: false, role: "client", hub: { port: 18800, teamName: "", teamToken: "" }, client: { hubAddress: "", userToken: "" }, capabilities: {} },
+        autoRecall,
+      },
+    }),
+  }));
+
+  vi.doMock("../src/storage/ensure-binding", () => ({ ensureSqliteBinding: () => {} }));
+  vi.doMock("../src/storage/sqlite", () => ({
+    SqliteStore: class {
+      recordToolCall() {}
+      recordApiLog() {}
+      getTask() { return null; }
+      getChunksByTask() { return []; }
+      getSkillsByTask() { return []; }
+      listLocalSharedTasks() { return []; }
+      getClientHubConnection() { return null; }
+      getChunk() { return null; }
+      getChunkForOwners() { return null; }
+      getNeighborChunks() { return []; }
+      getSkill() { return null; }
+      getLatestSkillVersion() { return null; }
+      close() {}
+    },
+  }));
+
+  vi.doMock("../src/embedding", () => ({ Embedder: class { provider = "openclaw"; constructor() {} async embed() { return []; } } }));
+
+  vi.doMock("../src/ingest/worker", () => ({
+    IngestWorker: class {
+      getTaskProcessor() { return { onTaskCompleted() {} }; }
+      enqueue() {}
+      async flush() {}
+    },
+  }));
+
+  vi.doMock("../src/recall/engine", () => ({
+    RecallEngine: class {
+      async search(input: { query: string }) {
+        recallSearchCalls.push({ query: input.query });
+        return { hits: [], meta: {} };
+      }
+      async searchSkills() { return []; }
+    },
+  }));
+
+  vi.doMock("../src/ingest/providers", () => ({
+    Summarizer: class {
+      constructor() {}
+      async filterRelevant() { return null; }
+    },
+  }));
+
+  vi.doMock("../src/viewer/server", () => ({
+    ViewerServer: class {
+      async start() { return "http://127.0.0.1:18799"; }
+      stop() {}
+      getResetToken() { return "tok"; }
+    },
+  }));
+
+  vi.doMock("../src/hub/server", () => ({
+    HubServer: class {
+      async start() { return "http://127.0.0.1:18800"; }
+      async stop() {}
+    },
+  }));
+
+  vi.doMock("../src/client/hub", () => ({
+    hubGetMemoryDetail: async () => ({}),
+    hubRequestJson: async () => ({}),
+    hubSearchMemories: async () => ({ hits: [], meta: {} }),
+    hubSearchSkills: async () => ({ hits: [] }),
+    resolveHubClient: async () => ({ hubUrl: "", userToken: "", userId: "" }),
+  }));
+
+  vi.doMock("../src/client/connector", () => ({
+    getHubStatus: async () => ({ connected: false }),
+    connectToHub: async () => ({ username: "test", userId: "test" }),
+  }));
+
+  vi.doMock("../src/client/skill-sync", () => ({
+    fetchHubSkillBundle: async () => ({}),
+    publishSkillBundleToHub: async () => ({}),
+    restoreSkillBundleFromHub: () => ({}),
+    unpublishSkillBundleFromHub: async () => ({}),
+  }));
+
+  vi.doMock("../src/skill/evolver", () => ({
+    SkillEvolver: class {
+      onSkillEvolved: unknown = null;
+      async onTaskCompleted() {}
+      async recoverOrphanedTasks() { return 0; }
+    },
+  }));
+
+  vi.doMock("../src/skill/installer", () => ({
+    SkillInstaller: class {
+      install() { return { message: "" }; }
+      getCompanionManifest() { return null; }
+      readCompanionFile() { return { error: "n/a" } as any; }
+    },
+  }));
+
+  vi.doMock("../src/skill/bundled-memory-guide", () => ({ MEMORY_GUIDE_SKILL_MD: "# mock" }));
+
+  vi.doMock("../src/telemetry", () => ({
+    Telemetry: class {
+      trackError() {}
+      trackToolCalled() {}
+      trackAutoRecall() {}
+      trackMemoryIngested() {}
+      trackSkillInstalled() {}
+      trackSkillEvolved() {}
+      trackPluginStarted() {}
+      trackViewerOpened() {}
+      async shutdown() {}
+    },
+  }));
+
+  vi.doMock("../src/capture", () => ({
+    captureMessages: () => [],
+    stripInboundMetadata: (s: string) => s,
+  }));
+
+  let hookHandler: HarnessResult["hookHandler"] = null;
+  const fakeApi = {
+    id: "memos-local-openclaw-plugin",
+    pluginConfig: {},
+    config: {},
+    resolvePath: () => "/tmp/memos-cron-gate",
+    logger: { info() {}, warn() {} },
+    registerTool: () => {},
+    registerMemoryCapability: () => {},
+    registerService: () => {},
+    on: (eventName: string, handler: (e: unknown, ctx: unknown) => unknown) => {
+      if (eventName === "before_prompt_build") hookHandler = handler as HarnessResult["hookHandler"];
+    },
+  } as any;
+
+  const pluginModule = await import("../plugin-impl");
+  pluginModule.default.register(fakeApi);
+
+  return { recallSearchCalls, hookHandler };
+}
+
+describe("before_prompt_build cron-session gate (GitHub #1311)", () => {
+  it("skips engine.search for cron sessionKey when excludeCron defaults to true", async () => {
+    const { recallSearchCalls, hookHandler } = await buildPlugin(undefined);
+    expect(hookHandler).toBeTypeOf("function");
+
+    const result = await hookHandler!(
+      { prompt: "Trade the morning open and report PnL." },
+      { agentId: "main", sessionKey: "agent:main:cron:job-abc" },
+    );
+
+    expect(result).toBeUndefined();
+    expect(recallSearchCalls).toHaveLength(0);
+  });
+
+  it("still runs engine.search for non-cron chat sessionKey", async () => {
+    const { recallSearchCalls, hookHandler } = await buildPlugin(undefined);
+
+    await hookHandler!(
+      { prompt: "Trade the morning open and report PnL." },
+      { agentId: "main", sessionKey: "agent:main:chat:hello" },
+    );
+
+    expect(recallSearchCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("runs engine.search for cron sessions when excludeCron=false", async () => {
+    const { recallSearchCalls, hookHandler } = await buildPlugin({
+      excludeCron: false,
+    });
+
+    await hookHandler!(
+      { prompt: "Trade the morning open and report PnL." },
+      { agentId: "main", sessionKey: "agent:main:cron:job-abc" },
+    );
+
+    expect(recallSearchCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("honours excludeSessionKeyPatterns", async () => {
+    const { recallSearchCalls, hookHandler } = await buildPlugin({
+      excludeCron: false,
+      excludeSessionKeyPatterns: ["^agent:debug:"],
+    });
+
+    await hookHandler!(
+      { prompt: "Trade the morning open and report PnL." },
+      { agentId: "main", sessionKey: "agent:debug:gateway:hello" },
+    );
+
+    expect(recallSearchCalls).toHaveLength(0);
+  });
+});

--- a/apps/memos-local-openclaw/tests/session-policy.test.ts
+++ b/apps/memos-local-openclaw/tests/session-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { shouldSkipAutoRecallForSession } from "../src/recall/session-policy";
+
+describe("shouldSkipAutoRecallForSession", () => {
+  it("skips cron session keys with default config (excludeCron defaults to true)", () => {
+    expect(shouldSkipAutoRecallForSession("agent:main:cron:job-abc", undefined)).toBe(true);
+    expect(shouldSkipAutoRecallForSession("agent:main:cron:job-abc", {})).toBe(true);
+  });
+
+  it("matches the `cron` segment regardless of position", () => {
+    expect(shouldSkipAutoRecallForSession("cron:tick-1", {})).toBe(true);
+    expect(shouldSkipAutoRecallForSession("agent:alpha:cron", {})).toBe(true);
+    expect(shouldSkipAutoRecallForSession("CRON:Job-9", {})).toBe(true); // case-insensitive
+  });
+
+  it("does NOT match identifiers that merely contain the substring `cron`", () => {
+    // boundary guard: 'cronos' is its own word, 'chat-cron-debug' uses '-' not ':'
+    expect(shouldSkipAutoRecallForSession("agent:main:chat:cronos", {})).toBe(false);
+    expect(shouldSkipAutoRecallForSession("agent:main:chat-cron-debug", {})).toBe(false);
+  });
+
+  it("does NOT skip regular chat sessions", () => {
+    expect(shouldSkipAutoRecallForSession("agent:main:chat:hello", {})).toBe(false);
+    expect(shouldSkipAutoRecallForSession("default", {})).toBe(false);
+  });
+
+  it("returns false when sessionKey is missing or empty (no opinion)", () => {
+    expect(shouldSkipAutoRecallForSession(undefined, {})).toBe(false);
+    expect(shouldSkipAutoRecallForSession("", {})).toBe(false);
+  });
+
+  it("respects excludeCron=false to keep cron auto-recall enabled", () => {
+    expect(
+      shouldSkipAutoRecallForSession("agent:main:cron:abc", { excludeCron: false }),
+    ).toBe(false);
+  });
+
+  it("applies user-supplied regex patterns from excludeSessionKeyPatterns", () => {
+    expect(
+      shouldSkipAutoRecallForSession("agent:debug:gateway:hello", {
+        excludeCron: false,
+        excludeSessionKeyPatterns: ["^agent:debug:"],
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSkipAutoRecallForSession("agent:main:chat:hello", {
+        excludeCron: false,
+        excludeSessionKeyPatterns: ["^agent:debug:"],
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back gracefully when a regex pattern is invalid", () => {
+    // '[' is an invalid regex; should be ignored, not throw
+    expect(() =>
+      shouldSkipAutoRecallForSession("agent:main:chat:hello", {
+        excludeCron: false,
+        excludeSessionKeyPatterns: ["["],
+      }),
+    ).not.toThrow();
+    expect(
+      shouldSkipAutoRecallForSession("agent:main:chat:hello", {
+        excludeCron: false,
+        excludeSessionKeyPatterns: ["["],
+      }),
+    ).toBe(false);
+  });
+
+  it("combines excludeCron and excludeSessionKeyPatterns (OR semantics)", () => {
+    expect(
+      shouldSkipAutoRecallForSession("agent:main:cron:abc", {
+        excludeCron: true,
+        excludeSessionKeyPatterns: ["nope"],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixed GitHub issue #1311 (openclaw-plugin cron-run contamination by auto-recall).

Root cause: the `before_prompt_build` hook in `apps/memos-local-openclaw/index.ts` ignored `hookCtx.sessionKey` and used the cron prompt itself as the recall query. Because cron jobs reuse stable session keys of the form `agent:<id>:cron:<jobId>` and prior meta-discussion about the cron (prompt tuning, debugging, rerun requests) lives under the same agent owner with vocabulary that mirrors the cron body, those discussions ranked highest and got injected back as a `## User's conversation history (from memory system)` system block on the next scheduled run, derailing the cron output.

Fix: added a new pure helper `shouldSkipAutoRecallForSession(sessionKey, cfg)` in `apps/memos-local-openclaw/src/recall/session-policy.ts` and an early-return gate at the top of the hook that short-circuits the entire memory + skill auto-recall path for cron / excluded session keys. Behaviour is controlled by a new optional `autoRecall` config block on `MemosLocalConfig` with `excludeCron` (default true) and `excludeSessionKeyPatterns` (default empty). The cron-segment matcher is `/(?:^|:)cron(?::|$)/i`, which is `:`-boundary aware so identifiers like `cronos` are not caught. Capture and the explicit `memory_search` / `memory_get` tools are intentionally untouched — only the *automatic* injection is suppressed inside cron runs.

Tests: 9 unit cases for the policy helper (default behaviour, cron-segment matching, boundary guard, opt-out, custom regex, invalid regex fallback) plus 4 integration cases that drive the actual hook with mocked storage/engine/summarizer and assert `RecallEngine.search` is/isn't called depending on session key + config. `npx vitest run tests/{session-policy,auto-recall-cron-gate,config,plugin-openclaw-wiring,openclaw-fallback}.test.ts` → 5 files, 32 tests pass. `npx tsc --noEmit` → exit 0.

Diff is contained to 6 files inside `apps/memos-local-openclaw/`: index.ts (8-line early-return gate + 1 import), src/recall/session-policy.ts (new helper), src/types.ts (new `AutoRecallConfig` interface), src/config.ts (default `autoRecall` block in `resolveConfig`), tests/session-policy.test.ts (new), tests/auto-recall-cron-gate.test.ts (new). No DB schema change, no public tool-API change, no data migration.

Related Issue (Required):  Fixes #1311

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1311
- [ ] Made sure Checks passed
- [ ] Tests have been provided
