### PR TITLE
fix: honor retry-after in provider fetchers

### DIFF
--- a/apps/memos-local-plugin/core/embedding/fetcher.ts
+++ b/apps/memos-local-plugin/core/embedding/fetcher.ts
@@ -54,7 +54,7 @@ export async function httpPostJson<TResp>(opts: HttpPostOpts<unknown>): Promise<
           durationMs: Date.now() - start,
         });
         if (transient && attempt <= maxRetries) {
-          await backoff(attempt);
+          await backoff(attempt, retryAfterMs(resp));
           continue;
         }
         throw new MemosError(
@@ -123,10 +123,20 @@ function isTransientError(err: unknown): boolean {
   return false;
 }
 
-async function backoff(attempt: number): Promise<void> {
+function retryAfterMs(resp: Response): number | undefined {
+  const raw = resp.headers.get("retry-after");
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return undefined;
+}
+
+async function backoff(attempt: number, retryAfter: number | undefined = undefined): Promise<void> {
   const base = 200;
   const jitter = Math.floor(Math.random() * 100);
-  const ms = base * 2 ** (attempt - 1) + jitter;
+  const ms = retryAfter ?? base * 2 ** (attempt - 1) + jitter;
   await new Promise((r) => setTimeout(r, ms));
 }
 

--- a/apps/memos-local-plugin/core/llm/fetcher.ts
+++ b/apps/memos-local-plugin/core/llm/fetcher.ts
@@ -64,7 +64,7 @@ export async function httpPostJson<TResp>(opts: HttpPostOpts<unknown>): Promise<
         });
         if (transient && attempt <= opts.maxRetries) {
           opts.onRetry?.(attempt);
-          await backoff(attempt);
+          await backoff(attempt, retryAfterMs(resp));
           continue;
         }
         throw new MemosError(
@@ -233,10 +233,20 @@ function isTimeout(err: unknown): boolean {
   return false;
 }
 
-async function backoff(attempt: number): Promise<void> {
+function retryAfterMs(resp: Response): number | undefined {
+  const raw = resp.headers.get("retry-after");
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return undefined;
+}
+
+async function backoff(attempt: number, retryAfter: number | undefined = undefined): Promise<void> {
   const base = 250;
   const jitter = Math.floor(Math.random() * 120);
-  const ms = base * 2 ** (attempt - 1) + jitter;
+  const ms = retryAfter ?? base * 2 ** (attempt - 1) + jitter;
   await new Promise((r) => setTimeout(r, ms));
 }
 

--- a/apps/memos-local-plugin/tests/unit/embedding/fetcher.test.ts
+++ b/apps/memos-local-plugin/tests/unit/embedding/fetcher.test.ts
@@ -22,6 +22,7 @@ describe("embedding/fetcher", () => {
   });
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   function mockFetch(responses: Array<Response | Error>) {
@@ -78,6 +79,30 @@ describe("embedding/fetcher", () => {
       log: nullLogger(),
       maxRetries: 1,
     });
+    expect(f).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After seconds before retrying transient responses", async () => {
+    vi.useFakeTimers();
+    const f = mockFetch([
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "2" } }),
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 }),
+    ]);
+
+    const req = httpPostJson<{ ok: number }>({
+      url: "https://x",
+      body: {},
+      provider: "cohere",
+      log: nullLogger(),
+      maxRetries: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(req).resolves.toEqual({ ok: 1 });
     expect(f).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/memos-local-plugin/tests/unit/llm/fetcher.test.ts
+++ b/apps/memos-local-plugin/tests/unit/llm/fetcher.test.ts
@@ -29,7 +29,10 @@ function mockFetch(replies: Array<Response | Error>) {
 
 describe("llm/fetcher", () => {
   beforeAll(() => initTestLogger());
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
 
   it("returns parsed JSON on 200", async () => {
     mockFetch([new Response(JSON.stringify({ a: 1 }), { status: 200 })]);
@@ -58,6 +61,60 @@ describe("llm/fetcher", () => {
       provider: "anthropic",
       log: nullLog(),
     });
+    expect(f).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After seconds before retrying transient responses", async () => {
+    vi.useFakeTimers();
+    const f = mockFetch([
+      new Response("slow down", { status: 429, headers: { "Retry-After": "2" } }),
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 }),
+    ]);
+
+    const req = httpPostJson({
+      url: "https://x",
+      body: {},
+      timeoutMs: 5_000,
+      maxRetries: 1,
+      provider: "openai_compatible",
+      log: nullLog(),
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(req).resolves.toMatchObject({ json: { ok: 1 } });
+    expect(f).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After HTTP-date before retrying transient responses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const f = mockFetch([
+      new Response("try later", {
+        status: 503,
+        headers: { "Retry-After": "Thu, 01 Jan 2026 00:00:03 GMT" },
+      }),
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 }),
+    ]);
+
+    const req = httpPostJson({
+      url: "https://x",
+      body: {},
+      timeoutMs: 5_000,
+      maxRetries: 1,
+      provider: "anthropic",
+      log: nullLog(),
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(f).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(req).resolves.toMatchObject({ json: { ok: 1 } });
     expect(f).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Description

Fixes #1620.

LLM and embedding provider fetchers now honor the upstream `Retry-After` header before retrying transient HTTP responses. The parser supports integer seconds and HTTP-date values, and falls back to the existing exponential backoff when the header is absent or invalid.

Related Issue (Required): Fixes #1620

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `cd apps/memos-local-plugin && npm test -- --run tests/unit/llm/fetcher.test.ts tests/unit/embedding/fetcher.test.ts` passed with 22 tests.
- [x] `cd apps/memos-local-plugin && npm run lint` passed.
- [ ] `make format` could not run because `poetry` is not installed: `make: poetry: Command not found`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
