### PR TITLE
Fix #1514: Auto-recall hardcodes maxResults: 10, ignoring recall.maxResultsDefault config

### DIFF
--- a/apps/memos-local-openclaw/README.md
+++ b/apps/memos-local-openclaw/README.md
@@ -514,6 +514,7 @@ All optional — shown with defaults:
     "recall": {
       "maxResultsDefault": 6,     // Default search results
       "maxResultsMax": 20,        // Max search results
+      "autoRecallMaxResults": 6,  // Optional: override max results for the auto-recall hook only. Defaults to `maxResultsDefault`. Set lower (e.g. 3 or 5) to reduce auto-injected tokens while keeping `memory_search` results richer.
       "minScoreDefault": 0.45,    // Default min score threshold
       "minScoreFloor": 0.35,      // Lowest allowed min score
       "rrfK": 60,                 // RRF fusion constant

--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -1889,9 +1889,20 @@ Groups: ${groupNames.length > 0 ? groupNames.join(", ") : "(none)"}`,
         ctx.log.debug(`auto-recall: query="${query.slice(0, 80)}"`);
 
         // ── Phase 1: Local search ∥ Hub search (parallel) ──
-        const arLocalP = engine.search({ query, maxResults: 10, minScore: 0.45, ownerFilter: recallOwnerFilter });
+        // Issue #1514: previously hardcoded maxResults: 10 here, which made
+        // `recall.maxResultsDefault` and the new `recall.autoRecallMaxResults`
+        // ineffective for the auto-recall path. Resolution order:
+        //   1. `recall.autoRecallMaxResults` (explicit auto-recall cap)
+        //   2. `recall.maxResultsDefault`    (shared default with memory_search)
+        //   3. literal 10                    (defensive — `resolveConfig`
+        //      always fills `maxResultsDefault`, so this fires only if a
+        //      caller built a context without going through `resolveConfig`).
+        const recallCfg = ctx.config.recall ?? {};
+        const autoRecallMax = recallCfg.autoRecallMaxResults ?? recallCfg.maxResultsDefault ?? 10;
+
+        const arLocalP = engine.search({ query, maxResults: autoRecallMax, minScore: 0.45, ownerFilter: recallOwnerFilter });
         const arHubP = ctx.config?.sharing?.enabled
-          ? hubSearchMemories(store, ctx, { query, maxResults: 10, scope: "all" })
+          ? hubSearchMemories(store, ctx, { query, maxResults: autoRecallMax, scope: "all" })
               .catch((err: any) => { ctx.log.debug(`auto-recall: hub search failed (${err})`); return { hits: [] as any[], meta: {} }; })
           : Promise.resolve({ hits: [] as any[], meta: {} });
 

--- a/apps/memos-local-openclaw/src/config.ts
+++ b/apps/memos-local-openclaw/src/config.ts
@@ -60,6 +60,10 @@ export function resolveConfig(raw: Partial<MemosLocalConfig> | undefined, stateD
     recall: {
       maxResultsDefault: cfg.recall?.maxResultsDefault ?? DEFAULTS.maxResultsDefault,
       maxResultsMax: cfg.recall?.maxResultsMax ?? DEFAULTS.maxResultsMax,
+      // Optional override for the `before_prompt_build` auto-recall hook.
+      // Left undefined when the user does not configure it so the hook can
+      // fall through to `maxResultsDefault` at call time (issue #1514).
+      autoRecallMaxResults: cfg.recall?.autoRecallMaxResults,
       minScoreDefault: cfg.recall?.minScoreDefault ?? DEFAULTS.minScoreDefault,
       minScoreFloor: cfg.recall?.minScoreFloor ?? DEFAULTS.minScoreFloor,
       rrfK: cfg.recall?.rrfK ?? DEFAULTS.rrfK,

--- a/apps/memos-local-openclaw/src/types.ts
+++ b/apps/memos-local-openclaw/src/types.ts
@@ -305,6 +305,14 @@ export interface MemosLocalConfig {
   recall?: {
     maxResultsDefault?: number;
     maxResultsMax?: number;
+    /**
+     * Override the maximum number of candidates the `before_prompt_build`
+     * auto-recall hook fetches per source (local + Hub). When undefined the
+     * hook falls back to `maxResultsDefault`. Use this to make auto-recall
+     * leaner (e.g. 3 or 5) without shrinking the result set of explicit
+     * `memory_search` tool calls. See issue #1514.
+     */
+    autoRecallMaxResults?: number;
     minScoreDefault?: number;
     minScoreFloor?: number;
     rrfK?: number;

--- a/apps/memos-local-openclaw/tests/config.test.ts
+++ b/apps/memos-local-openclaw/tests/config.test.ts
@@ -48,6 +48,46 @@ describe("resolveConfig", () => {
     });
   });
 
+  describe("recall.autoRecallMaxResults", () => {
+    it("leaves autoRecallMaxResults undefined when no recall config is provided (fall-through to maxResultsDefault)", () => {
+      const resolved = resolveConfig(undefined, "/tmp/memos-config-recall-default");
+
+      // Default policy: auto-recall path inherits maxResultsDefault when not overridden.
+      expect(resolved.recall?.maxResultsDefault).toBe(6);
+      expect(resolved.recall?.autoRecallMaxResults).toBeUndefined();
+    });
+
+    it("preserves an explicit autoRecallMaxResults value when set", () => {
+      const resolved = resolveConfig(
+        {
+          recall: {
+            maxResultsDefault: 6,
+            autoRecallMaxResults: 3,
+          },
+        } as any,
+        "/tmp/memos-config-recall-override",
+      );
+
+      expect(resolved.recall?.maxResultsDefault).toBe(6);
+      expect(resolved.recall?.autoRecallMaxResults).toBe(3);
+    });
+
+    it("allows independent control: maxResultsDefault for memory_search, autoRecallMaxResults for auto-recall", () => {
+      const resolved = resolveConfig(
+        {
+          recall: {
+            maxResultsDefault: 10,
+            autoRecallMaxResults: 5,
+          },
+        } as any,
+        "/tmp/memos-config-recall-split",
+      );
+
+      expect(resolved.recall?.maxResultsDefault).toBe(10);
+      expect(resolved.recall?.autoRecallMaxResults).toBe(5);
+    });
+  });
+
   it("preserves explicit user providers when host capabilities are enabled", () => {
     const resolved = resolveConfig(
       {


### PR DESCRIPTION
## Description

Fixed issue #1514 — the `before_prompt_build` auto-recall hook in `apps/memos-local-openclaw/index.ts` hardcoded `maxResults: 10` for both the local `engine.search` and the Hub `hubSearchMemories` calls, so `recall.maxResultsDefault` was effectively ignored on the auto-recall path.

The fix introduces a new optional `recall.autoRecallMaxResults` config field (option 2 from the issue) and replaces both literal `10` values with `recallCfg.autoRecallMaxResults ?? recallCfg.maxResultsDefault ?? 10`. This is a strict superset of the simpler "just read maxResultsDefault" fix: when the new field is unset the hook falls through to `maxResultsDefault` (which defaults to 6), so the effective behaviour for users with no config changes from 10 → 6 — exactly what the issue requests. Operators who want a richer `memory_search` set and a leaner auto-recall set can now configure them independently.

Touched files: `apps/memos-local-openclaw/index.ts` (hook resolution chain + comment), `src/config.ts` (carry the new field through `resolveConfig`), `src/types.ts` (type declaration with doc comment referencing issue #1514), `README.md` (Advanced Configuration entry), and `tests/config.test.ts` (3 new resolveConfig tests: undefined default, explicit override, independent control alongside `maxResultsDefault`).

Tests: `npx vitest run tests/config.test.ts tests/integration.test.ts tests/recall.test.ts tests/worker-lifecycle.test.ts` → 39 passed / 0 failed. `tsc --noEmit` clean. The 5 unrelated failures across `accuracy.test.ts` / `skill-auto-install.test.ts` / `task-processor.test.ts` / `update-install.test.ts` reproduce identically on the unmodified baseline (verified via `git stash` round-trip), so they are pre-existing and out of scope.

Related Issue (Required):  Fixes #1514

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1514
- [ ] Made sure Checks passed
- [ ] Tests have been provided
