### PR TITLE
Fix #2090: fix: README benchmark scores in News section don't match Performance table (LoCo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 ### News
 
 - **2026-07-02** · 🏆 **MemOS Advances Agent and User Memory Benchmarks**
-  With MemOS, **OpenClaw** improves average task completion from **36.63% to 50.87%** across five agent tasks. MemOS also achieves **92.34 on LoCoMo** and **93.40 on LongMemEval**, and leads in **OmniMemEval**, a unified evaluation of 14 commercial memory products across ten datasets.
+  With MemOS, **OpenClaw** improves average task completion from **36.63% to 50.87%** across five agent tasks. MemOS also achieves **88.83 on LoCoMo** and **89.20 on LongMemEval**, and leads in **OmniMemEval**, a unified evaluation of 14 commercial memory products across ten datasets.
 
 - **2026-05-09** · 🧠 **memos-local-plugin 2.0**
   Official local memory plugin for **Hermes Agent** and **OpenClaw**. One core powers self-evolving memory across L1 traces, L2 policies, L3 world models, and crystallized Skills, with local-first storage and feedback-driven retrieval.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -46,7 +46,7 @@
 ### News
 
 - **2026-07-02** · 🏆 **MemOS 在 Agent 与用户记忆榜单上全面领先**
-  在 MemOS 的加持下，**OpenClaw** 在五个 Agent 任务上的平均任务完成率从 **36.63% 提升到 50.87%**。MemOS 在 **LoCoMo** 取得 **92.34**、**LongMemEval** 取得 **93.40**，并在 **OmniMemEval**（覆盖 14 款商业记忆产品、十个数据集的统一评测）中领先。
+  在 MemOS 的加持下，**OpenClaw** 在五个 Agent 任务上的平均任务完成率从 **36.63% 提升到 50.87%**。MemOS 在 **LoCoMo** 取得 **88.83**、**LongMemEval** 取得 **89.20**，并在 **OmniMemEval**（覆盖 14 款商业记忆产品、十个数据集的统一评测）中领先。
 
 - **2026-05-09** · 🧠 **memos-local-plugin 2.0**
   **Hermes Agent** 与 **OpenClaw** 官方本地记忆插件。单一核心驱动自演化记忆：L1 轨迹、L2 策略、L3 世界模型与结晶化 Skill，本地优先存储 + 反馈驱动检索。


### PR DESCRIPTION
## Description

Fixed the README score mismatch (LoCoMo 92.34→88.83, LongMemEval 93.40→89.20) in both `README.md` and `README_ZH.md`, aligning the News section with the Performance table. Committed on the working branch (`64cddbfb`) and pushed to `origin`. Task spec archived to the sibling `memos-autodev-specs` repo (`main` @ `d8af691`).

Now submitting the completion envelope so the scheduler can open the PR.

Sources:
- Issue: https://github.com/MemTensor/MemOS/issues/2090

Related Issue (Required):  Fixes #2090

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@MatthewZhuang, @CarltonXiang, @syzsunshine219, @World-controller please review this PR.

## Reviewer Checklist
- [x] closes #2090
- [ ] Made sure Checks passed
- [ ] Tests have been provided
