### PR TITLE
fix: promote untouched L2 candidates that meet thresholds

### DIFF
--- a/apps/memos-local-plugin/core/memory/l2/l2.ts
+++ b/apps/memos-local-plugin/core/memory/l2/l2.ts
@@ -34,7 +34,7 @@ import { L2_INDUCTION_PROMPT } from "../../llm/prompts/l2-induction.js";
 import { associateTraces } from "./associate.js";
 import { makeCandidatePool } from "./candidate-pool.js";
 import { buildPolicyRow, induceDraft } from "./induce.js";
-import { applyGain, computeGain, smoothGain } from "./gain.js";
+import { applyGain, computeGain, nextStatus, smoothGain } from "./gain.js";
 import { signatureOf } from "./signature.js";
 import { tracePolicySimilarity } from "./similarity.js";
 import type {
@@ -450,6 +450,39 @@ export async function runL2(
         status: persisted.status,
         support: persisted.support,
         gain: persisted.gain,
+      });
+    }
+
+    for (const policy of repos.policies.list({ status: "candidate", limit: 5_000 })) {
+      if (touched.has(policy.id)) continue;
+      const status = nextStatus({
+        currentStatus: policy.status,
+        support: policy.support,
+        gain: policy.gain,
+        thresholds,
+      });
+      if (status === policy.status) continue;
+      const updatedAt = input.now ?? Date.now();
+      repos.policies.updateStats(policy.id, {
+        support: policy.support,
+        gain: policy.gain,
+        status,
+        updatedAt,
+      });
+      touched.set(policy.id, { ...policy, status, updatedAt });
+      emit(bus, {
+        kind: "l2.policy.updated",
+        episodeId: input.episodeId,
+        policyId: policy.id,
+        status,
+        support: policy.support,
+        gain: policy.gain,
+      });
+      log.info("run.recheck_candidate_promoted", {
+        policyId: policy.id,
+        status,
+        support: policy.support,
+        gain: policy.gain,
       });
     }
     timings.gain = Date.now() - t0;

--- a/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
@@ -815,4 +815,64 @@ describe("memory/l2/integration", () => {
     expect(updated.gain).toBeLessThan(0.1);
     expect(updated.status).toBe("active");
   });
+
+  it("promotes untouched candidate policies whose stored support and gain meet thresholds", async () => {
+    ensureEpisode(handle, "ep_recheck", "s_int");
+    handle.repos.policies.insert({
+      id: "po_ready_candidate" as never,
+      title: "reuse verified deployment checklist",
+      trigger: "deployment has recurring verification steps",
+      procedure: "run the known checklist and report failures",
+      verification: "all checklist items are completed",
+      boundary: "only for deployment validation tasks",
+      support: 3,
+      gain: 0.2,
+      status: "candidate",
+      sourceEpisodeIds: ["ep_old" as EpisodeId],
+      inducedBy: "unit-test",
+      decisionGuidance: { preference: [], antiPattern: [] },
+      vec: null,
+      createdAt: NOW as never,
+      updatedAt: NOW as never,
+    });
+
+    const bus = createL2EventBus();
+    const events: L2Event[] = [];
+    bus.onAny((e) => events.push(e));
+
+    const result = await runL2(
+      {
+        episodeId: "ep_recheck" as EpisodeId,
+        sessionId: "s_int" as SessionId,
+        traces: [],
+        trigger: "manual",
+        now: NOW + 10,
+      },
+      {
+        db: handle.db,
+        repos: handle.repos,
+        llm: fakeLlm({ completeJson: {} }),
+        log: rootLogger.child({ channel: "core.memory.l2" }),
+        bus,
+        config: cfg(),
+        thresholds: { minSupport: 3, minGain: 0.15, archiveGain: -0.05 },
+      },
+    );
+
+    const updated = handle.repos.policies.getById("po_ready_candidate" as never)!;
+    expect(updated.status).toBe("active");
+    expect(updated.support).toBe(3);
+    expect(updated.gain).toBe(0.2);
+    expect(updated.updatedAt).toBe(NOW + 10);
+    expect(result.touchedPolicyIds).toContain("po_ready_candidate");
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        kind: "l2.policy.updated",
+        policyId: "po_ready_candidate",
+        status: "active",
+        support: 3,
+        gain: 0.2,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1932.

- Re-check untouched candidate policies after the normal L2 touched-policy gain pass.
- Promote candidates whose stored support/gain already satisfy thresholds, even when the current episode did not associate any trace with them.
- Emit the usual `l2.policy.updated` event and include the promoted candidate in `touchedPolicyIds`.

## Validation

- `npm run lint`

Attempted but blocked by the local environment:

- `npm test -- --run tests/unit/memory/l2/l2.integration.test.ts -t "untouched candidate"`

The targeted test fails before assertions because this environment lacks a usable `better-sqlite3` native binding. Rebuilding the binding is blocked here by Node 18 and a compiler that rejects `-std=c++20`.