### PR TITLE
fix(api): show structured add example in /docs for /product/add

### DIFF
--- a/src/memos/api/product_models.py
+++ b/src/memos/api/product_models.py
@@ -608,6 +608,21 @@ class APISearchRequest(BaseRequest):
 class APIADDRequest(BaseRequest):
     """Request model for creating memories."""
 
+    # Model-level example so the interactive docs (/docs) show a copy-paste-ready
+    # payload. Without it, Swagger UI renders the leading `str` branch of the
+    # `messages` union as `"string"` (see issue #1505). This only affects the
+    # generated OpenAPI schema, not validation or runtime behaviour.
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "user_id": "8736b16e-1d20-4163-980b-a5063c3facdc",
+                "writable_cube_ids": ["b32d0977-435d-4828-a86f-4f47f8b55bca"],
+                "messages": [{"role": "user", "content": "I am learning ggplot2 in R."}],
+                "async_mode": "async",
+            }
+        }
+    }
+
     # ==== Basic identifiers ====
     user_id: str = Field(None, description="User ID")
     session_id: str | None = Field(

--- a/tests/api/test_product_models.py
+++ b/tests/api/test_product_models.py
@@ -1,0 +1,41 @@
+"""Unit tests for API request-model OpenAPI schemas.
+
+These tests lock the OpenAPI schema behaviour of request models so the
+interactive docs (``/docs``) stay consistent with the documented contract.
+
+Regression guard for issue #1505: the ``/product/add`` example must render
+``messages`` as a structured message list instead of a bare ``"string"``.
+Because ``messages`` is typed as ``str | MessageList | RawMessageList``, Swagger
+UI would otherwise pick the leading ``str`` branch of the ``anyOf`` and show
+``"messages": "string"``, which misleads users into sending plain text.
+"""
+
+from memos.api.product_models import APIADDRequest
+
+
+def test_add_request_exposes_model_level_example():
+    """APIADDRequest must ship a model-level example for the interactive docs."""
+    schema = APIADDRequest.model_json_schema()
+
+    assert "example" in schema, "APIADDRequest should define a model-level example"
+
+
+def test_add_request_example_messages_is_structured_list():
+    """The example's ``messages`` must be a non-empty list of role/content items."""
+    example = APIADDRequest.model_json_schema()["example"]
+
+    messages = example.get("messages")
+    assert isinstance(messages, list), "messages example must be a list, not a bare string"
+    assert messages, "messages example should not be empty"
+
+    first = messages[0]
+    assert first.get("role"), "each example message needs a role"
+    assert first.get("content"), "each example message needs content"
+
+
+def test_add_request_example_covers_core_fields():
+    """The example should be a copy-paste-ready payload for the core add flow."""
+    example = APIADDRequest.model_json_schema()["example"]
+
+    assert "user_id" in example
+    assert "writable_cube_ids" in example


### PR DESCRIPTION
## Description

The interactive API docs (`/docs`) for `POST /product/add` show `"messages": "string"` in the request example, which conflicts with the official docs (a structured message list) and misleads users into sending plain text.

**Root cause**: `APIADDRequest.messages` is typed `str | MessageList | RawMessageList`. Pydantic v2 renders this as an `anyOf`, and Swagger UI builds the "Example Value" from the first branch (`str`), so it displays `"string"`. Fields like `chat_history` (a plain list) render correctly, which confirms the cause.

**Fix**: add a model-level `json_schema_extra` example to `APIADDRequest` so `/docs` shows a copy-paste-ready payload with a structured `messages` list plus the common fields. This is a **schema-only** change — field types, validation, the deprecated-field validator and runtime behaviour are all unchanged, so the core add pipeline is unaffected.

Related Issue (Required): Fixes #1505

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Added `tests/api/test_product_models.py`, which asserts the generated OpenAPI schema exposes a model-level `example` whose `messages` is a non-empty structured list (not a bare string) and covers the core add fields.

```
$ uv run --with pytest pytest tests/api/test_product_models.py -v
tests/api/test_product_models.py::test_add_request_exposes_model_level_example PASSED
tests/api/test_product_models.py::test_add_request_example_messages_is_structured_list PASSED
tests/api/test_product_models.py::test_add_request_example_covers_core_fields PASSED
3 passed, 2 warnings in 25.30s
```

Also ran `ruff format --check` and `ruff check` on the changed files — all passed.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in MemOS-Docs (if applicable) — repo docs already list `messages` as `list/str`; no docs change needed
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR
- [ ] I have mentioned the person who will review this PR

## Reviewer Checklist
- [x] closes #1505
- [ ] Made sure Checks passed
- [x] Tests have been provided

Made with [Cursor](https://cursor.com)