### PR TITLE
fix: tighten skill generation policy prompts

### DIFF
--- a/apps/memos-local-openclaw/src/skill/evaluator.ts
+++ b/apps/memos-local-openclaw/src/skill/evaluator.ts
@@ -19,7 +19,7 @@ export interface UpgradeEvalResult {
   confidence: number;
 }
 
-const CREATE_EVAL_PROMPT = `You are a strict experience evaluation expert. Based on the completed task record below, decide whether this task contains **reusable, transferable** experience worth distilling into a "skill".
+export const CREATE_EVAL_PROMPT = `You are a strict experience evaluation expert. Based on the completed task record below, decide whether this task contains **reusable, transferable** experience worth distilling into a "skill".
 
 A skill is a reusable guide that helps an AI agent handle **the same type of task** better in the future. The key question is: "Will someone likely need to do this exact type of thing again?"
 
@@ -47,6 +47,13 @@ NOT worth distilling (if ANY matches, return shouldGenerate=false):
 - Organizing/listing personal information (work history, resume, contacts)
 - Generic product/system overviews without specific operational steps
 - Tasks where the "steps" are just the AI answering questions (no real workflow)
+- Simple tool installation plus basic preference/config setup that an experienced developer would already know how to do
+- Exploratory tasks where the final conclusion was to revert, abandon, or keep the original approach without a reusable diagnostic method
+- Tasks whose primary output is discussion, comparison, or evaluation rather than an actionable workflow that can be repeated
+
+Before deciding shouldGenerate=true, ask yourself:
+"If an experienced developer encounters this type of problem, would they already know how to handle it without this skill?"
+If yes, return shouldGenerate=false.
 
 Task title: {TITLE}
 Task summary:

--- a/apps/memos-local-openclaw/src/skill/generator.ts
+++ b/apps/memos-local-openclaw/src/skill/generator.ts
@@ -18,7 +18,7 @@ import { buildSkillConfigChain, callLLMWithFallback } from "../shared/llm-call";
 //   - Imperative form, keep it concise
 //   - Generalize from the specific task, don't over-fit
 
-const STEP1_SKILL_MD_PROMPT = `You are a Skill creation expert. Your job is to distill a completed task's execution record into a reusable SKILL.md file.
+export const STEP1_SKILL_MD_PROMPT = `You are a Skill creation expert. Your job is to distill a completed task's execution record into a reusable SKILL.md file.
 
 This Skill is special: it comes from real execution experience — every step was actually run, every pitfall was actually encountered and resolved.
 
@@ -41,6 +41,9 @@ The description field decides whether the agent activates this skill. Write it "
 - Explain WHY for each step, not just HOW — today's LLMs respond better to reasoning than rigid rules
 - Seeing yourself write ALWAYS or NEVER in caps is a yellow flag — rephrase with reasoning instead
 - Generalize from the specific task so the skill works for similar future scenarios, don't over-fit to this exact project
+- Pattern over procedure: make the core steps reusable patterns, and demote project-specific file names, feature names, versions, and implementation details to examples unless they are required prerequisites
+- Abstract the mistake, not just the fix: capture the diagnostic method that found the problem, not only the specific error message or patch from this task
+- Do not make a specific project name, product version, branch, or one-off rollback decision a required part of the skill unless the future task truly depends on it
 - Keep real commands/code/config from the task record — these are verified to work
 
 ### Language matching (CRITICAL)

--- a/apps/memos-local-openclaw/tests/skill-prompt-policy.test.ts
+++ b/apps/memos-local-openclaw/tests/skill-prompt-policy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { CREATE_EVAL_PROMPT } from "../src/skill/evaluator";
+import { STEP1_SKILL_MD_PROMPT } from "../src/skill/generator";
+
+describe("skill prompt policy", () => {
+  it("filters low-reuse tasks before generating skills", () => {
+    expect(CREATE_EVAL_PROMPT).toContain("Simple tool installation plus basic");
+    expect(CREATE_EVAL_PROMPT).toContain("revert, abandon, or keep the original approach");
+    expect(CREATE_EVAL_PROMPT).toContain("discussion, comparison, or evaluation");
+    expect(CREATE_EVAL_PROMPT).toContain(
+      "would they already know how to handle it without this skill?",
+    );
+  });
+
+  it("asks the generator to abstract reusable patterns", () => {
+    expect(STEP1_SKILL_MD_PROMPT).toContain("Pattern over procedure");
+    expect(STEP1_SKILL_MD_PROMPT).toContain("Abstract the mistake");
+    expect(STEP1_SKILL_MD_PROMPT).toContain("project name, product version");
+  });
+});


### PR DESCRIPTION
Fixes #1380.

Summary
- Tighten the skill creation evaluator prompt so low-reuse tasks are rejected before skill generation.
- Add explicit filters for simple tool installation plus basic config, exploratory revert/abandon outcomes, and discussion/comparison-only outputs.
- Add the requested experienced-developer self-check before returning shouldGenerate=true.
- Reinforce generator guidance to prefer reusable patterns, abstract diagnostic mistakes, and keep project/version-specific details as examples unless required.
- Add a prompt-policy regression test for the new evaluator and generator guidance.

Validation
- Direct Node prompt-policy string check passed.
- Attempted: npm test -- --run tests/skill-prompt-policy.test.ts; blocked because vitest is not installed in this worktree.
- Attempted: npm run build; blocked because tsc is not installed in this worktree.
- Attempted: make format; blocked because poetry is not installed in this environment.