### PR TITLE
Fix #1377: fix: Title: memos-local-openclaw-plugin corrupts openclaw.json by inserting "gro

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -31,6 +31,7 @@ import { SkillInstaller } from "./src/skill/installer";
 import { Summarizer } from "./src/ingest/providers";
 import { MEMORY_GUIDE_SKILL_MD } from "./src/skill/bundled-memory-guide";
 import { Telemetry } from "./src/telemetry";
+import { ensureToolsAllowEntry } from "./src/openclaw-config";
 
 
 /** Remove near-duplicate hits based on summary word overlap (>70%). Keeps first (highest-scored) hit. */
@@ -356,18 +357,10 @@ const memosLocalPlugin = {
       const openclawJsonPath = path.join(stateDir, "openclaw.json");
       if (fs.existsSync(openclawJsonPath)) {
         const raw = fs.readFileSync(openclawJsonPath, "utf-8");
-        const cfg = JSON.parse(raw);
-        const allow: string[] | undefined = cfg?.tools?.allow;
-        if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins") && !allow.includes("*")) {
-          const lastEntry = JSON.stringify(allow[allow.length - 1]);
-          const patched = raw.replace(
-            new RegExp(`(${lastEntry})(\\s*\\])`),
-            `$1,\n      "group:plugins"$2`,
-          );
-          if (patched !== raw && patched.includes("group:plugins")) {
-            fs.writeFileSync(openclawJsonPath, patched, "utf-8");
-            ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
-          }
+        const patched = ensureToolsAllowEntry(raw, "group:plugins");
+        if (patched !== raw) {
+          fs.writeFileSync(openclawJsonPath, patched, "utf-8");
+          ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
         }
       }
     } catch (e) {

--- a/apps/memos-local-openclaw/src/openclaw-config.ts
+++ b/apps/memos-local-openclaw/src/openclaw-config.ts
@@ -1,0 +1,69 @@
+/**
+ * Helpers for safely mutating ~/.openclaw/openclaw.json from the plugin.
+ *
+ * Previously this lived inline in index.ts and used a hand-written regex
+ * on the raw JSON text. That approach corrupted the config when the same
+ * literal that ended `tools.allow` also appeared elsewhere in the file
+ * (e.g. inside `models.providers.*.models[*].input`). See issue #1377:
+ *   memos-local-openclaw-plugin corrupts openclaw.json by inserting
+ *   "group:plugins" into models[*].input.
+ *
+ * The fixed implementation parses the JSON, mutates the parsed object,
+ * and re-serialises it. That guarantees the new entry can only land in
+ * tools.allow.
+ */
+
+/** Detect indent unit (2 / 4 spaces or tab) by sampling the first indented line. */
+function detectIndent(raw: string): string | number {
+  const match = raw.match(/\n([ \t]+)\S/);
+  if (!match) return 2;
+  const indent = match[1];
+  if (indent.startsWith("\t")) return "\t";
+  return indent.length;
+}
+
+/**
+ * Ensure that `entry` is present in `tools.allow` inside the given raw
+ * openclaw.json text. Returns the (possibly updated) JSON text.
+ *
+ * Behaviour:
+ *   - If parsing fails, the input is returned unchanged.
+ *   - If `tools.allow` is missing, empty, contains `"*"`, or already
+ *     contains `entry`, the input is returned unchanged (referentially
+ *     equal to the input string) — callers can detect "no change" by
+ *     identity comparison and skip the disk write.
+ *   - Otherwise, the entry is appended to `tools.allow` and the result
+ *     is re-serialised with the original indentation. The original
+ *     trailing newline is preserved.
+ */
+export function ensureToolsAllowEntry(raw: string, entry: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return raw;
+  }
+  const root = parsed as Record<string, unknown>;
+  const tools = root.tools;
+  if (!tools || typeof tools !== "object") {
+    return raw;
+  }
+  const allow = (tools as Record<string, unknown>).allow;
+  if (!Array.isArray(allow) || allow.length === 0) {
+    return raw;
+  }
+  if (allow.includes(entry) || allow.includes("*")) {
+    return raw;
+  }
+
+  const next = { ...root, tools: { ...(tools as Record<string, unknown>), allow: [...allow, entry] } };
+  const indent = detectIndent(raw);
+  let serialised = JSON.stringify(next, null, indent as any);
+  if (raw.endsWith("\n") && !serialised.endsWith("\n")) {
+    serialised += "\n";
+  }
+  return serialised;
+}

--- a/apps/memos-local-openclaw/tests/openclaw-config.test.ts
+++ b/apps/memos-local-openclaw/tests/openclaw-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { ensureToolsAllowEntry } from "../src/openclaw-config";
+
+describe("ensureToolsAllowEntry", () => {
+  it("adds the entry to tools.allow when missing", () => {
+    const raw = JSON.stringify(
+      {
+        tools: {
+          allow: ["file_search", "shell"],
+        },
+      },
+      null,
+      2,
+    );
+
+    const patched = ensureToolsAllowEntry(raw, "group:plugins");
+    expect(patched).not.toBe(raw);
+
+    const parsed = JSON.parse(patched);
+    expect(parsed.tools.allow).toEqual(["file_search", "shell", "group:plugins"]);
+  });
+
+  it("does NOT modify any other array that happens to contain the same string as the last tools.allow entry", () => {
+    // Regression: issue #1377. The previous implementation used `raw.replace(new RegExp(`(${lastEntry})(\\s*\\])`))`
+    // which is non-global and matches the FIRST occurrence in the file. When models.providers.*.models[*].input
+    // appeared BEFORE tools.allow and ended with the same JSON value as the last tools.allow entry, it patched the
+    // wrong array, corrupting openclaw.json:
+    //   "input": ["text", "image"]      → "input": ["text", "image", "group:plugins"]   ← BUG
+    //   "allow": ["file_search", "image"] (was meant to be patched here)
+    const raw = JSON.stringify(
+      {
+        models: {
+          providers: {
+            qwen: {
+              models: [
+                {
+                  id: "qwen3.5-plus-search",
+                  name: "qwen3.5-plus-search",
+                  input: ["text", "image"],
+                },
+              ],
+            },
+          },
+        },
+        tools: {
+          allow: ["file_search", "image"],
+        },
+      },
+      null,
+      2,
+    );
+
+    const patched = ensureToolsAllowEntry(raw, "group:plugins");
+    const parsed = JSON.parse(patched);
+
+    expect(parsed.models.providers.qwen.models[0].input).toEqual(["text", "image"]);
+    expect(parsed.tools.allow).toEqual(["file_search", "image", "group:plugins"]);
+  });
+
+  it("is a no-op when the entry is already present", () => {
+    const raw = JSON.stringify(
+      {
+        tools: { allow: ["file_search", "group:plugins"] },
+      },
+      null,
+      2,
+    );
+    expect(ensureToolsAllowEntry(raw, "group:plugins")).toBe(raw);
+  });
+
+  it("is a no-op when tools.allow contains a wildcard", () => {
+    const raw = JSON.stringify({ tools: { allow: ["*"] } }, null, 2);
+    expect(ensureToolsAllowEntry(raw, "group:plugins")).toBe(raw);
+  });
+
+  it("is a no-op when tools.allow is missing or empty", () => {
+    expect(ensureToolsAllowEntry(JSON.stringify({}), "group:plugins")).toBe(JSON.stringify({}));
+    const emptyAllow = JSON.stringify({ tools: { allow: [] } }, null, 2);
+    expect(ensureToolsAllowEntry(emptyAllow, "group:plugins")).toBe(emptyAllow);
+  });
+
+  it("preserves indentation style when rewriting", () => {
+    const raw =
+      "{\n" +
+      "  \"tools\": {\n" +
+      "    \"allow\": [\n" +
+      "      \"file_search\",\n" +
+      "      \"shell\"\n" +
+      "    ]\n" +
+      "  },\n" +
+      "  \"models\": { \"providers\": {} }\n" +
+      "}\n";
+
+    const patched = ensureToolsAllowEntry(raw, "group:plugins");
+    const parsed = JSON.parse(patched);
+    expect(parsed.tools.allow).toEqual(["file_search", "shell", "group:plugins"]);
+    // Detected 2-space indent should be preserved
+    expect(patched.split("\n").some((line) => line.startsWith("    \"allow\""))).toBe(true);
+    // Original trailing newline is kept
+    expect(patched.endsWith("\n")).toBe(true);
+  });
+
+  it("handles regex-special characters in the last tools.allow entry", () => {
+    // Previous regex approach used JSON.stringify(value) inline and did not escape regex metacharacters.
+    const raw = JSON.stringify({ tools: { allow: ["a", "weird.name+x"] } }, null, 2);
+    const patched = ensureToolsAllowEntry(raw, "group:plugins");
+    const parsed = JSON.parse(patched);
+    expect(parsed.tools.allow).toEqual(["a", "weird.name+x", "group:plugins"]);
+  });
+
+  it("returns the input unchanged when JSON cannot be parsed", () => {
+    const raw = "not really json";
+    expect(ensureToolsAllowEntry(raw, "group:plugins")).toBe(raw);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1377: the memos-local-openclaw plugin was corrupting ~/.openclaw/openclaw.json by writing "group:plugins" into models.providers.*.models[*].input instead of tools.allow.

Root cause: the original implementation in apps/memos-local-openclaw/index.ts used a non-global String.replace against the raw JSON text. The regex looked for the JSON literal of the last tools.allow entry followed by `]`. Because models.providers.*.models[*].input appears before tools.allow in the default OpenClaw layout, and the input array often ends with the same literal (e.g. "image") as the last tools.allow entry, the first match landed inside the wrong array. The literal was also fed to RegExp without escaping regex metacharacters.

Fix: extracted a small pure helper `ensureToolsAllowEntry(raw, entry)` in apps/memos-local-openclaw/src/openclaw-config.ts that parses the JSON, appends the entry to tools.allow only, and re-serialises while preserving the original indent and trailing newline. The helper is a no-op when the entry is already present, when tools.allow contains "*", when tools.allow is missing/empty, or when the input cannot be parsed. index.ts now calls the helper instead of running the textual patch.

Tests: added tests/openclaw-config.test.ts with 8 cases, including a direct regression reproducing the exact input/allow shape from the issue. Verified locally: `vitest run` on the new test plus 5 neighbouring suites — 35/35 passed in 8.96s; `tsc --noEmit` clean. Pushed bugfix/autodev-1377 to origin; opsp specs archived to memos-autodev-specs#main (commit ca26b01). Scheduler should now open the PR against dev-20260624-v2.0.22.

Related Issue (Required):  Fixes #1377

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1377
- [ ] Made sure Checks passed
- [ ] Tests have been provided
