### PR TITLE
Fix #1372: fix(memos-local-openclaw): Viewer API search 接口 limit 和 minScore 参数不生效

### DIFF
--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -928,6 +928,20 @@ export class ViewerServer {
     const dateFrom = url.searchParams.get("dateFrom") ?? undefined;
     const dateTo = url.searchParams.get("dateTo") ?? undefined;
 
+    // Issue #1372: honor `limit` and `minScore` query params.
+    // - `limit` is clamped to [1, 100]; default 20 to match the historical
+    //   FTS-fallback slice so behavior is unchanged when the client omits it.
+    // - `minScore` is clamped to [0.35, 1]; default 0.64 preserves the
+    //   previous semantic-similarity gate.
+    const rawLimit = Number(url.searchParams.get("limit"));
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0
+      ? Math.min(100, Math.max(1, Math.floor(rawLimit)))
+      : 20;
+    const rawMinScore = Number(url.searchParams.get("minScore"));
+    const minScore = Number.isFinite(rawMinScore) && rawMinScore > 0
+      ? Math.max(0.35, Math.min(1, rawMinScore))
+      : 0.64;
+
     const passesFilter = (r: any): boolean => {
       if (role && r.role !== role) return false;
       if (session && r.session_key !== session) return false;
@@ -962,7 +976,7 @@ export class ViewerServer {
       }
     }
 
-    const SEMANTIC_THRESHOLD = 0.64;
+    const SEMANTIC_THRESHOLD = minScore;
     const VECTOR_TIMEOUT_MS = 8000;
     let vectorResults: any[] = [];
     let scoreMap = new Map<string, number>();
@@ -1001,7 +1015,7 @@ export class ViewerServer {
       if (!seenIds.has(r.id)) { seenIds.add(r.id); merged.push(r); }
     }
 
-    const results = merged.length > 0 ? merged : ftsResults.slice(0, 20);
+    const results = (merged.length > 0 ? merged : ftsResults).slice(0, limit);
 
     this.store.recordViewerEvent("search");
     this.jsonResponse(res, {
@@ -1010,6 +1024,8 @@ export class ViewerServer {
       vectorCount: vectorResults.length,
       ftsCount: ftsResults.length,
       total: results.length,
+      limit,
+      minScore,
     });
   }
 

--- a/apps/memos-local-openclaw/tests/viewer-search-params.test.ts
+++ b/apps/memos-local-openclaw/tests/viewer-search-params.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SqliteStore } from "../src/storage/sqlite";
+import { ViewerServer } from "../src/viewer/server";
+
+/**
+ * Regression coverage for issue #1372 — `/api/search?q=...&limit=...&minScore=...`
+ * must respect both query parameters.
+ *
+ * Before the fix:
+ *   - `limit` was never read; merged results were returned in full and the
+ *     fallback hard-coded `.slice(0, 20)`.
+ *   - `minScore` was never read; the semantic gate was the constant 0.64.
+ *
+ * After the fix the handler clamps `limit` to [1, 100] (default 20) and
+ * `minScore` to [0.35, 1] (default 0.64), echoes both values in the response,
+ * and truncates the result set accordingly.
+ */
+
+const noopLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+let tmpDirs: string[] = [];
+let stores: SqliteStore[] = [];
+let viewer: ViewerServer | null = null;
+
+afterEach(() => {
+  viewer?.stop();
+  viewer = null;
+  for (const store of stores.splice(0)) store.close();
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+async function viewerAuthCookie(baseUrl: string) {
+  const res = await fetch(`${baseUrl}/api/auth/setup`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ password: "passw0rd" }),
+  });
+  const setCookie = res.headers.get("set-cookie") || "";
+  return setCookie.split(";")[0];
+}
+
+interface SeededChunk {
+  id: string;
+  content: string;
+  vector: number[];
+}
+
+/**
+ * Embedder stub: returns a fixed query vector and exposes a deterministic
+ * embed() for backfill calls (returns the zero vector so it never affects
+ * scoring). The real ViewerServer code only calls `embedQuery()` inside
+ * `serveSearch`, so this is the only critical knob.
+ */
+function makeStubEmbedder(queryVector: number[]) {
+  const dim = queryVector.length;
+  return {
+    provider: "local",
+    dimensions: dim,
+    async embed(texts: string[]) {
+      return texts.map(() => new Array(dim).fill(0));
+    },
+    async embedQuery(_text: string) {
+      return queryVector;
+    },
+  } as any;
+}
+
+function seedChunks(store: SqliteStore, chunks: SeededChunk[]) {
+  const now = Date.now();
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    store.insertChunk({
+      id: c.id,
+      sessionKey: "session-1372",
+      turnId: `turn-${i}`,
+      seq: i,
+      role: "assistant",
+      content: c.content,
+      kind: "paragraph",
+      summary: c.content,
+      embedding: null,
+      taskId: null,
+      skillId: null,
+      owner: "agent:main",
+      dedupStatus: "active",
+      dedupTarget: null,
+      dedupReason: null,
+      mergeCount: 0,
+      lastHitAt: null,
+      mergeHistory: "[]",
+      createdAt: now + i,
+      updatedAt: now + i,
+    } as any);
+    store.upsertEmbedding(c.id, c.vector);
+  }
+}
+
+function pickPort() {
+  return 19400 + Math.floor(Math.random() * 400);
+}
+
+describe("ViewerServer /api/search query parameter handling (issue #1372)", () => {
+  it("respects ?limit= by truncating the returned result list", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-search-limit-"));
+    tmpDirs.push(dir);
+    const store = new SqliteStore(path.join(dir, "viewer.db"), noopLog as any);
+    stores.push(store);
+
+    // Five chunks, all containing the literal "rollout" so FTS will return
+    // every row; vector path is disabled by making embedQuery reject below.
+    const seeded = Array.from({ length: 5 }, (_, i) => ({
+      id: `chunk-rollout-${i}`,
+      content: `rollout checklist step ${i + 1}`,
+      vector: new Array(8).fill(0),
+    }));
+    seedChunks(store, seeded);
+
+    const embedder = {
+      provider: "local",
+      dimensions: 8,
+      async embed(texts: string[]) { return texts.map(() => new Array(8).fill(0)); },
+      async embedQuery() { throw new Error("vector path disabled for this test"); },
+    } as any;
+
+    viewer = new ViewerServer({
+      store,
+      embedder,
+      port: pickPort(),
+      log: noopLog as any,
+      dataDir: dir,
+    });
+    const url = await viewer.start();
+    const cookie = await viewerAuthCookie(url);
+
+    const limited = await fetch(`${url}/api/search?q=rollout&limit=3`, { headers: { cookie } });
+    expect(limited.status).toBe(200);
+    const limitedJson = await limited.json();
+    expect(limitedJson.results.length).toBe(3);
+    expect(limitedJson.total).toBe(3);
+    expect(limitedJson.limit).toBe(3);
+
+    const defaultLimit = await fetch(`${url}/api/search?q=rollout`, { headers: { cookie } });
+    const defaultJson = await defaultLimit.json();
+    expect(defaultJson.limit).toBe(20);
+    expect(defaultJson.results.length).toBe(5); // only 5 chunks seeded, all returned within default cap
+  });
+
+  it("clamps ?limit= into [1, 100]", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-search-clamp-"));
+    tmpDirs.push(dir);
+    const store = new SqliteStore(path.join(dir, "viewer.db"), noopLog as any);
+    stores.push(store);
+
+    seedChunks(store, [
+      { id: "chunk-clamp-1", content: "rollout clamp one", vector: new Array(8).fill(0) },
+      { id: "chunk-clamp-2", content: "rollout clamp two", vector: new Array(8).fill(0) },
+    ]);
+
+    viewer = new ViewerServer({
+      store,
+      embedder: {
+        provider: "local", dimensions: 8,
+        async embed(texts: string[]) { return texts.map(() => new Array(8).fill(0)); },
+        async embedQuery() { throw new Error("vector path disabled"); },
+      } as any,
+      port: pickPort(),
+      log: noopLog as any,
+      dataDir: dir,
+    });
+    const url = await viewer.start();
+    const cookie = await viewerAuthCookie(url);
+
+    const tooSmall = await (await fetch(`${url}/api/search?q=rollout&limit=0`, { headers: { cookie } })).json();
+    expect(tooSmall.limit).toBe(20); // 0 is falsy → falls back to default 20
+
+    const negative = await (await fetch(`${url}/api/search?q=rollout&limit=-5`, { headers: { cookie } })).json();
+    expect(negative.limit).toBe(20); // negative → falls back to default 20
+
+    const tooLarge = await (await fetch(`${url}/api/search?q=rollout&limit=9999`, { headers: { cookie } })).json();
+    expect(tooLarge.limit).toBe(100);
+
+    const garbage = await (await fetch(`${url}/api/search?q=rollout&limit=NaN`, { headers: { cookie } })).json();
+    expect(garbage.limit).toBe(20);
+  });
+
+  it("respects ?minScore= by raising the semantic similarity gate", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-search-score-"));
+    tmpDirs.push(dir);
+    const store = new SqliteStore(path.join(dir, "viewer.db"), noopLog as any);
+    stores.push(store);
+
+    // Three chunks with engineered vectors so cosine similarity vs the query
+    // vector [1,0,0,0] is deterministic:
+    //   - high   ≈ 1.00 (passes minScore=0.8)
+    //   - medium ≈ 0.70 (passes default 0.64 but fails 0.8)
+    //   - low    ≈ 0.40 (fails both)
+    // All chunks contain the literal "vector" so FTS also returns them; the
+    // test asserts behavior on the merged response.
+    seedChunks(store, [
+      { id: "chunk-vec-high", content: "vector high similarity", vector: [1, 0, 0, 0] },
+      { id: "chunk-vec-med", content: "vector medium similarity", vector: [0.7, Math.sqrt(1 - 0.49), 0, 0] },
+      { id: "chunk-vec-low", content: "vector low similarity", vector: [0.4, Math.sqrt(1 - 0.16), 0, 0] },
+    ]);
+
+    const embedder = makeStubEmbedder([1, 0, 0, 0]);
+
+    viewer = new ViewerServer({
+      store,
+      embedder,
+      port: pickPort(),
+      log: noopLog as any,
+      dataDir: dir,
+    });
+    const url = await viewer.start();
+    const cookie = await viewerAuthCookie(url);
+
+    const strict = await (await fetch(`${url}/api/search?q=vector&minScore=0.8&limit=10`, { headers: { cookie } })).json();
+    expect(strict.minScore).toBe(0.8);
+    // With minScore=0.8 only the high-similarity vector chunk passes the
+    // semantic gate; the merged result list therefore starts with it and the
+    // FTS-only chunks (medium/low) are appended after — but the issue's
+    // contract is that the response should not silently dump every FTS row.
+    // Concretely, vectorCount must equal 1.
+    expect(strict.vectorCount).toBe(1);
+
+    const lax = await (await fetch(`${url}/api/search?q=vector&minScore=0.64&limit=10`, { headers: { cookie } })).json();
+    expect(lax.minScore).toBe(0.64);
+    expect(lax.vectorCount).toBeGreaterThanOrEqual(2); // high + medium both clear 0.64
+  });
+
+  it("echoes default minScore (0.64) when the param is omitted", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-search-default-score-"));
+    tmpDirs.push(dir);
+    const store = new SqliteStore(path.join(dir, "viewer.db"), noopLog as any);
+    stores.push(store);
+
+    seedChunks(store, [
+      { id: "chunk-default-1", content: "rollout default one", vector: new Array(8).fill(0) },
+    ]);
+
+    viewer = new ViewerServer({
+      store,
+      embedder: {
+        provider: "local", dimensions: 8,
+        async embed(texts: string[]) { return texts.map(() => new Array(8).fill(0)); },
+        async embedQuery() { throw new Error("vector path disabled"); },
+      } as any,
+      port: pickPort(),
+      log: noopLog as any,
+      dataDir: dir,
+    });
+    const url = await viewer.start();
+    const cookie = await viewerAuthCookie(url);
+
+    const resp = await (await fetch(`${url}/api/search?q=rollout`, { headers: { cookie } })).json();
+    expect(resp.limit).toBe(20);
+    expect(resp.minScore).toBe(0.64);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1372 — viewer `/api/search` was silently dropping the `limit` and `minScore` query parameters. The handler in `apps/memos-local-openclaw/src/viewer/server.ts` never read either field: the merged result list was returned unbounded (or the fallback slice was hardcoded to 20), and the semantic-similarity gate stayed pinned at the constant 0.64.

The patch parses both params, clamps `limit` to [1, 100] (default 20, preserving the previous fallback slice size) and `minScore` to [0.35, 1] (default 0.64, preserving the previous semantic gate), uses the requested floor in place of the hardcoded `SEMANTIC_THRESHOLD`, truncates the final merged result list, and echoes both values back in the response JSON so callers can verify which thresholds were applied.

Regression coverage: new `tests/viewer-search-params.test.ts` adds four cases — limit truncation, limit clamping (zero/negative/over-100/NaN fallbacks), `minScore` raising the semantic gate (with a stub embedder producing deterministic cosine scores), and default-echo on a bare query. `npx vitest run tests/viewer-search-params.test.ts` → 4 passed. Full `npx vitest run` → 226 passed; the 5 remaining failures (accuracy semantic precision, summary length, skill-auto-install default, task-processor session-change, update-install SIGUSR1 timing) reproduce identically on the unchanged base branch (verified via `git stash` rerun) and are pre-existing — none touch `serveSearch` or `/api/search`. `npx tsc --noEmit` clean.

Related Issue (Required):  Fixes #1372

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1372
- [ ] Made sure Checks passed
- [ ] Tests have been provided
