### PR TITLE
Fix #2008: fix: ci test failed

### DIFF
--- a/src/memos/utils.py
+++ b/src/memos/utils.py
@@ -179,6 +179,11 @@ def timed_with_status(
                 if fallback is not None and callable(fallback):
                     result = fallback(e, *args, **kwargs)
                     return result
+                # No fallback: re-raise so callers see the real error instead
+                # of a silent None return. The `finally` block still runs and
+                # emits the [TIMER_WITH_STATUS] FAILED log line before the
+                # exception propagates.
+                raise
             finally:
                 elapsed_ms = (time.perf_counter() - start) * 1000.0
 

--- a/tests/graph_dbs/test_neo4j_vector_search.py
+++ b/tests/graph_dbs/test_neo4j_vector_search.py
@@ -248,10 +248,14 @@ class TestSourcesKeyErrorRegression:
 # ──────────────────────────────────────────────────────────────────────────────
 # Integration tests (require a running Neo4j 5.18+ with vector index)
 #
-# Activate by setting environment variables:
-#   NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+# Opt in explicitly by setting `NEO4J_INTEGRATION_TESTS=1` **and** providing
+# `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`. The explicit opt-in flag is
+# required so that unit runs do not fail with `neo4j.exceptions.ServiceUnavailable`
+# just because those connection variables happen to be present in the shell
+# (e.g. from a nearby production config).
 #
-# Run:
+# To run: set NEO4J_INTEGRATION_TESTS=1 together with NEO4J_URI / NEO4J_USER /
+# NEO4J_PASSWORD, then invoke
 #   pytest tests/graph_dbs/test_neo4j_vector_search.py -k Integration -v
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -265,8 +269,19 @@ def _neo4j_package_available():
         return False
 
 
-_neo4j_configured = _neo4j_package_available() and all(
-    os.getenv(k) for k in ("NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD")
+def _neo4j_integration_opt_in() -> bool:
+    """Explicit opt-in flag for the Neo4j integration test class.
+
+    Truthy values: '1', 'true', 'yes', 'on' (case-insensitive).
+    """
+    flag = os.getenv("NEO4J_INTEGRATION_TESTS", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+_neo4j_configured = (
+    _neo4j_package_available()
+    and _neo4j_integration_opt_in()
+    and all(os.getenv(k) for k in ("NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD"))
 )
 _TEST_RUN_ID = uuid.uuid4().hex[:8]
 _TARGET_USER = f"__test_target_{_TEST_RUN_ID}"
@@ -295,7 +310,10 @@ def _make_unit_vector(
 @pytest.fixture(scope="module")
 def integration_config():
     if not _neo4j_configured:
-        pytest.skip("Neo4j not configured (need NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD)")
+        pytest.skip(
+            "Neo4j integration tests not enabled "
+            "(need NEO4J_INTEGRATION_TESTS=1 plus NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD)"
+        )
     return Neo4jGraphDBConfig(
         uri=os.getenv("NEO4J_URI"),
         user=os.getenv("NEO4J_USER"),
@@ -315,7 +333,7 @@ def integration_db(integration_config):
     return Neo4jGraphDB(integration_config)
 
 
-@pytest.mark.skipif(not _neo4j_configured, reason="Neo4j not configured")
+@pytest.mark.skipif(not _neo4j_configured, reason="Neo4j integration tests not enabled")
 class TestNeo4jPreFilterIntegration:
     """
     Integration test: pre-filtered vector search in a multi-user shared database.

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -313,11 +313,14 @@ class TestTimedWithStatusRegression:
         assert "ok_func" in logs[0]
 
     def test_failure_logging_no_fallback(self, caplog):
+        """When no fallback is configured, timed_with_status logs FAILED
+        and re-raises the original exception (does not swallow silently)."""
+
         @timed_with_status
         def fail_func():
             raise RuntimeError("bad")
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.INFO), pytest.raises(RuntimeError, match="bad"):
             fail_func()
         logs = _collect_timer_with_status_logs(caplog)
         assert len(logs) == 1


### PR DESCRIPTION
## Description

Fixes the two CI failures reported in issue #2008.

**1. `timed_with_status` re-raises on failure (no fallback)** — `src/memos/utils.py::timed_with_status` used to catch every exception and, when no `fallback=` was configured, silently return `None`. That masked real errors from callers like `OpenAILLM.generate` and `UniversalAPIEmbedder.embed` which internally `raise` expecting propagation. The decorator now re-raises after logging the `[TIMER_WITH_STATUS] status: FAILED` line whenever no fallback is set; callers that pass a `fallback=` behave exactly as before. `tests/test_utils_timing.py::TestTimedWithStatusRegression::test_failure_logging_no_fallback` was updated to wrap the call in `pytest.raises(RuntimeError, match="bad")` while still asserting the FAILED log line is emitted.

**2. Neo4j integration tests now require explicit opt-in** — `tests/graph_dbs/test_neo4j_vector_search.py::TestNeo4jPreFilterIntegration` used to activate whenever `NEO4J_URI` / `NEO4J_USER` / `NEO4J_PASSWORD` were present in the environment, which turned unrelated shell config into a `neo4j.exceptions.ServiceUnavailable` failure. The class-level gate now additionally requires `NEO4J_INTEGRATION_TESTS=1` (accepts `1`/`true`/`yes`/`on`). The skip reason and header docs are updated to reflect the new invocation.

**Test evidence**: `pytest tests/test_utils_timing.py` → 31 passed. `NEO4J_URI=bolt://192.0.2.1:7687 NEO4J_USER=neo4j NEO4J_PASSWORD=fake pytest tests/graph_dbs/test_neo4j_vector_search.py` (the exact issue-reported scenario) → 9 passed, 3 skipped; before the fix this would have raised `ServiceUnavailable`. Broader sanity run across `tests/test_utils_timing.py tests/graph_dbs/ tests/embedders/ tests/llms/ tests/reranker/` → 111 passed, 3 skipped. `ruff check` and `ruff format` both clean on the three touched files. Other unrelated failures under `tests/api/`, `tests/parsers/`, `tests/vec_dbs/` are pre-existing missing-plugin / missing-module issues that reproduce identically on the untouched base branch.

**Files touched**: `src/memos/utils.py`, `tests/test_utils_timing.py`, `tests/graph_dbs/test_neo4j_vector_search.py` (3 files, +34 / -8). `.ai-tasks/` and `openspec/changes/` are gitignored per project rules and did not enter the PR; task file + verification report have been archived to the sibling memos-autodev-specs repo.

Related Issue (Required):  Fixes #2008

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #2008
- [ ] Made sure Checks passed
- [ ] Tests have been provided
