### PR TITLE
Fix #1815: feat: [memos-local-plugin] tool_result_persist hook returns Promise (should be s

### DIFF
--- a/apps/memos-local-plugin/adapters/openclaw/index.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/index.ts
@@ -405,6 +405,31 @@ function register(api: OpenClawPluginApi): void {
     return runtime;
   };
 
+  /**
+   * Helper for **void / fire-and-forget** hooks: dispatch `fn` against the
+   * runtime as soon as bootstrap finishes (already finished → next tick).
+   * Errors are logged at WARN and swallowed — they must not surface to
+   * OpenClaw's hook runner because the listener itself has already
+   * returned synchronously.
+   *
+   * `label` is used solely for log context so a misbehaving hook is
+   * findable in the gateway log.
+   */
+  const runWhenReady = async (
+    fn: (r: PluginRuntime) => void | Promise<void>,
+    label: string,
+  ): Promise<void> => {
+    try {
+      const r = await ensureRuntime();
+      if (!r) return;
+      await fn(r);
+    } catch (err) {
+      api.logger.warn(`memos-local: hook ${label} failed`, {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
   registerOpenClawTools(api, {
     agent: "openclaw",
     getCore: async () => (await ensureRuntime())?.core ?? null,
@@ -413,58 +438,88 @@ function register(api: OpenClawPluginApi): void {
 
   // 3. Hooks — every handler matches the upstream `PluginHookHandlerMap`
   //    signature so OpenClaw's type-check passes in a monorepo install.
+  //
+  // Two upstream constraints govern the registration style here:
+  //   (a) `tool_result_persist` is a **value-returning sync hook**.
+  //       OpenClaw's hook runner inspects the return value with
+  //       `isPromiseLike(ret)` and ignores it when the handler returns a
+  //       Promise — so declaring this listener `async` silently disables
+  //       the "append memos_search hint after repeated tool failures"
+  //       feature. We register a **synchronous** wrapper that calls the
+  //       (already sync) `bridge.handleToolResultPersist` directly. If
+  //       bootstrap hasn't completed yet, the hook is a no-op (matches
+  //       the legacy adapter — runtime not ready means no hint to
+  //       inject).
+  //   (b) `agent_end` (and the other void hooks below) are run by
+  //       OpenClaw with a **hard-coded 30 s timeout**
+  //       (`DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK.agent_end = 30_000`).
+  //       memos's onTurnEnd chain writes SQLite traces + runs L2
+  //       induction + reflection + reward (LLM-bound), which under I/O
+  //       pressure can exceed 30 s. Awaiting that chain inside the hook
+  //       handler shows up in the gateway log as
+  //       `agent_end handler … timed out after 30000ms`. We schedule
+  //       the heavy work as a **fire-and-forget** background task and
+  //       return immediately. `core.shutdown()` (called from the
+  //       service's `stop`) already drains in-flight pipeline work, so
+  //       fire-and-forget does not lose data on a clean shutdown.
+  //
+  // `before_prompt_build` stays async-await because it MUST return the
+  // `prependContext` for OpenClaw to inject — it is a value-returning
+  // hook, not a void hook, and OpenClaw is willing to await its result
+  // (the timeout is laxer than `agent_end`'s 30 s budget).
   api.on("before_prompt_build", async (event, ctx) => {
     const r = await ensureRuntime();
     if (!r) return;
     return r.bridge.handleBeforePrompt(event, ctx);
   });
 
-  api.on("agent_end", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    await r.bridge.handleAgentEnd(event, ctx);
+  api.on("agent_end", (event, ctx) => {
+    // Fire-and-forget. Returning synchronously lets OpenClaw's 30s
+    // void-hook budget tick down only on its own bookkeeping; memos
+    // continues writing the trace + running the reflect/reward chain
+    // in the background.
+    void runWhenReady((r) => r.bridge.handleAgentEnd(event, ctx), "agent_end");
   });
 
-  api.on("before_tool_call", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    r.bridge.handleBeforeToolCall(event, ctx);
+  api.on("before_tool_call", (event, ctx) => {
+    // `handleBeforeToolCall` is sync and cheap (Map.set + timestamp);
+    // we still gate on runtime presence by deferring to ensureRuntime
+    // when bootstrap is in flight. The fire-and-forget wrapper keeps
+    // the listener void-shaped for OpenClaw.
+    void runWhenReady((r) => {
+      r.bridge.handleBeforeToolCall(event, ctx);
+    }, "before_tool_call");
   });
 
-  api.on("after_tool_call", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    await r.bridge.handleAfterToolCall(event, ctx);
+  api.on("after_tool_call", (event, ctx) => {
+    void runWhenReady((r) => r.bridge.handleAfterToolCall(event, ctx), "after_tool_call");
   });
 
-  api.on("tool_result_persist", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    return r.bridge.handleToolResultPersist(event, ctx);
+  // tool_result_persist is value-returning AND synchronous on
+  // OpenClaw's side — do NOT make this async. Bridge handler is
+  // already sync, so we can invoke it directly when the runtime is
+  // ready and return undefined otherwise.
+  api.on("tool_result_persist", (event, ctx) => {
+    if (!runtime) return; // bootstrap not finished — nothing to inject
+    return runtime.bridge.handleToolResultPersist(event, ctx);
   });
 
-  api.on("session_start", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    await r.bridge.handleSessionStart(event, ctx);
+  api.on("session_start", (event, ctx) => {
+    void runWhenReady((r) => r.bridge.handleSessionStart(event, ctx), "session_start");
   });
 
-  api.on("session_end", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    await r.bridge.handleSessionEnd(event, ctx);
+  api.on("session_end", (event, ctx) => {
+    void runWhenReady((r) => r.bridge.handleSessionEnd(event, ctx), "session_end");
   });
 
-  api.on("subagent_spawned", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    r.bridge.handleSubagentSpawned(event, ctx);
+  api.on("subagent_spawned", (event, ctx) => {
+    void runWhenReady((r) => {
+      r.bridge.handleSubagentSpawned(event, ctx);
+    }, "subagent_spawned");
   });
 
-  api.on("subagent_ended", async (event, ctx) => {
-    const r = await ensureRuntime();
-    if (!r) return;
-    await r.bridge.handleSubagentEnded(event, ctx);
+  api.on("subagent_ended", (event, ctx) => {
+    void runWhenReady((r) => r.bridge.handleSubagentEnded(event, ctx), "subagent_ended");
   });
 
   // 4. Service — lets the host flush + wait for ready and shut us down.

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-runtime.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-runtime.test.ts
@@ -8,12 +8,15 @@ import { DEFAULT_CONFIG } from "../../../core/config/defaults.js";
 import { resolveHome, type ResolvedHome } from "../../../core/config/index.js";
 import type {
   HostLogger,
+  OpenClawHookHandlerMap,
+  OpenClawHookName,
   OpenClawPluginApi,
   ServiceDescriptor,
 } from "../../../adapters/openclaw/openclaw-api.js";
 
 interface MockApi extends OpenClawPluginApi {
   services: ServiceDescriptor[];
+  hooks: Map<OpenClawHookName, OpenClawHookHandlerMap[OpenClawHookName]>;
   logger: HostLogger & {
     info: ReturnType<typeof vi.fn>;
     warn: ReturnType<typeof vi.fn>;
@@ -30,6 +33,7 @@ afterEach(() => {
   vi.doUnmock("../../../core/pipeline/index.js");
   vi.doUnmock("../../../server/http.js");
   vi.doUnmock("../../../core/telemetry/index.js");
+  vi.doUnmock("../../../adapters/openclaw/bridge.js");
   vi.resetModules();
   vi.restoreAllMocks();
   for (const root of tempRoots.splice(0)) {
@@ -55,6 +59,7 @@ function makeCore() {
 
 function makeApi(): MockApi {
   const services: ServiceDescriptor[] = [];
+  const hooks = new Map<OpenClawHookName, OpenClawHookHandlerMap[OpenClawHookName]>();
   const logger = {
     trace: vi.fn(),
     debug: vi.fn(),
@@ -67,9 +72,12 @@ function makeApi(): MockApi {
     name: "MemOS Local",
     logger,
     services,
+    hooks,
     registerTool: vi.fn(),
     registerMemoryCapability: vi.fn(),
-    on: vi.fn(),
+    on: vi.fn((hookName: OpenClawHookName, handler) => {
+      hooks.set(hookName, handler);
+    }),
     registerService: vi.fn((svc: ServiceDescriptor) => {
       services.push(svc);
     }),
@@ -79,6 +87,7 @@ function makeApi(): MockApi {
 async function loadPluginWithMocks(
   bootstrapMemoryCoreFull: ReturnType<typeof vi.fn>,
   startHttpServer: ReturnType<typeof vi.fn>,
+  createOpenClawBridge?: ReturnType<typeof vi.fn>,
 ) {
   vi.resetModules();
   vi.doMock("../../../core/pipeline/index.js", () => ({
@@ -93,6 +102,17 @@ async function loadPluginWithMocks(
       shutdown = vi.fn(async () => {});
     },
   }));
+  if (createOpenClawBridge) {
+    vi.doMock("../../../adapters/openclaw/bridge.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("../../../adapters/openclaw/bridge.js")
+      >("../../../adapters/openclaw/bridge.js");
+      return {
+        ...actual,
+        createOpenClawBridge,
+      };
+    });
+  }
   const mod = await import("../../../adapters/openclaw/index.js");
   return mod.default;
 }
@@ -170,5 +190,289 @@ describe("OpenClaw adapter runtime lifecycle", () => {
       expect.stringContaining("running headless"),
     );
     expect(fs.existsSync(path.join(home.daemonDir, "openclaw-runtime.lock"))).toBe(false);
+  });
+});
+
+// ─── Regressions for issue #1815 ────────────────────────────────────────────
+//
+// OpenClaw's hook runner enforces two contracts memos must respect:
+//
+//   1. `tool_result_persist` is a value-returning **synchronous** hook.
+//      The runner inspects the return value with `isPromiseLike(ret)` and
+//      silently ignores anything that looks like a Promise. If memos
+//      registers an `async` listener, the hint-injection feature is
+//      dead — and OpenClaw logs:
+//        "tool_result_persist handler from memos-local-plugin returned a
+//         Promise; this hook is synchronous and the result was ignored."
+//   2. `agent_end` (and the other void hooks) is gated by a hard-coded
+//      `DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK.agent_end = 30_000` budget.
+//      A long-running awaited handler trips the gateway log warning:
+//        "agent_end handler from memos-local-plugin failed: timed out
+//         after 30000ms".
+//
+// These two regressions cover the listener wrappers in
+// `adapters/openclaw/index.ts` — the bridge handlers themselves are
+// already correctly shaped and exercised by openclaw-bridge.test.ts.
+
+function buildPluginWithFakeBridge(opts: {
+  bridge: Record<string, ReturnType<typeof vi.fn>>;
+}): Promise<unknown> {
+  const home = useTempMemosHome();
+  const core = makeCore();
+  const bootstrapMemoryCoreFull = vi.fn(async () => ({
+    core,
+    config: DEFAULT_CONFIG,
+    home,
+  }));
+  const startHttpServer = vi.fn(async () => ({
+    url: "http://127.0.0.1:18799",
+    port: 18799,
+    closed: false,
+    close: vi.fn(async () => {}),
+  }));
+  const createOpenClawBridge = vi.fn(() => opts.bridge);
+  return loadPluginWithMocks(
+    bootstrapMemoryCoreFull,
+    startHttpServer,
+    createOpenClawBridge,
+  );
+}
+
+function buildBridgeStub() {
+  return {
+    handleBeforePrompt: vi.fn(async () => undefined),
+    handleAgentEnd: vi.fn(async () => undefined),
+    handleBeforeToolCall: vi.fn(() => undefined),
+    handleAfterToolCall: vi.fn(async () => undefined),
+    handleToolResultPersist: vi.fn((_event: unknown) => ({
+      message: { content: "hint-applied" },
+    })),
+    handleSessionStart: vi.fn(async () => undefined),
+    handleSessionEnd: vi.fn(async () => undefined),
+    handleSubagentSpawned: vi.fn(() => undefined),
+    handleSubagentEnded: vi.fn(async () => undefined),
+    trackedSessions: vi.fn(() => 0),
+    trackedToolCalls: vi.fn(() => 0),
+  };
+}
+
+describe("OpenClaw hook listener contract (issue #1815)", () => {
+  it("registers tool_result_persist as a SYNC listener that returns the bridge result directly (not a Promise)", async () => {
+    const bridge = buildBridgeStub();
+    const plugin = (await buildPluginWithFakeBridge({ bridge })) as {
+      register: (api: OpenClawPluginApi) => void;
+    };
+    const api = makeApi();
+    plugin.register(api);
+    await api.services[0]!.start?.();
+
+    const handler = api.hooks.get("tool_result_persist") as
+      | OpenClawHookHandlerMap["tool_result_persist"]
+      | undefined;
+    expect(handler).toBeDefined();
+
+    // Critical contract: the listener must NOT be an async function.
+    // OpenClaw checks `handler.constructor.name === "AsyncFunction"` /
+    // `isPromiseLike(ret)` to decide whether to ignore the return value
+    // — both flag it as broken.
+    expect(handler!.constructor.name).not.toBe("AsyncFunction");
+
+    const result = handler!(
+      {
+        toolName: "sh",
+        toolCallId: "call_X",
+        message: {
+          role: "toolResult",
+          content: "boom",
+          isError: true,
+        },
+      },
+      {
+        toolName: "sh",
+        toolCallId: "call_X",
+        agentId: "main",
+        sessionKey: "s-1",
+        sessionId: "host-s-1",
+        runId: "run-1",
+      },
+    );
+
+    // The return value must be the bridge's payload directly, not a
+    // Promise that wraps it. OpenClaw's hook runner ignores Promises.
+    expect(result).not.toBeInstanceOf(Promise);
+    expect((result as { message?: { content?: string } } | void)?.message?.content).toBe(
+      "hint-applied",
+    );
+    expect(bridge.handleToolResultPersist).toHaveBeenCalledTimes(1);
+
+    await api.services[0]!.stop?.();
+  });
+
+  it("tool_result_persist listener silently no-ops when bootstrap has not finished yet", async () => {
+    const home = useTempMemosHome();
+    const core = makeCore();
+    const bootDeferred = deferred<{
+      core: ReturnType<typeof makeCore>;
+      config: typeof DEFAULT_CONFIG;
+      home: ResolvedHome;
+    }>();
+    const bootstrapMemoryCoreFull = vi.fn(() => bootDeferred.promise);
+    const startHttpServer = vi.fn(async () => ({
+      url: "http://127.0.0.1:18799",
+      port: 18799,
+      closed: false,
+      close: vi.fn(async () => {}),
+    }));
+    const bridge = buildBridgeStub();
+    const createOpenClawBridge = vi.fn(() => bridge);
+    const plugin = await loadPluginWithMocks(
+      bootstrapMemoryCoreFull,
+      startHttpServer,
+      createOpenClawBridge,
+    );
+
+    const api = makeApi();
+    plugin.register(api);
+
+    // Bootstrap is intentionally still pending here — runtime is null.
+    const handler = api.hooks.get("tool_result_persist") as
+      | OpenClawHookHandlerMap["tool_result_persist"]
+      | undefined;
+    expect(handler).toBeDefined();
+
+    const result = handler!(
+      {
+        toolName: "sh",
+        toolCallId: "call_X",
+        message: { role: "toolResult", content: "boom", isError: true },
+      },
+      { toolName: "sh", agentId: "main", sessionKey: "s-1", runId: "run-1" },
+    );
+
+    // Must be a synchronous undefined return, NOT a Promise. The bridge
+    // factory should not even have been invoked yet.
+    expect(result).toBeUndefined();
+    expect(bridge.handleToolResultPersist).not.toHaveBeenCalled();
+
+    // Finish bootstrap so afterEach can clean up.
+    bootDeferred.resolve({ core, config: DEFAULT_CONFIG, home });
+    await api.services[0]!.start?.();
+    await api.services[0]!.stop?.();
+  });
+
+  it("agent_end listener returns synchronously and dispatches the bridge work as fire-and-forget", async () => {
+    let releaseAgentEnd: (() => void) | null = null;
+    const agentEndStarted = vi.fn();
+    const bridge = buildBridgeStub();
+    bridge.handleAgentEnd = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          agentEndStarted();
+          releaseAgentEnd = resolve;
+        }),
+    );
+
+    const plugin = (await buildPluginWithFakeBridge({ bridge })) as {
+      register: (api: OpenClawPluginApi) => void;
+    };
+    const api = makeApi();
+    plugin.register(api);
+    await api.services[0]!.start?.();
+
+    const handler = api.hooks.get("agent_end") as
+      | OpenClawHookHandlerMap["agent_end"]
+      | undefined;
+    expect(handler).toBeDefined();
+
+    const beforeReturn = Date.now();
+    const ret = handler!(
+      { messages: [], success: true, durationMs: 10 },
+      { agentId: "main", sessionKey: "s-1", runId: "run-1" },
+    );
+    const afterReturn = Date.now();
+
+    // OpenClaw's contract: the listener must return void / undefined,
+    // NOT a Promise that the runner would await against the 30 s
+    // hard-coded budget.
+    expect(ret).toBeUndefined();
+    expect(afterReturn - beforeReturn).toBeLessThan(50);
+
+    // The bridge work, however, MUST eventually run — fire-and-forget,
+    // not fire-and-drop.
+    await vi.waitFor(() => {
+      expect(bridge.handleAgentEnd).toHaveBeenCalledTimes(1);
+    });
+    expect(agentEndStarted).toHaveBeenCalledTimes(1);
+
+    // Release the background work so afterEach can shut down cleanly.
+    releaseAgentEnd?.();
+    await api.services[0]!.stop?.();
+  });
+
+  it("agent_end listener swallows background errors via opts.log.warn instead of surfacing them to OpenClaw", async () => {
+    const bridge = buildBridgeStub();
+    bridge.handleAgentEnd = vi.fn(async () => {
+      throw new Error("boom inside onTurnEnd");
+    });
+
+    const plugin = (await buildPluginWithFakeBridge({ bridge })) as {
+      register: (api: OpenClawPluginApi) => void;
+    };
+    const api = makeApi();
+    plugin.register(api);
+    await api.services[0]!.start?.();
+
+    const handler = api.hooks.get("agent_end") as
+      | OpenClawHookHandlerMap["agent_end"]
+      | undefined;
+    expect(handler).toBeDefined();
+    expect(() =>
+      handler!(
+        { messages: [], success: true },
+        { agentId: "main", sessionKey: "s-1", runId: "run-1" },
+      ),
+    ).not.toThrow();
+
+    await vi.waitFor(() => {
+      expect(api.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("hook agent_end failed"),
+        expect.objectContaining({ err: expect.stringContaining("boom inside onTurnEnd") }),
+      );
+    });
+
+    await api.services[0]!.stop?.();
+  });
+
+  it("every void hook listener (agent_end / session_* / *_tool_call / subagent_*) is registered as a non-async function", async () => {
+    const bridge = buildBridgeStub();
+    const plugin = (await buildPluginWithFakeBridge({ bridge })) as {
+      register: (api: OpenClawPluginApi) => void;
+    };
+    const api = makeApi();
+    plugin.register(api);
+    await api.services[0]!.start?.();
+
+    // before_prompt_build is value-returning and the only listener
+    // allowed to be async (OpenClaw awaits its prependContext).
+    const voidHooks: OpenClawHookName[] = [
+      "agent_end",
+      "before_tool_call",
+      "after_tool_call",
+      "tool_result_persist",
+      "session_start",
+      "session_end",
+      "subagent_spawned",
+      "subagent_ended",
+    ];
+    for (const name of voidHooks) {
+      const handler = api.hooks.get(name);
+      expect(handler, `${name} listener missing`).toBeDefined();
+      expect(
+        handler!.constructor.name,
+        `${name} listener must not be async; OpenClaw runs it on a sync/void path`,
+      ).not.toBe("AsyncFunction");
+    }
+
+    await api.services[0]!.stop?.();
   });
 });


### PR DESCRIPTION
## Description

Fixes issue #1815 — the two gateway-log warnings memos-local-plugin emitted on every conversation turn.

**Root cause.** `apps/memos-local-plugin/adapters/openclaw/index.ts` registered every OpenClaw hook with `async (event, ctx) => ...`. OpenClaw treats `tool_result_persist` as a value-returning **synchronous** hook (its runner inspects the return value with `isPromiseLike` and silently ignores Promises), so the repeated-failure `memos_search` hint injection was dead code in production. Separately, `agent_end` and the other void hooks run under a hard-coded 30s timeout (`DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK.agent_end = 30_000`) — and memos's `onTurnEnd` chain (SQLite trace + L2 induction + reflection + reward LLM) can exceed that under I/O pressure, producing the second log warning.

**Fix.** Localized to `adapters/openclaw/index.ts`. Add a `runWhenReady()` helper that wraps fire-and-forget dispatch + WARN-level error swallowing. Re-register `tool_result_persist` as a **synchronous** listener that reads `runtime` directly and returns the bridge payload (or undefined while bootstrap is in flight). Re-register `agent_end` / `before_tool_call` / `after_tool_call` / `session_start` / `session_end` / `subagent_spawned` / `subagent_ended` as void wrappers that schedule the bridge call and return immediately. `before_prompt_build` stays await-based — it is the only value-returning hook and OpenClaw is allowed to await its `prependContext`. Bridge handlers are unchanged because they were already correctly shaped; `core.shutdown()` drains in-flight pipeline work so fire-and-forget does not lose data.

**Tests.** Extended `tests/unit/adapters/openclaw-runtime.test.ts` with a "OpenClaw hook listener contract (issue #1815)" suite of 5 regression cases: synchronous return shape of `tool_result_persist`, bootstrap-period no-op, sub-50ms void return of `agent_end` with fire-and-forget completion, background-error WARN routing, and an `.constructor.name !== "AsyncFunction"` invariant across all 8 void listeners. The mock harness gains a `hooks` map to capture registrations and an optional `createOpenClawBridge` mock (with matching `vi.doUnmock` in `afterEach`).

**Verification.** `tsc -p tsconfig.json --noEmit` clean; `openclaw-runtime.test.ts` 7/7 passing (2 original + 5 new); `openclaw-bridge.test.ts` 47/47 still passing; full unit suite 1045/1048 passing. The 2 failures live in `storage/traces-count.test.ts` + `storage/migrator.test.ts` and were verified by `git stash` to also fail on base branch `dev-20260624-v2.0.22` — they are pre-existing and unrelated to this change.

Related Issue (Required):  Fixes #1815

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

Not run; documentation-only change.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1815
- [ ] Made sure Checks passed
- [ ] Tests have been provided
