### PR TITLE
Fix #1342: [Bug] v2.0.10 依赖冲突: numpy/scipy/chonkie 版本不兼容

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ mem-user = [
 
 # MemReader
 mem-reader = [
+    # chonkie>=1.6 pulls numpy>=2.0; any environment that also has scipy
+    # installed must use scipy>=1.13 (older scipy pins numpy<1.27). See #1342.
     "chonkie (>=1.0.7,<2.0.0)",  # Sentence chunking library
     "markitdown[docx,pdf,pptx,xls,xlsx] (>=0.1.1,<0.2.0)",  # Markdown parser for various file formats
     "langchain-text-splitters (>=1.0.0,<2.0.0)", # markdown chunk for langchain
@@ -193,7 +195,9 @@ zep-cloud = "^2.15.0"
 rouge-score = "^0.1.2"
 nltk = "^3.9.1"
 bert-score = "^0.3.13"
-scipy = "^1.10.1"
+# scipy 1.13+ supports numpy 2.x. Older scipy (1.10/1.11/1.12) pins numpy<1.27
+# which collides with chonkie>=1.6 (requires numpy>=2.0.0) — see issue #1342.
+scipy = "^1.13.0"
 python-dotenv = "^1.1.1"
 langgraph = "^0.5.1"
 


### PR DESCRIPTION
## Description

## Summary

Fixes #1342: numpy / scipy / chonkie version conflict.

**Root cause.** `pyproject.toml [tool.poetry.group.eval]` declared `scipy = "^1.10.1"`. scipy 1.10.x pins `numpy<1.27.0` (verified via the PyPI JSON metadata), while `chonkie>=1.6.0` requires `numpy>=2.0.0`. The two constraints are jointly unsatisfiable, so any environment that ends up with both packages (the user's reproduction installs chonkie on top of an apt-installed scipy 1.10.x) raises `ImportError: numpy.core.multiarray failed to import`.

**Fix.** Bumped the eval-group scipy floor from `^1.10.1` to `^1.13.0` (scipy 1.13 is the first release supporting numpy 2.x) and added two explanatory comments — one near the bumped floor and one above the `chonkie` entry in the `mem-reader` extras — so future readers see the numpy 2.x implication.

**Scope.** `scipy` is only imported by `evaluation/scripts/longmemeval/lme_eval.py` and `evaluation/scripts/locomo/locomo_eval.py`; nothing under `src/memos/` references it (grep clean). The change is therefore constraint-only, no source code path is affected.

**Verification.** `ruff check pyproject.toml` → "All checks passed!"; `ruff format --check pyproject.toml` → no diff; `pytest tests/chunkers/` → 3 passed in 4.26s; TOML reparsed via `tomli.load` reports `eval scipy= ^1.13.0`. The committed `poetry.lock` already resolves scipy to 1.15.3 / 1.16.0 and numpy to 2.2.6 / 2.3.1, all of which satisfy the new `^1.13.0` floor, so a re-lock would be a no-op and is deferred to the pre-commit `poetry-lock` hook on the maintainer's machine.

Related Issue (Required):  Fixes #1342

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1342
- [ ] Made sure Checks passed
- [ ] Tests have been provided
