### PR TITLE
Fix #1733: [Bug] @memtensor/memos-lite-openclaw-plugin v0.2.3 fails to load: ReferenceError

### DIFF
--- a/apps/memos-local-openclaw/tests/module-format.test.ts
+++ b/apps/memos-local-openclaw/tests/module-format.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression test for issue #1733
+ * (@memtensor/memos-lite-openclaw-plugin v0.2.3 fails to load:
+ *  "ReferenceError: exports is not defined in ES module scope").
+ *
+ * Root cause: package.json declared `"type": "module"` while tsconfig.json
+ * emitted CommonJS (`"module": "CommonJS"`). Node.js treated the compiled
+ * `dist/index.js` as ESM, saw the `exports.` writes, and refused to load
+ * the plugin.
+ *
+ * Guard the invariant so it cannot silently drift again:
+ *  - When package.json says "type": "module", tsconfig must emit an ESM
+ *    module format (not CommonJS / node16 / commonjs variants).
+ *  - When ESM is chosen, `moduleResolution` must be one of the ESM-safe
+ *    variants ("bundler" / "nodenext" / "node16"). Bare `"node"` (which is
+ *    equivalent to the legacy classic CJS resolver) would silently mask
+ *    ESM-only imports at build time.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+// Strip // and /* */ comments and trailing commas so JSON.parse can eat tsconfig.
+function readJsoncSync(path: string): any {
+  const raw = readFileSync(path, "utf-8");
+  const noBlock = raw.replace(/\/\*[\s\S]*?\*\//g, "");
+  const noLine = noBlock.replace(/(^|[^:])\/\/.*$/gm, "$1");
+  const noTrailingCommas = noLine.replace(/,(\s*[}\]])/g, "$1");
+  return JSON.parse(noTrailingCommas);
+}
+
+const pluginRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgJsonPath = resolve(pluginRoot, "package.json");
+const tsconfigPath = resolve(pluginRoot, "tsconfig.json");
+
+const CJS_MODULES = new Set(["commonjs", "node16-commonjs"]);
+const ESM_MODULES = new Set([
+  "es2015",
+  "es2020",
+  "es2022",
+  "esnext",
+  "node16",
+  "node18",
+  "nodenext",
+]);
+const ESM_SAFE_RESOLUTIONS = new Set([
+  "bundler",
+  "node16",
+  "node18",
+  "nodenext",
+]);
+
+describe("regression #1733 — plugin module-format alignment", () => {
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+  const tsconfig = readJsoncSync(tsconfigPath);
+  const module = String(tsconfig.compilerOptions?.module ?? "").toLowerCase();
+  const moduleResolution = String(
+    tsconfig.compilerOptions?.moduleResolution ?? "",
+  ).toLowerCase();
+
+  it("package.json declares ESM", () => {
+    // If this ever flips back to CommonJS or is removed, the tsconfig side
+    // of the invariant needs to be revisited in tandem.
+    expect(pkg.type).toBe("module");
+  });
+
+  it("tsconfig emits an ESM-compatible module format", () => {
+    expect(ESM_MODULES.has(module), `tsconfig module=${module} is CJS-flavoured; would recreate the v0.2.3 "exports is not defined" crash when dist/index.js is loaded under package.json "type": "module".`).toBe(true);
+    expect(CJS_MODULES.has(module)).toBe(false);
+  });
+
+  it("tsconfig moduleResolution is ESM-safe", () => {
+    expect(
+      ESM_SAFE_RESOLUTIONS.has(moduleResolution),
+      `moduleResolution="${moduleResolution}" pairs the ESM emit with the legacy CJS resolver — imports get silently rewritten in ways Node can't execute at runtime.`,
+    ).toBe(true);
+  });
+
+  it("no legacy CommonJS entry point sneaks back in", () => {
+    // main + openclaw.extensions must not reference a CJS-only artifact.
+    const main: string = pkg.main ?? "";
+    expect(main.endsWith(".cjs")).toBe(false);
+
+    const ext = pkg.openclaw?.extensions;
+    if (Array.isArray(ext)) {
+      for (const e of ext) {
+        expect(
+          String(e).endsWith(".cjs"),
+          `openclaw.extensions entry "${e}" would force CommonJS load under type:module.`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/apps/memos-local-openclaw/tsconfig.json
+++ b/apps/memos-local-openclaw/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
+    "module": "ES2022",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",
@@ -13,7 +13,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
## Description

Fixed issue #1733: aligned the successor plugin's TypeScript build with its declared module type so the ESM/CJS mismatch that broke `@memtensor/memos-lite-openclaw-plugin` v0.2.3 ("ReferenceError: exports is not defined in ES module scope") cannot recur.

Root cause: `apps/memos-local-openclaw/tsconfig.json` had `"module": "CommonJS"` + `"moduleResolution": "node"`, but `package.json` declares `"type": "module"`. When the legacy v0.2.3 build accidentally shipped its `dist/` output, Node 22 read the compiled CommonJS wrappers (`exports.initPlugin = ...`) as ESM and refused to load them. The successor plugin doesn't currently ship `dist/` (its `files` list excludes it, and OpenClaw loads `index.ts` directly via tsx), so the crash is latent — but the misalignment sat exactly on the seed of the reported bug, and the source already uses ESM-only constructs (`import.meta.url`, `createRequire(import.meta.url)`).

Fix (2 files, +99/-2):
- `apps/memos-local-openclaw/tsconfig.json`: `module` -> `ES2022`, `moduleResolution` -> `bundler` (matches sibling `apps/memos-local-plugin` and the `"type": "module"` declaration).
- `apps/memos-local-openclaw/tests/module-format.test.ts`: new regression guard that pins the invariant — package.json `"type": "module"` implies tsconfig emits an ESM module format, `moduleResolution` is ESM-safe, and no `.cjs` entry point sneaks back into `main` or `openclaw.extensions`. Verified to fail with the exact v0.2.3 diagnostic when tsconfig is reverted to the old CommonJS setup, and to pass with the fix.

Verification: `vitest run tests/module-format.test.ts` -> 4/4 passed; `tsc --noEmit` clean; `tsc` build now emits ESM (`import`/`export`) with zero `exports.` / `module.exports` markers in `dist/*.js`; sanity-checked chunker / config / storage / plugin-openclaw-wiring / plugin-impl-access suites (32 tests) still pass. Branch pushed to origin/bugfix/autodev-1733; task archived to memos-autodev-specs.

Related Issue (Required):  Fixes #1733

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1733
- [ ] Made sure Checks passed
- [ ] Tests have been provided
