### PR TITLE
Fix #1722: fix: memory_search returned error

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -1280,7 +1280,7 @@ class MemTensorProvider(MemoryProvider):
                 }
                 if bool(args.get("sessionScope", False)):
                     params["sessionId"] = self._session_id
-                resp = self._bridge.request(
+                resp = self._bridge_request_with_retry(
                     "memory.search",
                     params,
                 )
@@ -1298,7 +1298,7 @@ class MemTensorProvider(MemoryProvider):
                 method = methods.get(kind)
                 if method is None:
                     return json.dumps({"error": f"unknown memory kind: {kind}"})
-                item = self._bridge.request(
+                item = self._bridge_request_with_retry(
                     method, {"id": item_id, "namespace": self._runtime_namespace()}
                 )
                 if not item:
@@ -1343,7 +1343,7 @@ class MemTensorProvider(MemoryProvider):
                     }
                 )
             if tool_name == "memos_timeline":
-                resp = self._bridge.request(
+                resp = self._bridge_request_with_retry(
                     "memory.timeline",
                     {
                         "episodeId": args.get("episodeId", self._episode_id),
@@ -1358,12 +1358,12 @@ class MemTensorProvider(MemoryProvider):
                 params = {"limit": limit, "namespace": self._runtime_namespace()}
                 if args.get("status"):
                     params["status"] = args["status"]
-                return json.dumps(self._bridge.request("skill.list", params))
+                return json.dumps(self._bridge_request_with_retry("skill.list", params))
             if tool_name == "memos_environment":
                 query = (args.get("query") or "").strip()
                 limit = self._int_arg(args, "limit", 5, 1, 30)
                 if not query:
-                    resp = self._bridge.request(
+                    resp = self._bridge_request_with_retry(
                         "memory.list_world_models",
                         {"limit": limit, "offset": 0, "namespace": self._runtime_namespace()},
                     )
@@ -1379,7 +1379,7 @@ class MemTensorProvider(MemoryProvider):
                             "queried": False,
                         }
                     )
-                resp = self._bridge.request(
+                resp = self._bridge_request_with_retry(
                     "memory.search",
                     {
                         "agent": "hermes",
@@ -1412,7 +1412,7 @@ class MemTensorProvider(MemoryProvider):
                 skill_id = (args.get("id") or "").strip()
                 if not skill_id:
                     return json.dumps({"error": "missing id"})
-                skill = self._bridge.request(
+                skill = self._bridge_request_with_retry(
                     "skill.get",
                     {
                         "id": skill_id,
@@ -1724,6 +1724,40 @@ class MemTensorProvider(MemoryProvider):
         msg = str(err).lower()
         return "broken pipe" in msg or "bridge closed" in msg or "transport_closed" in msg
 
+    def _should_reconnect_after_keepalive_failure(self, err: Exception) -> bool:
+        """Return True when a keepalive-detected failure should trigger reconnect.
+
+        Reconnect when any of the following holds — a superset of the
+        original "transport_closed only" gate:
+
+        1. ``transport_closed`` (existing behaviour: broken pipe /
+           subprocess close observed by the reader thread).
+        2. ``BridgeError("timeout", …)`` — the exact code raised when
+           the bridge stops answering. This is the primary #1722 signal:
+           the subprocess is alive but hung, so every 5 s keepalive
+           health-check times out and we would otherwise never recover.
+        3. The subprocess is dead: ``self._bridge._proc.poll()`` is
+           non-``None`` even if the error itself is generic (defends
+           against edge cases where a crash surfaces as a shape-parse
+           exception rather than a transport signal).
+        """
+        if self._is_transport_closed(err):
+            return True
+        if isinstance(err, BridgeError) and err.code == "timeout":
+            return True
+        bridge = self._bridge
+        if bridge is not None:
+            proc = getattr(bridge, "_proc", None)
+            try:
+                if proc is not None and proc.poll() is not None:
+                    return True
+            except Exception:
+                # Defensive: if poll() itself raises, do NOT reconnect —
+                # we cannot prove the subprocess is dead and reconnecting
+                # on every ambiguous error would create a storm.
+                return False
+        return False
+
     def _reconnect_bridge(self, session_id: str = "", *, timeout: float = 30.0) -> None:
         # Don't reconnect if we're shutting down
         if self._bridge_keepalive_stop.is_set():
@@ -1785,6 +1819,48 @@ class MemTensorProvider(MemoryProvider):
             self._bridge = None
             return False
 
+    def _bridge_request_with_retry(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Issue a bridge request, reconnecting + retrying once on stale pipe.
+
+        Mirrors the write-path pattern already used by :meth:`sync_turn`.
+        Read-path memory tools (``memos_search``, ``memos_get``,
+        ``memos_timeline``, ``memos_environment``, ``memos_skill_list``,
+        ``memos_skill_get``) route through here so a hung / dead bridge
+        no longer surfaces a bare ``transport_closed`` on the *first*
+        user call after the keepalive tears it down.
+
+        Only ``transport_closed`` is retried — every other error
+        (``timeout``, ``internal``, …) is surfaced verbatim so callers
+        can decide how to react. Only a single retry is attempted; a
+        second failure raises so the tool response contains the error
+        text unchanged.
+        """
+        if self._bridge is None:
+            raise BridgeError("transport_closed", "bridge client is closed")
+        kwargs: dict[str, Any] = {}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        try:
+            return self._bridge.request(method, params, **kwargs) or {}
+        except BridgeError as err:
+            if not self._is_transport_closed(err):
+                raise
+            logger.warning(
+                "MemOS: bridge transport closed during %s; reconnecting and retrying once — %s",
+                method,
+                err,
+            )
+            self._reconnect_bridge(self._session_id, timeout=30.0)
+            if self._bridge is None:
+                raise
+            return self._bridge.request(method, params, **kwargs) or {}
+
     def _start_bridge_keepalive(self) -> None:
         if self._bridge_keepalive_thread and self._bridge_keepalive_thread.is_alive():
             return
@@ -1798,8 +1874,12 @@ class MemTensorProvider(MemoryProvider):
                     assert self._bridge is not None
                     self._bridge.request("core.health", {}, timeout=10.0)
                 except Exception as err:
-                    if self._is_transport_closed(err):
-                        logger.info("MemOS: bridge keepalive reconnecting after transport close")
+                    if self._should_reconnect_after_keepalive_failure(err):
+                        logger.info(
+                            "MemOS: bridge keepalive reconnecting — %s: %s",
+                            err.__class__.__name__,
+                            err,
+                        )
                         with contextlib.suppress(Exception):
                             self._reconnect_bridge(self._session_id, timeout=10.0)
                     else:

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -172,6 +172,18 @@ class MemosBridgeClient:
     ) -> dict[str, Any]:
         if self._closed:
             raise BridgeError("transport_closed", "bridge client is closed")
+        # Fast-fail path: if the subprocess is already gone, stdin.write
+        # would still succeed thanks to OS pipe buffering, and the
+        # caller would then park on ``waiter.wait(timeout)`` for the
+        # full 30 s before failing. Detecting the exit here surfaces
+        # the correct code (``transport_closed``) immediately, which
+        # ``_bridge_request_with_retry`` uses to trigger recovery.
+        exit_code = self._proc.poll()
+        if exit_code is not None:
+            raise BridgeError(
+                "transport_closed",
+                f"bridge subprocess exited (code={exit_code})",
+            )
         with self._lock:
             rpc_id = self._next_id
             self._next_id += 1
@@ -274,87 +286,117 @@ class MemosBridgeClient:
                 except subprocess.TimeoutExpired:
                     logger.error("MemOS: bridge process %d could not be killed", pid)
 
-        # 5. Clean up pending requests
-        with self._lock:
-            for entry in list(self._pending.values()):
-                entry["error"] = {
-                    "code": -32000,
-                    "message": "bridge closed",
-                    "data": {"code": "transport_closed"},
-                }
-                entry["event"].set()
-            self._pending.clear()
+        # 5. Clean up pending requests. Shares the abort path with the
+        # reader thread so any callers still parked on a waiter are
+        # released with ``transport_closed`` from a single code path.
+        self._abort_pending("bridge closed")
 
     # ─── Internals ──
 
     def _read_loop(self) -> None:
         assert self._proc.stdout is not None
-        for line in self._proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                msg = json.loads(line)
-            except json.JSONDecodeError:
-                logger.debug("bridge: malformed line: %r", line[:120])
-                continue
-            if "id" in msg and msg["id"] is not None and ("result" in msg or "error" in msg):
-                self._resolve(msg)
-                continue
-            if msg.get("method") == "events.notify":
-                for cb in list(self._events):
-                    try:
-                        cb(msg.get("params") or {})
-                    except Exception:
-                        logger.debug("event listener threw", exc_info=True)
-                continue
-            if msg.get("method") == "logs.forward":
-                for cb in list(self._logs):
-                    try:
-                        cb(msg.get("params") or {})
-                    except Exception:
-                        logger.debug("log listener threw", exc_info=True)
-                continue
-            # Reverse-direction request: the bridge is asking the
-            # adapter to do something (e.g. run a fallback LLM call
-            # via `host.llm.complete`). Dispatch to the registered
-            # handler and write the response back synchronously.
-            method = msg.get("method")
-            rpc_id = msg.get("id")
-            if (
-                isinstance(method, str)
-                and rpc_id is not None
-                and "result" not in msg
-                and "error" not in msg
-            ):
-                handler = self._host_handler_for(method)
-                if handler is None:
-                    self._send_response(
-                        rpc_id,
-                        error={
-                            "code": -32601,
-                            "message": f"method not found: {method}",
-                            "data": {"code": "unknown_method"},
-                        },
-                    )
+        try:
+            for line in self._proc.stdout:
+                line = line.strip()
+                if not line:
                     continue
-                params = msg.get("params") or {}
-                if not isinstance(params, dict):
-                    params = {}
                 try:
-                    result = handler(params)
-                    self._send_response(rpc_id, result=result)
-                except Exception as err:
-                    logger.warning("host handler %s failed: %s", method, err)
-                    self._send_response(
-                        rpc_id,
-                        error={
-                            "code": -32000,
-                            "message": str(err) or err.__class__.__name__,
-                            "data": {"code": "host_handler_failed"},
-                        },
-                    )
-                continue
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("bridge: malformed line: %r", line[:120])
+                    continue
+                if "id" in msg and msg["id"] is not None and ("result" in msg or "error" in msg):
+                    self._resolve(msg)
+                    continue
+                if msg.get("method") == "events.notify":
+                    for cb in list(self._events):
+                        try:
+                            cb(msg.get("params") or {})
+                        except Exception:
+                            logger.debug("event listener threw", exc_info=True)
+                    continue
+                if msg.get("method") == "logs.forward":
+                    for cb in list(self._logs):
+                        try:
+                            cb(msg.get("params") or {})
+                        except Exception:
+                            logger.debug("log listener threw", exc_info=True)
+                    continue
+                # Reverse-direction request: the bridge is asking the
+                # adapter to do something (e.g. run a fallback LLM call
+                # via `host.llm.complete`). Dispatch to the registered
+                # handler and write the response back synchronously.
+                method = msg.get("method")
+                rpc_id = msg.get("id")
+                if (
+                    isinstance(method, str)
+                    and rpc_id is not None
+                    and "result" not in msg
+                    and "error" not in msg
+                ):
+                    handler = self._host_handler_for(method)
+                    if handler is None:
+                        self._send_response(
+                            rpc_id,
+                            error={
+                                "code": -32601,
+                                "message": f"method not found: {method}",
+                                "data": {"code": "unknown_method"},
+                            },
+                        )
+                        continue
+                    params = msg.get("params") or {}
+                    if not isinstance(params, dict):
+                        params = {}
+                    try:
+                        result = handler(params)
+                        self._send_response(rpc_id, result=result)
+                    except Exception as err:
+                        logger.warning("host handler %s failed: %s", method, err)
+                        self._send_response(
+                            rpc_id,
+                            error={
+                                "code": -32000,
+                                "message": str(err) or err.__class__.__name__,
+                                "data": {"code": "host_handler_failed"},
+                            },
+                        )
+                    continue
+        except Exception:
+            # Any unexpected exception on the reader thread (e.g. the
+            # subprocess died mid-write and raised OSError inside the
+            # iterator) is logged and treated as EOF — the finally
+            # block below unblocks every parked waiter.
+            logger.debug("bridge reader thread crashed", exc_info=True)
+        finally:
+            # The reader thread has stopped consuming responses. Any
+            # pending JSON-RPC waiter would otherwise sleep for the
+            # full per-request timeout. Wake them all up with the
+            # correct code so callers can trigger reconnect + retry.
+            self._abort_pending("bridge subprocess exited")
+
+    def _abort_pending(self, message: str) -> None:
+        """Release every pending waiter with ``transport_closed``.
+
+        Called from the reader thread on EOF / exception, so any
+        request that had already sent its bytes but never received a
+        response is woken up immediately instead of parking on its
+        per-request timeout. ``close()`` also delegates here so the
+        cleanup is defined in exactly one place.
+        """
+        with self._host_handlers_cv:
+            self._closed = True
+            self._host_handlers_cv.notify_all()
+        with self._lock:
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for entry in pending:
+            entry["error"] = {
+                "code": -32000,
+                "message": message,
+                "data": {"code": "transport_closed"},
+            }
+            entry["event"].set()
 
     def _host_handler_for(
         self,

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -68,6 +68,12 @@ class FakePopen:
     def kill(self) -> None:
         pass
 
+    # ``request()`` short-circuits on a dead subprocess by consulting
+    # ``poll()``. The default fake process is "alive" (returns None); a
+    # specific test can monkeypatch this to simulate an exit.
+    def poll(self) -> int | None:
+        return None
+
 
 class _ServerStream(io.StringIO):
     """Script bridge responses as if coming from the Node subprocess."""
@@ -342,6 +348,68 @@ class BridgeClientTests(unittest.TestCase):
                     return msg
             time.sleep(0.01)
         self.fail("timed out waiting for client write")
+
+    def test_reader_exit_marks_pending_as_transport_closed(self) -> None:
+        """When the reader loop exits (subprocess died), pending waiters
+        must be released immediately with ``transport_closed`` instead of
+        parking on the caller's ``timeout``."""
+        client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+        assert self._fake is not None
+
+        # Enqueue a request the server will NEVER answer, then simulate
+        # subprocess exit by draining the stdout stream and marking it
+        # done. The reader thread must observe EOF and abort every
+        # pending request.
+        results: dict[str, Exception | None] = {"err": None}
+
+        def _call() -> None:
+            try:
+                client.request("core.health", timeout=30.0)
+            except BridgeError as err:
+                results["err"] = err
+
+        # Craft a request whose response the fake server won't produce.
+        # We do that by temporarily swapping the fake's on_request so no
+        # answer is enqueued.
+        self._fake.stdout.on_request = lambda _raw: None  # type: ignore[assignment]
+
+        thread = threading.Thread(target=_call, daemon=True)
+        thread.start()
+
+        # Give the writer + reader a moment to register the pending id.
+        time.sleep(0.05)
+
+        # Simulate subprocess exit: no more bytes ever, iterator returns.
+        self._fake.stdout._done = True
+        # Nudge the reader thread out of its 50 ms wait.
+        self._fake.stdout._event.set()
+
+        thread.join(timeout=2.0)
+        self.assertFalse(thread.is_alive(), "waiter never released after EOF")
+
+        err = results["err"]
+        self.assertIsInstance(err, BridgeError)
+        assert isinstance(err, BridgeError)
+        self.assertEqual(err.code, "transport_closed")
+        client.close()
+
+    def test_request_fast_fails_when_subprocess_already_dead(self) -> None:
+        """A dead subprocess (``poll()`` non-None) must raise
+        ``transport_closed`` before we write to a broken pipe."""
+        client = MemosBridgeClient(bridge_path="/tmp/bridge.cts")
+        assert self._fake is not None
+
+        # Simulate subprocess exit (exit code 137 = OOM kill).
+        self._fake.poll = lambda: 137  # type: ignore[assignment]
+
+        with self.assertRaises(BridgeError) as ctx:
+            client.request("core.health", timeout=1.0)
+        self.assertEqual(ctx.exception.code, "transport_closed")
+        self.assertIn("137", str(ctx.exception))
+        # We must not have written anything to the dead stdin pipe.
+        stdin_writes = [line for line in self._fake._stdin_lines if line]
+        self.assertEqual(stdin_writes, [])
+        client.close()
 
 
 class MemTensorProviderTests(unittest.TestCase):
@@ -626,6 +694,167 @@ class MemTensorProviderTests(unittest.TestCase):
         self.assertIn("中东", retry_payload["userText"])
         self.assertIn("局势", retry_payload["agentText"])
         self.assertEqual(retry_payload["toolCalls"][0]["name"], "search_files")
+
+    # ─── Regression tests for #1722 ──────────────────────────────────
+    #
+    # A hung / dead bridge subprocess used to make every memory tool
+    # block for the full 30 s per-request timeout without ever
+    # recovering. The three layers below cover:
+    #
+    #   1. keepalive detects a hung bridge (timeout / dead subprocess)
+    #      and triggers a reconnect;
+    #   2. keepalive stays quiet for a live subprocess with a transient
+    #      parse error (no reconnect storms);
+    #   3. read-path tools reconnect and retry once on a stale bridge,
+    #      mirroring the write-path behaviour already covered above.
+
+    def test_keepalive_reconnects_on_health_timeout(self) -> None:
+        """``BridgeError('timeout', …)`` must count as reconnect-worthy."""
+
+        class TimingOutBridge:
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def close(self) -> None:
+                pass
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                self.calls.append(method)
+                if method == "core.health":
+                    raise BridgeError("timeout", "core.health did not respond within 10.0s")
+                return {}
+
+        p = self._provider_mod.MemTensorProvider()
+        # The helper is the sole decision point the keepalive consults;
+        # exercising it directly keeps this test hermetic.
+        err = BridgeError("timeout", "core.health did not respond within 10.0s")
+        p._bridge = TimingOutBridge()
+        self.assertTrue(p._should_reconnect_after_keepalive_failure(err))
+
+    def test_keepalive_reconnects_when_subprocess_is_dead(self) -> None:
+        """Any error whose subprocess reports ``poll() != None`` triggers reconnect."""
+
+        class DeadBridge:
+            def __init__(self) -> None:
+                class _Proc:
+                    def poll(self_inner) -> int:  # noqa: N805
+                        return 1
+
+                self._proc = _Proc()
+
+            def close(self) -> None:
+                pass
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                raise BridgeError("internal", "shape parse failed")
+
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = DeadBridge()
+        err = BridgeError("internal", "shape parse failed")
+        self.assertTrue(p._should_reconnect_after_keepalive_failure(err))
+
+    def test_keepalive_does_not_reconnect_on_transient_generic_error(self) -> None:
+        """A live subprocess + generic error must NOT trigger reconnect
+        (avoids reconnect storms on transient parse noise)."""
+
+        class LiveNoisyBridge:
+            def __init__(self) -> None:
+                class _Proc:
+                    def poll(self_inner) -> None:  # noqa: N805
+                        return None
+
+                self._proc = _Proc()
+
+            def close(self) -> None:
+                pass
+
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = LiveNoisyBridge()
+        err = BridgeError("internal", "malformed response")
+        self.assertFalse(p._should_reconnect_after_keepalive_failure(err))
+
+    def test_handle_tool_call_retries_memos_search_after_transport_closed(self) -> None:
+        """Read-path memory tools must reconnect + retry once on stale bridge."""
+
+        class StaleBridge:
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+
+            def close(self) -> None:
+                pass
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                self.calls.append(method)
+                raise BridgeError("transport_closed", "[Errno 32] Broken pipe")
+
+        class HealthyBridge:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, dict]] = []
+
+            def register_host_handler(self, *_a, **_k) -> None:
+                return None
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                payload = params or {}
+                self.calls.append((method, payload))
+                if method == "session.open":
+                    return {"sessionId": payload.get("sessionId", "sess")}
+                if method == "memory.search":
+                    return {"hits": [{"refId": "tr-after", "score": 0.9}]}
+                return {}
+
+        stale = StaleBridge()
+        healthy = HealthyBridge()
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = stale
+        p._session_id = "sess_search"
+        p._episode_id = "ep_search"
+
+        with patch("memos_provider.MemosBridgeClient", return_value=healthy):
+            raw = p.handle_tool_call("memos_search", {"query": "yesterday"})
+
+        parsed = json.loads(raw)
+        self.assertNotIn("error", parsed)
+        self.assertEqual(parsed["hits"][0]["refId"], "tr-after")
+        # First call went to the stale bridge; the retry hit the healthy one.
+        self.assertEqual(stale.calls, ["memory.search"])
+        self.assertIn("memory.search", [m for m, _ in healthy.calls])
+
+    def test_handle_tool_call_surfaces_second_transport_failure(self) -> None:
+        """If the retry ALSO fails, the tool must surface an error verbatim."""
+
+        class AlwaysStaleBridge:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def close(self) -> None:
+                pass
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                self.calls += 1
+                raise BridgeError("transport_closed", "[Errno 32] Broken pipe")
+
+        class ReplacementBridge:
+            def register_host_handler(self, *_a, **_k) -> None:
+                return None
+
+            def request(self, method: str, params: dict | None = None, **_kw) -> dict:
+                if method == "session.open":
+                    return {"sessionId": (params or {}).get("sessionId", "sess")}
+                # Retry still hits transport_closed.
+                raise BridgeError("transport_closed", "[Errno 32] Broken pipe again")
+
+        p = self._provider_mod.MemTensorProvider()
+        p._bridge = AlwaysStaleBridge()
+        p._session_id = "sess_search"
+        p._episode_id = "ep_search"
+
+        with patch("memos_provider.MemosBridgeClient", return_value=ReplacementBridge()):
+            raw = p.handle_tool_call("memos_search", {"query": "yesterday"})
+
+        parsed = json.loads(raw)
+        self.assertIn("error", parsed)
+        self.assertIn("Broken pipe", parsed["error"])
 
     def test_get_config_schema_describes_known_fields(self) -> None:
         p = self._provider_mod.MemTensorProvider()


### PR DESCRIPTION
## Description

Fixes #1722 (memory_search / turn.end returning `[timeout]` after the Hermes agent has been running for an hour or two) in the Python side of the MemOS Local plugin without touching the Node bridge or the JSON-RPC wire format.

Three cooperating Python defects made a dead / hung bridge subprocess repeatedly stall every memory tool for 30 s per call. The fix has four layers: (1) `MemosBridgeClient._read_loop` now runs in try/except/finally and, on any exit, calls a new `_abort_pending("bridge subprocess exited")` helper that wakes every parked JSON-RPC waiter with `BridgeError("transport_closed", ...)` in under a second; (2) `MemosBridgeClient.request` fast-fails with `transport_closed` when `Popen.poll()` reports the subprocess has exited, so we never write to a broken pipe that the OS would silently buffer; (3) `MemTensorProvider._start_bridge_keepalive` now uses `_should_reconnect_after_keepalive_failure(err)` to reconnect on `transport_closed`, `BridgeError("timeout", ...)`, or any error observed while the subprocess is dead — while explicitly NOT reconnecting on a live subprocess with a transient generic error, to avoid reconnect storms; (4) `MemTensorProvider.handle_tool_call` routes every read-path memory tool (`memos_search`, `memos_get`, `memos_timeline`, `memos_environment`, `memos_skill_list`, `memos_skill_get`) through the new `_bridge_request_with_retry` helper that reconnects + retries exactly once on `transport_closed`, mirroring the write-path pattern already used by `sync_turn`.

Tests: `apps/memos-local-plugin/tests/python/test_bridge_client.py` gains six new cases covering reader-thread abort, request fast-fail, keepalive reconnect on timeout / dead subprocess, the negative case for transient generic errors, and both read-path retry outcomes. Execution results: `python3 -m unittest tests.python.test_bridge_client` → 33 tests OK; `python3 -m unittest tests.python.test_hermes_provider_pipeline` → 16 tests OK; `python3 -m ruff check adapters/hermes/memos_provider/ tests/python/` → all clean; `python3 -m ruff format --check adapters/hermes/memos_provider/ tests/python/` → 5 files already formatted.

Committed as cc352cc7 on branch bugfix/autodev-1722 (base dev-20260624-v2.0.22); working branch pushed to origin, ready for the scheduler to open the PR. Specs archive (task.md + proposal / spec / design / verification-report) pushed to memos-autodev-specs main under 2026-07-01-1722-fix-memorysearch-returned-error/.

Related Issue (Required):  Fixes #1722

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1722
- [ ] Made sure Checks passed
- [ ] Tests have been provided
