### PR TITLE
release: @memtensor/memos-local-plugin v2.0.10

### DIFF
--- a/apps/memos-local-plugin/package-lock.json
+++ b/apps/memos-local-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.5",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memtensor/memos-local-plugin",
-      "version": "2.0.5",
+      "version": "2.0.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/memos-local-plugin/package.json
+++ b/apps/memos-local-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.5",
+  "version": "2.0.10",
   "description": "Reflect2Evolve memory plugin: layered L1/L2/L3 memory, reflection-weighted value backprop, cross-task policy induction, skill crystallization, three-tier retrieval. Adapters for OpenClaw and Hermes Agent via a shared algorithm core.",
   "type": "module",
   "main": "dist/core/index.js",


### PR DESCRIPTION
Bumps apps/memos-local-plugin/package.json and package-lock.json for the published npm release 2.0.10.

Published package: https://www.npmjs.com/package/@memtensor/memos-local-plugin/v/2.0.10
Release tag: memos-local-plugin-v2.0.10