### PR TITLE
fix: load bridge package version without require

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -171,7 +171,9 @@ async function main(): Promise<void> {
   )) as typeof import("./server/http.js");
 
   const rootDir = pluginRoot();
-  const pkgVersion = require(path.join(rootDir, "package.json")).version;
+  const pkgVersion = JSON.parse(
+    fs.readFileSync(path.join(rootDir, "package.json"), "utf8"),
+  ).version;
 
   // ─── Host LLM bridge (reverse RPC, lazy-bound to stdio) ────────
   // We need to register the bridge BEFORE bootstrap creates the

--- a/apps/memos-local-plugin/tests/unit/bridge/package-version.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/package-version.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("bridge package version loading", () => {
+  it("does not require package.json after dynamic ESM imports", () => {
+    const source = readFileSync(resolve("bridge.cts"), "utf8");
+
+    expect(source).not.toMatch(/require\([^)]*package\.json[^)]*\)/);
+    expect(source).toMatch(/readFileSync\([^)]*package\.json[^)]*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1736.

- Load `package.json` via `fs.readFileSync` + `JSON.parse` in `bridge.cts` instead of calling `require(...package.json)` after dynamic ESM imports.
- Add a regression test that guards the bridge entrypoint against reintroducing package metadata loading through `require()`.

## Validation

- `npm test -- --run tests/unit/bridge/package-version.test.ts`
- `npm test -- --run tests/unit/bridge`
- `npm run lint`

Note: `make format` could not run in this environment because `poetry` is not installed: `make: poetry: Command not found`.