### PR TITLE
Fix #2028: fix: memory error

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import re
 import sys
 import threading
@@ -88,6 +89,34 @@ _TOOL_FAILURE_REPAIR_HINT = (
     "`memos_search` for relevant past experience before deciding what to do next."
 )
 _TOOL_FAILURE_HINT_THRESHOLD = 3
+
+
+def _long_rpc_timeout_default() -> float:
+    """Resolve the timeout used for long-running JSON-RPC calls.
+
+    After 1-2 hours of Hermes use the memory / capture / reflection
+    pipeline grows past the 30s JSON-RPC default and surfaces as
+    ``[timeout] memory.search did not respond within 30.0s`` and
+    ``[timeout] turn.end did not respond within 30.0s`` in the host
+    logs (issue #2028). ``feedback.submit`` already opts into 75s;
+    ``sync_turn``'s ``_ensure_bridge`` also uses 75s. Aligning the
+    heavy retrieval / capture RPCs with the same 75s ceiling gives
+    the pipeline enough headroom without turning genuinely hung
+    calls into an indefinite wait. The value is overridable via
+    ``MEMOS_HERMES_LONG_RPC_TIMEOUT`` for site-specific tuning; any
+    unparseable / non-positive value falls back to the default.
+    """
+    raw = os.environ.get("MEMOS_HERMES_LONG_RPC_TIMEOUT", "")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 75.0
+    if value <= 0:
+        return 75.0
+    return value
+
+
+_LONG_RPC_TIMEOUT = _long_rpc_timeout_default()
 
 _HERMES_INTERNAL_REVIEW_PREFIXES = (
     "review the conversation above and consider saving to memory if appropriate.",
@@ -1283,6 +1312,7 @@ class MemTensorProvider(MemoryProvider):
                 resp = self._bridge.request(
                     "memory.search",
                     params,
+                    timeout=_LONG_RPC_TIMEOUT,
                 )
                 return json.dumps({"hits": resp.get("hits", [])})
             if tool_name == "memos_get":
@@ -1387,6 +1417,7 @@ class MemTensorProvider(MemoryProvider):
                         "query": query,
                         "topK": {"tier1": 0, "tier2": 0, "tier3": limit},
                     },
+                    timeout=_LONG_RPC_TIMEOUT,
                 )
                 hits = [
                     h
@@ -1829,6 +1860,7 @@ class MemTensorProvider(MemoryProvider):
                 },
                 "ts": int(time.time() * 1000),
             },
+            timeout=_LONG_RPC_TIMEOUT,
         )
         # Stash the real episode id the pipeline auto-created (V7
         # §0.1 may have boundary-cut the previous episode and started
@@ -1875,7 +1907,7 @@ class MemTensorProvider(MemoryProvider):
         }
         if agent_thinking:
             payload["agentThinking"] = agent_thinking
-        result = self._bridge.request("turn.end", payload)
+        result = self._bridge.request("turn.end", payload, timeout=_LONG_RPC_TIMEOUT)
         # Capture the trace ID for feedback submission
         if result and isinstance(result, dict):
             trace_ids = result.get("traceIds", [])

--- a/apps/memos-local-plugin/tests/python/test_bridge_client.py
+++ b/apps/memos-local-plugin/tests/python/test_bridge_client.py
@@ -164,10 +164,20 @@ class RecordingBridge:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
+        # Kwargs captured per call — used by tests that assert on the
+        # per-request `timeout` kwarg the provider now passes for
+        # long-running operations (memory.search / turn.start / turn.end).
+        self.call_kwargs: list[dict] = []
 
-    def request(self, method: str, params: dict | None = None) -> dict | None:
+    def request(
+        self,
+        method: str,
+        params: dict | None = None,
+        **kwargs,
+    ) -> dict | None:
         payload = params or {}
         self.calls.append((method, payload))
+        self.call_kwargs.append(dict(kwargs))
         if method == "memory.search":
             return {
                 "hits": [
@@ -534,7 +544,7 @@ class MemTensorProviderTests(unittest.TestCase):
                 return {}
 
         class RetryFailBridge:
-            def request(self, method, params=None):
+            def request(self, method, params=None, **_kwargs):
                 if method == "session.open":
                     return {"sessionId": (params or {}).get("sessionId", "sess")}
                 if method == "turn.start":
@@ -571,7 +581,7 @@ class MemTensorProviderTests(unittest.TestCase):
             def close(self):
                 self.closed = True
 
-            def request(self, method, params=None):
+            def request(self, method, params=None, **_kwargs):
                 if method == "turn.end":
                     raise BridgeError("transport_closed", "[Errno 32] Broken pipe")
                 return {}
@@ -656,6 +666,90 @@ class MemTensorProviderTests(unittest.TestCase):
             loaded = yaml.safe_load(cfg_path.read_text())
             self.assertEqual(loaded["viewer"]["port"], 18920)
             self.assertEqual(loaded["llm"]["provider"], "openai_compatible")
+
+    # ─── Long-operation RPC timeouts (issue #2028) ──────────────────────
+    #
+    # After 1-2 hours of Hermes use the memory / capture / reflection
+    # pipeline legitimately needs more than the 30s JSON-RPC default,
+    # which surfaced as:
+    #     [timeout] memory.search did not respond within 30.0s
+    #     [timeout] turn.end did not respond within 30.0s
+    # `feedback.submit` already opts into 75s, and `sync_turn` already
+    # opts into a 75s `_ensure_bridge`, but the actual `memory.search`
+    # and `turn.start` / `turn.end` requests still fell back to 30s.
+    # These tests pin the fix.
+
+    _EXPECTED_LONG_TIMEOUT = 75.0
+
+    def test_memos_search_uses_long_rpc_timeout(self) -> None:
+        p = self._provider_mod.MemTensorProvider()
+        bridge = RecordingBridge()
+        p._bridge = bridge
+        p._session_id = "hermes:session:1"
+
+        p.handle_tool_call("memos_search", {"query": "yesterday"})
+        method, _params = bridge.calls[-1]
+        self.assertEqual(method, "memory.search")
+        kwargs = bridge.call_kwargs[-1]
+        self.assertIn("timeout", kwargs)
+        self.assertGreaterEqual(
+            kwargs["timeout"],
+            self._EXPECTED_LONG_TIMEOUT,
+            "memory.search must not fall back to the 30s JSON-RPC default; "
+            "large memories legitimately need more time (issue #2028).",
+        )
+
+    def test_memos_environment_search_uses_long_rpc_timeout(self) -> None:
+        p = self._provider_mod.MemTensorProvider()
+        bridge = RecordingBridge()
+        p._bridge = bridge
+        p._session_id = "hermes:session:1"
+
+        # memos_environment routes to memory.search when a query is passed.
+        p.handle_tool_call("memos_environment", {"query": "install path"})
+        method, _params = bridge.calls[-1]
+        self.assertEqual(method, "memory.search")
+        kwargs = bridge.call_kwargs[-1]
+        self.assertGreaterEqual(kwargs.get("timeout", 0.0), self._EXPECTED_LONG_TIMEOUT)
+
+    def test_sync_turn_uses_long_rpc_timeout_for_turn_end(self) -> None:
+        p = self._provider_mod.MemTensorProvider()
+        bridge = RecordingBridge()
+        p._bridge = bridge
+        p._session_id = "hermes:session:1"
+        p._episode_id = "ep-1"  # skip the turn.start prelude
+
+        p.sync_turn("what did we do?", "we tested memory")
+        methods = [m for m, _ in bridge.calls]
+        self.assertIn("turn.end", methods)
+        end_index = methods.index("turn.end")
+        end_kwargs = bridge.call_kwargs[end_index]
+        self.assertIn("timeout", end_kwargs)
+        self.assertGreaterEqual(
+            end_kwargs["timeout"],
+            self._EXPECTED_LONG_TIMEOUT,
+            "turn.end must not fall back to the 30s JSON-RPC default; "
+            "the V7 capture/reflection pipeline grows past 30s in long "
+            "sessions (issue #2028).",
+        )
+
+    def test_prefetch_uses_long_rpc_timeout_for_turn_start(self) -> None:
+        p = self._provider_mod.MemTensorProvider()
+        bridge = RecordingBridge()
+        p._bridge = bridge
+        p._session_id = "hermes:session:1"
+
+        p.prefetch("what did I do yesterday?", session_id="hermes:session:1")
+        methods = [m for m, _ in bridge.calls]
+        self.assertIn("turn.start", methods)
+        start_index = methods.index("turn.start")
+        start_kwargs = bridge.call_kwargs[start_index]
+        self.assertGreaterEqual(
+            start_kwargs.get("timeout", 0.0),
+            self._EXPECTED_LONG_TIMEOUT,
+            "turn.start suffers the same long-tail latency as turn.end and "
+            "must share the long RPC timeout (issue #2028).",
+        )
 
 
 class ViewerDaemonTests(unittest.TestCase):


### PR DESCRIPTION
## Description

Root cause of the reported "[timeout] memory.search did not respond within 30.0s" and "[timeout] turn.end did not respond within 30.0s" errors (issue #2028) is that the Hermes memtensor provider (apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py) was calling `_bridge.request(...)` for four heavy pipeline methods — memory.search (invoked from both memos_search and the keyword branch of memos_environment), turn.start, and turn.end — without a `timeout=` kwarg, so all four fell back to the 30s JSON-RPC default. After 1-2 hours of continuous Hermes use, the accumulated MemOS memory makes the V7 retrieval / capture / reflection pipeline legitimately run past 30s and the calls time out even though the bridge subprocess is alive.

The fix introduces a module-level `_LONG_RPC_TIMEOUT` (default 75.0s, override via `MEMOS_HERMES_LONG_RPC_TIMEOUT`; unparseable or non-positive values fall back to the default) and threads it through those four call sites. 75s matches the ceiling that `feedback.submit` and `sync_turn`'s `_ensure_bridge` already opt into, so we're closing an internal inconsistency rather than inventing a new magic number. Short-latency RPCs (session.open, core.health, memory.get_trace/policy/world, memory.timeline, skill.list/get, subagent.record, session.close, memory.list_world_models) intentionally stay on the existing 30s fast-path so genuine regressions there stay visible.

TDD evidence: four new tests were added to tests/python/test_bridge_client.py (test_memos_search_uses_long_rpc_timeout, test_memos_environment_search_uses_long_rpc_timeout, test_sync_turn_uses_long_rpc_timeout_for_turn_end, test_prefetch_uses_long_rpc_timeout_for_turn_start). All four failed against the pre-fix code (recorded RPC kwargs had no `timeout` key, so `kwargs.get("timeout", 0.0)` came back as 0.0 < 75.0) and pass after the fix. Combined pytest run for the two Hermes test modules: `python3 -m unittest tests.python.test_bridge_client tests.python.test_hermes_provider_pipeline` reports `Ran 46 tests in 30.153s / OK` (30 in test_bridge_client, 16 in test_hermes_provider_pipeline). `ruff check` and `ruff format --check` are clean on both modified files.

opsp artefacts (task.md, proposal.md, design.md, spec.md, verification-report.md) have been archived to the sibling memos-autodev-specs repo under 2026-07-02-2028-fix-memory-error/ and pushed to main. Working branch bugfix/autodev-2028 has been pushed to origin at commit 3e808adedff3a520769862e4ca370fc3239bdda9. The change is scoped to the plugin and does not touch src/memos/api/ so no OpenAPI regeneration is needed.

Related Issue (Required):  Fixes #2028

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #2028
- [ ] Made sure Checks passed
- [ ] Tests have been provided
