### PR TITLE
fix: publish compiled OpenClaw plugin entry

### DIFF
--- a/apps/memos-local-openclaw/index.ts
+++ b/apps/memos-local-openclaw/index.ts
@@ -5,7 +5,6 @@
  * Provides: memory_search, memory_get, memory_timeline, task_summary, skill_get, skill_install, memory_viewer
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import * as fs from "fs";
 import * as path from "path";
@@ -34,6 +33,9 @@ import { MEMORY_GUIDE_SKILL_MD } from "./src/skill/bundled-memory-guide";
 import { Telemetry } from "./src/telemetry";
 import { parseJsonOrJson5 } from "./src/shared/json5";
 import { patchOpenclawAllowFile } from "./src/shared/openclaw-config";
+
+
+type OpenClawPluginApi = any;
 
 
 /** Remove near-duplicate hits based on summary word overlap (>70%). Keeps first (highest-scored) hit. */

--- a/apps/memos-local-openclaw/openclaw.plugin.json
+++ b/apps/memos-local-openclaw/openclaw.plugin.json
@@ -34,7 +34,7 @@
     ]
   },
   "extensions": [
-    "./index.ts"
+    "./dist/index.js"
   ],
   "contracts": {
     "tools": [

--- a/apps/memos-local-openclaw/package.json
+++ b/apps/memos-local-openclaw/package.json
@@ -2,11 +2,12 @@
   "name": "@memtensor/memos-local-openclaw-plugin",
   "version": "1.0.9-beta.1",
   "description": "MemOS Local memory plugin for OpenClaw — full-write, hybrid-recall, progressive retrieval",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "commonjs",
+  "main": "./dist/index.js",
   "files": [
     "dist",
+    "tsconfig.json",
+    "src",
     "skill",
     "prebuilds",
     "scripts/native-binding.cjs",
@@ -34,7 +35,7 @@
     "test:watch": "vitest",
     "test:accuracy": "tsx scripts/run-accuracy-test.ts",
     "postinstall": "node scripts/postinstall.cjs",
-    "prepack": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "openclaw",

--- a/apps/memos-local-openclaw/tests/package-manifest.test.ts
+++ b/apps/memos-local-openclaw/tests/package-manifest.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+
+describe("package manifest", () => {
+  it("publishes the compiled OpenClaw entrypoint", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(root, "package.json"), "utf-8"),
+    ) as {
+      type: string;
+      main: string;
+      files: string[];
+      openclaw: { extensions: string[] };
+      scripts: Record<string, string>;
+    };
+    const pluginJson = JSON.parse(
+      fs.readFileSync(path.join(root, "openclaw.plugin.json"), "utf-8"),
+    ) as { extensions: string[] };
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(root, "tsconfig.json"), "utf-8"),
+    ) as { compilerOptions: { rootDir: string }; include: string[] };
+
+    expect(packageJson.type).toBe("commonjs");
+    expect(packageJson.main).toBe("./dist/index.js");
+    expect(packageJson.openclaw.extensions).toEqual(["./dist/index.js"]);
+    expect(pluginJson.extensions).toEqual(["./dist/index.js"]);
+    expect(tsconfig.compilerOptions.rootDir).toBe(".");
+    expect(tsconfig.include).toContain("index.ts");
+    expect(packageJson.files).toEqual(expect.arrayContaining(["dist", "tsconfig.json"]));
+    expect(packageJson.files).not.toContain("index.ts");
+    expect(packageJson.scripts.prepublishOnly).toBe("npm run build");
+  });
+});

--- a/apps/memos-local-openclaw/tsconfig.json
+++ b/apps/memos-local-openclaw/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": ".",
-    "strict": false,
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -20,6 +20,6 @@
       "openclaw/plugin-sdk": ["./types/openclaw__plugin-sdk/index.d.ts"]
     }
   },
-  "include": ["src", "index.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "scripts", "tests", "skill", "plugin-impl.ts"]
+  "include": ["index.ts", "plugin-impl.ts", "src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
Re-applies the original change from #2013 onto the current development branch `dev-v2.0.23`.

Context:
- #2013 was accidentally merged into `main`.
- #2082 reverted that merge from `main`.
- This PR carries the same intended package/OpenClaw manifest fix into the active dev branch instead.

Conflict resolution:
- Preserved the existing `openclaw.plugin.json` `contracts.tools` entries from `dev-v2.0.23`.
- Updated only the OpenClaw extension entrypoint to `./dist/index.js`.

Validation:
- JSON parse check passed for `package.json`, `openclaw.plugin.json`, and `tsconfig.json`.
- Manifest assertions passed locally.
- `npm pack --dry-run --ignore-scripts --cache /tmp/npm-cache` passed.
- Attempted `npm test -- --run tests/package-manifest.test.ts`; blocked in this temporary clone because `vitest` is not installed.