### PR TITLE
Fix #2063: algorithm.lightweightMemory.enabled: true does not actually skip evolution pipel

### DIFF
--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -204,6 +204,7 @@ export function buildPipelineSubscribers(
   session?: PipelineSessionSet,
 ): PipelineSubscriberSet {
   const log = deps.log ?? rootLogger.child({ channel: "core.pipeline" });
+  const lightweightMode = algorithm.lightweightMemory.enabled;
 
   const captureRunner = createCaptureRunner({
     tracesRepo: deps.repos.traces,
@@ -216,6 +217,32 @@ export function buildPipelineSubscribers(
     cfg: algorithm.capture,
     now: deps.now,
   });
+
+  // Lightweight mode short-circuits the evolution pipeline: reward /
+  // L2 / L3 / skill / feedback subscribers are NOT attached to their
+  // upstream buses. This matches the schema comment on
+  // `algorithm.lightweightMemory.enabled` which promises that only
+  // summarize + embedding + retrieval filter remain active. Attaching
+  // the subscribers used to be unconditional (issue #2063) — every
+  // `episode.finalized` event still cascaded through the LLM-heavy
+  // evolution chain, defeating the flag.
+  if (lightweightMode) {
+    log.info("pipeline.lightweight_mode.enabled", {
+      skipped: ["reward", "l2", "l3", "skill", "feedback"],
+    });
+    return {
+      captureRunner,
+      rewardRunner: lightweightRewardRunnerStub(),
+      l2: lightweightL2Handle(),
+      l3: lightweightL3Handle(),
+      skills: lightweightSkillHandle(),
+      feedback: lightweightFeedbackHandle(),
+      subscriptions: {
+        capture: lightweightCaptureSubscription(),
+        reward: lightweightRewardSubscription(),
+      },
+    };
+  }
 
   const rewardRunner = createRewardRunner({
     tracesRepo: deps.repos.traces,
@@ -406,3 +433,156 @@ export type {
   SkillEventBus,
   SkillSubscriberHandle,
 };
+
+// ─── Lightweight-mode subscriber stubs ────────────────────────────────────
+//
+// When `algorithm.lightweightMemory.enabled` is `true`, the pipeline skips
+// mounting the reward / L2 / L3 / skill / feedback runners entirely (see
+// issue #2063). Downstream code (memory-core, orchestrator) still holds
+// references to these handles for shape compatibility (`flush()` /
+// `shutdown()` walk the whole subscriber set) but every caller that would
+// actually invoke a runner is already gated behind the same lightweight
+// check — so these stubs must only satisfy the type shape + drain/stop
+// lifecycle without producing events or LLM traffic.
+
+function throwLightweight(feature: string): never {
+  throw new Error(
+    `pipeline: ${feature} is unavailable while ` +
+      `algorithm.lightweightMemory.enabled=true. Every caller must gate ` +
+      `on the same flag before invoking it.`,
+  );
+}
+
+function lightweightRewardRunnerStub(): RewardRunner {
+  return {
+    async run() {
+      return throwLightweight("rewardRunner.run");
+    },
+  };
+}
+
+function lightweightRewardSubscription(): RewardSubscription {
+  return {
+    submitFeedback() {
+      throwLightweight("rewardSubscription.submitFeedback");
+    },
+    async runManually() {
+      throwLightweight("rewardSubscription.runManually");
+    },
+    stop() {
+      /* no-op — nothing was attached */
+    },
+    async drain() {
+      /* no-op — no in-flight work in lightweight mode */
+    },
+    pendingCount() {
+      return 0;
+    },
+  };
+}
+
+function lightweightCaptureSubscription(): CaptureSubscription {
+  return {
+    stop() {
+      /* no-op — capture subscriber is not attached in lightweight mode */
+    },
+    async drain() {
+      /* no-op — orchestrator calls runLightweight/runLite directly */
+    },
+    pendingCount() {
+      return 0;
+    },
+  };
+}
+
+function lightweightL2Handle(): L2SubscriberHandle {
+  return {
+    detach() {
+      /* no-op */
+    },
+    async runOnce() {
+      throwLightweight("l2.runOnce");
+    },
+    async drain() {
+      /* no-op */
+    },
+  };
+}
+
+function lightweightL3Handle(): L3SubscriberHandle {
+  return {
+    detach() {
+      /* no-op */
+    },
+    async drain() {
+      /* no-op */
+    },
+    async runOnce() {
+      return throwLightweight("l3.runOnce");
+    },
+    async adjustFeedback() {
+      return throwLightweight("l3.adjustFeedback");
+    },
+  };
+}
+
+function lightweightSkillHandle(): SkillSubscriberHandle {
+  return {
+    dispose() {
+      /* no-op */
+    },
+    async runOnce() {
+      return throwLightweight("skills.runOnce");
+    },
+    applyFeedback() {
+      throwLightweight("skills.applyFeedback");
+    },
+    async lifecycleTick() {
+      /* no-op */
+    },
+    async flush() {
+      /* no-op */
+    },
+  };
+}
+
+function lightweightFeedbackHandle(): FeedbackSubscriberHandle {
+  const signals: FeedbackSubscriberHandle["signals"] = {
+    recordFailure() {
+      return null;
+    },
+    recordSuccess() {
+      /* no-op */
+    },
+    peek() {
+      return null;
+    },
+    clear() {
+      /* no-op */
+    },
+    stats() {
+      return { states: 0, totalFailures: 0 };
+    },
+  };
+  return {
+    recordToolFailure() {
+      /* no-op — feedback subsystem is off in lightweight mode */
+    },
+    recordToolSuccess() {
+      /* no-op */
+    },
+    async submitUserFeedback() {
+      return throwLightweight("feedback.submitUserFeedback");
+    },
+    async runOnce() {
+      return throwLightweight("feedback.runOnce");
+    },
+    signals,
+    async flush() {
+      /* no-op */
+    },
+    dispose() {
+      /* no-op */
+    },
+  };
+}

--- a/apps/memos-local-plugin/core/pipeline/deps.ts
+++ b/apps/memos-local-plugin/core/pipeline/deps.ts
@@ -467,7 +467,7 @@ function lightweightRewardSubscription(): RewardSubscription {
       throwLightweight("rewardSubscription.submitFeedback");
     },
     async runManually() {
-      throwLightweight("rewardSubscription.runManually");
+      return throwLightweight("rewardSubscription.runManually");
     },
     stop() {
       /* no-op — nothing was attached */
@@ -501,7 +501,7 @@ function lightweightL2Handle(): L2SubscriberHandle {
       /* no-op */
     },
     async runOnce() {
-      throwLightweight("l2.runOnce");
+      return throwLightweight("l2.runOnce");
     },
     async drain() {
       /* no-op */

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -597,6 +597,11 @@ export function createMemoryCore(
     const nowMs = Date.now();
     if (nowMs - lastStaleScan < 30_000) return;
     lastStaleScan = nowMs;
+    // Issue #2063: lightweight mode disables reward / L2 / L3 / skill;
+    // the periodic auto-finalize used to emit `episode.finalized` for
+    // every stale open topic, which still cascaded into the evolution
+    // chain in earlier releases. Close them silently instead.
+    const lightweightMode = handle.algorithm.lightweightMemory.enabled;
     try {
       const openEpisodes = handle.repos.episodes
         .list({ status: "open", limit: 200 })
@@ -615,7 +620,27 @@ export function createMemoryCore(
           stale.push(ep);
         }
       }
-      if (stale.length > 0) await recoverOpenEpisodesAsSessionEnd(stale);
+      if (stale.length === 0) return;
+      if (lightweightMode) {
+        for (const ep of stale) {
+          try {
+            handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
+            handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
+              lightweightMemory: true,
+              closeReason: "finalized",
+              recoveredAtStartup: nowMs,
+              recoveryReason: "lightweight_stale_topic_close",
+            });
+          } catch (err) {
+            log.debug("stale_topic.lightweight_close_error", {
+              episodeId: ep.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        return;
+      }
+      await recoverOpenEpisodesAsSessionEnd(stale);
     } catch (err) {
       log.debug("stale_topic.scan_error", {
         err: err instanceof Error ? err.message : String(err),
@@ -627,6 +652,11 @@ export function createMemoryCore(
     const nowMs = Date.now();
     if (nowMs - lastDirtyClosedScan < 30_000) return;
     lastDirtyClosedScan = nowMs;
+    // Issue #2063: lightweight mode explicitly disables reward — the
+    // periodic dirty-closed rescan (which would emit
+    // `episode.finalized` and call `handle.rewardRunner.run(...)`)
+    // must be a no-op.
+    if (handle.algorithm.lightweightMemory.enabled) return;
     try {
       const allDirty = handle.repos.episodes
         .list({ status: "closed", limit: 500 })
@@ -926,53 +956,82 @@ export function createMemoryCore(
       const orphans = handle.repos.episodes.list({ status: "open", limit: 500 });
       if (orphans.length > 0) {
         const nowMs = Date.now();
-        const lightweight = orphans.filter((ep) => isLightweightEpisode(ep));
-        for (const ep of lightweight) {
+        // Issue #2063: when `algorithm.lightweightMemory.enabled` is
+        // true, treat EVERY orphan episode as lightweight — legacy rows
+        // written before the flag was flipped lack
+        // `meta.lightweightMemory=true`, and prior versions still
+        // re-emitted `episode.finalized` on them at startup which
+        // cascaded into reward / L2 / L3 / skill LLM calls (the
+        // "backlog of evolution calls after every bridge restart"
+        // reported by the issue). Closing them silently here matches
+        // the schema-comment guarantee that the flag disables the
+        // whole evolution pipeline.
+        const lightweightMode = handle.algorithm.lightweightMemory.enabled;
+        const treatAsLightweight = lightweightMode
+          ? orphans
+          : orphans.filter((ep) => isLightweightEpisode(ep));
+        for (const ep of treatAsLightweight) {
           handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
           handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
             lightweightMemory: true,
             closeReason: "finalized",
             recoveredAtStartup: nowMs,
-            recoveryReason: "lightweight_startup_close",
+            recoveryReason: lightweightMode && !isLightweightEpisode(ep)
+              ? "lightweight_startup_close_backfill"
+              : "lightweight_startup_close",
           });
         }
-        const normalOrphans = orphans.filter((ep) => !isLightweightEpisode(ep));
-        const stale = normalOrphans.filter(
-          (ep) =>
-            ep.rTask != null ||
-            (ep.traceIds?.length ?? 0) > 0 ||
-            nowMs - (ep.endedAt ?? ep.startedAt) > STALE_EPISODE_TIMEOUT_MS,
-        );
-        const recent = normalOrphans.filter((ep) => !stale.includes(ep));
-        for (const ep of recent) {
-          handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
-            topicState: (ep.meta?.topicState as string | undefined) ?? "interrupted",
-            pauseReason: (ep.meta?.pauseReason as string | undefined) ?? "startup_recovered_open_topic",
-            recoveredAtStartup: nowMs,
-          });
-        }
-        staleForBackground = stale;
-      }
-      const nowForDirty = Date.now();
-      const allDirty = handle.repos.episodes
-        .list({ status: "closed", limit: 500 })
-        .filter((ep) => !isLightweightEpisode(ep) && episodeRewardIsDirty(ep));
-      const dirtyClosed: typeof allDirty = [];
-      for (const ep of allDirty) {
-        if (dirtyEpisodeBackoffElapsed(ep, nowForDirty)) {
-          dirtyClosed.push(ep);
+        if (lightweightMode) {
+          // No reward / L2 / L3 / skill work is scheduled when the
+          // pipeline is lightweight — leave both background queues
+          // empty so the recovery promise short-circuits below.
+          staleForBackground = [];
+          dirtyClosedForBackground = [];
         } else {
-          const dirtyMeta = (ep.meta?.rewardDirty as
-            | { failedAttempts?: number; lastFailureAt?: number }
-            | undefined) ?? {};
-          log.debug("init.dirty_closed_episodes.skip_backoff", {
-            episodeId: ep.id,
-            failedAttempts: dirtyMeta.failedAttempts ?? 0,
-            lastFailureAt: dirtyMeta.lastFailureAt ?? 0,
-          });
+          const normalOrphans = orphans.filter((ep) => !isLightweightEpisode(ep));
+          const stale = normalOrphans.filter(
+            (ep) =>
+              ep.rTask != null ||
+              (ep.traceIds?.length ?? 0) > 0 ||
+              nowMs - (ep.endedAt ?? ep.startedAt) > STALE_EPISODE_TIMEOUT_MS,
+          );
+          const recent = normalOrphans.filter((ep) => !stale.includes(ep));
+          for (const ep of recent) {
+            handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
+              topicState: (ep.meta?.topicState as string | undefined) ?? "interrupted",
+              pauseReason: (ep.meta?.pauseReason as string | undefined) ?? "startup_recovered_open_topic",
+              recoveredAtStartup: nowMs,
+            });
+          }
+          staleForBackground = stale;
         }
       }
-      dirtyClosedForBackground = dirtyClosed;
+      if (handle.algorithm.lightweightMemory.enabled) {
+        // Same story for dirty-closed episodes — never rescore them
+        // when the pipeline is intentionally light.
+        dirtyClosedForBackground = [];
+      } else {
+        const nowForDirty = Date.now();
+        const allDirty = handle.repos.episodes
+          .list({ status: "closed", limit: 500 })
+          .filter((ep) => !isLightweightEpisode(ep) && episodeRewardIsDirty(ep));
+        const dirtyClosed: typeof allDirty = [];
+        for (const ep of allDirty) {
+          if (dirtyEpisodeBackoffElapsed(ep, nowForDirty)) {
+            dirtyClosed.push(ep);
+          } else {
+            const dirtyMeta = (ep.meta?.rewardDirty as
+              | { failedAttempts?: number; lastFailureAt?: number }
+              | undefined) ?? {};
+            log.debug("init.dirty_closed_episodes.skip_backoff", {
+              episodeId: ep.id,
+              failedAttempts: dirtyMeta.failedAttempts ?? 0,
+              lastFailureAt: dirtyMeta.lastFailureAt ?? 0,
+            });
+          }
+        }
+        dirtyClosedForBackground = dirtyClosed;
+      }
     } catch (err) {
       log.debug("init.orphan_scan.failed", {
         err: err instanceof Error ? err.message : String(err),

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -976,19 +976,40 @@ export function createMemoryCore(
           ? orphans
           : orphans.filter((ep) => isLightweightEpisode(ep));
         for (const ep of treatAsLightweight) {
+          const isBackfill = lightweightMode && !isLightweightEpisode(ep);
           let recoveryReason: string;
-          if (lightweightMode && !isLightweightEpisode(ep)) {
+          if (isBackfill) {
             recoveryReason = "lightweight_startup_close_backfill";
           } else {
             recoveryReason = "lightweight_startup_close";
           }
-          handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
-          handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
-            lightweightMemory: true,
-            closeReason: "finalized",
-            recoveredAtStartup: nowMs,
-            recoveryReason,
-          });
+          try {
+            // Write the lightweight flag BEFORE close() so that even if
+            // close() throws, `isLightweightEpisode()` still returns true
+            // for this row and the periodic non-lightweight rescan paths
+            // (autoRescoreDirtyClosedEpisodes) skip it instead of feeding
+            // it into the reward / L2 / L3 pipeline. Mirrors the ordering
+            // used by the periodic stale-topic close above.
+            handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
+              lightweightMemory: true,
+              // Legacy rows being backfilled were never actually
+              // finalized through the evolution pipeline; tag them with
+              // a distinct closeReason so analytics can distinguish a
+              // real finalize from a lightweight backfill.
+              closeReason: isBackfill ? "lightweight_backfill" : "finalized",
+              recoveredAtStartup: nowMs,
+              recoveryReason,
+            });
+            handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
+          } catch (err) {
+            // Isolate per-episode failures so a single DB lock /
+            // constraint violation cannot abort the whole startup
+            // orphan-close loop. Mirrors the periodic stale-topic path.
+            log.debug("init.lightweight_close_error", {
+              episodeId: ep.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
         if (lightweightMode) {
           // No reward / L2 / L3 / skill work is scheduled when the

--- a/apps/memos-local-plugin/core/pipeline/memory-core.ts
+++ b/apps/memos-local-plugin/core/pipeline/memory-core.ts
@@ -624,13 +624,18 @@ export function createMemoryCore(
       if (lightweightMode) {
         for (const ep of stale) {
           try {
-            handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
+            // Write the lightweight flag BEFORE close() so that even if
+            // close() throws mid-way, `isLightweightEpisode()` still
+            // returns true and the periodic non-lightweight rescan paths
+            // (autoRescoreDirtyClosedEpisodes) skip this episode instead
+            // of feeding it into the reward / L2 / L3 pipeline.
             handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
               lightweightMemory: true,
-              closeReason: "finalized",
-              recoveredAtStartup: nowMs,
+              closeReason: "lightweight_stale",
+              closedAtMs: nowMs,
               recoveryReason: "lightweight_stale_topic_close",
             });
+            handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
           } catch (err) {
             log.debug("stale_topic.lightweight_close_error", {
               episodeId: ep.id,
@@ -971,14 +976,18 @@ export function createMemoryCore(
           ? orphans
           : orphans.filter((ep) => isLightweightEpisode(ep));
         for (const ep of treatAsLightweight) {
+          let recoveryReason: string;
+          if (lightweightMode && !isLightweightEpisode(ep)) {
+            recoveryReason = "lightweight_startup_close_backfill";
+          } else {
+            recoveryReason = "lightweight_startup_close";
+          }
           handle.repos.episodes.close(ep.id as EpisodeId, nowMs, ep.rTask ?? undefined);
           handle.repos.episodes.updateMeta(ep.id as EpisodeId, {
             lightweightMemory: true,
             closeReason: "finalized",
             recoveredAtStartup: nowMs,
-            recoveryReason: lightweightMode && !isLightweightEpisode(ep)
-              ? "lightweight_startup_close_backfill"
-              : "lightweight_startup_close",
+            recoveryReason,
           });
         }
         if (lightweightMode) {

--- a/apps/memos-local-plugin/tests/unit/pipeline/lightweight-mode.test.ts
+++ b/apps/memos-local-plugin/tests/unit/pipeline/lightweight-mode.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for issue #2063 — `algorithm.lightweightMemory.enabled:
+ * true` must actually skip the evolution pipeline (reward / L2 / L3 /
+ * skill / feedback), not just short-circuit inside `flush()`. The bug was
+ * that `buildPipelineSubscribers` unconditionally attached every runner
+ * to the buses, so every `capture.done` / `reward.updated` / ... event
+ * still cascaded through the LLM-heavy evolution chain even with the
+ * flag on.
+ *
+ * These tests lock in the schema-comment contract:
+ * > When enabled, the runtime skips task/reward/L2/L3/skill evolution
+ * > and keeps only summarize + embedding + retrieval filter.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildPipelineBuses,
+  buildPipelineSession,
+  buildPipelineSubscribers,
+  createPipeline,
+  extractAlgorithmConfig,
+  type PipelineDeps,
+  type PipelineHandle,
+} from "../../../core/pipeline/index.js";
+import { DEFAULT_CONFIG } from "../../../core/config/defaults.js";
+import { resolveHome } from "../../../core/config/paths.js";
+import { rootLogger } from "../../../core/logger/index.js";
+import { makeTmpDb, type TmpDbHandle } from "../../helpers/tmp-db.js";
+import { fakeEmbedder } from "../../helpers/fake-embedder.js";
+import type { EpisodeSnapshot } from "../../../core/session/index.js";
+
+let dbHandle: TmpDbHandle | null = null;
+let pipeline: PipelineHandle | null = null;
+
+function configWithLightweightMemory(enabled: boolean): typeof DEFAULT_CONFIG {
+  return {
+    ...DEFAULT_CONFIG,
+    algorithm: {
+      ...DEFAULT_CONFIG.algorithm,
+      lightweightMemory: {
+        ...DEFAULT_CONFIG.algorithm.lightweightMemory,
+        enabled,
+      },
+    },
+  };
+}
+
+function buildDeps(
+  h: TmpDbHandle,
+  lightweight: boolean,
+): PipelineDeps {
+  return {
+    agent: "openclaw",
+    home: resolveHome("openclaw", "/tmp/memos-lightweight-test"),
+    config: configWithLightweightMemory(lightweight),
+    db: h.db,
+    repos: h.repos,
+    llm: null,
+    reflectLlm: null,
+    embedder: fakeEmbedder({ dimensions: 384 }),
+    log: rootLogger.child({ channel: "test.lightweight" }),
+    namespace: { agentKind: "openclaw", profileId: "main" },
+    now: () => 1_700_000_000_000,
+  };
+}
+
+beforeEach(() => {
+  dbHandle = makeTmpDb();
+  pipeline = null;
+});
+
+afterEach(async () => {
+  if (pipeline) {
+    try {
+      await pipeline.shutdown("test.cleanup");
+    } catch {
+      /* ignore */
+    }
+    pipeline = null;
+  }
+  dbHandle?.cleanup();
+  dbHandle = null;
+});
+
+describe("pipeline/lightweight-mode wiring (issue #2063)", () => {
+  it("normal mode attaches reward/L2/L3/skill subscribers to their upstream buses", () => {
+    const buses = buildPipelineBuses();
+    const deps = buildDeps(dbHandle!, false);
+    const algorithm = extractAlgorithmConfig(deps);
+    const session = buildPipelineSession(deps, buses.session);
+    buildPipelineSubscribers(deps, buses, algorithm, session);
+
+    // rewardSub listens on captureBus for `capture.done`.
+    expect(buses.capture.listenerCount("capture.done")).toBeGreaterThan(0);
+    // L2Sub + SkillSub listen on rewardBus.
+    expect(buses.reward.listenerCount()).toBeGreaterThan(0);
+    // L3Sub + SkillSub listen on l2Bus.
+    expect(buses.l2.listenerCount()).toBeGreaterThan(0);
+  });
+
+  it("lightweight mode does NOT attach reward/L2/L3/skill subscribers", () => {
+    const buses = buildPipelineBuses();
+    const deps = buildDeps(dbHandle!, true);
+    const algorithm = extractAlgorithmConfig(deps);
+    const session = buildPipelineSession(deps, buses.session);
+    buildPipelineSubscribers(deps, buses, algorithm, session);
+
+    // The evolution pipeline must be completely off — no listeners on
+    // the upstream buses that would drive reward / L2 / L3 / skill
+    // runners.
+    expect(buses.capture.listenerCount("capture.done")).toBe(0);
+    expect(buses.reward.listenerCount()).toBe(0);
+    expect(buses.l2.listenerCount()).toBe(0);
+  });
+
+  it("lightweight pipeline exposes no evolution listeners even on session bus recovery", async () => {
+    // Simulate the bug from the issue: bridge starts up in lightweight
+    // mode, `recoverOpenEpisodesAsSessionEnd` re-emits
+    // `episode.finalized` for a legacy episode that was closed before
+    // lightweight mode was turned on (so `meta.lightweightMemory` is
+    // missing). No LLM-heavy runners must fire.
+    pipeline = createPipeline(buildDeps(dbHandle!, true));
+
+    let rewardScheduled = 0;
+    let l2Started = 0;
+    let l3Started = 0;
+    let skillStarted = 0;
+    pipeline.buses.reward.onAny(() => {
+      rewardScheduled++;
+    });
+    pipeline.buses.l2.onAny(() => {
+      l2Started++;
+    });
+    pipeline.buses.l3.onAny(() => {
+      l3Started++;
+    });
+    pipeline.buses.skill.onAny(() => {
+      skillStarted++;
+    });
+
+    // Fabricate a plain (non-lightweight) episode snapshot and emit a
+    // recovery-style finalization exactly as `memory-core.ts` does at
+    // startup.
+    const legacyEpisode: EpisodeSnapshot = {
+      id: "ep_legacy" as never,
+      sessionId: "se_legacy" as never,
+      status: "closed",
+      startedAt: 1_699_000_000_000 as never,
+      endedAt: 1_699_000_005_000 as never,
+      rTask: null,
+      traceIds: [],
+      meta: {},
+      turns: [],
+      turnCount: 0,
+      intent: {
+        kind: "task",
+        confidence: 0.5,
+        reason: "test-fixture",
+        retrieval: { tier1: true, tier2: true, tier3: true },
+        signals: [],
+      },
+    };
+    pipeline.buses.session.emit({
+      kind: "episode.finalized",
+      episode: legacyEpisode,
+      closedBy: "finalized",
+    });
+
+    await pipeline.flush();
+
+    // In lightweight mode, no reward / L2 / L3 / skill events must
+    // fire from a session-bus finalization. This is the exact regression
+    // called out in issue #2063.
+    expect(rewardScheduled).toBe(0);
+    expect(l2Started).toBe(0);
+    expect(l3Started).toBe(0);
+    expect(skillStarted).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Fixed issue #2063 — `algorithm.lightweightMemory.enabled: true` now actually skips the evolution pipeline in @memtensor/memos-local-plugin. Two independent root causes were addressed. First, `buildPipelineSubscribers` in `apps/memos-local-plugin/core/pipeline/deps.ts` used to attach reward / L2 / L3 / skill / feedback subscribers unconditionally, so every `episode.finalized` event still cascaded through the LLM-heavy chain — the fix short-circuits the subscriber wiring and returns no-op stubs whose `drain`/`stop`/`detach`/`dispose` are safe to call from `flush()` / `shutdown()`, and whose runner methods throw with a "lightweight mode" message if reached (every real caller is already gated on the flag). Second, `memory-core.ts` startup + periodic recovery paths (`init`, `autoFinalizeStaleTasks`, `autoRescoreDirtyClosedEpisodes`) used to re-emit `episode.finalized` for legacy episodes lacking `meta.lightweightMemory === true`, producing the >19k `skill_generate` / >4.7k `world_model_generate` / >2.1k `policy_evolve` backlog reported in the issue — those paths now close orphan / stale / dirty-closed episodes silently when the flag is on and tag their meta so subsequent restarts stay quiet. Regression coverage added at `tests/unit/pipeline/lightweight-mode.test.ts`: three tests exercising normal-mode listener presence, lightweight-mode listener absence on capture / reward / L2 buses, and a synthetic `episode.finalized` recovery emission that must produce zero reward / L2 / L3 / skill events. All 50 existing pipeline unit tests + the openclaw full-chain integration test still pass; TypeScript strict typecheck (`tsc --noEmit`) is clean. Three pre-existing test failures (`startup-recovery`, `storage/migrator`, `v7-full-chain e2e`) reproduce on the pristine base branch and are out of scope.

Related Issue (Required):  Fixes #2063

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@hijzy please review this PR.

## Reviewer Checklist
- [x] closes #2063
- [ ] Made sure Checks passed
- [ ] Tests have been provided
