### PR TITLE
Fix #1595: FTS5 query failures with Hermes Agent instructional prompts

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -94,7 +94,11 @@ const buildMemoryPromptSection = ({ availableTools, citationsMode }: {
   return lines;
 };
 
-function normalizeAutoRecallQuery(rawPrompt: string): string {
+const INSTRUCTIONAL_PROMPT_MAX_LEN = 300;
+const SYSTEM_ROLE_PROMPT_RE = /^You are\b/i;
+const HERMES_SKILL_REVIEW_RE = /Review the conversation above/i;
+
+export function normalizeAutoRecallQuery(rawPrompt: string): string {
   let query = rawPrompt.trim();
 
   const senderTag = "Sender (untrusted metadata):";
@@ -124,6 +128,17 @@ function normalizeAutoRecallQuery(rawPrompt: string): string {
 
   query = query.replace(INTERNAL_CONTEXT_RE, "").trim();
   query = query.replace(CONTINUE_PROMPT_RE, "").trim();
+
+  // Drop instructional prompts (system role prompts, Hermes skill-review prompts,
+  // over-long instruction blobs). These shapes are not user search intents — passing
+  // them to FTS5 fails the sanitize step and wastes a downstream LLM filter call.
+  if (
+    query.length > INSTRUCTIONAL_PROMPT_MAX_LEN
+    || SYSTEM_ROLE_PROMPT_RE.test(query)
+    || HERMES_SKILL_REVIEW_RE.test(query)
+  ) {
+    return "";
+  }
 
   return query;
 }

--- a/apps/memos-local-openclaw/tests/normalize-auto-recall-query.test.ts
+++ b/apps/memos-local-openclaw/tests/normalize-auto-recall-query.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAutoRecallQuery } from "../index";
+
+describe("normalizeAutoRecallQuery — instructional-prompt filtering (issue #1595)", () => {
+  it("returns the original short user query unchanged", () => {
+    const query = "What did we decide about the migration plan?";
+    expect(normalizeAutoRecallQuery(query)).toBe(query);
+  });
+
+  it("returns empty string for prompts longer than 300 characters", () => {
+    const longInstructional =
+      "Please carefully review the following lengthy set of system instructions and follow them precisely without deviation. ".repeat(
+        4,
+      );
+    expect(longInstructional.length).toBeGreaterThan(300);
+    expect(normalizeAutoRecallQuery(longInstructional)).toBe("");
+  });
+
+  it("returns empty string for system prompts starting with 'You are'", () => {
+    const sysPrompt = "You are a helpful assistant tasked with summarizing logs.";
+    expect(normalizeAutoRecallQuery(sysPrompt)).toBe("");
+  });
+
+  it("'You are' check is case-insensitive", () => {
+    const sysPrompt = "you are an expert reviewer.";
+    expect(normalizeAutoRecallQuery(sysPrompt)).toBe("");
+  });
+
+  it("returns empty string for the Hermes _SKILL_REVIEW_PROMPT (canonical reproducer from #1595)", () => {
+    const hermesReview =
+      "Review the conversation above, consider saving / updating a skill if appropriate. " +
+      "Focus on what was non-trivial — approach used to complete a task that required trial / error, " +
+      "changing course due to experiential findings along the way. Did the user expect / desire a " +
+      "different method or outcome? If a relevant skill already exists, update it with what you " +
+      "learned. Otherwise, create a new skill if the approach is reusable. If nothing is worth " +
+      "saving, just say 'Nothing to save' and stop.";
+    expect(normalizeAutoRecallQuery(hermesReview)).toBe("");
+  });
+
+  it("matches 'Review the conversation above' case-insensitively", () => {
+    const review = "review the conversation above and think about what skill to add.";
+    expect(normalizeAutoRecallQuery(review)).toBe("");
+  });
+
+  it("does not falsely strip a normal-length user message that happens to be > 300 chars after sanitization", () => {
+    // Boundary: exactly 300 chars should still pass (the rule is strictly > 300).
+    const boundary = "a".repeat(300);
+    expect(normalizeAutoRecallQuery(boundary)).toBe(boundary);
+  });
+
+  it("still strips known new-session preamble before applying the instructional-prompt filter", () => {
+    const newSession =
+      "A new session was started via /new or /reset. Execute your Session Startup sequence now.";
+    expect(normalizeAutoRecallQuery(newSession)).toBe("");
+  });
+});


### PR DESCRIPTION
## Description

Fix issue #1595 — FTS5 query failures with Hermes Agent instructional prompts.

Root cause: `normalizeAutoRecallQuery()` in `apps/memos-local-openclaw/index.ts` scrubbed only known metadata envelopes; it never inspected the shape of the resulting query. When Hermes Agent v0.10.0 fired its `_SKILL_REVIEW_PROMPT` (~600 chars of "Review the conversation above..." instructions), the function returned the prompt verbatim, FTS5 failed to sanitize it (`[warn] FTS query failed for: "..." returning empty`), and the auto-recall path then wasted an LLM `filterRelevant()` call on the empty hit set.

Fix: added three early-exit rules at the end of `normalizeAutoRecallQuery()` (after the existing metadata / HTML / new-session / internal-context / continue-prompt scrubbing, so legitimate user content embedded in a `Sender (untrusted metadata):` envelope is still surfaced before the length check): `query.length > 300` → "", `/^You are\b/i` → "", `/Review the conversation above/i` → "". The caller's existing `if (query.length < 2)` guard then skips both the FTS5 lookup and the LLM filter call. The function was exported so it can be unit-tested; the default export `memosLocalPlugin` is unchanged.

Tests: 8 new Vitest cases in `apps/memos-local-openclaw/tests/normalize-auto-recall-query.test.ts` covering each rule, the case-insensitive variants, the 300-character boundary, and the interaction with the existing new-session preamble strip — all passing. Full plugin suite: 230/235 passing; the 5 remaining failures (accuracy.test.ts C5-C8 + E1-E3, skill-auto-install autoInstall default, task-processor session boundary, update-install SIGUSR1) are pre-existing on the base branch (verified by stash + rerun) and are unrelated to this change. `npx tsc --noEmit` exits 0.

Branch `bugfix/autodev-1595` pushed to `origin`; head commit `2dee2d04`. Spec archive synced to `memos-autodev-specs/2026-06-29-1595-fts5-query-failures-with-hermes-agent-instructional-prompts/task.md`.

Related Issue (Required):  Fixes #1595

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1595
- [ ] Made sure Checks passed
- [ ] Tests have been provided
