### PR TITLE
fix: batch missing search embeddings

### DIFF
--- a/src/memos/api/handlers/search_handler.py
+++ b/src/memos/api/handlers/search_handler.py
@@ -34,6 +34,7 @@ _ENV_CONTEXT_RECALL_TOP_K = "MEMOS_DREAM_CONTEXT_RECALL_TOP_K"
 _DEFAULT_CONTEXT_RECALL_TOP_K = 2
 _ENV_MMR_CANDIDATE_PRUNING = "MEMOS_MMR_CANDIDATE_PRUNING_ENABLED"
 _MMR_CANDIDATE_MULTIPLIER = 2
+_MISSING_EMBEDDING_BATCH_SIZE = 10
 
 
 def _env_enabled(name: str, default: str = "off") -> bool:
@@ -683,10 +684,13 @@ class SearchHandler(BaseHandler):
             missing_documents.append(mem.get("memory", ""))
 
         if missing_indices:
-            computed = self.searcher.embedder.embed(missing_documents)
-            for idx, embedding in zip(missing_indices, computed, strict=False):
-                embeddings[idx] = embedding
-                memories[idx]["metadata"]["embedding"] = embedding
+            for start in range(0, len(missing_documents), _MISSING_EMBEDDING_BATCH_SIZE):
+                batch_documents = missing_documents[start : start + _MISSING_EMBEDDING_BATCH_SIZE]
+                batch_indices = missing_indices[start : start + _MISSING_EMBEDDING_BATCH_SIZE]
+                computed = self.searcher.embedder.embed(batch_documents)
+                for idx, embedding in zip(batch_indices, computed, strict=False):
+                    embeddings[idx] = embedding
+                    memories[idx]["metadata"]["embedding"] = embedding
 
         return embeddings
 

--- a/tests/api/test_search_handler_embedding_batches.py
+++ b/tests/api/test_search_handler_embedding_batches.py
@@ -1,0 +1,38 @@
+from memos.api.handlers.base_handler import HandlerDependencies
+from memos.api.handlers.search_handler import SearchHandler
+
+
+class BatchLimitedEmbedder:
+    def __init__(self, *, limit: int):
+        self.limit = limit
+        self.calls: list[list[str]] = []
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if len(texts) > self.limit:
+            raise AssertionError(f"batch too large: {len(texts)}")
+        return [[float(len(text)), 0.0] for text in texts]
+
+
+def _handler(embedder: BatchLimitedEmbedder) -> SearchHandler:
+    searcher = type("FakeSearcher", (), {"embedder": embedder})()
+    return SearchHandler(
+        HandlerDependencies(
+            naive_mem_cube=object(),
+            mem_scheduler=object(),
+            searcher=searcher,
+            deepsearch_agent=object(),
+        )
+    )
+
+
+def test_extract_embeddings_batches_missing_documents():
+    embedder = BatchLimitedEmbedder(limit=10)
+    handler = _handler(embedder)
+    memories = [{"memory": f"memory {idx}", "metadata": {}} for idx in range(25)]
+
+    embeddings = handler._extract_embeddings(memories)
+
+    assert [len(call) for call in embedder.calls] == [10, 10, 5]
+    assert len(embeddings) == 25
+    assert all(mem["metadata"]["embedding"] for mem in memories)


### PR DESCRIPTION
## Description

Related Issue (Required): Fixes #1482

Batches missing embedding backfills during API search MMR deduplication.

`SearchHandler._extract_embeddings()` previously sent every memory without cached embedding in one embedder call. Providers such as DashScope `text-embedding-v4` reject batches larger than 10, so a search result with many missing embeddings could fail during deduplication. This change caps each missing-embedding call at 10 documents while preserving the returned embeddings in the original memory order.

No public API, request/response model, OpenAPI, dependency, or database schema changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

Commands run:

```bash
python3 -m py_compile src/memos/api/handlers/search_handler.py tests/api/test_search_handler_embedding_batches.py
```

Result: passed.

Also attempted:

```bash
PYTHONPATH=src python3 -m pytest tests/api/test_search_handler_embedding_batches.py -q
make format
```

These are blocked in the local environment because `pytest` and `poetry` are not installed. Direct test-function execution is also blocked because `pydantic` is not installed.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
