### PR TITLE
ci: create GitHub Release for OpenClaw local plugin publish

### DIFF
--- a/.github/workflows/memos-local-plugin-publish.yml
+++ b/.github/workflows/memos-local-plugin-publish.yml
@@ -14,6 +14,9 @@ on:
         description: "Git ref to build from (branch, tag, or SHA). Leave blank to use the branch selected above."
         required: false
         default: ""
+      release_notes:
+        description: "Markdown release notes for GitHub Release and docs changelog. Include a ## Changelog section."
+        required: true
 
 concurrency:
   group: memos-local-plugin-publish
@@ -133,15 +136,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+          if [ -z "$(printf '%s' "${RELEASE_NOTES}" | tr -d '[:space:]')" ]; then
+            echo "::error::release_notes is required so Doc Agent can update docs."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          release_tag="memos-local-plugin-v${RELEASE_VERSION}"
+          release_tag="openclaw-local-plugin-v${RELEASE_VERSION}"
           release_branch="release/${release_tag}"
           release_title="release: @memtensor/memos-local-plugin v${RELEASE_VERSION}"
+          release_notes_file="$(mktemp)"
+          printf '%s\n' "${RELEASE_NOTES}" > "${release_notes_file}"
 
           git add apps/memos-local-plugin/package.json apps/memos-local-plugin/package-lock.json
           created_release_commit=false
@@ -164,6 +175,16 @@ jobs:
           else
             git tag "${release_tag}"
             git push origin "refs/tags/${release_tag}"
+          fi
+
+          if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
+          else
+            gh release create "${release_tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "$(git rev-parse HEAD)" \
+              --title "OpenClaw Local Plugin v${RELEASE_VERSION}" \
+              --notes-file "${release_notes_file}"
           fi
 
           if [ "${created_release_commit}" = "true" ]; then

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   deploy:
+    if: startsWith(github.event.release.tag_name, 'v')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 背景

为了让 Doc Agent 通过 `release.published` 自动同步 OpenClaw 本地插件更新到 MemOS-Docs Plugin tab，本地插件发布 workflow 需要在 npm publish/tag 成功后创建规范 GitHub Release。

## 改动

- 新增 `release_notes` workflow_dispatch 输入，要求发布时填写可供 docs 同步消费的 Markdown changelog。
- 将本地插件新发版 tag 统一为 `openclaw-local-plugin-v{version}`。
- npm publish/tag 成功后自动创建 GitHub Release。
- Release 已存在时保持幂等，不重复覆盖。

## 不做什么

- 本 PR 不发布 npm 包。
- 本 PR 不创建产品 Release。
- 本 PR 不触发 MemOS-Docs 更新。
- CLI 和云插件后续单独处理。

## 验证

- 本地 YAML 解析通过。
- `git diff --check` 通过。

合并后，下一步会用 OpenClaw 本地插件做第一条完整链路验证：GitHub Release -> 106 Doc Agent -> docs PR -> auto merge -> pre -> 等待 360 秒 -> gray，且不触发 production。
