### PR TITLE
Fix #1490: fix: 本地viewer不会解析配置文件的环境变量

### DIFF
--- a/apps/memos-local-openclaw/src/config.ts
+++ b/apps/memos-local-openclaw/src/config.ts
@@ -4,11 +4,11 @@ import { OpenClawAPIClient, type HostModelsConfig } from "./openclaw-api";
 
 const ENV_RE = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
 
-function resolveEnvVars(value: string): string {
+export function resolveEnvVars(value: string): string {
   return value.replace(ENV_RE, (_, name) => process.env[name] ?? "");
 }
 
-function deepResolveEnv<T>(obj: T): T {
+export function deepResolveEnv<T>(obj: T): T {
   if (typeof obj === "string") return resolveEnvVars(obj) as unknown as T;
   if (Array.isArray(obj)) return obj.map(deepResolveEnv) as unknown as T;
   if (obj && typeof obj === "object") {

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -14,7 +14,7 @@ import { vectorSearch } from "../storage/vector";
 import { TaskProcessor } from "../ingest/task-processor";
 import { RecallEngine } from "../recall/engine";
 import { SkillEvolver } from "../skill/evolver";
-import { resolveConfig } from "../config";
+import { resolveConfig, deepResolveEnv } from "../config";
 import { getHubStatus } from "../client/connector";
 import { type ResolvedHubClient, hubGetMemoryDetail, hubListMemories, hubListTasks, hubListSkills, hubRequestJson, hubSearchMemories, hubSearchSkills, hubUpdateUsername, normalizeHubUrl, resolveHubClient } from "../client/hub";
 import { buildSkillBundleForHub, fetchHubSkillBundle, restoreSkillBundleFromHub } from "../client/skill-sync";
@@ -1934,6 +1934,42 @@ export class ViewerServer {
     return path.join(ocHome, "openclaw.json");
   }
 
+  /**
+   * Read openclaw.json without env-var resolution. Used by serveConfig (UI editor needs to
+   * see raw `${VAR}` literals so saves don't accidentally leak resolved secrets back into
+   * the config file). Returns `null` when the file is missing or unreadable.
+   */
+  private readOpenClawRawConfig(): Record<string, any> | null {
+    try {
+      const cfgPath = this.getOpenClawConfigPath();
+      if (!fs.existsSync(cfgPath)) return null;
+      return JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Read openclaw.json and apply `${VAR}` env-var resolution. Use this whenever the
+   * resulting value is consumed by something that actually contacts the network
+   * (apiKey/endpoint/baseUrl). Returns `null` when the file is missing or unreadable.
+   */
+  private readOpenClawResolvedConfig(): Record<string, any> | null {
+    const raw = this.readOpenClawRawConfig();
+    if (!raw) return null;
+    return deepResolveEnv(raw);
+  }
+
+  /**
+   * Read this plugin's section from openclaw.json with `${VAR}` env vars resolved.
+   * Used by migration / model tests that need real apiKey strings.
+   */
+  private readPluginConfigResolved(): Record<string, any> {
+    const raw = this.readOpenClawResolvedConfig();
+    if (!raw) return {};
+    return this.getPluginEntryConfig(raw);
+  }
+
   private getPluginEntryConfig(raw: any): Record<string, unknown> {
     const entries = raw?.plugins?.entries ?? {};
     return entries["memos-local-openclaw-plugin"]?.config
@@ -3514,12 +3550,14 @@ export class ViewerServer {
 
   private serveFallbackModel(res: http.ServerResponse): void {
     try {
-      const cfgPath = this.getOpenClawConfigPath();
-      if (!fs.existsSync(cfgPath)) {
+      // Resolve ${VAR} env-vars so providers.<id>.{baseUrl,apiKey} that reference
+      // process env (e.g. apiKey="${OPENAI_API_KEY}") evaluate before we report
+      // the fallback model as available.
+      const raw = this.readOpenClawResolvedConfig();
+      if (!raw) {
         this.jsonResponse(res, { available: false });
         return;
       }
-      const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
       const agentModel: string | undefined = raw?.agents?.defaults?.model?.primary;
       if (!agentModel) {
         this.jsonResponse(res, { available: false });
@@ -3786,6 +3824,11 @@ export class ViewerServer {
     if (provider === "local") {
       return 384;
     }
+    // Resolve ${VAR} env-var literals: the UI forwards the raw value pulled from
+    // openclaw.json verbatim (see serveConfig), so we must expand here before hitting
+    // the network — otherwise Bearer headers contain the literal "${MY_KEY}" string.
+    endpoint = deepResolveEnv(endpoint || "");
+    apiKey = deepResolveEnv(apiKey || "");
     const baseUrl = (endpoint || "https://api.openai.com/v1").replace(/\/+$/, "");
     const embUrl = baseUrl.endsWith("/embeddings") ? baseUrl : `${baseUrl}/embeddings`;
     const headers: Record<string, string> = {
@@ -3853,6 +3896,10 @@ export class ViewerServer {
   }
 
   private async testChatModel(provider: string, model: string, endpoint: string, apiKey: string): Promise<void> {
+    // Same env-var expansion as testEmbeddingModel: openclaw.json values such as
+    // "${OPENAI_API_KEY}" must be resolved before hitting the network.
+    endpoint = deepResolveEnv(endpoint || "");
+    apiKey = deepResolveEnv(apiKey || "");
     const baseUrl = (endpoint || "https://api.openai.com/v1").replace(/\/+$/, "");
     if (provider === "anthropic") {
       const url = endpoint || "https://api.anthropic.com/v1/messages";
@@ -4199,16 +4246,12 @@ export class ViewerServer {
     let totalSkipped = 0;
     let totalErrors = 0;
 
-    const cfgPath = this.getOpenClawConfigPath();
-    let summarizerCfg: any;
-    try {
-      const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
-      const pluginCfg = raw?.plugins?.entries?.["memos-local-openclaw-plugin"]?.config ??
-                        raw?.plugins?.entries?.["memos-local"]?.config ??
-                        raw?.plugins?.entries?.["memos-lite-openclaw-plugin"]?.config ??
-                        raw?.plugins?.entries?.["memos-lite"]?.config ?? {};
-      summarizerCfg = pluginCfg.summarizer;
-    } catch { /* no config */ }
+    // Build the migration Summarizer from the env-resolved plugin config so any
+    // apiKey/endpoint of the form "${OPENAI_API_KEY}" is expanded against process.env
+    // before the LLM call. Without this the migration's summarizer hits remote APIs
+    // with literal "${VAR}" Bearer tokens and 401s out.
+    const pluginCfg = this.readPluginConfigResolved();
+    const summarizerCfg = (pluginCfg as any)?.summarizer;
 
     const summarizer = new Summarizer(summarizerCfg, this.log);
 

--- a/apps/memos-local-openclaw/tests/viewer-env-resolution.test.ts
+++ b/apps/memos-local-openclaw/tests/viewer-env-resolution.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { SqliteStore } from "../src/storage/sqlite";
+import { ViewerServer } from "../src/viewer/server";
+
+const noopLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+let tmpDir = "";
+let originalEnv: NodeJS.ProcessEnv;
+let store: SqliteStore | null = null;
+
+beforeEach(() => {
+  originalEnv = { ...process.env };
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-viewer-env-"));
+  process.env.OPENCLAW_STATE_DIR = tmpDir;
+  process.env.OPENCLAW_CONFIG_PATH = path.join(tmpDir, "openclaw.json");
+});
+
+afterEach(() => {
+  store?.close();
+  store = null;
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = "";
+  // Restore env without leaking test keys
+  for (const k of Object.keys(process.env)) {
+    if (!(k in originalEnv)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(originalEnv)) {
+    process.env[k] = v;
+  }
+});
+
+function makeViewer(): ViewerServer {
+  store = new SqliteStore(path.join(tmpDir, "test.db"), noopLog);
+  return new ViewerServer({
+    store,
+    embedder: { provider: "local" } as any,
+    port: 19998,
+    log: noopLog,
+    dataDir: tmpDir,
+  });
+}
+
+describe("viewer env var resolution", () => {
+  it("handleTestModel should resolve ${VAR} in apiKey/endpoint before sending", async () => {
+    process.env.MY_FAKE_API_KEY = "sk-resolved-key";
+    process.env.MY_FAKE_ENDPOINT = "https://example.test/v1";
+
+    const viewer = makeViewer();
+
+    // Stub fetch to capture the headers/url that the test path would call
+    const captured: { url: string; headers: Record<string, string>; body: string } = { url: "", headers: {}, body: "" };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      captured.url = String(input);
+      captured.headers = { ...((init?.headers as Record<string, string>) ?? {}) };
+      captured.body = String(init?.body ?? "");
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+      } as any;
+    }) as any;
+
+    try {
+      const dim = await (viewer as any).testEmbeddingModel(
+        "openai",
+        "text-embedding-3-small",
+        "${MY_FAKE_ENDPOINT}",
+        "${MY_FAKE_API_KEY}",
+      );
+      expect(dim).toBe(3);
+      // The Authorization header must contain the resolved key, not the literal ${VAR}.
+      expect(captured.headers.Authorization).toBe("Bearer sk-resolved-key");
+      expect(captured.url).toContain("https://example.test/v1");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("serveFallbackModel should resolve ${VAR} in providers.baseUrl/apiKey", () => {
+    process.env.MY_FAKE_BASE = "https://provider.test/v1";
+    process.env.MY_FAKE_API_KEY = "sk-resolved-key";
+
+    fs.writeFileSync(
+      process.env.OPENCLAW_CONFIG_PATH!,
+      JSON.stringify({
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "${MY_FAKE_BASE}",
+              apiKey: "${MY_FAKE_API_KEY}",
+            },
+          },
+        },
+      }),
+    );
+
+    const viewer = makeViewer();
+    let payload: any = null;
+    const res: any = {
+      writeHead() {},
+      end(body: string) { payload = JSON.parse(body); },
+    };
+    (viewer as any).serveFallbackModel(res);
+    expect(payload).toBeTruthy();
+    expect(payload.available).toBe(true);
+    expect(payload.baseUrl).toBe("https://provider.test/v1");
+    expect(payload.model).toBe("gpt-4o-mini");
+  });
+
+  it("readPluginConfigResolved reads openclaw.json and resolves ${VAR} into apiKey", () => {
+    process.env.MY_FAKE_SUM_KEY = "sk-resolved-summary";
+    fs.writeFileSync(
+      process.env.OPENCLAW_CONFIG_PATH!,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "memos-local-openclaw-plugin": {
+              enabled: true,
+              config: {
+                summarizer: {
+                  provider: "openai",
+                  apiKey: "${MY_FAKE_SUM_KEY}",
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const viewer = makeViewer();
+    const cfg = (viewer as any).readPluginConfigResolved();
+    expect(cfg.summarizer.apiKey).toBe("sk-resolved-summary");
+  });
+
+  it("serveConfig should keep raw ${VAR} literals so UI can still edit them", () => {
+    process.env.MY_FAKE_EMB_KEY = "sk-should-stay-hidden";
+    fs.writeFileSync(
+      process.env.OPENCLAW_CONFIG_PATH!,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "memos-local-openclaw-plugin": {
+              enabled: true,
+              config: {
+                embedding: {
+                  provider: "openai",
+                  apiKey: "${MY_FAKE_EMB_KEY}",
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const viewer = makeViewer();
+    let payload: any = null;
+    const res: any = {
+      writeHead() {},
+      end(body: string) { payload = JSON.parse(body); },
+    };
+    (viewer as any).serveConfig(res);
+    expect(payload).toBeTruthy();
+    // UI should still see the raw env var literal so users can keep secrets out of the file.
+    expect(payload.embedding.apiKey).toBe("${MY_FAKE_EMB_KEY}");
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1490: the local viewer in `apps/memos-local-openclaw` was reading `openclaw.json` directly in three paths (`handleTestModel`, `serveFallbackModel`, `runMigration`) without expanding `${VAR}` env-var literals. Users who stored secrets in their config as `"apiKey": "${MY_API_KEY}"` saw 401s because the literal placeholder ended up in the Bearer header. `resolveConfig()` already had a `deepResolveEnv()` helper, but it was private and only applied to the in-memory plugin context.

The fix exports `deepResolveEnv` / `resolveEnvVars` from `src/config.ts`, adds `readPluginConfigResolved` / `readOpenClawResolvedConfig` helpers in `ViewerServer`, and routes every "about-to-call-the-network" string (apiKey/endpoint/baseUrl in the migration summarizer, fallback model probe, and embedding/chat test endpoints) through the resolver. `serveConfig` is intentionally left raw so the UI can still display `${VAR}` literals for editing — secrets never round-trip back into the file.

Test plan: added `tests/viewer-env-resolution.test.ts` (4 cases) covering test-model env expansion, fallback-model env expansion, the new resolved-config helper, and the raw-passthrough property of `serveConfig`. All 4 pass. Full vitest suite: 226 pass / 5 fail, where the 5 failures (`accuracy`, `skill-auto-install`, `task-processor`, `update-install`) reproduce identically on unmodified `dev-20260615-v2.0.20` (confirmed via `git stash` baseline) and depend on the local huggingface embedding cache / fake-timer process.kill timing — unrelated to this change. `tsc` build passes clean.

Related Issue (Required):  Fixes #1490

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1490
- [ ] Made sure Checks passed
- [ ] Tests have been provided
