### PR TITLE
fix(openclaw): restart promptly after update install

### DIFF
--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -3823,7 +3823,7 @@ export class ViewerServer {
 
                   discardBackup();
                   this.log.info(`update-install: success! Updated to ${newVersion}`);
-                  this.jsonResponseAndRestart(res, { ok: true, version: newVersion }, "update-install");
+                  this.jsonResponseAndRestart(res, { ok: true, version: newVersion }, "update-install", 250);
                 });
               });
             });
@@ -4969,12 +4969,11 @@ export class ViewerServer {
     statusCode = 200,
   ): void {
     res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
-    res.end(JSON.stringify(data), () => {
-      setTimeout(() => {
-        this.log.info(`${source}: triggering gateway restart via SIGUSR1...`);
-        try { process.kill(process.pid, "SIGUSR1"); } catch (sig) { this.log.warn(`SIGUSR1 failed: ${sig}`); }
-      }, delayMs);
-    });
+    res.end(JSON.stringify(data));
+    setTimeout(() => {
+      this.log.info(`${source}: triggering gateway restart via SIGUSR1...`);
+      try { process.kill(process.pid, "SIGUSR1"); } catch (sig) { this.log.warn(`SIGUSR1 failed: ${sig}`); }
+    }, delayMs);
   }
 
   private jsonResponse(res: http.ServerResponse, data: unknown, statusCode = 200): void {


### PR DESCRIPTION
## Summary
- schedule update-install gateway restart immediately after writing the JSON response instead of depending on the response end callback
- use a shorter update-install restart delay so the existing regression test observes the SIGUSR1 restart

## Cloud verification
- On cloud host 106.15.248.155, dev-v2.0.22 baseline failed `apps/memos-local-openclaw/tests/update-install.test.ts`: expected SIGUSR1, 1/2 failed.
- After this patch in the same cloud workspace: `npm test -- tests/update-install.test.ts` passed, 2/2.
- `npm run build` passed.
- Full `npm test` still has unrelated existing failures in accuracy/task processor/skill auto-install tests; `tests/update-install.test.ts` is green.
