### PR TITLE
Fix #1493: fix: /product/add returns 200 success but stores no memory (No add/update items 

### DIFF
--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -287,7 +287,7 @@ class SimpleStructMemReader(BaseMemReader, ABC):
 
         if not response_json:
             return {
-                "memory_list": [
+                "memory list": [
                     {
                         "key": mem_str[:10],
                         "memory_type": "UserMemory",

--- a/tests/mem_reader/test_simple_struct_fallback.py
+++ b/tests/mem_reader/test_simple_struct_fallback.py
@@ -1,0 +1,111 @@
+"""Regression tests for issue #1493.
+
+`POST /product/add` returned 200 + "Memory added successfully" but persisted no
+memory items. Root cause: when the LLM response fails JSON parsing,
+`SimpleStructMemReader._get_llm_response` is supposed to emit a fallback dict
+with a single salvaged `UserMemory` item so the request still produces at least
+one stored memory. However, the fallback used the key `"memory_list"`
+(underscore) while every downstream consumer reads `"memory list"` (space),
+making the fallback unreachable and leaving `_process_chat_data` returning an
+empty list.
+
+These tests pin the fallback contract and the end-to-end reader behavior so the
+regression cannot reappear.
+"""
+
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+from memos.chunkers import ChunkerFactory
+from memos.configs.mem_reader import SimpleStructMemReaderConfig
+from memos.embedders.factory import EmbedderFactory
+from memos.llms.factory import LLMFactory
+from memos.mem_reader.simple_struct import SimpleStructMemReader
+from memos.memories.textual.item import TextualMemoryItem
+
+
+class TestSimpleStructFallbackKey(unittest.TestCase):
+    """Pin the fallback contract: key must match what consumers read."""
+
+    def setUp(self):
+        self.config = MagicMock(spec=SimpleStructMemReaderConfig)
+        self.config.llm = MagicMock()
+        self.config.general_llm = None
+        self.config.embedder = MagicMock()
+        self.config.chunker = MagicMock()
+        self.config.remove_prompt_example = MagicMock()
+
+        with (
+            patch.object(LLMFactory, "from_config", return_value=MagicMock()),
+            patch.object(EmbedderFactory, "from_config", return_value=MagicMock()),
+            patch.object(ChunkerFactory, "from_config", return_value=MagicMock()),
+        ):
+            self.reader = SimpleStructMemReader(self.config)
+
+        self.reader.llm = MagicMock()
+        self.reader.general_llm = self.reader.llm
+        self.reader.embedder = MagicMock()
+        self.reader.embedder.embed = MagicMock(return_value=[[0.0] * 4])
+        self.reader.chunker = MagicMock()
+
+    def test_get_llm_response_fallback_key_matches_consumer(self):
+        """Fallback dict must expose its item under the consumer-side key.
+
+        Downstream consumers in `_process_chat_data` (line 397) and
+        `_process_transfer_chat_data` (line 434) both read `"memory list"`
+        (with space). The fallback dict therefore MUST use the same key, or it
+        is effectively dead code and the request stores nothing.
+        """
+        # Force `_safe_parse` to behave as if the LLM returned unparseable
+        # output (the realistic failure mode reported in #1493 / #1355).
+        self.reader.llm.generate.return_value = "this is not json at all"
+
+        result = self.reader._get_llm_response("I like strawberry.", custom_tags=None)
+
+        self.assertIn(
+            "memory list",
+            result,
+            "Fallback dict must use the consumer-side key 'memory list' (with space). "
+            "Using 'memory_list' (underscore) leaves the fallback unreachable.",
+        )
+        self.assertEqual(len(result["memory list"]), 1)
+        item = result["memory list"][0]
+        self.assertEqual(item["memory_type"], "UserMemory")
+        self.assertEqual(item["value"], "I like strawberry.")
+
+    def test_process_chat_data_fine_yields_node_when_llm_unparseable(self):
+        """End-to-end: fine-mode `_process_chat_data` must still produce a
+        `TextualMemoryItem` when the LLM output is unparseable JSON.
+
+        This is the symptom-level test for #1493: an `/product/add` call
+        carrying `"I like strawberry."` should result in at least one memory
+        item even when the LLM emits non-JSON chatter.
+        """
+        # Realistic Kimi-K2 style failure: LLM wraps response in chatter so
+        # `parse_json_result` returns `{}`, `_safe_parse` returns `None`,
+        # `not response_json` is True and the fallback fires.
+        self.reader.llm.generate.return_value = (
+            "Here is what I extracted: ... unfortunately I cannot output JSON."
+        )
+
+        scene_data_info = [{"role": "user", "content": "I like strawberry."}]
+        info = {"user_id": "user1", "session_id": "session1"}
+
+        result = self.reader._process_chat_data(scene_data_info, info, mode="fine")
+
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(
+            len(result),
+            1,
+            "Fallback must produce at least one TextualMemoryItem when LLM "
+            "output cannot be parsed; otherwise /product/add stores nothing "
+            "while still returning 200.",
+        )
+        self.assertIsInstance(result[0], TextualMemoryItem)
+        # The fallback value contains the original user input verbatim.
+        self.assertIn("strawberry", result[0].memory)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Fixed `/product/add` silently dropping memories under sync mode (#1493).

Root cause: `SimpleStructMemReader._get_llm_response` in `src/memos/mem_reader/simple_struct.py` returned its salvage-fallback dict under the key `"memory_list"` (with underscore), while every downstream consumer in the same file (`_process_chat_data` line 397, `_process_transfer_chat_data` line 434) reads `"memory list"` (with space). The fallback was therefore dead code: when the LLM returned non-strict JSON for short inputs like "I like strawberry." (a common Kimi-K2 failure mode), `_safe_parse` returned `{}`, the fallback fired but emitted the wrong key, `_process_chat_data` yielded zero items, `text_mem.add([])` wrote nothing to Neo4j/Qdrant, and `/product/add` still returned 200 + `data: []` while the scheduler's downstream `log_add_messages` audit logged "No add/update items prepared". This is a duplicate of #1355 in symptom and root cause; the #1355 fix was merged on a different branch and had not propagated to `dev-20260624-v2.0.22`.

Fix: one-character key rename from `"memory_list"` to `"memory list"` in the fallback branch (lines 288-299 of `simple_struct.py`), bringing the dead fallback back into alignment with the two consumers and the two sibling readers (`multi_modal_struct.py:500`, `strategy_struct.py:67`). Added 2 unit-level regression tests in `tests/mem_reader/test_simple_struct_fallback.py` that (a) pin the fallback dict key contract and (b) prove end-to-end that `_process_chat_data(mode="fine")` emits at least one `TextualMemoryItem` when the LLM output is unparseable. Both tests fail red on the buggy code (verified by running them pre-fix) and pass green after the one-character change.

Verification: `python3 -m pytest tests/mem_reader/test_simple_struct_fallback.py -v` → 2 passed; `python3 -m pytest tests/mem_reader/ -q` → 44 passed + 2 pre-existing markitdown-extras failures (confirmed unrelated via `git stash`/rerun); `python3 -m pytest tests/mem_scheduler/ -q` → 61 passed + 1 skipped; `ruff check` and `ruff format --check` both clean on the two touched files. Committed `b241194d` and pushed `bugfix/autodev-1493` to origin. opsp artifacts (task.md, proposal.md, spec.md, design.md, verification-report.md) are written under `.ai-tasks/` and `openspec/changes/` (excluded from the working branch via .git/info/exclude) and were synced to the sibling `memos-autodev-specs` repo at commit `6e2e41b` on main.

Related Issue (Required):  Fixes #1493

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1493
- [ ] Made sure Checks passed
- [ ] Tests have been provided
