### PR TITLE
refactor: remove dead strategy prompt example branch

### DIFF
--- a/src/memos/mem_reader/strategy_struct.py
+++ b/src/memos/mem_reader/strategy_struct.py
@@ -13,8 +13,6 @@ from memos.templates.mem_reader_prompts import (
     CUSTOM_TAGS_INSTRUCTION_ZH,
     SIMPLE_STRUCT_DOC_READER_PROMPT,
     SIMPLE_STRUCT_DOC_READER_PROMPT_ZH,
-    SIMPLE_STRUCT_MEM_READER_EXAMPLE,
-    SIMPLE_STRUCT_MEM_READER_EXAMPLE_ZH,
 )
 from memos.templates.mem_reader_strategy_prompts import (
     STRATEGY_STRUCT_MEM_READER_PROMPT,
@@ -27,8 +25,6 @@ STRATEGY_PROMPT_DICT = {
     "chat": {
         "en": STRATEGY_STRUCT_MEM_READER_PROMPT,
         "zh": STRATEGY_STRUCT_MEM_READER_PROMPT_ZH,
-        "en_example": SIMPLE_STRUCT_MEM_READER_EXAMPLE,
-        "zh_example": SIMPLE_STRUCT_MEM_READER_EXAMPLE_ZH,
     },
     "doc": {"en": SIMPLE_STRUCT_DOC_READER_PROMPT, "zh": SIMPLE_STRUCT_DOC_READER_PROMPT_ZH},
     "custom_tags": {"en": CUSTOM_TAGS_INSTRUCTION, "zh": CUSTOM_TAGS_INSTRUCTION_ZH},
@@ -45,7 +41,6 @@ class StrategyStructMemReader(SimpleStructMemReader, ABC):
     def _get_llm_response(self, mem_str: str, custom_tags: list[str] | None) -> dict:
         lang = detect_lang(mem_str)
         template = STRATEGY_PROMPT_DICT["chat"][lang]
-        examples = STRATEGY_PROMPT_DICT["chat"][f"{lang}_example"]
         prompt = template.replace("${conversation}", mem_str)
 
         custom_tags_prompt = (
@@ -55,8 +50,6 @@ class StrategyStructMemReader(SimpleStructMemReader, ABC):
         )
         prompt = prompt.replace("${custom_tags_prompt}", custom_tags_prompt)
 
-        if self.config.remove_prompt_example:  # TODO unused
-            prompt = prompt.replace(examples, "")
         messages = [{"role": "user", "content": prompt}]
         try:
             response_text = self.llm.generate(messages)

--- a/tests/mem_reader/test_strategy_struct_dead_branch.py
+++ b/tests/mem_reader/test_strategy_struct_dead_branch.py
@@ -1,0 +1,34 @@
+import ast
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[2] / "src/memos/mem_reader/strategy_struct.py"
+
+
+def _get_llm_response_body():
+    module = ast.parse(SOURCE.read_text())
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "StrategyStructMemReader":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "_get_llm_response":
+                    return item.body
+    raise AssertionError("StrategyStructMemReader._get_llm_response not found")
+
+
+def test_strategy_struct_reader_does_not_keep_dead_prompt_example_branch():
+    body = _get_llm_response_body()
+    names = {
+        node.id
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Name)
+    }
+    attrs = {
+        node.attr
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Attribute)
+    }
+
+    assert "remove_prompt_example" not in attrs
+    assert "examples" not in names


### PR DESCRIPTION
Summary
- Fixes #1792.
- Remove the no-op `remove_prompt_example` branch from `StrategyStructMemReader`.
- Drop the now-unused strategy prompt example imports and dictionary entries.
- Add a static regression test to keep the dead branch from returning.

Validation
- static strategy_struct dead-branch test passed
- python3 -m py_compile src/memos/mem_reader/strategy_struct.py tests/mem_reader/test_strategy_struct_dead_branch.py
- python3 -m pytest tests/mem_reader/test_strategy_struct_dead_branch.py -q (blocked: No module named pytest)
- make format (blocked: poetry: Command not found)

Note
- There is an older open PR for this issue (#1794), but it targets `dev-v2.0.22` and is behind. This PR is a fresh minimal version based on `main`.
