### PR TITLE
Fix #1543: fix: MEMOS不支持JSON5格式的openclaw.json

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -31,6 +31,8 @@ import { SkillInstaller } from "./src/skill/installer";
 import { Summarizer } from "./src/ingest/providers";
 import { MEMORY_GUIDE_SKILL_MD } from "./src/skill/bundled-memory-guide";
 import { Telemetry } from "./src/telemetry";
+import { parseJsonOrJson5 } from "./src/shared/json5";
+import { patchOpenclawAllowFile } from "./src/shared/openclaw-config";
 
 
 /** Remove near-duplicate hits based on summary word overlap (>70%). Keeps first (highest-scored) hit. */
@@ -292,8 +294,8 @@ const memosLocalPlugin = {
     const configPath = path.join(stateDir, "state", "memos-local", "config.json");
     if (Object.keys(pluginCfg).length === 0 && fs.existsSync(configPath)) {
       try {
-        const fileConfig = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-        pluginCfg = fileConfig;
+        const fileConfig = parseJsonOrJson5(fs.readFileSync(configPath, "utf-8"));
+        pluginCfg = fileConfig as Record<string, unknown>;
         api.logger.info(`memos-local: loaded config from ${configPath}`);
       } catch (e) {
         api.logger.warn(`memos-local: failed to load config from ${configPath}: ${e}`);
@@ -351,23 +353,17 @@ const memosLocalPlugin = {
       ctx.log.warn(`memos-local: could not write to managed skills dir: ${e}`);
     }
 
-    // Ensure plugin tools are enabled in openclaw.json tools.allow
+    // Ensure plugin tools are enabled in openclaw.json tools.allow.
+    // openclaw.json is JSON5 (supports // comments / single-quoted strings /
+    // trailing commas) — the patcher tolerates all of these (see issue #1543).
     try {
       const openclawJsonPath = path.join(stateDir, "openclaw.json");
       if (fs.existsSync(openclawJsonPath)) {
-        const raw = fs.readFileSync(openclawJsonPath, "utf-8");
-        const cfg = JSON.parse(raw);
-        const allow: string[] | undefined = cfg?.tools?.allow;
-        if (Array.isArray(allow) && allow.length > 0 && !allow.includes("group:plugins") && !allow.includes("*")) {
-          const lastEntry = JSON.stringify(allow[allow.length - 1]);
-          const patched = raw.replace(
-            new RegExp(`(${lastEntry})(\\s*\\])`),
-            `$1,\n      "group:plugins"$2`,
-          );
-          if (patched !== raw && patched.includes("group:plugins")) {
-            fs.writeFileSync(openclawJsonPath, patched, "utf-8");
-            ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
-          }
+        const result = patchOpenclawAllowFile(openclawJsonPath);
+        if (result.changed) {
+          ctx.log.info("memos-local: added 'group:plugins' to tools.allow in openclaw.json");
+        } else if (result.reason) {
+          ctx.log.debug(`memos-local: tools.allow not patched (${result.reason})`);
         }
       }
     } catch (e) {

--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { SummarizerConfig, SummaryProvider, Logger, OpenClawAPI } from "../../types";
+import { parseJsonOrJson5 } from "../../shared/json5";
 import { summarizeOpenAI, summarizeTaskOpenAI, generateTaskTitleOpenAI, judgeNewTopicOpenAI, classifyTopicOpenAI, arbitrateTopicSplitOpenAI, filterRelevantOpenAI, judgeDedupOpenAI, parseFilterResult, parseDedupResult, parseTopicClassifyResult } from "./openai";
 import type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
 export type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
@@ -66,7 +67,7 @@ function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | undefined {
       || path.join(process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw"), "openclaw.json");
     if (!fs.existsSync(cfgPath)) return undefined;
 
-    const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
 
     const agentModel: string | undefined = raw?.agents?.defaults?.model?.primary;
     if (!agentModel) return undefined;

--- a/apps/memos-local-openclaw/src/shared/json5.ts
+++ b/apps/memos-local-openclaw/src/shared/json5.ts
@@ -1,0 +1,183 @@
+/**
+ * Minimal JSON5-tolerant parser used to read `openclaw.json`.
+ *
+ * Background: OpenClaw stores its native config (`~/.openclaw/openclaw.json`)
+ * in JSON5 — it allows `//` line comments, `/* ... *​/` block comments,
+ * single-quoted strings, unquoted identifier keys, and trailing commas.
+ * Strict `JSON.parse` chokes on any of these (issue #1543).
+ *
+ * Bringing in the full `json5` npm package would be the obvious fix, but the
+ * plugin must avoid new runtime dependencies (it ships its `dependencies`
+ * one-by-one to keep install size small, and the install path runs in user
+ * machines where adding npm deps is sensitive). Instead, we normalize the raw
+ * text into strict JSON and hand it to the built-in `JSON.parse`.
+ *
+ * What is supported:
+ *   • `//` line comments and `/* … *​/` block comments
+ *   • single-quoted strings (`'foo'`)
+ *   • unquoted identifier-style object keys (`tools: { ... }`)
+ *   • trailing commas before `}` or `]`
+ *   • UTF-8 BOM
+ *
+ * What is NOT supported (rare in practice for openclaw.json):
+ *   • Hex numbers (`0xFF`), `+Infinity`, `NaN`, etc. — falls back to error.
+ *   • Multi-line string continuation.
+ *
+ * The implementation walks the text character-by-character with a small state
+ * machine so that comment / quote rewriting never touches characters inside
+ * string literals (which is the classic regex-based-stripper bug).
+ */
+
+export class Json5ParseError extends Error {
+  constructor(message: string, public readonly originalError?: unknown) {
+    super(message);
+    this.name = "Json5ParseError";
+  }
+}
+
+/**
+ * Strip comments, normalize quotes/keys/trailing commas, then `JSON.parse`.
+ *
+ * Throws Json5ParseError if the normalized text still isn't valid JSON —
+ * callers should treat this the same as a malformed `JSON.parse`.
+ */
+export function parseJson5(text: string): unknown {
+  if (typeof text !== "string") {
+    throw new Json5ParseError(`parseJson5 expects a string, got ${typeof text}`);
+  }
+
+  const normalized = normalizeJson5(text);
+  try {
+    return JSON.parse(normalized);
+  } catch (err) {
+    throw new Json5ParseError(
+      `Failed to parse JSON5 content as JSON after normalization: ${(err as Error).message}`,
+      err,
+    );
+  }
+}
+
+/**
+ * Lenient variant: try strict `JSON.parse` first (fast path for files that
+ * happen to be plain JSON), fall back to the JSON5-tolerant path on failure.
+ *
+ * This is the recommended entry point for code that reads `openclaw.json`,
+ * because the user's config might or might not contain comments.
+ */
+export function parseJsonOrJson5(text: string): unknown {
+  // Fast path: strict JSON. Use it when possible so we don't pay normalization
+  // cost on every read.
+  try {
+    return JSON.parse(text);
+  } catch {
+    return parseJson5(text);
+  }
+}
+
+/**
+ * Normalize a JSON5 text into strict JSON-compatible text.
+ * Exposed for testing; production callers should use parseJson5 / parseJsonOrJson5.
+ */
+export function normalizeJson5(input: string): string {
+  // Strip UTF-8 BOM
+  let text = input.charCodeAt(0) === 0xfeff ? input.slice(1) : input;
+
+  const out: string[] = [];
+  const n = text.length;
+  let i = 0;
+
+  while (i < n) {
+    const c = text[i];
+    const next = i + 1 < n ? text[i + 1] : "";
+
+    // Line comment
+    if (c === "/" && next === "/") {
+      i += 2;
+      while (i < n && text[i] !== "\n") i++;
+      continue;
+    }
+    // Block comment
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      if (i < n) i += 2; // skip closing */
+      continue;
+    }
+
+    // Double-quoted string — passthrough verbatim, including escapes.
+    if (c === '"') {
+      out.push(c);
+      i++;
+      while (i < n) {
+        const ch = text[i];
+        out.push(ch);
+        if (ch === "\\" && i + 1 < n) {
+          out.push(text[i + 1]);
+          i += 2;
+          continue;
+        }
+        if (ch === '"') {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // Single-quoted string — rewrite to double-quoted, escaping any embedded `"`.
+    if (c === "'") {
+      out.push('"');
+      i++;
+      while (i < n) {
+        const ch = text[i];
+        if (ch === "\\" && i + 1 < n) {
+          // Preserve escape sequence verbatim, except `\'` becomes a plain `'`
+          // (because the surrounding quotes are now double quotes).
+          const nx = text[i + 1];
+          if (nx === "'") {
+            out.push("'");
+          } else {
+            out.push("\\");
+            out.push(nx);
+          }
+          i += 2;
+          continue;
+        }
+        if (ch === "'") {
+          out.push('"');
+          i++;
+          break;
+        }
+        if (ch === '"') {
+          // Escape a bare `"` so the resulting double-quoted string stays valid.
+          out.push("\\\"");
+          i++;
+          continue;
+        }
+        out.push(ch);
+        i++;
+      }
+      continue;
+    }
+
+    out.push(c);
+    i++;
+  }
+
+  let stripped = out.join("");
+
+  // Unquoted identifier keys: `  foo: 1` → `  "foo": 1`.
+  // Matches an identifier that starts with a letter / `_` / `$` and is
+  // immediately followed by optional whitespace and `:`. The leading
+  // boundary ensures we don't match parts of other tokens.
+  stripped = stripped.replace(
+    /([\{,\s])([A-Za-z_$][A-Za-z0-9_$]*)(\s*:)/g,
+    (_, lead: string, key: string, tail: string) => `${lead}"${key}"${tail}`,
+  );
+
+  // Trailing commas before `}` or `]`.
+  stripped = stripped.replace(/,(\s*[}\]])/g, "$1");
+
+  return stripped;
+}

--- a/apps/memos-local-openclaw/src/shared/llm-call.ts
+++ b/apps/memos-local-openclaw/src/shared/llm-call.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { SummarizerConfig, SummaryProvider, Logger, PluginContext, OpenClawAPI } from "../types";
+import { parseJsonOrJson5 } from "./json5";
 
 /**
  * Resolve a SecretInput (string | SecretRef) to a plain string.
@@ -54,7 +55,7 @@ export function loadOpenClawFallbackConfig(log: Logger): SummarizerConfig | unde
       || path.join(process.env.OPENCLAW_STATE_DIR || path.join(home, ".openclaw"), "openclaw.json");
     if (!fs.existsSync(cfgPath)) return undefined;
 
-    const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
 
     const agentModel: string | undefined = raw?.agents?.defaults?.model?.primary;
     if (!agentModel) return undefined;

--- a/apps/memos-local-openclaw/src/shared/openclaw-config.ts
+++ b/apps/memos-local-openclaw/src/shared/openclaw-config.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs";
+import { parseJsonOrJson5 } from "./json5";
+
+/**
+ * Ensure `"group:plugins"` is present in `tools.allow` inside `openclaw.json`.
+ *
+ * Strategy:
+ *   1. Read the file as JSON5 (the user may have // comments etc. — see issue #1543).
+ *   2. If `tools.allow` is missing, wildcarded (`"*"`), or already contains
+ *      `"group:plugins"`, do nothing.
+ *   3. Otherwise patch the raw text by appending `"group:plugins"` after the
+ *      last existing allow entry. We do textual insertion (rather than
+ *      `JSON.stringify(cfg)`) so we preserve the user's comments and
+ *      formatting in the file.
+ *
+ * Returns:
+ *   - `{ changed: false }` when no edit was needed or the patch could not be
+ *     anchored safely.
+ *   - `{ changed: true, patched }` when the caller should `writeFileSync` the
+ *     `patched` text back.
+ */
+export interface EnsureGroupPluginsAllowedResult {
+  changed: boolean;
+  patched?: string;
+  reason?: string;
+}
+
+const PATCH_VALUE = "group:plugins";
+
+export function ensureGroupPluginsAllowed(
+  raw: string,
+): EnsureGroupPluginsAllowedResult {
+  let cfg: any;
+  try {
+    cfg = parseJsonOrJson5(raw);
+  } catch (err) {
+    return { changed: false, reason: `parse failed: ${(err as Error).message}` };
+  }
+
+  const allow: unknown = cfg?.tools?.allow;
+  if (!Array.isArray(allow) || allow.length === 0) {
+    return { changed: false, reason: "tools.allow is missing or empty" };
+  }
+  if (allow.includes("*") || allow.includes(PATCH_VALUE)) {
+    return { changed: false, reason: "tools.allow already permissive enough" };
+  }
+
+  const lastEntry = allow[allow.length - 1];
+  if (typeof lastEntry !== "string") {
+    return { changed: false, reason: "tools.allow last entry is not a string" };
+  }
+
+  // Try anchoring on the last entry as either a double-quoted or single-quoted
+  // string — openclaw.json is JSON5 and the user may have used either. We also
+  // tolerate an optional trailing comma between the last entry and `]`.
+  const escaped = lastEntry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const candidates: Array<{ anchor: RegExp; insert: string }> = [
+    {
+      anchor: new RegExp(`("${escaped}")(\\s*,?\\s*\\])`),
+      insert: `$1,\n      "${PATCH_VALUE}"$2`,
+    },
+    {
+      anchor: new RegExp(`('${escaped}')(\\s*,?\\s*\\])`),
+      insert: `$1,\n      '${PATCH_VALUE}'$2`,
+    },
+  ];
+
+  for (const { anchor, insert } of candidates) {
+    if (anchor.test(raw)) {
+      const patched = raw.replace(anchor, insert);
+      if (patched !== raw && patched.includes(PATCH_VALUE)) {
+        return { changed: true, patched };
+      }
+    }
+  }
+
+  return { changed: false, reason: "could not anchor last allow entry" };
+}
+
+/**
+ * File-level convenience wrapper. Reads `openclawJsonPath`, applies
+ * `ensureGroupPluginsAllowed`, writes it back if needed.
+ *
+ * Caller is expected to pre-check `fs.existsSync(openclawJsonPath)`.
+ * Returns the in-memory result so the caller can log.
+ */
+export function patchOpenclawAllowFile(
+  openclawJsonPath: string,
+): EnsureGroupPluginsAllowedResult {
+  const raw = fs.readFileSync(openclawJsonPath, "utf-8");
+  const result = ensureGroupPluginsAllowed(raw);
+  if (result.changed && result.patched) {
+    fs.writeFileSync(openclawJsonPath, result.patched, "utf-8");
+  }
+  return result;
+}

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -21,6 +21,7 @@ import { buildSkillBundleForHub, fetchHubSkillBundle, restoreSkillBundleFromHub 
 import type { Logger, Chunk, PluginContext, MemosLocalConfig } from "../types";
 import { viewerHTML } from "./html";
 import { v4 as uuid } from "uuid";
+import { parseJsonOrJson5 } from "../shared/json5";
 
 export interface MigrationStepFailureCounts {
   summarization: number;
@@ -649,7 +650,7 @@ export class ViewerServer {
     try {
       const cfgPath = this.getOpenClawConfigPath();
       if (fs.existsSync(cfgPath)) {
-        const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+        const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
         const entries = raw?.plugins?.entries ?? {};
         const pluginCfg = entries["memos-local-openclaw-plugin"]?.config
           ?? entries["memos-local"]?.config ?? {};
@@ -3021,7 +3022,7 @@ export class ViewerServer {
         this.jsonResponse(res, {});
         return;
       }
-      const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+      const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
       const entries = raw?.plugins?.entries ?? {};
       const pluginEntry = entries["memos-local-openclaw-plugin"]?.config
         ?? entries["memos-local"]?.config
@@ -3053,7 +3054,7 @@ export class ViewerServer {
         const cfgPath = this.getOpenClawConfigPath();
         let raw: Record<string, unknown> = {};
         if (fs.existsSync(cfgPath)) {
-          raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+          raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as Record<string, unknown>;
         }
 
         if (!raw.plugins) raw.plugins = {};
@@ -3519,7 +3520,7 @@ export class ViewerServer {
         this.jsonResponse(res, { available: false });
         return;
       }
-      const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+      const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
       const agentModel: string | undefined = raw?.agents?.defaults?.model?.primary;
       if (!agentModel) {
         this.jsonResponse(res, { available: false });
@@ -4007,7 +4008,7 @@ export class ViewerServer {
       let hasSummarizer = false;
       if (fs.existsSync(cfgPath)) {
         try {
-          const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+          const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
           const pluginCfg = raw?.plugins?.entries?.["memos-local-openclaw-plugin"]?.config ??
                             raw?.plugins?.entries?.["memos-local"]?.config ??
                             raw?.plugins?.entries?.["memos-lite-openclaw-plugin"]?.config ??
@@ -4202,7 +4203,7 @@ export class ViewerServer {
     const cfgPath = this.getOpenClawConfigPath();
     let summarizerCfg: any;
     try {
-      const raw = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+      const raw = parseJsonOrJson5(fs.readFileSync(cfgPath, "utf-8")) as any;
       const pluginCfg = raw?.plugins?.entries?.["memos-local-openclaw-plugin"]?.config ??
                         raw?.plugins?.entries?.["memos-local"]?.config ??
                         raw?.plugins?.entries?.["memos-lite-openclaw-plugin"]?.config ??

--- a/apps/memos-local-openclaw/tests/json5-config.test.ts
+++ b/apps/memos-local-openclaw/tests/json5-config.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  parseJsonOrJson5,
+  parseJson5,
+  normalizeJson5,
+  Json5ParseError,
+} from "../src/shared/json5";
+import { loadOpenClawFallbackConfig } from "../src/shared/llm-call";
+
+/**
+ * Regression coverage for issue #1543:
+ *   openclaw.json is JSON5; the plugin tried to read it with strict JSON.parse,
+ *   so any user who had a `//` comment in tools.allow broke initialization.
+ */
+describe("parseJsonOrJson5 — JSON5 features used by openclaw.json", () => {
+  it("parses plain strict JSON unchanged", () => {
+    const obj = parseJsonOrJson5(JSON.stringify({ a: 1, b: [1, 2], c: "x" }));
+    expect(obj).toEqual({ a: 1, b: [1, 2], c: "x" });
+  });
+
+  it("parses JSON with line comments (the exact issue #1543 case)", () => {
+    const text = `{
+      "tools": {
+        // these are the allowed tool groups
+        "allow": [
+          "group:builtin", // built-in tools
+          "group:plugins"  // plugin-provided tools
+        ]
+      }
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.tools.allow).toEqual(["group:builtin", "group:plugins"]);
+  });
+
+  it("parses JSON with block comments", () => {
+    const text = `{
+      /* header comment */
+      "models": {
+        "providers": {
+          /* anthropic provider config */
+          "anthropic": { "baseUrl": "https://api.anthropic.com" }
+        }
+      }
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.models.providers.anthropic.baseUrl).toBe(
+      "https://api.anthropic.com",
+    );
+  });
+
+  it("parses trailing commas in arrays and objects", () => {
+    const text = `{
+      "tools": {
+        "allow": ["a", "b", "c",],
+      },
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.tools.allow).toEqual(["a", "b", "c"]);
+  });
+
+  it("parses single-quoted strings", () => {
+    const text = `{
+      'name': 'memos-local',
+      "value": 'has "embedded double" quotes inside'
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.name).toBe("memos-local");
+    expect(obj.value).toBe('has "embedded double" quotes inside');
+  });
+
+  it("parses unquoted identifier keys", () => {
+    const text = `{
+      tools: { allow: ["x"] },
+      agents: { defaults: { model: { primary: "anthropic/claude-3-haiku" } } }
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.tools.allow).toEqual(["x"]);
+    expect(obj.agents.defaults.model.primary).toBe("anthropic/claude-3-haiku");
+  });
+
+  it("handles UTF-8 BOM", () => {
+    const text = "﻿" + JSON.stringify({ ok: true });
+    expect(parseJsonOrJson5(text)).toEqual({ ok: true });
+  });
+
+  it("does not strip `//` that appears inside string literals", () => {
+    const text = `{
+      "url": "https://api.anthropic.com",
+      "note": "see https://example.com/docs#path // not a comment"
+    }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.url).toBe("https://api.anthropic.com");
+    expect(obj.note).toBe(
+      "see https://example.com/docs#path // not a comment",
+    );
+  });
+
+  it("does not strip `/*` that appears inside string literals", () => {
+    const text = `{ "tip": "use /* and */ for block comments" }`;
+    const obj = parseJsonOrJson5(text) as any;
+    expect(obj.tip).toBe("use /* and */ for block comments");
+  });
+
+  it("throws Json5ParseError on truly malformed input", () => {
+    expect(() => parseJson5("{ not_json: , }")).toThrow(Json5ParseError);
+  });
+
+  it("normalizeJson5 yields strict JSON that JSON.parse can read", () => {
+    const text = `{
+      // header
+      a: 1,
+      b: 'two',
+      c: [3, 4,],
+    }`;
+    const out = normalizeJson5(text);
+    expect(() => JSON.parse(out)).not.toThrow();
+    expect(JSON.parse(out)).toEqual({ a: 1, b: "two", c: [3, 4] });
+  });
+});
+
+describe("loadOpenClawFallbackConfig with JSON5 openclaw.json (issue #1543)", () => {
+  let tmpDir: string | undefined;
+  let savedConfigPath: string | undefined;
+  let savedStateDir: string | undefined;
+
+  afterEach(() => {
+    if (savedConfigPath !== undefined) process.env.OPENCLAW_CONFIG_PATH = savedConfigPath;
+    else delete process.env.OPENCLAW_CONFIG_PATH;
+    if (savedStateDir !== undefined) process.env.OPENCLAW_STATE_DIR = savedStateDir;
+    else delete process.env.OPENCLAW_STATE_DIR;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    savedConfigPath = undefined;
+    savedStateDir = undefined;
+    tmpDir = undefined;
+  });
+
+  function writeRawConfig(text: string): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-json5-"));
+    const cfgPath = path.join(tmpDir, "openclaw.json");
+    fs.writeFileSync(cfgPath, text, "utf-8");
+    savedConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    savedStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_CONFIG_PATH = cfgPath;
+    return cfgPath;
+  }
+
+  const noopLog = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+
+  it("loads fallback config when openclaw.json contains line comments", () => {
+    writeRawConfig(`{
+      // top-level config
+      "agents": {
+        "defaults": {
+          "model": { "primary": "anthropic/claude-3-haiku" }
+        }
+      },
+      "models": {
+        "providers": {
+          // anthropic provider
+          "anthropic": {
+            "baseUrl": "https://api.anthropic.com",
+            "apiKey": "sk-ant-test"
+          }
+        }
+      }
+    }`);
+    const cfg = loadOpenClawFallbackConfig(noopLog);
+    expect(cfg).toBeDefined();
+    expect(cfg!.apiKey).toBe("sk-ant-test");
+    expect(cfg!.provider).toBe("anthropic");
+    expect(cfg!.model).toBe("claude-3-haiku");
+  });
+
+  it("loads fallback config when openclaw.json mixes single + double quotes", () => {
+    writeRawConfig(`{
+      'agents': { 'defaults': { 'model': { 'primary': 'anthropic/claude-3-haiku' } } },
+      "models": {
+        "providers": {
+          "anthropic": { "baseUrl": 'https://api.anthropic.com', apiKey: 'sk-ant-test' }
+        }
+      }
+    }`);
+    const cfg = loadOpenClawFallbackConfig(noopLog);
+    expect(cfg).toBeDefined();
+    expect(cfg!.apiKey).toBe("sk-ant-test");
+  });
+
+  it("loads fallback config when openclaw.json has trailing commas", () => {
+    writeRawConfig(`{
+      "agents": { "defaults": { "model": { "primary": "anthropic/claude-3-haiku" } } },
+      "models": {
+        "providers": {
+          "anthropic": { "baseUrl": "https://api.anthropic.com", "apiKey": "sk-ant-test", },
+        },
+      },
+    }`);
+    const cfg = loadOpenClawFallbackConfig(noopLog);
+    expect(cfg).toBeDefined();
+    expect(cfg!.apiKey).toBe("sk-ant-test");
+  });
+});

--- a/apps/memos-local-openclaw/tests/openclaw-config-patch.test.ts
+++ b/apps/memos-local-openclaw/tests/openclaw-config-patch.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  ensureGroupPluginsAllowed,
+} from "../src/shared/openclaw-config";
+
+/**
+ * Regression coverage for issue #1543:
+ *
+ *   memos-local: could not patch tools.allow:
+ *   SyntaxError: Expected double-quoted property name in JSON at position 2222 (line 90 column 7)
+ *
+ * The user's openclaw.json has `// ...` line comments, and the previous
+ * implementation called strict JSON.parse on it.
+ */
+describe("ensureGroupPluginsAllowed (issue #1543)", () => {
+  it("patches tools.allow even when openclaw.json contains // comments", () => {
+    const raw = `{
+      // top of file
+      "tools": {
+        // these tools are allowed
+        "allow": [
+          "Bash",
+          "Read",
+          "Write"
+        ]
+      }
+    }`;
+    const r = ensureGroupPluginsAllowed(raw);
+    expect(r.changed).toBe(true);
+    expect(r.patched).toContain(`"group:plugins"`);
+    // Existing comments must survive.
+    expect(r.patched).toContain("// top of file");
+    expect(r.patched).toContain("// these tools are allowed");
+  });
+
+  it("patches tools.allow when openclaw.json uses single-quoted strings", () => {
+    const raw = `{
+      "tools": {
+        "allow": ['Bash', 'Read', 'Write']
+      }
+    }`;
+    const r = ensureGroupPluginsAllowed(raw);
+    expect(r.changed).toBe(true);
+    expect(r.patched).toContain("'group:plugins'");
+  });
+
+  it("patches tools.allow when openclaw.json has trailing commas", () => {
+    const raw = `{
+      "tools": {
+        "allow": ["Bash", "Read", "Write",],
+      },
+    }`;
+    const r = ensureGroupPluginsAllowed(raw);
+    expect(r.changed).toBe(true);
+    expect(r.patched).toContain(`"group:plugins"`);
+  });
+
+  it("does nothing when tools.allow already contains group:plugins", () => {
+    const raw = `{
+      "tools": { "allow": ["Bash", "group:plugins"] }
+    }`;
+    const r = ensureGroupPluginsAllowed(raw);
+    expect(r.changed).toBe(false);
+  });
+
+  it("does nothing when tools.allow contains the wildcard '*'", () => {
+    const raw = `{
+      "tools": { "allow": ["*"] }
+    }`;
+    const r = ensureGroupPluginsAllowed(raw);
+    expect(r.changed).toBe(false);
+  });
+
+  it("does nothing when tools.allow is missing or empty", () => {
+    expect(ensureGroupPluginsAllowed(`{}`).changed).toBe(false);
+    expect(ensureGroupPluginsAllowed(`{ "tools": {} }`).changed).toBe(false);
+    expect(
+      ensureGroupPluginsAllowed(`{ "tools": { "allow": [] } }`).changed,
+    ).toBe(false);
+  });
+
+  it("returns changed=false (no throw) when the file is truly malformed", () => {
+    const r = ensureGroupPluginsAllowed("{ not_json: , bad: }");
+    expect(r.changed).toBe(false);
+    expect(r.reason).toMatch(/parse failed/);
+  });
+});


### PR DESCRIPTION
## Description

Fix issue #1543: memos-local-openclaw plugin now reads ~/.openclaw/openclaw.json as JSON5 instead of strict JSON.

Root cause: OpenClaw's host config is officially JSON5 (allows `//` and `/* */` comments, single-quoted strings, unquoted identifier keys, trailing commas). The plugin previously called strict `JSON.parse` on the file in six places, including the `tools.allow` patcher that runs on every plugin startup — which is what produced the reported warning `memos-local: could not patch tools.allow: SyntaxError: Expected double-quoted property name in JSON at position 2222 (line 90 column 7)` whenever a user kept comments in their config.

Fix:
1. New zero-dependency `src/shared/json5.ts` provides `parseJsonOrJson5` — a strict-JSON fast path with a JSON5-tolerant fallback that strips comments via a string-respecting state machine, rewrites single quotes, quotes unquoted identifier keys, and tolerates trailing commas and UTF-8 BOM.
2. New `src/shared/openclaw-config.ts` extracts the `tools.allow` patch logic into a unit-testable helper that anchors on both double- and single-quoted last entries and tolerates trailing commas. It never throws.
3. All six `JSON.parse(fs.readFileSync(<openclaw.json>...))` call sites are routed through the new helper: `index.ts`, `src/shared/llm-call.ts`, `src/ingest/providers/index.ts`, and six endpoints inside `src/viewer/server.ts`. Plain-JSON configs are unaffected thanks to the fast path.

Tests added (21 new, all green): `tests/json5-config.test.ts` covers the issue case, block comments, trailing commas, single/mixed quotes, unquoted keys, BOM, the classic "// inside a URL string literal" bug, malformed input, and an end-to-end exercise of `loadOpenClawFallbackConfig`. `tests/openclaw-config-patch.test.ts` covers the patcher across comments, single quotes, trailing commas, and the no-op paths (`*`, already-present, empty, malformed). Regression sweep across `openclaw-fallback`, `config`, `viewer-config`, `storage`, `policy`, `capture`, `recall`, `chunker`, `migration-status`, `postinstall-native-binding` — 105 tests pass; `tsc --noEmit` clean.

Related Issue (Required):  Fixes #1543

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1543
- [ ] Made sure Checks passed
- [ ] Tests have been provided
