### PR TITLE
fix: Tighten preference memory prompt to avoid over-extractions.

### DIFF
--- a/src/memos/templates/prefer_complete_prompt.py
+++ b/src/memos/templates/prefer_complete_prompt.py
@@ -3,14 +3,16 @@ You are a preference extraction assistant.
 Please extract the user's explicitly mentioned preferences from the following conversation.
 
 Notes:
-- A preference means the user's explicit attitude or choice toward something. It is not limited to words like "like/dislike/want/don't want/prefer".
-- This includes, but is not limited to, any user's explicitly expressed inclination, desire, rejection, or priority that counts as an explicit preference.
-- Focus on extracting the user's preferences in query. Do not extract preferences from the assistant's responses unless the user explicitly agrees with or endorses the assistant's suggestions.
+- A preference means the user's own explicit, relatively stable, and reusable attitude, choice, constraint, or habit. It should be useful for future interactions, recommendations, or personalization.
+- A single user statement can be enough for an explicit preference when the user clearly states a personal preference or a future handling rule; repeated behavior is not required for explicit preferences.
+- Words like "like/dislike/want/don't want/prefer" are helpful signals, but a current task request, information-seeking question, temporary state, or safety/factual concern is not a preference by itself.
+- Expressions scoped to the current moment or task, such as "now", "today", "this time", "this document", "this task", or "current", are scope cues rather than automatic exclusions. Treat them as one-off needs unless the user also states a reusable personal preference or a future handling rule, such as "from now on", "in the future", "every time", "always", or "use this going forward".
+- Focus on preferences stated by the user. Do not turn assistant advice, search suggestions, safety guidance, factual explanations, or answer content into user preferences unless the user explicitly endorses them as their own reusable choice.
 - When the user modifies or updates their preferences for the same topic or event, extract the complete evolution process of their preference changes, including both the original and updated preferences.
 
 Requirements:
-1. Keep only the preferences explicitly mentioned by the user. Do not infer or assume. If the user mentions reasons for their preferences, include those reasons as well.
-2. Output should be a list of entries concise natural language summaries and the corresponding context summary, context summary must contain complete information of the conversation fragment that the preference is mentioned.
+1. Keep only the preferences explicitly mentioned by the user and reasonably reusable beyond the current turn. Do not infer or assume. If the user mentions reasons for their preferences, include those reasons as well.
+2. Output should be a list of concise natural language summaries and the corresponding context summary. The context summary should preserve the evidence for the user's preference, without rewriting assistant-only content as if it were the user's preference.
 3. If multiple preferences are mentioned within the same topic or domain, you MUST combine them into a single entry, keep each entry information complete. Different topics of preferences should be divided into multiple entries.
 4. If no explicit preference can be reasonably extracted, return [].
 
@@ -36,14 +38,16 @@ NAIVE_EXPLICIT_PREFERENCE_EXTRACT_PROMPT_ZH = """
 请从以下对话中提取用户明确提及的偏好。
 
 注意事项：
-- 偏好是指用户对某事物的明确态度或选择，不仅限于"喜欢/不喜欢/想要/不想要/偏好"等词汇。
-- 包括但不限于用户明确表达的任何倾向、渴望、拒绝或优先级，这些都算作显式偏好。
-- 重点提取用户在查询中的偏好。不要从助手的回复中提取偏好，除非用户明确同意或认可助手的建议。
+- 偏好是指用户自身明确表达的、相对稳定且可复用的态度、选择、约束或习惯，通常能用于后续交互、推荐或个性化服务。
+- 对于显式偏好，只要用户单次清楚表达了个人偏好或后续处理规则，就可以提取；显式偏好不要求出现重复行为。
+- "喜欢/不喜欢/想要/不想要/偏好"等词汇是重要信号，但当前任务请求、信息查询、临时状态、安全或事实性疑问本身并不等同于偏好。
+- 带有“现在、今天、这次、这份、本次、当前”等当前时间或任务范围限定的表达，是范围线索而不是自动排除条件。除非用户同时表达了可复用的个人偏好或后续处理规则，如“以后、长期、每次、都按这个、今后”等，否则将其视为一次性需求。
+- 重点提取用户自己陈述的偏好。不要把助手建议、检索建议、安全提醒、事实解释或回答内容转写成用户偏好，除非用户明确认可其为自己的可复用选择。
 - 当用户针对同一主题或事件修改或更新其偏好时，提取其偏好变化的完整演变过程，包括原始偏好和更新后的偏好。
 
 要求：
-1. 只保留用户明确提到的偏好，不要推断或假设。如果用户提到了偏好的原因，也要包含这些原因。
-2. 输出应该是一个条目列表，包含简洁的自然语言摘要和相应的上下文摘要，上下文摘要必须包含提到偏好的对话片段的完整信息。
+1. 只保留用户明确提到且可合理复用于当前轮次之外的偏好，不要推断或假设。如果用户提到了偏好的原因，也要包含这些原因。
+2. 输出应该是一个条目列表，包含简洁的自然语言摘要和相应的上下文摘要。上下文摘要应保留用户偏好的证据，不要把仅来自助手的内容改写成用户偏好。
 3. 如果在同一主题或领域内提到了多个偏好，你必须将它们合并为一个条目，保持每个条目信息完整。不同话题的偏好要分为多个条目。
 4. 如果没有可以合理提取的显式偏好，返回[]。
 
@@ -66,10 +70,13 @@ NAIVE_EXPLICIT_PREFERENCE_EXTRACT_PROMPT_ZH = """
 
 NAIVE_IMPLICIT_PREFERENCE_EXTRACT_PROMPT = """
 You are a preference inference assistant. Please extract **implicit preferences** from the following conversation
-(preferences that the user did not explicitly state but can be reasonably inferred from their underlying motivations, behavioral patterns, decision-making logic, and latent needs).
+(stable user preferences that were not directly stated, but are strongly supported by the user's own repeated behavior, decisions, or explicit acceptance across the conversation).
 
 Notes:
-- For Assistant's responses or suggestions, they can only be extracted as the user's implicit preferences if there is evidence in subsequent conversation that the user implicitly accepted them (e.g., adoption, agreement, acting on the suggestion, etc.). Assistant suggestions alone do not constitute user preferences.
+- Implicit preferences are rare. They should describe the user's reusable personal tendency, constraint, or choice, not the assistant's recommendation or a temporary task need.
+- Expressions limited to the current moment or task, such as "now", "today", "this time", "this document", "this task", or "current", are weak evidence for implicit preferences. Treat them as one-off needs unless there is additional user-side evidence of a recurring and reusable pattern.
+- For Assistant's responses or suggestions, they can only be extracted as the user's implicit preferences if the user later provides clear positive evidence, such as adoption, agreement, or action based on the suggestion. Silence, no objection, no follow-up challenge, or simply continuing the conversation is not acceptance.
+- Do not infer implicit preferences from assistant-only safety warnings, factual explanations, tool/search suggestions, or general advice. These may be useful facts, but they are not user preferences without user-side evidence.
 - For conversations with only one question-answer turn (single Q&A), implicit preferences cannot be extracted due to insufficient context and behavioral patterns. Implicit preferences require observation of recurring patterns or subsequent behaviors across multiple conversation turns.
 
 Counter-examples:
@@ -92,18 +99,17 @@ Analysis: This is just a single simple Q&A exchange. The user provided no furthe
 Result: Cannot extract implicit preference
 
 - Implicit preferences refer to user inclinations or choices that are not directly expressed, but can be deeply inferred by analyzing:
-  * **Hidden motivations**: What underlying needs or goals might drive the user's behavior?
-  * **Behavioral patterns**: What recurring patterns or tendencies can be observed?
-  * **Decision-making logic**: What reasoning or trade-offs might the user be considering?
-  * **Latent preferences**: What preferences might the user have but haven't yet articulated?
-  * **Contextual signals**: What do the user's choices, comparisons, exclusions, or scenario selections reveal about their deeper preferences?
+  * **User-side behavior**: What did the user repeatedly choose, accept, reject, or act on?
+  * **Behavioral patterns**: What recurring patterns or tendencies are observable across turns?
+  * **Decision-making logic**: What stable trade-offs did the user demonstrate through their own choices?
+  * **Contextual signals**: What do the user's comparisons, exclusions, or scenario selections reveal about their reusable preferences?
 - Do not treat explicitly stated preferences as implicit preferences; this prompt is only for inferring preferences that are not directly mentioned.
-- Go beyond surface-level facts to understand the user's hidden possibilities and underlying logic.
+- Stay conservative. If the evidence could also be explained as a one-time request, temporary condition, factual question, safety concern, or assistant suggestion, return [].
 
 Requirements:
-1. Only make inferences when there is sufficient evidence in the conversation; avoid unsupported or far-fetched guesses.
+1. Only make inferences when there is sufficient user-side evidence in the conversation; avoid unsupported or far-fetched guesses.
 2. Inferred implicit preferences must not conflict with explicit preferences.
-3. For implicit_preference: only output the preference statement itself; do not include any extra explanation, reasoning, or confidence information. Put all reasoning and explanation in the reasoning field.
+3. For implicit_preference: only output the preference statement itself; do not include assistant advice, facts, or one-off task instructions. Put all reasoning and evidence in the reasoning field.
 4. In the reasoning field, explicitly explain the underlying logic and hidden motivations you identified.
 5. Different topics of preferences should be divided into multiple entries.
 6. If no implicit preference can be reasonably inferred, return [].
@@ -128,10 +134,13 @@ Don't output anything except the JSON.
 
 NAIVE_IMPLICIT_PREFERENCE_EXTRACT_PROMPT_ZH = """
 你是一个偏好推理助手。请从以下对话中提取**隐式偏好**
-（用户没有明确表述，但可以通过分析其潜在动机、行为模式、决策逻辑和隐藏需求深度推断出的偏好）。
+（用户没有直接表述，但能由用户自己的重复行为、选择、决策或明确接受强力支持的稳定偏好）。
 
 注意事项：
-- 对于Assistant的回答内容或建议，只有在后续对话中用户表现出隐含接受（如采纳、认同、按建议行动等）的情况下，才能将相关内容提取为用户的隐式偏好。单纯的Assistant建议本身不构成用户偏好。
+- 隐式偏好应谨慎提取。它应描述用户可复用的个人倾向、约束或选择，而不是助手的建议或一次性的任务需求。
+- “现在、今天、这次、这份、本次、当前”等限定在当前轮次或当前任务的表达，对隐式偏好来说只是弱证据。除非还有额外用户侧证据显示重复、稳定、可复用的模式，否则视为一次性需求。
+- 对于Assistant的回答内容或建议，只有在后续对话中用户提供明确的正向证据（如采纳、认同、按建议行动等）时，才能将相关内容提取为用户的隐式偏好。沉默、未反驳、未追问、继续对话本身都不代表接受。
+- 不要从仅由助手给出的安全提醒、事实解释、工具/检索建议或一般建议中推断隐式偏好。这些内容可以是有用事实，但没有用户侧证据时不是用户偏好。
 - 对于只有一轮问答（一问一答）的对话，由于缺乏足够的上下文和行为模式，不能提取隐式偏好。隐式偏好需要从多轮对话中观察到的重复模式或后续行为来推断。
 
 反例示例：
@@ -154,18 +163,17 @@ Assistant: 《沙丘2》口碑不错，是科幻史诗类型的。
 结果：无法提取隐式偏好
 
 - 隐式偏好是指用户未直接表达，但可以通过深入分析以下方面推断出的倾向或选择：
-  * **隐藏动机**：什么样的潜在需求或目标可能驱动用户的行为？
-  * **行为模式**：可以观察到什么样的重复模式或倾向？
-  * **决策逻辑**：用户可能在考虑什么样的推理或权衡？
-  * **潜在偏好**：用户可能有但尚未明确表达的偏好是什么？
-  * **情境信号**：用户的选择、比较、排除或场景选择揭示了什么样的深层偏好？
+  * **用户侧行为**：用户反复选择、接受、拒绝或实际采纳了什么？
+  * **行为模式**：多轮对话中可以观察到什么样的重复模式或倾向？
+  * **决策逻辑**：用户通过自己的选择体现了什么稳定的权衡？
+  * **情境信号**：用户自己的比较、排除或场景选择揭示了什么可复用偏好？
 - 不要将明确陈述的偏好视为隐式偏好；此提示仅用于推断未直接提及的偏好。
-- 超越表面事实，理解用户的隐藏可能性和背后的逻辑。
+- 保持保守。如果证据也可以解释为一次性请求、临时状态、事实问题、安全疑问或助手建议，返回[]。
 
 要求：
-1. 仅在对话中有充分证据时进行推断；避免无根据或牵强的猜测。
+1. 仅在对话中有充分的用户侧证据时进行推断；避免无根据或牵强的猜测。
 2. 推断的隐式偏好不得与显式偏好冲突。
-3. 对于 implicit_preference：仅输出偏好陈述本身；不要包含任何额外的解释、推理或置信度信息。将所有推理和解释放在 reasoning 字段中。
+3. 对于 implicit_preference：仅输出偏好陈述本身；不要包含助手建议、事实信息或一次性任务指令。将所有推理和证据放在 reasoning 字段中。
 4. 在 reasoning 字段中，明确解释你识别出的底层逻辑和隐藏动机。
 5. 如果在同一主题或领域内提到了多个偏好，你必须将它们合并为一个条目，保持每个条目信息完整。不同话题的偏好要分为多个条目。
 6. 如果没有可以合理推断的隐式偏好，返回[]。


### PR DESCRIPTION
## Description

fix: Tighten preference memory prompt to avoid over-extractions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test - tests/memories/textual/test_tree_searcher.py & tests/api/test_search_pipeline_hooks.py

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided