### PR TITLE
fix(skill-crystallize): retry with context when LLM returns empty response

### DIFF
--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -176,7 +176,7 @@ export async function crystallizeDraft(
     }
 
     // ── retry with correction context if raw output is available ──
-    if (rawPreview) {
+    if (rawPreview !== null) {
       log.warn("skill.crystallize.retry", {
         policyId: input.policy.id,
         error: message,

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -235,6 +235,10 @@ The error was: ${message}. Please correct this and generate a valid JSON skill d
           return { ok: false, skippedReason: "llm-refusal", modelRefusal };
         }
         if (deps.validate) deps.validate(draft);
+        log.warn("skill.crystallize.retry_succeeded", {
+          policyId: input.policy.id,
+          error: message,
+        });
         return { ok: true, draft };
       } catch (retryErr) {
         const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -9,7 +9,7 @@
  * traces we fail fast with `skipped_reason="no-evidence"`.
  */
 
-import type { LlmClient } from "../llm/types.js";
+import type { LlmClient, LlmMessage } from "../llm/types.js";
 import { detectModelRefusal } from "../llm/refusal.js";
 import {
   detectDominantLanguage,
@@ -174,6 +174,78 @@ export async function crystallizeDraft(
       });
       return { ok: false, skippedReason: "llm-refusal", modelRefusal };
     }
+
+    // ── retry with correction context if raw output is available ──
+    if (rawPreview) {
+      log.warn("skill.crystallize.retry", {
+        policyId: input.policy.id,
+        error: message,
+      });
+      const correctionMessages: LlmMessage[] = [
+        { role: "system", content: SKILL_CRYSTALLIZE_PROMPT.system },
+        { role: "system", content: languageSteeringLine(evidenceLang) },
+        { role: "user", content: userPayload },
+        { role: "assistant", content: rawPreview },
+        {
+          role: "user",
+          content: `The previous attempt produced the following output:
+
+${rawPreview}
+
+The error was: ${message}. Please correct this and generate a valid JSON skill definition. Ensure the output is valid JSON and follows the required schema.`,
+        },
+      ];
+      try {
+        const rsp = await llm.completeJson<Record<string, unknown>>(
+          correctionMessages,
+          {
+            op: "skill.crystallize",
+            phase: "skill",
+            episodeId: input.episodeId,
+            schemaHint: "skill-crystallize.v2",
+          },
+        );
+        const retryRawRefusal = detectModelRefusal(rsp.raw);
+        if (retryRawRefusal) {
+          const modelRefusal = {
+            provider: rsp.provider,
+            model: rsp.model,
+            servedBy: rsp.servedBy,
+            ...retryRawRefusal,
+          };
+          log.error("skill.crystallize.retry_model_refusal", {
+            policyId: input.policy.id,
+            ...modelRefusal,
+          });
+          return { ok: false, skippedReason: "llm-refusal", modelRefusal };
+        }
+        const draft = normaliseDraft(rsp.value, input);
+        const draftRefusal = detectModelRefusal(draft);
+        if (draftRefusal) {
+          const modelRefusal = {
+            provider: rsp.provider,
+            model: rsp.model,
+            servedBy: rsp.servedBy,
+            ...draftRefusal,
+          };
+          log.error("skill.crystallize.retry_model_refusal", {
+            policyId: input.policy.id,
+            ...modelRefusal,
+          });
+          return { ok: false, skippedReason: "llm-refusal", modelRefusal };
+        }
+        if (deps.validate) deps.validate(draft);
+        return { ok: true, draft };
+      } catch (retryErr) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        log.error("skill.crystallize.retry_failed", {
+          policyId: input.policy.id,
+          error: retryMsg,
+        });
+        return { ok: false, skippedReason: `llm-failed: ${retryMsg}` };
+      }
+    }
+
     log.error("skill.crystallize.failed", { policyId: input.policy.id, error: message });
     return { ok: false, skippedReason: `llm-failed: ${message}` };
   }


### PR DESCRIPTION
## Problem

When `crystallizeDraft()` receives an empty response from the LLM (e.g., due to transient model issues or rate limiting), the function immediately fails with a generic `llm-failed` error. There is no retry mechanism and no diagnostic context, making it difficult to recover or debug.

## Changes

- Added a retry-with-correction-context block in the catch handler of `crystallizeDraft()`
- When `rawPreview` is available and the LLM call throws, the retry sends the original raw output plus the error message back to the LLM with a correction instruction
- If the retry also fails (including model refusal), the function returns a descriptive failure instead of crashing
- The retry preserves the same `llm.completeJson` schema hint (`skill-crystallize.v2`) for consistent parsing

## Related

Closes #2062