### PR TITLE
fix: ignore ghost trace ids in reward dirty check

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -1294,7 +1294,8 @@ export function createMemoryCore(
     if (!reward || typeof reward !== "object") return false;
     const traceCount = (reward as { traceCount?: unknown }).traceCount;
     if (typeof traceCount === "number") {
-      return traceCount !== (ep.traceIds?.length ?? 0);
+      const traceIds = (ep.traceIds ?? []) as TraceId[];
+      return traceCount !== handle.repos.traces.countExistingIds(traceIds);
     }
 
     // Backward compatibility for episodes scored before reward coverage

--- a/apps/memos-local-plugin/core/storage/repos/traces.ts
+++ b/apps/memos-local-plugin/core/storage/repos/traces.ts
@@ -109,6 +109,20 @@ export function makeTracesRepo(db: StorageDb) {
       return rows.map(mapRow);
     },
 
+    countExistingIds(ids: readonly TraceId[]): number {
+      if (ids.length === 0) return 0;
+      const uniqueIds = [...new Set(ids)];
+      const CHUNK_SIZE = 900;
+      let total = 0;
+      for (let i = 0; i < uniqueIds.length; i += CHUNK_SIZE) {
+        const chunk = uniqueIds.slice(i, i + CHUNK_SIZE);
+        const placeholders = buildInClause(chunk.length);
+        const sql = `SELECT COUNT(*) AS n FROM traces WHERE id ${placeholders}`;
+        total += db.prepare<readonly string[], { n: number }>(sql).get(chunk)?.n ?? 0;
+      }
+      return total;
+    },
+
     /**
      * Cheap existence check: does ANY trace in `ids` carry a timestamp
      * strictly greater than `ts`?

--- a/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/memory-core.test.ts
@@ -1414,6 +1414,106 @@ algorithm:
     expect(meta.reward?.traceIds).toEqual(["tr_dirty"]);
   });
 
+  it("does not rescore closed episodes only because trace_ids_json contains a missing trace id", async () => {
+    home = await makeTmpHome({
+      agent: "openclaw",
+      configYaml: FULL_MEMORY_CONFIG_YAML,
+    });
+
+    const seeder = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "ghost-trace-seed",
+    });
+    await seeder.init();
+    await seeder.shutdown();
+
+    const Sqlite = (await import("better-sqlite3")).default;
+    const writeDb = new Sqlite(home.home.dbFile);
+    const ts = Date.now() - 1_000;
+    writeDb
+      .prepare(
+        `INSERT INTO sessions (id, agent, started_at, last_seen_at, meta_json) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("se_ghost", "openclaw", ts, ts, "{}");
+    writeDb
+      .prepare(
+        `INSERT INTO episodes (id, session_id, started_at, ended_at, trace_ids_json, r_task, status, meta_json) VALUES (?, ?, ?, ?, ?, ?, 'closed', ?)`,
+      )
+      .run(
+        "ep_ghost",
+        "se_ghost",
+        ts,
+        ts + 1,
+        JSON.stringify(["tr_real", "tr_missing"]),
+        0.7,
+        JSON.stringify({
+          closeReason: "finalized",
+          reward: {
+            rHuman: 0.7,
+            scoredAt: ts + 1,
+            traceCount: 1,
+            traceIds: ["tr_real"],
+          },
+        }),
+      );
+    writeDb
+      .prepare(
+        `INSERT INTO traces (
+          id, episode_id, session_id, ts, user_text, agent_text, summary,
+          tool_calls_json, reflection, agent_thinking, value, alpha, r_human,
+          priority, tags_json, error_signatures_json, vec_summary, vec_action,
+          share_scope, share_target, shared_at, turn_id, schema_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        "tr_real",
+        "ep_ghost",
+        "se_ghost",
+        ts,
+        "请总结这段调试经历",
+        "问题来自一个已经不存在的 trace id，不需要重新评分。",
+        "ghost trace regression",
+        "[]",
+        null,
+        null,
+        0,
+        0,
+        null,
+        0.5,
+        "[]",
+        "[]",
+        ts,
+        1,
+      );
+    writeDb.close();
+
+    core = await bootstrapMemoryCore({
+      agent: "openclaw",
+      home: home.home,
+      config: home.config,
+      pkgVersion: "ghost-trace-recover",
+    });
+    await core.init();
+
+    const readDb = new Sqlite(home.home.dbFile, { readonly: true });
+    const episode = readDb
+      .prepare("SELECT r_task, meta_json FROM episodes WHERE id = ?")
+      .get("ep_ghost") as { r_task: number | null; meta_json: string } | undefined;
+    readDb.close();
+
+    expect(episode).toBeDefined();
+    expect(episode!.r_task).toBe(0.7);
+    const meta = JSON.parse(episode!.meta_json) as {
+      recoveryReason?: string;
+      reward?: { traceCount?: number; traceIds?: string[] };
+    };
+    expect(meta.recoveryReason).toBeUndefined();
+    expect(meta.reward?.traceCount).toBe(1);
+    expect(meta.reward?.traceIds).toEqual(["tr_real"]);
+  });
+
   it("rescoring finalized closed episodes that have traces but no reward metadata", async () => {
     home = await makeTmpHome({
       agent: "openclaw",

--- a/apps/memos-local-plugin/tests/unit/storage/repos.test.ts
+++ b/apps/memos-local-plugin/tests/unit/storage/repos.test.ts
@@ -116,6 +116,7 @@ describe("storage/repos — happy paths", () => {
 
       const bulk = repos.traces.getManyByIds(["t0", "t2", "missing"]);
       expect(bulk.map((t) => t.id).sort()).toEqual(["t0", "t2"]);
+      expect(repos.traces.countExistingIds(["t0", "t2", "missing", "t2"])).toBe(2);
 
       repos.traces.updateScore("t0", { value: -0.5, alpha: 0.6, priority: 1.5 });
       expect(repos.traces.getById("t0")!.value).toBe(-0.5);


### PR DESCRIPTION
## Summary

Fixes #1966.

- Make closed-episode reward dirty detection compare stored reward coverage against the number of trace IDs that actually exist in the traces table.
- Add a lightweight `traces.countExistingIds()` helper so the startup dirty scan does not hydrate full trace rows just to ignore missing IDs.
- Add regression coverage for ghost trace IDs and duplicate/missing trace ID counting.

## Validation

- `npm run lint`

Attempted but blocked by the local environment:

- `npm test -- --run tests/unit/pipeline/memory-core.test.ts -t "missing trace id"`
- `npm test -- --run tests/unit/storage/repos.test.ts -t "bulk fetch"`

Both targeted tests fail before assertions because this environment lacks a usable `better-sqlite3` native binding. Rebuilding the binding is also blocked here: the workspace runs Node 18 while the package requires Node >=20, and local g++ rejects `-std=c++20`. Root `make format` is blocked because `poetry` is not installed.