### PR TITLE
Fix #1797: bug(hermes): _bridge_ok cache permanently disables provider after transient star

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 _lock = threading.RLock()
 _bridge_ok: bool | None = None
+_bridge_ok_at: float = 0.0
 _viewer_status: str | None = None
 _viewer_last_probe_at = 0.0
 _viewer_process: subprocess.Popen | None = None
@@ -42,6 +43,11 @@ HERMES_VIEWER_PORT = 18800
 VIEWER_PROBE_TTL_SEC = 30.0
 VIEWER_START_LOCK_TIMEOUT_SEC = 20.0
 VIEWER_START_LOCK_STALE_SEC = 60.0
+# Bound how long a cached `_bridge_ok` answer is trusted. Without this, a
+# single transient `_node_available()` failure during gateway startup
+# (subprocess race, `.env` loaded after the first probe) would pin the
+# provider to "unavailable" for the lifetime of the process — see #1797.
+BRIDGE_OK_TTL_SEC = 60.0
 
 
 @contextlib.contextmanager
@@ -153,22 +159,39 @@ def ensure_bridge_running(*, probe_only: bool = False) -> bool:
     ``probe_only=True`` performs a lightweight availability check without
     launching a long-lived subprocess. This is what
     ``MemTensorProvider.is_available`` calls during Hermes startup.
+
+    The cached answer is honoured only inside ``BRIDGE_OK_TTL_SEC``; once
+    it expires we revalidate. A transient ``_node_available()`` failure
+    therefore self-heals on the next probe instead of permanently
+    disabling the provider (see issue #1797).
     """
-    global _bridge_ok
+    global _bridge_ok, _bridge_ok_at
     with _lock:
-        if _bridge_ok is not None and probe_only:
+        now = time.time()
+        if _bridge_ok is not None and probe_only and (now - _bridge_ok_at) < BRIDGE_OK_TTL_SEC:
             return _bridge_ok
         script = _bridge_script()
         if not script.exists():
             logger.warning("MemOS: bridge script missing at %s", script)
             _bridge_ok = False
+            _bridge_ok_at = now
             return False
-        if not _node_available():
-            logger.warning("MemOS: Node.js not found on PATH")
-            _bridge_ok = False
-            return False
-        _bridge_ok = True
-        return True
+        if _node_available():
+            _bridge_ok = True
+            _bridge_ok_at = now
+            return True
+        # Node binary check just failed. A MemOS bridge already running on
+        # :18800 is definitive proof Node works on this host (the daemon
+        # itself was launched via Node); trust it and recover rather than
+        # report unavailable forever.
+        if _probe_viewer() == "running_memos":
+            _bridge_ok = True
+            _bridge_ok_at = now
+            return True
+        logger.warning("MemOS: Node.js not found on PATH")
+        _bridge_ok = False
+        _bridge_ok_at = now
+        return False
 
 
 def _probe_viewer() -> str:
@@ -331,9 +354,10 @@ def ensure_viewer_daemon(*, probe_only: bool = False) -> bool:
 
 def shutdown_bridge() -> None:
     """Best-effort cleanup; each client owns its own subprocess."""
-    global _bridge_ok
+    global _bridge_ok, _bridge_ok_at
     with _lock:
         _bridge_ok = None
+        _bridge_ok_at = 0.0
 
 
 def wait_for_process_exit(pid: int, timeout: float = 5.0) -> bool:

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -743,5 +743,143 @@ class ViewerDaemonTests(unittest.TestCase):
             popen.assert_not_called()
 
 
+class BridgeOkCacheTests(unittest.TestCase):
+    """Regression tests for issue #1797.
+
+    `ensure_bridge_running(probe_only=True)` used to cache a `False`
+    result permanently. These tests pin down the new contract: cache
+    entries have a TTL, and a running MemOS bridge on :18800 is a
+    fallback signal that Node works on this host even if a transient
+    `_node_available()` call failed.
+    """
+
+    def setUp(self) -> None:
+        # Make sure each test starts from a clean module-level cache.
+        daemon_manager_mod._bridge_ok = None
+        daemon_manager_mod._bridge_ok_at = 0.0
+        # Pretend the compiled bridge script exists so the "script
+        # missing" early-return does not steal the test.
+        self._script_patch = patch.object(
+            daemon_manager_mod,
+            "_bridge_script",
+            return_value=Path("/fake/bridge.cjs"),
+        )
+        self._script_patch.start()
+        self._exists_patch = patch.object(Path, "exists", return_value=True)
+        self._exists_patch.start()
+
+    def tearDown(self) -> None:
+        self._exists_patch.stop()
+        self._script_patch.stop()
+        daemon_manager_mod._bridge_ok = None
+        daemon_manager_mod._bridge_ok_at = 0.0
+
+    def test_probe_only_when_cache_empty_revalidates(self) -> None:
+        with (
+            patch.object(daemon_manager_mod, "_node_available", return_value=True) as node,
+            patch.object(daemon_manager_mod, "_probe_viewer") as probe,
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+            node.assert_called_once()
+            probe.assert_not_called()
+
+    def test_cached_false_returns_immediately_within_ttl(self) -> None:
+        # Seed the cache with a fresh False as if a transient failure occurred.
+        now = 1_000_000.0
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now),
+            patch.object(daemon_manager_mod, "_node_available", return_value=False),
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="free"),
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+
+        # Within TTL, _node_available must NOT be called again — the cached
+        # False is returned directly.
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now + 1.0),
+            patch.object(daemon_manager_mod, "_node_available") as node,
+            patch.object(daemon_manager_mod, "_probe_viewer") as probe,
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+            node.assert_not_called()
+            probe.assert_not_called()
+
+    def test_cached_false_expires_after_ttl_and_recovers(self) -> None:
+        now = 2_000_000.0
+        # Seed cache with a False at t=now.
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now),
+            patch.object(daemon_manager_mod, "_node_available", return_value=False),
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="free"),
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+
+        # After TTL + 1s, Node is now reachable. probe_only=True must
+        # revalidate and switch the cache to True.
+        with (
+            patch.object(
+                daemon_manager_mod.time,
+                "time",
+                return_value=now + daemon_manager_mod.BRIDGE_OK_TTL_SEC + 1.0,
+            ),
+            patch.object(daemon_manager_mod, "_node_available", return_value=True),
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+        # And the value is cached.
+        self.assertTrue(daemon_manager_mod._bridge_ok)
+
+    def test_running_bridge_overrides_failed_node_probe(self) -> None:
+        # A live MemOS bridge is definitive proof Node worked; trust it
+        # even if `_node_available` returns False (e.g. env-var race).
+        now = 3_000_000.0
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now),
+            patch.object(daemon_manager_mod, "_node_available", return_value=False),
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="running_memos"),
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+        self.assertTrue(daemon_manager_mod._bridge_ok)
+        self.assertEqual(daemon_manager_mod._bridge_ok_at, now)
+
+    def test_shutdown_bridge_resets_cache_and_timestamp(self) -> None:
+        now = 4_000_000.0
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now),
+            patch.object(daemon_manager_mod, "_node_available", return_value=True),
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+
+        self.assertIsNotNone(daemon_manager_mod._bridge_ok)
+        self.assertGreater(daemon_manager_mod._bridge_ok_at, 0.0)
+
+        daemon_manager_mod.shutdown_bridge()
+        self.assertIsNone(daemon_manager_mod._bridge_ok)
+        self.assertEqual(daemon_manager_mod._bridge_ok_at, 0.0)
+
+        # After reset, the next probe must call `_node_available` again.
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now + 1.0),
+            patch.object(daemon_manager_mod, "_node_available", return_value=True) as node,
+        ):
+            self.assertTrue(daemon_manager_mod.ensure_bridge_running(probe_only=True))
+            node.assert_called_once()
+
+    def test_full_call_always_revalidates(self) -> None:
+        # `probe_only=False` (called from `MemTensorProvider.initialize`)
+        # must bypass the cache and refresh.
+        now = 5_000_000.0
+        # Pre-seed a stale True.
+        daemon_manager_mod._bridge_ok = True
+        daemon_manager_mod._bridge_ok_at = now - 1.0
+        with (
+            patch.object(daemon_manager_mod.time, "time", return_value=now),
+            patch.object(daemon_manager_mod, "_node_available", return_value=False) as node,
+            patch.object(daemon_manager_mod, "_probe_viewer", return_value="free"),
+        ):
+            self.assertFalse(daemon_manager_mod.ensure_bridge_running())
+            node.assert_called_once()
+        self.assertFalse(daemon_manager_mod._bridge_ok)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Fixes #1797: `_bridge_ok` cache in `apps/memos-local-plugin/adapters/hermes/memos_provider/daemon_manager.py` had no expiry, so a single transient `_node_available()` failure during Hermes gateway startup permanently disabled `MemTensorProvider`. The cache now expires after 60 seconds, and `_node_available()` failures fall through to a `_probe_viewer()` check that accepts an already-running MemOS bridge on :18800 as proof the environment is viable. `shutdown_bridge()` also resets the new `_bridge_ok_at` timestamp.

Added regression tests (`BridgeOkCacheTests`, 6 cases) covering cold-start revalidation, cache-hit short-circuit within TTL, TTL-expiry recovery, running-bridge fallback, shutdown reset, and full-call (non-probe) revalidation. Full plugin python suite green: 48 passed (42 existing + 6 new). Ruff lint and format both clean. Branch `bugfix/autodev-1797` pushed to `origin`; openspec artifacts archived to `memos-autodev-specs`.

Related Issue (Required):  Fixes #1797

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1797
- [ ] Made sure Checks passed
- [ ] Tests have been provided
