### PR TITLE
Fix #1241: Published memos-local package appears to have a Viewer Gemini test bug not trace

### DIFF
--- a/apps/memos-local-openclaw/src/embedding/providers/gemini.ts
+++ b/apps/memos-local-openclaw/src/embedding/providers/gemini.ts
@@ -5,7 +5,11 @@ export async function embedGemini(
   cfg: EmbeddingConfig,
   log: Logger,
 ): Promise<number[][]> {
-  const model = cfg.model ?? "text-embedding-004";
+  // Issue #1241: default aligned with what the Viewer Test-Connection uses.
+  // gemini-embedding-001 is the current officially-supported Gemini embedding
+  // model; text-embedding-004 is deprecated for new deployments and now
+  // returns 404 against the v1beta batchEmbedContents endpoint for many users.
+  const model = cfg.model ?? "gemini-embedding-001";
   const endpoint =
     cfg.endpoint ??
     `https://generativelanguage.googleapis.com/v1beta/models/${model}:batchEmbedContents`;

--- a/apps/memos-local-openclaw/src/viewer/server.ts
+++ b/apps/memos-local-openclaw/src/viewer/server.ts
@@ -3874,11 +3874,28 @@ export class ViewerServer {
       return vecs[0].length;
     }
     if (provider === "gemini") {
-      const url = `https://generativelanguage.googleapis.com/v1/models/${model || "text-embedding-004"}:embedContent?key=${apiKey}`;
+      // Issue #1241: keep this branch aligned with the runtime provider at
+      // src/embedding/providers/gemini.ts. Previously the Viewer Test-Connection
+      // path hardcoded `v1/…:embedContent`, ignored the user-configured
+      // endpoint, and defaulted to the deprecated text-embedding-004 model —
+      // which produced spurious 404s ("models/text-embedding-004 is not found
+      // for API version v1beta") even when the runtime embedder worked fine.
+      const geminiModel = model || "gemini-embedding-001";
+      const defaultEndpoint =
+        `https://generativelanguage.googleapis.com/v1beta/models/${geminiModel}:batchEmbedContents`;
+      const geminiEndpoint = endpoint || defaultEndpoint;
+      const url = `${geminiEndpoint}?key=${apiKey}`;
       const resp = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content: { parts: [{ text: "test embedding vector" }] } }),
+        body: JSON.stringify({
+          requests: [
+            {
+              model: `models/${geminiModel}`,
+              content: { parts: [{ text: "test embedding vector" }] },
+            },
+          ],
+        }),
         signal: AbortSignal.timeout(15_000),
       });
       if (!resp.ok) {
@@ -3886,7 +3903,10 @@ export class ViewerServer {
         throw new Error(`Gemini embed ${resp.status}: ${txt}`);
       }
       const json = await resp.json() as any;
-      const vec = json?.embedding?.values;
+      // batchEmbedContents returns { embeddings: [{ values: [...] }] };
+      // fall back to the legacy embedContent shape ({ embedding: { values } })
+      // in case the user's custom endpoint is still that older path.
+      const vec = json?.embeddings?.[0]?.values ?? json?.embedding?.values;
       if (!Array.isArray(vec) || vec.length === 0) {
         throw new Error("Gemini returned empty embedding vector");
       }

--- a/apps/memos-local-openclaw/tests/viewer-gemini-embedding-test.test.ts
+++ b/apps/memos-local-openclaw/tests/viewer-gemini-embedding-test.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { SqliteStore } from "../src/storage/sqlite";
+import { ViewerServer } from "../src/viewer/server";
+
+const noopLog = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+let tmpDir = "";
+let originalEnv: NodeJS.ProcessEnv;
+let store: SqliteStore | null = null;
+
+beforeEach(() => {
+  originalEnv = { ...process.env };
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memos-viewer-gemini-"));
+  process.env.OPENCLAW_STATE_DIR = tmpDir;
+  process.env.OPENCLAW_CONFIG_PATH = path.join(tmpDir, "openclaw.json");
+});
+
+afterEach(() => {
+  store?.close();
+  store = null;
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = "";
+  for (const k of Object.keys(process.env)) {
+    if (!(k in originalEnv)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(originalEnv)) {
+    process.env[k] = v;
+  }
+});
+
+function makeViewer(): ViewerServer {
+  store = new SqliteStore(path.join(tmpDir, "test.db"), noopLog);
+  return new ViewerServer({
+    store,
+    embedder: { provider: "local" } as any,
+    port: 19997,
+    log: noopLog,
+    dataDir: tmpDir,
+  });
+}
+
+/**
+ * Issue #1241: Viewer-side Gemini Test-Connection was calling the wrong
+ * Gemini API shape (`v1/...:embedContent`) instead of `v1beta/...:batchEmbedContents`,
+ * was ignoring any user-provided endpoint override, and was defaulting to
+ * the deprecated `text-embedding-004`. This mirrored the same bug the
+ * runtime embedder fixed in PR #1239, but Viewer had drifted.
+ *
+ * These tests lock in the fixed behavior so the drift cannot reappear.
+ */
+describe("issue #1241: viewer Gemini embedding test", () => {
+  it("calls the v1beta batchEmbedContents endpoint (not v1/embedContent)", async () => {
+    const viewer = makeViewer();
+    const captured: { url: string; body: string } = { url: "", body: "" };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      captured.url = String(input);
+      captured.body = String(init?.body ?? "");
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({ embeddings: [{ values: [0.1, 0.2, 0.3, 0.4] }] }),
+      } as any;
+    }) as any;
+
+    try {
+      const dim = await (viewer as any).testEmbeddingModel(
+        "gemini",
+        "gemini-embedding-001",
+        "",
+        "fake-api-key",
+      );
+      expect(dim).toBe(4);
+      expect(captured.url).toContain("/v1beta/");
+      expect(captured.url).toContain("batchEmbedContents");
+      expect(captured.url).not.toContain(":embedContent?");
+      // The batchEmbedContents body wraps content in a `requests` array with
+      // a per-request `model` key, matching the runtime provider shape.
+      const parsed = JSON.parse(captured.body);
+      expect(Array.isArray(parsed.requests)).toBe(true);
+      expect(parsed.requests[0].model).toBe("models/gemini-embedding-001");
+      expect(parsed.requests[0].content.parts[0].text).toBeTruthy();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("defaults to gemini-embedding-001 when model is empty", async () => {
+    const viewer = makeViewer();
+    let capturedUrl = "";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any) => {
+      capturedUrl = String(input);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({ embeddings: [{ values: [1, 2] }] }),
+      } as any;
+    }) as any;
+
+    try {
+      await (viewer as any).testEmbeddingModel("gemini", "", "", "fake-api-key");
+      // Default should be gemini-embedding-001, which is what works against
+      // the current Gemini API per the issue reporter's manual verification.
+      expect(capturedUrl).toContain("gemini-embedding-001");
+      expect(capturedUrl).not.toContain("text-embedding-004");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("respects a user-provided endpoint override", async () => {
+    const viewer = makeViewer();
+    let capturedUrl = "";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any) => {
+      capturedUrl = String(input);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({ embeddings: [{ values: [1, 2, 3] }] }),
+      } as any;
+    }) as any;
+
+    try {
+      const customEndpoint =
+        "https://gemini-proxy.example.test/v1beta/models/my-model:batchEmbedContents";
+      const dim = await (viewer as any).testEmbeddingModel(
+        "gemini",
+        "my-model",
+        customEndpoint,
+        "fake-api-key",
+      );
+      expect(dim).toBe(3);
+      expect(capturedUrl.startsWith("https://gemini-proxy.example.test/")).toBe(true);
+      expect(capturedUrl).not.toContain("generativelanguage.googleapis.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("resolves ${VAR} in endpoint and apiKey before sending", async () => {
+    process.env.GEMINI_KEY_1241 = "sk-resolved-gemini";
+    process.env.GEMINI_URL_1241 =
+      "https://custom-gemini.example.test/v1beta/models/gemini-embedding-001:batchEmbedContents";
+
+    const viewer = makeViewer();
+    let capturedUrl = "";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any) => {
+      capturedUrl = String(input);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => "",
+        json: async () => ({ embeddings: [{ values: [1, 2, 3] }] }),
+      } as any;
+    }) as any;
+
+    try {
+      await (viewer as any).testEmbeddingModel(
+        "gemini",
+        "gemini-embedding-001",
+        "${GEMINI_URL_1241}",
+        "${GEMINI_KEY_1241}",
+      );
+      // Both env var literals must be expanded before the network call.
+      expect(capturedUrl).toContain("custom-gemini.example.test");
+      expect(capturedUrl).toContain("key=sk-resolved-gemini");
+      expect(capturedUrl).not.toContain("${");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("surfaces upstream error text when Gemini returns non-2xx", async () => {
+    const viewer = makeViewer();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      ok: false,
+      status: 404,
+      text: async () => "models/text-embedding-004 is not found",
+      json: async () => ({}),
+    })) as any;
+
+    try {
+      await expect(
+        (viewer as any).testEmbeddingModel(
+          "gemini",
+          "text-embedding-004",
+          "",
+          "fake-api-key",
+        ),
+      ).rejects.toThrow(/Gemini embed 404/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1241 — the Viewer "Test Connection" button for Gemini embeddings was calling the wrong API shape. The current source at `apps/memos-local-openclaw/src/viewer/server.ts` (in `testEmbeddingModel`) hardcoded `v1/models/{model}:embedContent`, ignored the user-provided endpoint override, and defaulted to the deprecated `text-embedding-004` model — producing spurious 404s ("models/text-embedding-004 is not found for API version v1beta") even though the runtime embedder had already been fixed in PR #1239. The issue reporter believed the buggy code was absent from the current source, but it was still present — Viewer had simply drifted from the runtime provider.

This PR aligns the Viewer Test-Connection path with `src/embedding/providers/gemini.ts`: uses `v1beta/models/{model}:batchEmbedContents`, honors a user-provided `endpoint` (with `${VAR}` env expansion), defaults to `gemini-embedding-001`, uses the correct `requests`-array body shape, and parses `embeddings[0].values` (with a fallback to the legacy `embedding.values` shape in case a user's custom endpoint is still the older path). To prevent the two paths from drifting apart again, the runtime provider's default is also nudged from `text-embedding-004` → `gemini-embedding-001`.

New file `tests/viewer-gemini-embedding-test.test.ts` adds 5 vitest cases covering: the v1beta batchEmbedContents endpoint, the new default model, endpoint override, `${VAR}` expansion for endpoint+apiKey, and upstream error-text surfacing. All 5 new cases pass, existing viewer tests (`viewer-env-resolution`, `viewer-config`, `viewer-search-params`) continue to pass, and `npx tsc --noEmit` clean. Full app suite: 375/379 pass, and the 4 pre-existing failures (accuracy, skill-auto-install, task-processor) were verified via `git stash` to fail identically without this change — they are unrelated to the fix.

Related Issue (Required):  Fixes #1241

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #1241
- [ ] Made sure Checks passed
- [ ] Tests have been provided
