### PR TITLE
feat: Support independent model config for preference memory.

### DIFF
--- a/src/memos/api/config.py
+++ b/src/memos/api/config.py
@@ -979,6 +979,10 @@ class APIConfig:
                     "general_llm": APIConfig.get_memreader_general_llm_config(),
                     # Image parser LLM (requires vision model)
                     "image_parser_llm": APIConfig.get_image_parser_llm_config(),
+                    # Preference extractor LLM. Reader falls back to general_llm when unset.
+                    "preference_extractor_llm": APIConfig.get_preference_extractor_llm_config()
+                    if os.getenv("PREFERENCE_EXTRACTOR_MODEL")
+                    else None,
                     "embedder": APIConfig.get_embedder_config(),
                     "chunker": {
                         "backend": "sentence",
@@ -1108,6 +1112,10 @@ class APIConfig:
                     "general_llm": APIConfig.get_memreader_general_llm_config(),
                     # Image parser LLM (requires vision model)
                     "image_parser_llm": APIConfig.get_image_parser_llm_config(),
+                    # Preference extractor LLM. Reader falls back to general_llm when unset.
+                    "preference_extractor_llm": APIConfig.get_preference_extractor_llm_config()
+                    if os.getenv("PREFERENCE_EXTRACTOR_MODEL")
+                    else None,
                     "embedder": APIConfig.get_embedder_config(),
                     "chunker": {
                         "backend": "sentence",

--- a/src/memos/configs/mem_reader.py
+++ b/src/memos/configs/mem_reader.py
@@ -36,6 +36,10 @@ class BaseMemReaderConfig(BaseConfig):
         default=None,
         description="Vision LLM for image parsing. Falls back to general_llm if not set.",
     )
+    preference_extractor_llm: LLMConfigFactory | None = Field(
+        default=None,
+        description="LLM for preference extraction. Falls back to general_llm if not set.",
+    )
     embedder: EmbedderConfigFactory = Field(
         ..., description="Embedder configuration for the MemReader"
     )

--- a/src/memos/mem_reader/multi_modal_struct.py
+++ b/src/memos/mem_reader/multi_modal_struct.py
@@ -1035,7 +1035,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                     process_preference_fine,
                     non_file_url_fast_items,
                     info,
-                    self.general_llm,
+                    getattr(self, "preference_extractor_llm", self.general_llm),
                     self.embedder,
                     **kwargs,
                 )
@@ -1127,7 +1127,7 @@ class MultiModalStructMemReader(SimpleStructMemReader):
                 process_preference_fine,
                 non_file_url_nodes,
                 info,
-                self.general_llm,
+                getattr(self, "preference_extractor_llm", self.general_llm),
                 self.embedder,
                 **kwargs,
             )

--- a/src/memos/mem_reader/simple_struct.py
+++ b/src/memos/mem_reader/simple_struct.py
@@ -184,6 +184,12 @@ class SimpleStructMemReader(BaseMemReader, ABC):
             if config.general_llm is not None
             else self.llm
         )
+        preference_extractor_llm_config = getattr(config, "preference_extractor_llm", None)
+        self.preference_extractor_llm = (
+            LLMFactory.from_config(preference_extractor_llm_config)
+            if preference_extractor_llm_config is not None
+            else self.general_llm
+        )
         self.qwen_llm = None
         qwen_llm_config = getattr(config, "qwen_llm", None)
         if qwen_llm_config:

--- a/tests/mem_reader/test_preference_extractor_llm_config.py
+++ b/tests/mem_reader/test_preference_extractor_llm_config.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from memos.api.config import APIConfig
+from memos.chunkers import ChunkerFactory
+from memos.embedders.factory import EmbedderFactory
+from memos.llms.factory import LLMFactory
+from memos.mem_reader.multi_modal_struct import MultiModalStructMemReader
+from memos.mem_reader.simple_struct import SimpleStructMemReader
+from memos.memories.textual.item import (
+    SourceMessage,
+    TextualMemoryItem,
+    TreeNodeTextualMemoryMetadata,
+)
+
+
+def test_product_default_config_wires_preference_extractor_model(monkeypatch):
+    monkeypatch.setenv("PREFERENCE_EXTRACTOR_MODEL", "pref-model")
+    monkeypatch.setenv("PREFERENCE_EXTRACTOR_API_BASE", "https://pref.example/v1")
+    monkeypatch.setenv("PREFERENCE_EXTRACTOR_API_KEY", "pref-key")
+
+    config = APIConfig.get_product_default_config()["mem_reader"]["config"]
+
+    pref_config = config["preference_extractor_llm"]
+    assert pref_config["backend"] == "openai"
+    assert pref_config["config"]["model_name_or_path"] == "pref-model"
+    assert pref_config["config"]["api_base"] == "https://pref.example/v1"
+    assert pref_config["config"]["api_key"] == "pref-key"
+
+
+def test_product_default_config_leaves_preference_extractor_unset_without_model(monkeypatch):
+    monkeypatch.delenv("PREFERENCE_EXTRACTOR_MODEL", raising=False)
+    monkeypatch.delenv("PREFERENCE_EXTRACTOR_API_BASE", raising=False)
+    monkeypatch.delenv("PREFERENCE_EXTRACTOR_API_KEY", raising=False)
+
+    config = APIConfig.get_product_default_config()["mem_reader"]["config"]
+
+    assert config["preference_extractor_llm"] is None
+
+
+def test_simple_reader_uses_configured_preference_extractor_llm():
+    main_llm = object()
+    general_llm = object()
+    preference_llm = object()
+
+    config = SimpleNamespace(
+        llm="main-config",
+        general_llm="general-config",
+        preference_extractor_llm="preference-config",
+        qwen_llm=None,
+        embedder="embedder-config",
+        chunker="chunker-config",
+        remove_prompt_example=False,
+    )
+    chunker = MagicMock()
+    chunker.config.save_rawfile = False
+
+    with (
+        patch.object(
+            LLMFactory,
+            "from_config",
+            side_effect=[main_llm, general_llm, preference_llm],
+        ),
+        patch.object(EmbedderFactory, "from_config", return_value=MagicMock()),
+        patch.object(ChunkerFactory, "from_config", return_value=chunker),
+    ):
+        reader = SimpleStructMemReader(config)
+
+    assert reader.llm is main_llm
+    assert reader.general_llm is general_llm
+    assert reader.preference_extractor_llm is preference_llm
+
+
+def test_simple_reader_preference_extractor_llm_falls_back_to_general_llm():
+    main_llm = object()
+    general_llm = object()
+
+    config = SimpleNamespace(
+        llm="main-config",
+        general_llm="general-config",
+        preference_extractor_llm=None,
+        qwen_llm=None,
+        embedder="embedder-config",
+        chunker="chunker-config",
+        remove_prompt_example=False,
+    )
+    chunker = MagicMock()
+    chunker.config.save_rawfile = False
+
+    with (
+        patch.object(LLMFactory, "from_config", side_effect=[main_llm, general_llm]),
+        patch.object(EmbedderFactory, "from_config", return_value=MagicMock()),
+        patch.object(ChunkerFactory, "from_config", return_value=chunker),
+    ):
+        reader = SimpleStructMemReader(config)
+
+    assert reader.llm is main_llm
+    assert reader.general_llm is general_llm
+    assert reader.preference_extractor_llm is general_llm
+
+
+def test_multimodal_transfer_uses_preference_extractor_llm():
+    reader = MultiModalStructMemReader.__new__(MultiModalStructMemReader)
+    reader.general_llm = object()
+    reader.preference_extractor_llm = object()
+    reader.embedder = object()
+    reader.searcher = None
+    reader.graph_db = None
+    reader.oss_config = None
+    reader.skills_dir_config = None
+    reader.multi_modal_parser = MagicMock()
+    reader.multi_modal_parser.process_transfer.return_value = []
+
+    raw_node = TextualMemoryItem(
+        memory="User likes concise answers.",
+        metadata=TreeNodeTextualMemoryMetadata(
+            user_id="u1",
+            session_id="s1",
+            memory_type="LongTermMemory",
+            sources=[SourceMessage(type="chat", role="user", content="I like concise answers.")],
+        ),
+    )
+
+    with (
+        patch.object(reader, "_process_string_fine", return_value=[]),
+        patch.object(reader, "_process_tool_trajectory_fine", return_value=[]),
+        patch("memos.mem_reader.multi_modal_struct.process_skill_memory_fine", return_value=[]),
+        patch(
+            "memos.mem_reader.multi_modal_struct.process_preference_fine", return_value=[]
+        ) as mock_process_pref,
+    ):
+        reader._process_transfer_multi_modal_data([raw_node])
+
+    assert mock_process_pref.call_args.args[2] is reader.preference_extractor_llm


### PR DESCRIPTION
## Description

feat: Support independent model config for preference memory.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test - tests/mem_reader/test_preference_extractor_llm_config.py

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided