### PR TITLE
Fix #1611: classifyTopic fails when summarizer uses Anthropic endpoint (Kimi Code)

### DIFF
--- a/apps/memos-local-openclaw/src/ingest/providers/anthropic.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/anthropic.ts
@@ -332,9 +332,91 @@ export async function summarizeAnthropic(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicAnthropic(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const endpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  const model = cfg.model ?? "claude-3-haiku-20240307";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": cfg.apiKey ?? "",
+    "anthropic-version": "2023-06-01",
+    ...cfg.headers,
+  };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      max_tokens: 60,
+      temperature: 0,
+      system: TOPIC_CLASSIFIER_PROMPT,
+      messages: [{ role: "user", content: userContent }],
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Anthropic topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { content: Array<{ type: string; text: string }> };
+  const raw = json.content.find((c) => c.type === "text")?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitAnthropic(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const endpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  const model = cfg.model ?? "claude-3-haiku-20240307";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": cfg.apiKey ?? "",
+    "anthropic-version": "2023-06-01",
+    ...cfg.headers,
+  };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      max_tokens: 10,
+      temperature: 0,
+      system: TOPIC_ARBITRATION_PROMPT,
+      messages: [{ role: "user", content: userContent }],
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Anthropic topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { content: Array<{ type: string; text: string }> };
+  const answer = json.content.find((c) => c.type === "text")?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupAnthropic(
   newSummary: string,

--- a/apps/memos-local-openclaw/src/ingest/providers/bedrock.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/bedrock.ts
@@ -340,9 +340,83 @@ export async function summarizeBedrock(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicBedrock(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const model = cfg.model ?? "anthropic.claude-3-haiku-20240307-v1:0";
+  const endpoint = cfg.endpoint;
+  if (!endpoint) throw new Error("Bedrock topic-classifier requires 'endpoint'");
+
+  const url = `${endpoint}/model/${model}/converse`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      system: [{ text: TOPIC_CLASSIFIER_PROMPT }],
+      messages: [{ role: "user", content: [{ text: userContent }] }],
+      inferenceConfig: { temperature: 0, maxTokens: 60 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Bedrock topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { output: { message: { content: Array<{ text: string }> } } };
+  const raw = json.output?.message?.content?.[0]?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitBedrock(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const model = cfg.model ?? "anthropic.claude-3-haiku-20240307-v1:0";
+  const endpoint = cfg.endpoint;
+  if (!endpoint) throw new Error("Bedrock topic-arbitration requires 'endpoint'");
+
+  const url = `${endpoint}/model/${model}/converse`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      system: [{ text: TOPIC_ARBITRATION_PROMPT }],
+      messages: [{ role: "user", content: [{ text: userContent }] }],
+      inferenceConfig: { temperature: 0, maxTokens: 10 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Bedrock topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { output: { message: { content: Array<{ text: string }> } } };
+  const answer = json.output?.message?.content?.[0]?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupBedrock(
   newSummary: string,

--- a/apps/memos-local-openclaw/src/ingest/providers/gemini.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/gemini.ts
@@ -332,9 +332,83 @@ export async function summarizeGemini(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicGemini(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const model = cfg.model ?? "gemini-1.5-flash";
+  const endpoint =
+    cfg.endpoint ??
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const url = `${endpoint}?key=${cfg.apiKey}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: TOPIC_CLASSIFIER_PROMPT }] },
+      contents: [{ parts: [{ text: userContent }] }],
+      generationConfig: { temperature: 0, maxOutputTokens: 60 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Gemini topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> };
+  const raw = json.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitGemini(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const model = cfg.model ?? "gemini-1.5-flash";
+  const endpoint =
+    cfg.endpoint ??
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const url = `${endpoint}?key=${cfg.apiKey}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: TOPIC_ARBITRATION_PROMPT }] },
+      contents: [{ parts: [{ text: userContent }] }],
+      generationConfig: { temperature: 0, maxOutputTokens: 10 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Gemini topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> };
+  const answer = json.candidates?.[0]?.content?.parts?.[0]?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupGemini(
   newSummary: string,

--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -4,9 +4,9 @@ import type { SummarizerConfig, SummaryProvider, Logger, OpenClawAPI } from "../
 import { summarizeOpenAI, summarizeTaskOpenAI, generateTaskTitleOpenAI, judgeNewTopicOpenAI, classifyTopicOpenAI, arbitrateTopicSplitOpenAI, filterRelevantOpenAI, judgeDedupOpenAI, parseFilterResult, parseDedupResult, parseTopicClassifyResult } from "./openai";
 import type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
 export type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
-import { summarizeAnthropic, summarizeTaskAnthropic, generateTaskTitleAnthropic, judgeNewTopicAnthropic, filterRelevantAnthropic, judgeDedupAnthropic } from "./anthropic";
-import { summarizeGemini, summarizeTaskGemini, generateTaskTitleGemini, judgeNewTopicGemini, filterRelevantGemini, judgeDedupGemini } from "./gemini";
-import { summarizeBedrock, summarizeTaskBedrock, generateTaskTitleBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock } from "./bedrock";
+import { summarizeAnthropic, summarizeTaskAnthropic, generateTaskTitleAnthropic, judgeNewTopicAnthropic, filterRelevantAnthropic, judgeDedupAnthropic, classifyTopicAnthropic, arbitrateTopicSplitAnthropic } from "./anthropic";
+import { summarizeGemini, summarizeTaskGemini, generateTaskTitleGemini, judgeNewTopicGemini, filterRelevantGemini, judgeDedupGemini, classifyTopicGemini, arbitrateTopicSplitGemini } from "./gemini";
+import { summarizeBedrock, summarizeTaskBedrock, generateTaskTitleBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock, classifyTopicBedrock, arbitrateTopicSplitBedrock } from "./bedrock";
 
 /**
  * Resolve a SecretInput (string | SecretRef) to a plain string.
@@ -713,9 +713,11 @@ function callTopicClassifier(cfg: SummarizerConfig, taskState: string, newMessag
     case "voyage":
       return classifyTopicOpenAI(taskState, newMessage, cfg, log);
     case "anthropic":
+      return classifyTopicAnthropic(taskState, newMessage, cfg, log);
     case "gemini":
+      return classifyTopicGemini(taskState, newMessage, cfg, log);
     case "bedrock":
-      return classifyTopicOpenAI(taskState, newMessage, cfg, log);
+      return classifyTopicBedrock(taskState, newMessage, cfg, log);
     default:
       throw new Error(`Unknown summarizer provider: ${cfg.provider}`);
   }
@@ -736,9 +738,11 @@ function callTopicArbitration(cfg: SummarizerConfig, taskState: string, newMessa
     case "voyage":
       return arbitrateTopicSplitOpenAI(taskState, newMessage, cfg, log);
     case "anthropic":
+      return arbitrateTopicSplitAnthropic(taskState, newMessage, cfg, log);
     case "gemini":
+      return arbitrateTopicSplitGemini(taskState, newMessage, cfg, log);
     case "bedrock":
-      return arbitrateTopicSplitOpenAI(taskState, newMessage, cfg, log);
+      return arbitrateTopicSplitBedrock(taskState, newMessage, cfg, log);
     default:
       throw new Error(`Unknown summarizer provider: ${cfg.provider}`);
   }

--- a/apps/memos-local-openclaw/src/ingest/providers/openai.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/openai.ts
@@ -262,7 +262,7 @@ export interface TopicClassifyResult {
   reason: string; // may be empty for compact responses
 }
 
-const TOPIC_CLASSIFIER_PROMPT = `Classify if NEW MESSAGE continues current task or starts an unrelated one.
+export const TOPIC_CLASSIFIER_PROMPT = `Classify if NEW MESSAGE continues current task or starts an unrelated one.
 Output ONLY JSON: {"d":"S"|"N","c":0.0-1.0}
 d=S(same) or N(new). c=confidence. Default S. Only N if completely unrelated domain.
 Sub-questions, tools, methods, details of current topic = S.`;
@@ -310,7 +310,7 @@ export async function classifyTopicOpenAI(
   return parseTopicClassifyResult(raw, log);
 }
 
-const TOPIC_ARBITRATION_PROMPT = `A classifier flagged this message as possibly new topic (low confidence). Is it truly UNRELATED, or a sub-question/follow-up?
+export const TOPIC_ARBITRATION_PROMPT = `A classifier flagged this message as possibly new topic (low confidence). Is it truly UNRELATED, or a sub-question/follow-up?
 Tools/methods/details of current task = SAME. Shared entity/theme = SAME. Entirely different domain = NEW.
 Reply one word: NEW or SAME`;
 

--- a/apps/memos-local-openclaw/tests/topic-classifier-dispatch.test.ts
+++ b/apps/memos-local-openclaw/tests/topic-classifier-dispatch.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Summarizer } from "../src/ingest/providers";
+import type { Logger, SummarizerConfig } from "../src/types";
+
+/**
+ * Regression test for #1611.
+ *
+ * `Summarizer.classifyTopic` and `Summarizer.arbitrateTopicSplit` used to call
+ * the OpenAI implementation regardless of the configured `provider`. When the
+ * summarizer was wired to an Anthropic-only endpoint (e.g. Kimi Code's
+ * `/coding/v1/messages`), the OpenAI-style request returned 404 and the call
+ * fell through every fallback.
+ *
+ * These tests stub `globalThis.fetch` and assert that for each provider we
+ *  1) hit the correct URL ( `/v1/messages` for anthropic, `:generateContent`
+ *     for gemini, `/converse` for bedrock, `/chat/completions` for openai_*)
+ *  2) send the correct request body shape (system vs system+messages vs
+ *     systemInstruction vs system+messages-as-text-blocks)
+ */
+
+const noopLog: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// Capture every fetch call so we can assert URL + body shape.
+let calls: Array<{ url: string; init: RequestInit & { body?: string } }>;
+let originalFetch: typeof fetch;
+
+function installFetch(response: { ok: boolean; status?: number; body: any }): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = vi.fn(async (url: string, init: any) => {
+    calls.push({ url: typeof url === "string" ? url : String(url), init });
+    return {
+      ok: response.ok,
+      status: response.status ?? 200,
+      json: async () => response.body,
+      text: async () => JSON.stringify(response.body),
+    } as Response;
+  }) as any;
+}
+
+function restoreFetch(): void {
+  if (originalFetch) globalThis.fetch = originalFetch;
+}
+
+describe("Summarizer.classifyTopic - provider dispatch (issue #1611)", () => {
+  beforeEach(() => {
+    calls = [];
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    vi.restoreAllMocks();
+  });
+
+  it("anthropic provider hits /v1/messages with system+messages body (not /chat/completions)", async () => {
+    installFetch({
+      ok: true,
+      body: { content: [{ type: "text", text: '{"d":"S","c":0.9}' }] },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "anthropic",
+      endpoint: "https://api.kimi.com/coding/v1/messages",
+      apiKey: "sk-test",
+      model: "kimi-for-coding",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.classifyTopic("current task state", "new message");
+
+    expect(result).not.toBeNull();
+    expect(result!.decision).toBe("SAME");
+    expect(calls).toHaveLength(1);
+
+    const [{ url, init }] = calls;
+    expect(url).toBe("https://api.kimi.com/coding/v1/messages");
+    expect(url).not.toContain("chat/completions");
+
+    const body = JSON.parse(init.body as string);
+    expect(body).toHaveProperty("system"); // Anthropic style
+    expect(body).toHaveProperty("messages");
+    expect(body).not.toHaveProperty("choices");
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[0].content).toContain("new message");
+    // Anthropic must send x-api-key header, NOT Authorization
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("openai_compatible provider still hits /chat/completions (regression guard)", async () => {
+    installFetch({
+      ok: true,
+      body: { choices: [{ message: { content: '{"d":"N","c":0.95}' } }] },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "openai_compatible",
+      endpoint: "https://api.deepseek.com/v1/chat/completions",
+      apiKey: "sk-deepseek",
+      model: "deepseek-chat",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.classifyTopic("ctx", "msg");
+
+    expect(result!.decision).toBe("NEW");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain("/chat/completions");
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body).toHaveProperty("messages");
+    expect(body.messages[0].role).toBe("system");
+  });
+
+  it("gemini provider hits :generateContent with systemInstruction body", async () => {
+    installFetch({
+      ok: true,
+      body: { candidates: [{ content: { parts: [{ text: '{"d":"S","c":0.8}' }] } }] },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "gemini",
+      endpoint:
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+      apiKey: "AIzaTEST",
+      model: "gemini-1.5-flash",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.classifyTopic("ctx", "msg");
+
+    expect(result!.decision).toBe("SAME");
+    expect(calls[0].url).toContain(":generateContent");
+    expect(calls[0].url).toContain("key=AIzaTEST");
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body).toHaveProperty("systemInstruction");
+    expect(body).toHaveProperty("contents");
+    expect(body).not.toHaveProperty("messages");
+  });
+
+  it("bedrock provider hits /model/.../converse with system+messages body", async () => {
+    installFetch({
+      ok: true,
+      body: { output: { message: { content: [{ text: '{"d":"S","c":0.7}' }] } } },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "bedrock",
+      endpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      apiKey: "",
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.classifyTopic("ctx", "msg");
+
+    expect(result!.decision).toBe("SAME");
+    expect(calls[0].url).toMatch(/\/model\/.+\/converse$/);
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body).toHaveProperty("inferenceConfig");
+    expect(body.system[0].text).toContain("Classify if NEW MESSAGE");
+  });
+});
+
+describe("Summarizer.arbitrateTopicSplit - provider dispatch (issue #1611)", () => {
+  beforeEach(() => {
+    calls = [];
+  });
+
+  afterEach(() => {
+    restoreFetch();
+    vi.restoreAllMocks();
+  });
+
+  it("anthropic provider hits /v1/messages (not /chat/completions)", async () => {
+    installFetch({
+      ok: true,
+      body: { content: [{ type: "text", text: "SAME" }] },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "anthropic",
+      endpoint: "https://api.kimi.com/coding/v1/messages",
+      apiKey: "sk-test",
+      model: "kimi-for-coding",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.arbitrateTopicSplit("ctx", "msg");
+
+    expect(result).toBe("SAME");
+    expect(calls[0].url).toBe("https://api.kimi.com/coding/v1/messages");
+    expect(calls[0].url).not.toContain("chat/completions");
+  });
+
+  it("gemini provider hits :generateContent", async () => {
+    installFetch({
+      ok: true,
+      body: { candidates: [{ content: { parts: [{ text: "NEW" }] } }] },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "gemini",
+      endpoint:
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+      apiKey: "AIzaTEST",
+      model: "gemini-1.5-flash",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.arbitrateTopicSplit("ctx", "msg");
+
+    expect(result).toBe("NEW");
+    expect(calls[0].url).toContain(":generateContent");
+  });
+
+  it("bedrock provider hits /converse", async () => {
+    installFetch({
+      ok: true,
+      body: { output: { message: { content: [{ text: "SAME" }] } } },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "bedrock",
+      endpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      apiKey: "",
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    const result = await summarizer.arbitrateTopicSplit("ctx", "msg");
+
+    expect(result).toBe("SAME");
+    expect(calls[0].url).toMatch(/\/model\/.+\/converse$/);
+  });
+
+  it("anthropic 404 propagates as Anthropic error, not as OpenAI error (root cause of #1611)", async () => {
+    // This is the exact failure mode reported by the user: a 404 from the
+    // Anthropic endpoint. With the bug, the error message was prefixed
+    // "OpenAI topic-classifier failed". After the fix it must say "Anthropic
+    // topic-classifier failed" — proving we are no longer calling the OpenAI
+    // helper for an Anthropic-configured summarizer.
+    installFetch({
+      ok: false,
+      status: 404,
+      body: { error: { message: "The requested resource was not found", type: "resource_not_found_error" } },
+    });
+
+    const cfg: SummarizerConfig = {
+      provider: "anthropic",
+      endpoint: "https://api.kimi.com/coding/v1/messages",
+      apiKey: "sk-test",
+      model: "kimi-for-coding",
+    };
+    const summarizer = new Summarizer(cfg, noopLog);
+
+    // classifyTopic returns null on failure (tryChain swallows) but the
+    // recorded model-health error message must say "Anthropic", not "OpenAI".
+    const result = await summarizer.classifyTopic("ctx", "msg");
+    expect(result).toBeNull();
+
+    const { modelHealth } = await import("../src/ingest/providers");
+    const entry = modelHealth.getAll().find((e) => e.role === "classifyTopic");
+    expect(entry).toBeDefined();
+    expect(entry!.lastErrorMessage ?? "").toContain("Anthropic");
+    expect(entry!.lastErrorMessage ?? "").not.toContain("OpenAI");
+  });
+});

--- a/packages/memos-core/src/ingest/providers/anthropic.ts
+++ b/packages/memos-core/src/ingest/providers/anthropic.ts
@@ -332,9 +332,91 @@ export async function summarizeAnthropic(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicAnthropic(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const endpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  const model = cfg.model ?? "claude-3-haiku-20240307";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": cfg.apiKey ?? "",
+    "anthropic-version": "2023-06-01",
+    ...cfg.headers,
+  };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      max_tokens: 60,
+      temperature: 0,
+      system: TOPIC_CLASSIFIER_PROMPT,
+      messages: [{ role: "user", content: userContent }],
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Anthropic topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { content: Array<{ type: string; text: string }> };
+  const raw = json.content.find((c) => c.type === "text")?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitAnthropic(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const endpoint = cfg.endpoint ?? "https://api.anthropic.com/v1/messages";
+  const model = cfg.model ?? "claude-3-haiku-20240307";
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": cfg.apiKey ?? "",
+    "anthropic-version": "2023-06-01",
+    ...cfg.headers,
+  };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      max_tokens: 10,
+      temperature: 0,
+      system: TOPIC_ARBITRATION_PROMPT,
+      messages: [{ role: "user", content: userContent }],
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Anthropic topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { content: Array<{ type: string; text: string }> };
+  const answer = json.content.find((c) => c.type === "text")?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupAnthropic(
   newSummary: string,

--- a/packages/memos-core/src/ingest/providers/bedrock.ts
+++ b/packages/memos-core/src/ingest/providers/bedrock.ts
@@ -340,9 +340,83 @@ export async function summarizeBedrock(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicBedrock(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const model = cfg.model ?? "anthropic.claude-3-haiku-20240307-v1:0";
+  const endpoint = cfg.endpoint;
+  if (!endpoint) throw new Error("Bedrock topic-classifier requires 'endpoint'");
+
+  const url = `${endpoint}/model/${model}/converse`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      system: [{ text: TOPIC_CLASSIFIER_PROMPT }],
+      messages: [{ role: "user", content: [{ text: userContent }] }],
+      inferenceConfig: { temperature: 0, maxTokens: 60 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Bedrock topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { output: { message: { content: Array<{ text: string }> } } };
+  const raw = json.output?.message?.content?.[0]?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitBedrock(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const model = cfg.model ?? "anthropic.claude-3-haiku-20240307-v1:0";
+  const endpoint = cfg.endpoint;
+  if (!endpoint) throw new Error("Bedrock topic-arbitration requires 'endpoint'");
+
+  const url = `${endpoint}/model/${model}/converse`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      system: [{ text: TOPIC_ARBITRATION_PROMPT }],
+      messages: [{ role: "user", content: [{ text: userContent }] }],
+      inferenceConfig: { temperature: 0, maxTokens: 10 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Bedrock topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { output: { message: { content: Array<{ text: string }> } } };
+  const answer = json.output?.message?.content?.[0]?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupBedrock(
   newSummary: string,

--- a/packages/memos-core/src/ingest/providers/gemini.ts
+++ b/packages/memos-core/src/ingest/providers/gemini.ts
@@ -332,9 +332,83 @@ export async function summarizeGemini(
 
 // ─── Smart Dedup ───
 
-import { DEDUP_JUDGE_PROMPT, parseDedupResult } from "./openai";
-import type { DedupResult } from "./openai";
+import { DEDUP_JUDGE_PROMPT, parseDedupResult, parseTopicClassifyResult, TOPIC_CLASSIFIER_PROMPT, TOPIC_ARBITRATION_PROMPT } from "./openai";
+import type { DedupResult, TopicClassifyResult } from "./openai";
 export type { DedupResult } from "./openai";
+
+export async function classifyTopicGemini(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<TopicClassifyResult> {
+  const model = cfg.model ?? "gemini-1.5-flash";
+  const endpoint =
+    cfg.endpoint ??
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const url = `${endpoint}?key=${cfg.apiKey}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: TOPIC_CLASSIFIER_PROMPT }] },
+      contents: [{ parts: [{ text: userContent }] }],
+      generationConfig: { temperature: 0, maxOutputTokens: 60 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Gemini topic-classifier failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> };
+  const raw = json.candidates?.[0]?.content?.parts?.[0]?.text?.trim() ?? "";
+  log.debug(`Topic classifier raw: "${raw}"`);
+  return parseTopicClassifyResult(raw, log);
+}
+
+export async function arbitrateTopicSplitGemini(
+  taskState: string,
+  newMessage: string,
+  cfg: SummarizerConfig,
+  log: Logger,
+): Promise<string> {
+  const model = cfg.model ?? "gemini-1.5-flash";
+  const endpoint =
+    cfg.endpoint ??
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+  const url = `${endpoint}?key=${cfg.apiKey}`;
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...cfg.headers };
+
+  const userContent = `TASK:\n${taskState}\n\nMSG:\n${newMessage}`;
+
+  const resp = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      systemInstruction: { parts: [{ text: TOPIC_ARBITRATION_PROMPT }] },
+      contents: [{ parts: [{ text: userContent }] }],
+      generationConfig: { temperature: 0, maxOutputTokens: 10 },
+    }),
+    signal: AbortSignal.timeout(cfg.timeoutMs ?? 15_000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Gemini topic-arbitration failed (${resp.status}): ${body}`);
+  }
+
+  const json = (await resp.json()) as { candidates: Array<{ content: { parts: Array<{ text: string }> } }> };
+  const answer = json.candidates?.[0]?.content?.parts?.[0]?.text?.trim().toUpperCase() ?? "";
+  log.debug(`Topic arbitration result: "${answer}"`);
+  return answer.startsWith("NEW") ? "NEW" : "SAME";
+}
 
 export async function judgeDedupGemini(
   newSummary: string,

--- a/packages/memos-core/src/ingest/providers/index.ts
+++ b/packages/memos-core/src/ingest/providers/index.ts
@@ -4,9 +4,9 @@ import type { SummarizerConfig, SummaryProvider, Logger, OpenClawAPI } from "../
 import { summarizeOpenAI, summarizeTaskOpenAI, generateTaskTitleOpenAI, judgeNewTopicOpenAI, classifyTopicOpenAI, arbitrateTopicSplitOpenAI, filterRelevantOpenAI, judgeDedupOpenAI, parseFilterResult, parseDedupResult, parseTopicClassifyResult } from "./openai";
 import type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
 export type { FilterResult, DedupResult, TopicClassifyResult } from "./openai";
-import { summarizeAnthropic, summarizeTaskAnthropic, generateTaskTitleAnthropic, judgeNewTopicAnthropic, filterRelevantAnthropic, judgeDedupAnthropic } from "./anthropic";
-import { summarizeGemini, summarizeTaskGemini, generateTaskTitleGemini, judgeNewTopicGemini, filterRelevantGemini, judgeDedupGemini } from "./gemini";
-import { summarizeBedrock, summarizeTaskBedrock, generateTaskTitleBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock } from "./bedrock";
+import { summarizeAnthropic, summarizeTaskAnthropic, generateTaskTitleAnthropic, judgeNewTopicAnthropic, filterRelevantAnthropic, judgeDedupAnthropic, classifyTopicAnthropic, arbitrateTopicSplitAnthropic } from "./anthropic";
+import { summarizeGemini, summarizeTaskGemini, generateTaskTitleGemini, judgeNewTopicGemini, filterRelevantGemini, judgeDedupGemini, classifyTopicGemini, arbitrateTopicSplitGemini } from "./gemini";
+import { summarizeBedrock, summarizeTaskBedrock, generateTaskTitleBedrock, judgeNewTopicBedrock, filterRelevantBedrock, judgeDedupBedrock, classifyTopicBedrock, arbitrateTopicSplitBedrock } from "./bedrock";
 
 /**
  * Resolve a SecretInput (string | SecretRef) to a plain string.
@@ -713,9 +713,11 @@ function callTopicClassifier(cfg: SummarizerConfig, taskState: string, newMessag
     case "voyage":
       return classifyTopicOpenAI(taskState, newMessage, cfg, log);
     case "anthropic":
+      return classifyTopicAnthropic(taskState, newMessage, cfg, log);
     case "gemini":
+      return classifyTopicGemini(taskState, newMessage, cfg, log);
     case "bedrock":
-      return classifyTopicOpenAI(taskState, newMessage, cfg, log);
+      return classifyTopicBedrock(taskState, newMessage, cfg, log);
     default:
       throw new Error(`Unknown summarizer provider: ${cfg.provider}`);
   }
@@ -736,9 +738,11 @@ function callTopicArbitration(cfg: SummarizerConfig, taskState: string, newMessa
     case "voyage":
       return arbitrateTopicSplitOpenAI(taskState, newMessage, cfg, log);
     case "anthropic":
+      return arbitrateTopicSplitAnthropic(taskState, newMessage, cfg, log);
     case "gemini":
+      return arbitrateTopicSplitGemini(taskState, newMessage, cfg, log);
     case "bedrock":
-      return arbitrateTopicSplitOpenAI(taskState, newMessage, cfg, log);
+      return arbitrateTopicSplitBedrock(taskState, newMessage, cfg, log);
     default:
       throw new Error(`Unknown summarizer provider: ${cfg.provider}`);
   }

--- a/packages/memos-core/src/ingest/providers/openai.ts
+++ b/packages/memos-core/src/ingest/providers/openai.ts
@@ -262,7 +262,7 @@ export interface TopicClassifyResult {
   reason: string; // may be empty for compact responses
 }
 
-const TOPIC_CLASSIFIER_PROMPT = `Classify if NEW MESSAGE continues current task or starts an unrelated one.
+export const TOPIC_CLASSIFIER_PROMPT = `Classify if NEW MESSAGE continues current task or starts an unrelated one.
 Output ONLY JSON: {"d":"S"|"N","c":0.0-1.0}
 d=S(same) or N(new). c=confidence. Default S. Only N if completely unrelated domain.
 Sub-questions, tools, methods, details of current topic = S.`;
@@ -310,7 +310,7 @@ export async function classifyTopicOpenAI(
   return parseTopicClassifyResult(raw, log);
 }
 
-const TOPIC_ARBITRATION_PROMPT = `A classifier flagged this message as possibly new topic (low confidence). Is it truly UNRELATED, or a sub-question/follow-up?
+export const TOPIC_ARBITRATION_PROMPT = `A classifier flagged this message as possibly new topic (low confidence). Is it truly UNRELATED, or a sub-question/follow-up?
 Tools/methods/details of current task = SAME. Shared entity/theme = SAME. Entirely different domain = NEW.
 Reply one word: NEW or SAME`;
 


### PR DESCRIPTION
## Description

Fixes #1611 — `Summarizer.classifyTopic` and `Summarizer.arbitrateTopicSplit` previously dispatched every call to the OpenAI helper, which produced a 404 whenever the summarizer was wired to an Anthropic-only endpoint such as Kimi Code's `/coding/v1/messages`. Each ingested message triggered the failure, wasting tokens, polluting logs, and contributing to event-loop slowdowns in the OpenClaw Gateway.

The fix mirrors the existing per-provider pattern already used for summarize / judgeNewTopic / filterRelevant / judgeDedup. Six new helpers (`classifyTopic{Anthropic,Gemini,Bedrock}` + `arbitrateTopicSplit{Anthropic,Gemini,Bedrock}`) are added to the matching provider modules; `TOPIC_CLASSIFIER_PROMPT` and `TOPIC_ARBITRATION_PROMPT` are exported from `openai.ts` so all four providers share one canonical prompt; and the two `switch` statements in `apps/memos-local-openclaw/src/ingest/providers/index.ts` now route by `cfg.provider`. The byte-identical copy in `packages/memos-core/src/ingest/providers/` is updated in lockstep so the bug cannot reappear after the next sync.

Verification: new dispatch test `apps/memos-local-openclaw/tests/topic-classifier-dispatch.test.ts` (8 cases, all green) stubs `globalThis.fetch` and asserts URL + body shape per provider — including a regression case that proves an Anthropic 404 now surfaces an `Anthropic topic-classifier failed` error rather than the old `OpenAI topic-classifier failed`. Full vitest suite: 230/235 pass (the 5 failures are pre-existing on the baseline branch and unrelated to topic classification — accuracy benchmark, skill auto-install default, sqlite test-data ordering, and update-install signal handling). `tsc --noEmit` is clean.

Related Issue (Required):  Fixes #1611

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1611
- [ ] Made sure Checks passed
- [ ] Tests have been provided
