### PR TITLE
ci: automate OpenClaw local plugin release notes

### DIFF
--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -1,0 +1,1353 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+const PRODUCT_PATH = "apps/memos-local-plugin";
+const PRODUCT_ID = "openclaw-local-plugin";
+const PRODUCT_TITLE = {
+  zh: "OpenClaw 本地插件",
+  en: "OpenClaw Local Plugin",
+};
+export const RELEASE_NOTE_GUIDANCE = {
+  category_policy: {
+    Added:
+      "Use for newly exposed user-facing capabilities, configuration entries, model slots, language support, or workflow modes.",
+    Improved:
+      "Use for performance optimization, context formatting, compatibility hardening, startup/link/install robustness, or reliability improvements when the evidence is not primarily a broken-behavior fix.",
+    Fixed:
+      "Use for concrete broken behavior, regressions, data recovery bugs, failed retries, endpoint probing anomalies, or configuration that existed but did not take effect.",
+  },
+  quality_policy: [
+    "Prefer Added / Improved / Fixed sections when the evidence supports all three; omit a section only when evidence is insufficient.",
+    "Do not collapse a new configuration capability and a bug fix in the same subsystem into one Fixed item; keep the added capability and the fixed behavior separate when both are evidenced.",
+    "Map vector scan CPU reductions, XML memory-context boundaries, and Hermes provider startup/link/install compatibility to Improved unless the evidence clearly describes a user-visible regression.",
+    "Keep bullets short, product-facing, and evidence-backed; do not mention internal file names unless they are the feature name users recognize.",
+  ],
+  translation_policy: [
+    "Treat text_cn as the canonical release-note wording first, then translate text_cn into text_en.",
+    "Do not independently invent English facts beyond the Chinese canonical bullet and its source_refs.",
+    "Keep category and source_refs identical between Chinese and English outputs.",
+    "text_cn must contain Chinese text; text_en must not contain Chinese/CJK characters.",
+  ],
+};
+const CURRENT_TAG_PREFIX = "memos-local-plugin-v";
+const TAG_PREFIXES = [CURRENT_TAG_PREFIX, "openclaw-local-plugin-v"];
+const RELEASE_NOTES_MARKER = "doc-agent-release-notes-json";
+const RELEASE_CATEGORY_ORDER = ["Added", "Improved", "Fixed"];
+const MAX_DRAFT_REPAIR_ATTEMPTS = 2;
+const RELEASE_TO_DOC_CATEGORY = {
+  Added: "New Features",
+  Improved: "Improvements",
+  Fixed: "Bug Fixes",
+};
+const CJK_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
+
+function fail(message) {
+  throw new Error(String(message));
+}
+
+function warn(message) {
+  console.error(`::warning::${message}`);
+}
+
+function sh(args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  }).trim();
+}
+
+export function cleanVersion(raw) {
+  const value = String(raw || "").trim();
+  return value.startsWith("v") ? value.slice(1) : value;
+}
+
+export function displayVersion(raw) {
+  const value = cleanVersion(raw);
+  return value ? `v${value}` : "";
+}
+
+export function versionFromTag(tag) {
+  for (const prefix of TAG_PREFIXES) {
+    if (tag.startsWith(prefix)) {
+      return cleanVersion(tag.slice(prefix.length));
+    }
+  }
+  return "";
+}
+
+export function parseSemver(version) {
+  const cleaned = cleanVersion(version);
+  const match = cleaned.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+]([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] || "",
+  };
+}
+
+export function compareSemver(a, b) {
+  const av = parseSemver(a);
+  const bv = parseSemver(b);
+  if (!av || !bv) return String(a).localeCompare(String(b));
+  for (const key of ["major", "minor", "patch"]) {
+    if (av[key] !== bv[key]) return av[key] - bv[key];
+  }
+  if (av.prerelease === bv.prerelease) return 0;
+  if (!av.prerelease) return 1;
+  if (!bv.prerelease) return -1;
+  return av.prerelease.localeCompare(bv.prerelease);
+}
+
+function gitShowJson(ref, path) {
+  try {
+    return JSON.parse(sh(["show", `${ref}:${path}`]));
+  } catch {
+    return {};
+  }
+}
+
+function readJsonFile(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function tagInfo(ref) {
+  const text = sh(["show", "--no-patch", "--format=%H%n%ci%n%s", ref]);
+  const [sha = "", date = "", subject = ""] = text.split("\n");
+  return { tag: ref, sha, date, subject };
+}
+
+function refInfo(ref, tagLabel) {
+  const info = tagInfo(ref);
+  return { ...info, tag: tagLabel || ref, ref };
+}
+
+function refExists(ref) {
+  try {
+    sh(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveCurrentRef(
+  currentTag,
+  { requestedRef = process.env.RELEASE_EVIDENCE_REF || "", refExistsImpl = refExists } = {},
+) {
+  const explicit = String(requestedRef || "").trim();
+  if (explicit) {
+    if (!refExistsImpl(explicit)) {
+      fail(`RELEASE_EVIDENCE_REF does not exist or is not a commit: ${explicit}`);
+    }
+    return explicit;
+  }
+  if (currentTag && refExistsImpl(currentTag)) return currentTag;
+  return "HEAD";
+}
+
+function listProductTags() {
+  try {
+    sh(["fetch", "--tags", "--force", "origin"], { stdio: ["ignore", "ignore", "ignore"] });
+  } catch {
+    warn("Failed to fetch tags from origin; using locally available tags.");
+  }
+
+  const text = sh(["tag", "--list"]);
+  return text
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => ({ tag, version: versionFromTag(tag) }))
+    .filter((item) => item.version && parseSemver(item.version));
+}
+
+export function findPreviousTag(targetVersion, currentTag) {
+  const candidates = listProductTags()
+    .filter((item) => item.tag !== currentTag)
+    .filter((item) => compareSemver(item.version, targetVersion) < 0)
+    .sort((a, b) => {
+      const versionOrder = compareSemver(b.version, a.version);
+      if (versionOrder !== 0) return versionOrder;
+      const aPreferred = a.tag.startsWith(CURRENT_TAG_PREFIX) ? 1 : 0;
+      const bPreferred = b.tag.startsWith(CURRENT_TAG_PREFIX) ? 1 : 0;
+      return bPreferred - aPreferred;
+    });
+  return candidates[0]?.tag || "";
+}
+
+function parseCommits(previousTag, currentRef) {
+  const text = sh([
+    "log",
+    "--format=%H%x09%h%x09%s",
+    "--no-merges",
+    `${previousTag}..${currentRef}`,
+    "--",
+    PRODUCT_PATH,
+  ]);
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [sha = "", shortSha = "", subject = ""] = line.split("\t");
+      return { sha, short_sha: shortSha, subject };
+    });
+}
+
+function parseChangedFiles(previousTag, currentRef) {
+  const text = sh(["diff", "--name-status", `${previousTag}..${currentRef}`, "--", PRODUCT_PATH]);
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split("\t");
+      const item = { status: parts[0], path: parts[parts.length - 1] };
+      if (parts.length === 3) item.old_path = parts[1];
+      return item;
+    });
+}
+
+function packageChanges(previousTag, currentRef) {
+  const path = `${PRODUCT_PATH}/package.json`;
+  const before = gitShowJson(previousTag, path);
+  const after = currentRef === "HEAD" ? readJsonFile(path) : gitShowJson(currentRef, path);
+  return ["name", "version"]
+    .filter((field) => before[field] !== after[field])
+    .map((field) => ({ field, before: before[field], after: after[field] }));
+}
+
+function extractPullRequests(commits, repo = process.env.GITHUB_REPOSITORY || "MemTensor/MemOS") {
+  const seen = new Set();
+  for (const commit of commits) {
+    for (const match of String(commit.subject || "").matchAll(/#(\d+)/g)) {
+      seen.add(match[1]);
+    }
+  }
+  return [...seen].map((number) => ({
+    number,
+    url: `https://github.com/${repo}/pull/${number}`,
+  }));
+}
+
+function refsForGuidance(commit) {
+  const refs = [];
+  if (commit.short_sha) refs.push(commit.short_sha);
+  for (const match of String(commit.subject || "").matchAll(/#(\d+)/g)) {
+    const value = `#${match[1]}`;
+    if (!refs.includes(value)) refs.push(value);
+  }
+  return refs;
+}
+
+function categoryHintForSubject(subject) {
+  const value = String(subject || "");
+  const lower = value.toLowerCase();
+  if (
+    lower.startsWith("release:") ||
+    /^fix(\([^)]+\))?:\s*ruff\b/i.test(value) ||
+    /review feedback/i.test(value)
+  ) {
+    return null;
+  }
+  if (/^(feat|feature|add)(\([^)]+\))?:|^add\s+/i.test(value)) {
+    return {
+      category: "Added",
+      reason: "new user-facing capability or configuration support",
+    };
+  }
+  if (
+    /cpu|full-table vector scan|vector scan|xml boundary|memory context with xml|hermes|provider link|bridge package version|startup poll|double-spawn/i.test(
+      value,
+    )
+  ) {
+    return {
+      category: "Improved",
+      reason: "performance, context-boundary, or integration robustness improvement",
+    };
+  }
+  if (/^(perf|performance|refactor)(\([^)]+\))?:/i.test(value)) {
+    return {
+      category: "Improved",
+      reason: "performance or implementation improvement",
+    };
+  }
+  if (
+    /lightweightmemory|skip evolution|endpoint paths|openai_compatible|empty response|error response|dirty-reward|orphan trace|session exemption|loopback/i.test(
+      lower,
+    )
+  ) {
+    return {
+      category: "Fixed",
+      reason: "specific broken behavior, recovery boundary, retry, auth, or endpoint probing fix",
+    };
+  }
+  if (/^(fix|hotfix|bugfix)(\([^)]+\))?:|^fix\s+#\d+/i.test(value)) {
+    return {
+      category: "Fixed",
+      reason: "specific bug fix",
+    };
+  }
+  return null;
+}
+
+export function categoryHintsForCommits(commits) {
+  return commits
+    .map((commit) => {
+      const hint = categoryHintForSubject(commit.subject);
+      const sourceRefs = refsForGuidance(commit);
+      if (!hint || sourceRefs.length === 0) return null;
+      return {
+        ...hint,
+        source_refs: sourceRefs,
+        subject: commit.subject,
+      };
+    })
+    .filter(Boolean);
+}
+
+export function releaseNoteGuidanceForCommits(commits) {
+  return {
+    ...RELEASE_NOTE_GUIDANCE,
+    source_ref_category_hints: categoryHintsForCommits(commits),
+    source_ref_hint_policy:
+      "Treat source_ref_category_hints as advisory classification hints grounded in evidence. " +
+      "Use them to avoid moving performance/compatibility work into Fixed merely because the commit subject starts with fix.",
+  };
+}
+
+export function collectEvidence({ targetVersion, currentTag, previousTag, currentRef = "HEAD" }) {
+  const commits = parseCommits(previousTag, currentRef);
+  const changedFiles = parseChangedFiles(previousTag, currentRef);
+  const diffRange = `${previousTag}..${currentRef}`;
+  const repo = process.env.GITHUB_REPOSITORY || "MemTensor/MemOS";
+  const importantDiff = sh([
+    "diff",
+    "--unified=2",
+    diffRange,
+    "--",
+    PRODUCT_PATH,
+  ]).slice(0, 24000);
+
+  return {
+    product_id: PRODUCT_ID,
+    product_title: PRODUCT_TITLE,
+    release_note_guidance: releaseNoteGuidanceForCommits(commits),
+    repo,
+    previous_tag: previousTag,
+    current_tag: currentTag,
+    current_ref: currentRef,
+    diff_range: diffRange,
+    target_version: displayVersion(targetVersion),
+    git_ref: sh(["rev-parse", "--short=12", currentRef]),
+    previous: tagInfo(previousTag),
+    current: refInfo(currentRef, currentTag),
+    commits,
+    pull_requests: extractPullRequests(commits, repo),
+    changed_files: changedFiles,
+    diff_stat: sh(["diff", "--stat", diffRange, "--", PRODUCT_PATH]),
+    important_diff: {
+      [`${PRODUCT_PATH}/**`]: importantDiff,
+    },
+    package_changes: packageChanges(previousTag, currentRef),
+    test_changes: changedFiles.filter((item) => item.path.includes("/tests/")),
+    docs_changes: changedFiles.filter((item) => item.path.includes("/docs/")),
+  };
+}
+
+export function evidenceForInspection(evidence) {
+  const guidance = evidence?.release_note_guidance || {};
+  const {
+    release_note_guidance: _releaseNoteGuidance,
+    important_diff: _importantDiff,
+    ...publicEvidence
+  } = evidence || {};
+  return {
+    ...publicEvidence,
+    release_note_guidance: {
+      source_ref_category_hints: Array.isArray(guidance.source_ref_category_hints)
+        ? guidance.source_ref_category_hints
+        : [],
+    },
+    redactions: {
+      important_diff: "omitted from public workflow artifacts; sent only to the configured draft service",
+      release_note_prompt_guidance: "omitted from public workflow artifacts",
+    },
+  };
+}
+
+export function draftForInspection(draft) {
+  return {
+    ok: Boolean(draft?.ok),
+    needs_review: Boolean(draft?.needs_review),
+    confidence: draft?.confidence || "",
+    release_items: Array.isArray(draft?.release_items) ? draft.release_items : [],
+    coverage: {
+      needs_review: Boolean(draft?.coverage?.needs_review),
+      required_count: Number(draft?.coverage?.required_count || 0),
+      covered_required_count: Number(draft?.coverage?.covered_required_count || 0),
+      missing_required_count: Number(draft?.coverage?.missing_required_count || 0),
+      covered_refs: Array.isArray(draft?.coverage?.covered_refs) ? draft.coverage.covered_refs : [],
+      missing_required: Array.isArray(draft?.coverage?.missing_required) ? draft.coverage.missing_required : [],
+      invalid_item_refs: Array.isArray(draft?.coverage?.invalid_item_refs) ? draft.coverage.invalid_item_refs : [],
+    },
+    warnings: Array.isArray(draft?.warnings) ? draft.warnings : [],
+    language_issues: Array.isArray(draft?.language_issues) ? draft.language_issues : [],
+    postprocess: draft?.postprocess || {},
+    validation_report: draft?.validation_report || {},
+    validation_attempt_count: Number(draft?.validation_attempt_count || 0),
+    repair_attempt_count: Number(draft?.repair_attempt_count || 0),
+    repair_attempts: Array.isArray(draft?.repair_attempts) ? draft.repair_attempts : [],
+    redactions: {
+      server_debug_fields: "omitted from public workflow artifacts",
+      model_and_prompt_details: "omitted from public workflow artifacts",
+    },
+  };
+}
+
+function appendOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  writeFileSync(outputPath, `${name}<<__DOC_AGENT_EOF__\n${value}\n__DOC_AGENT_EOF__\n`, {
+    flag: "a",
+  });
+}
+
+export function ensureSourceHint(notes) {
+  const hint = `<!-- doc-agent: source-id=${PRODUCT_ID} -->`;
+  return notes.includes("doc-agent: source-id=") ? notes : `${notes.trim()}\n\n${hint}\n`;
+}
+
+function normalizeReleaseCategory(value) {
+  const text = String(value || "").trim();
+  return RELEASE_CATEGORY_ORDER.includes(text) ? text : "";
+}
+
+function normalizeSourceRef(value) {
+  const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
+  if (/^\d{2,}$/.test(text)) return `#${text}`;
+  if (/^#\d+$/.test(text)) return text;
+  if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
+  return "";
+}
+
+function normalizeSourceRefs(raw) {
+  const values = Array.isArray(raw) ? raw : String(raw || "").match(/#\d+|[a-fA-F0-9]{7,40}/g) || [];
+  const refs = [];
+  for (const value of values) {
+    const ref = normalizeSourceRef(value);
+    if (ref && !refs.includes(ref)) refs.push(ref);
+  }
+  return refs;
+}
+
+function refsForCommit(commit) {
+  const refs = [];
+  for (const ref of [commit?.short_sha, commit?.sha]) {
+    const normalized = normalizeSourceRef(ref);
+    if (normalized && !refs.includes(normalized)) refs.push(normalized);
+  }
+  for (const match of String(commit?.subject || "").matchAll(/#(\d+)/g)) {
+    const ref = `#${match[1]}`;
+    if (!refs.includes(ref)) refs.push(ref);
+  }
+  return refs;
+}
+
+function normalizeReleaseItem(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const category = normalizeReleaseCategory(raw.category);
+  const textCn = String(raw.text_cn || "").trim().replace(/^-+\s*/, "");
+  const textEn = String(raw.text_en || "").trim().replace(/^-+\s*/, "");
+  const sourceRefs = normalizeSourceRefs(raw.source_refs);
+  if (!category || !textCn || !textEn || sourceRefs.length === 0) return null;
+  return {
+    category,
+    text_cn: textCn,
+    text_en: textEn,
+    source_refs: sourceRefs,
+  };
+}
+
+function buildSourceRefIndex(evidence) {
+  const refToGroup = new Map();
+  const groups = new Map();
+  const knownRefs = new Set();
+
+  for (const commit of evidence?.commits || []) {
+    for (const ref of refsForCommit(commit)) knownRefs.add(ref);
+  }
+
+  for (const hint of evidence?.release_note_guidance?.source_ref_category_hints || []) {
+    const refs = normalizeSourceRefs(hint.source_refs);
+    const category = normalizeReleaseCategory(hint.category);
+    if (refs.length === 0 || !category) continue;
+    const groupKey = refs[0];
+    for (const ref of refs) {
+      knownRefs.add(ref);
+      refToGroup.set(ref, groupKey);
+    }
+    groups.set(groupKey, {
+      key: groupKey,
+      category,
+      refs,
+      subject: String(hint.subject || ""),
+      reason: String(hint.reason || ""),
+    });
+  }
+
+  return { refToGroup, groups, knownRefs };
+}
+
+function groupKeyForRef(ref, refToGroup) {
+  return refToGroup.get(ref) || ref;
+}
+
+function groupKeysForItem(item, refToGroup) {
+  const keys = [];
+  for (const ref of item.source_refs || []) {
+    const key = groupKeyForRef(ref, refToGroup);
+    if (!keys.includes(key)) keys.push(key);
+  }
+  return keys;
+}
+
+function bestHintCategoryForItem(item, index) {
+  const categories = [];
+  for (const key of groupKeysForItem(item, index.refToGroup)) {
+    const category = index.groups.get(key)?.category;
+    if (category && !categories.includes(category)) categories.push(category);
+  }
+  if (categories.length === 1) return categories[0];
+  return "";
+}
+
+function subjectsForItem(item, index) {
+  return groupKeysForItem(item, index.refToGroup)
+    .map((key) => index.groups.get(key)?.subject || "")
+    .filter(Boolean)
+    .join(" ");
+}
+
+function rewriteKnownReleaseItem(item, index) {
+  const subjectBlob = subjectsForItem(item, index).toLowerCase();
+  const currentBlob = `${item.text_cn || ""} ${item.text_en || ""}`.toLowerCase();
+  const blob = `${subjectBlob} ${currentBlob}`;
+
+  if (item.category === "Added") {
+    if (/l3|l3llm|abstraction/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**L3 抽象模型配置**：新增专用的 L3 LLM 配置入口，用于独立管理抽象总结阶段的模型调用。",
+        text_en:
+          "**L3 Abstraction Model Configuration**: Added a dedicated L3 LLM configuration entry for abstraction-stage model calls.",
+      };
+    }
+    if (/cjk|keyword tokenization|关键词|分词/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**中文关键词召回支持**：增强 CJK 关键词分词能力，提升中文内容的检索与召回效果。",
+        text_en:
+          "**Chinese Keyword Recall**: Improved CJK keyword tokenization to strengthen retrieval and recall for Chinese content.",
+      };
+    }
+  }
+
+  if (item.category === "Improved") {
+    if (/cpu|full-table vector scan|vector scan|向量/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**向量扫描性能优化**：优化同步全表向量扫描路径，降低大数据量场景下的网关 CPU 压力。",
+        text_en:
+          "**Vector Scan Performance**: Optimized synchronous full-table vector scanning to reduce gateway CPU pressure at larger data sizes.",
+      };
+    }
+    if (/xml boundary|memory context with xml|context boundary|上下文/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**检索上下文边界优化**：使用更清晰的 XML 边界组织记忆上下文，降低模型误读上下文的概率。",
+        text_en:
+          "**Retrieval Context Boundaries**: Organized memory context with clearer XML boundaries to reduce model misreads.",
+      };
+    }
+    if (/hermes|provider link|bridge package version|startup poll|double-spawn|bridge/.test(blob)) {
+      return {
+        ...item,
+        text_cn:
+          "**Hermes 集成稳定性增强**：优化 provider 启动等待、链接管理和桥接版本读取，提升本地插件与 Hermes 的兼容性。",
+        text_en:
+          "**Hermes Integration Stability**: Improved provider startup waits, link management, and bridge version loading for better Hermes compatibility.",
+      };
+    }
+  }
+
+  if (item.category === "Fixed") {
+    if (/lightweightmemory|skip evolution|轻量记忆/.test(blob)) {
+      return {
+        ...item,
+        text_cn:
+          "**轻量记忆模式不生效**：修复 `algorithm.lightweightMemory.enabled=true` 时仍可能触发演化流水线的问题。",
+        text_en:
+          "**Lightweight Memory Mode**: Fixed cases where `algorithm.lightweightMemory.enabled=true` could still trigger the evolution pipeline.",
+      };
+    }
+    if (/openai_compatible|endpoint paths|endpoint/.test(blob) && /session exemption|loopback|auth/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**连接与鉴权边界修复**：修复 OpenAI-compatible endpoint 完整路径探测和本地 RPC 会话豁免边界问题。",
+        text_en:
+          "**Connection and Auth Boundaries**: Fixed full-path OpenAI-compatible endpoint probing and local RPC session exemption boundaries.",
+      };
+    }
+    if (/openai_compatible|endpoint paths|endpoint/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**OpenAI-compatible endpoint 探测异常**：修复完整 endpoint 路径下 provider 探测不稳定的问题。",
+        text_en:
+          "**OpenAI-compatible Endpoint Probing**: Fixed unstable provider probing when a full endpoint path is configured.",
+      };
+    }
+    if (/session exemption|loopback|auth/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**RPC 会话鉴权边界修复**：收紧本地 RPC 会话豁免范围，避免非 loopback 调用误入免鉴权路径。",
+        text_en:
+          "**RPC Session Auth Boundary**: Tightened local RPC session exemptions so non-loopback calls cannot bypass auth handling.",
+      };
+    }
+    if (/empty response|error response|dirty-reward|orphan trace|llm|trace|recovery/.test(blob)) {
+      return {
+        ...item,
+        text_cn: "**记忆恢复与采集边界问题**：修复脏数据恢复、孤立 trace 写入和 LLM 空响应重试等稳定性问题。",
+        text_en:
+          "**Memory Recovery and Capture Boundaries**: Fixed dirty-data recovery, orphan trace writes, and LLM empty-response retry stability issues.",
+      };
+    }
+  }
+
+  return item;
+}
+
+function scoreOwnerCandidate(item, group, sourceGroupCount, order) {
+  let score = 0;
+  if (item.category === group.category) score += 100;
+  if (sourceGroupCount === 1) score += 20;
+  score -= sourceGroupCount;
+  score -= order / 1000;
+  return score;
+}
+
+function dedupeSourceRefsByBestCategory(items, index) {
+  const candidatesByGroup = new Map();
+  for (const [order, item] of items.entries()) {
+    for (const groupKey of groupKeysForItem(item, index.refToGroup)) {
+      const group = index.groups.get(groupKey);
+      if (!group) continue;
+      const sourceGroupCount = groupKeysForItem(item, index.refToGroup).length;
+      const candidates = candidatesByGroup.get(groupKey) || [];
+      candidates.push({ item, order, sourceGroupCount });
+      candidatesByGroup.set(groupKey, candidates);
+    }
+  }
+
+  const ownerByGroup = new Map();
+  for (const [groupKey, candidates] of candidatesByGroup.entries()) {
+    const group = index.groups.get(groupKey);
+    if (!group) continue;
+    const sorted = [...candidates].sort((a, b) => {
+      const scoreDelta =
+        scoreOwnerCandidate(b.item, group, b.sourceGroupCount, b.order) -
+        scoreOwnerCandidate(a.item, group, a.sourceGroupCount, a.order);
+      return scoreDelta || a.order - b.order;
+    });
+    ownerByGroup.set(groupKey, sorted[0].item);
+  }
+
+  let removedDuplicateRefs = 0;
+  let droppedItems = 0;
+  const filtered = [];
+  for (const item of items) {
+    const refs = [];
+    for (const ref of item.source_refs) {
+      const groupKey = groupKeyForRef(ref, index.refToGroup);
+      const owner = ownerByGroup.get(groupKey);
+      if (!owner || owner === item) {
+        if (!refs.includes(ref)) refs.push(ref);
+      } else {
+        removedDuplicateRefs += 1;
+      }
+    }
+    if (refs.length === 0) {
+      droppedItems += 1;
+      continue;
+    }
+    filtered.push({ ...item, source_refs: refs });
+  }
+  return { items: filtered, removedDuplicateRefs, droppedItems };
+}
+
+function dedupeReleaseItems(items) {
+  const byKey = new Map();
+  for (const item of items) {
+    const key = `${item.category}\n${item.text_cn}\n${item.text_en}`;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, { ...item, source_refs: [...item.source_refs] });
+      continue;
+    }
+    for (const ref of item.source_refs) {
+      if (!existing.source_refs.includes(ref)) existing.source_refs.push(ref);
+    }
+  }
+  return [...byKey.values()];
+}
+
+function categoriesFromReleaseItems(items) {
+  const releaseCategories = {};
+  const docsCategories = { cn: {}, en: {} };
+  for (const category of RELEASE_CATEGORY_ORDER) {
+    const categoryItems = items.filter((item) => item.category === category);
+    if (categoryItems.length === 0) continue;
+    releaseCategories[category] = categoryItems.map((item) => item.text_cn);
+    const docCategory = RELEASE_TO_DOC_CATEGORY[category];
+    docsCategories.cn[docCategory] = categoryItems.map((item) => item.text_cn);
+    docsCategories.en[docCategory] = categoryItems.map((item) => item.text_en);
+  }
+  return { releaseCategories, docsCategories };
+}
+
+function coverageFromReleaseItems(evidence, draft, items, index) {
+  const coveredRefs = [];
+  const coveredGroups = new Set();
+  const invalidItemRefs = [];
+  for (const item of items) {
+    for (const ref of item.source_refs || []) {
+      if (!coveredRefs.includes(ref)) coveredRefs.push(ref);
+      const groupKey = groupKeyForRef(ref, index.refToGroup);
+      if (index.groups.has(groupKey)) coveredGroups.add(groupKey);
+      if (index.knownRefs.size > 0 && !index.knownRefs.has(ref)) {
+        invalidItemRefs.push({
+          ref,
+          text_cn: item.text_cn,
+          category: item.category,
+        });
+      }
+    }
+  }
+
+  const required = [...index.groups.values()];
+  const missingRequired = required
+    .filter((group) => !coveredGroups.has(group.key))
+    .map((group) => ({
+      short_sha: group.refs.find((ref) => /^[a-f0-9]{7,40}$/.test(ref)) || "",
+      subject: group.subject,
+      refs: group.refs,
+      reason: group.reason || "important local-plugin release source",
+    }));
+  const previousCoverage = draft.coverage || {};
+  const requiredCount = required.length || Number(previousCoverage.required_count || 0);
+  const missingRequiredCount = required.length
+    ? missingRequired.length
+    : Number(previousCoverage.missing_required_count || 0);
+  const coveredRequiredCount = required.length
+    ? required.length - missingRequired.length
+    : Number(previousCoverage.covered_required_count || 0);
+  const needsReview = missingRequiredCount > 0 || invalidItemRefs.length > 0 || items.length === 0;
+
+  return {
+    ...previousCoverage,
+    needs_review: needsReview,
+    required_count: requiredCount,
+    covered_required_count: coveredRequiredCount,
+    missing_required_count: missingRequiredCount,
+    missing_required: missingRequired,
+    invalid_item_refs: invalidItemRefs,
+    covered_refs: coveredRefs.sort(),
+    policy:
+      previousCoverage.policy ||
+      "important feat/fix/perf/refactor commits must be referenced by at least one bullet source_ref",
+  };
+}
+
+function languageIssuesFromReleaseItems(items) {
+  const issues = [];
+  for (const [index, item] of items.entries()) {
+    if (!CJK_RE.test(item.text_cn || "")) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_cn",
+        current_text: item.text_cn || "",
+        reason: "Chinese release-note text must contain CJK characters.",
+      });
+    }
+    if (CJK_RE.test(item.text_en || "")) {
+      issues.push({
+        index,
+        category: item.category,
+        field: "text_en",
+        current_text: item.text_en || "",
+        reason: "English release-note text must not contain CJK characters.",
+      });
+    }
+  }
+  return issues;
+}
+
+function summarizeCoverageForValidation(coverage) {
+  const value = coverage || {};
+  return {
+    needs_review: Boolean(value.needs_review),
+    required_count: Number(value.required_count || 0),
+    covered_required_count: Number(value.covered_required_count || 0),
+    missing_required_count: Number(value.missing_required_count || 0),
+    missing_required: Array.isArray(value.missing_required) ? value.missing_required : [],
+    invalid_item_refs: Array.isArray(value.invalid_item_refs) ? value.invalid_item_refs : [],
+  };
+}
+
+function validationReportFromPostprocessedDraft(draft) {
+  const coverage = summarizeCoverageForValidation(draft?.coverage);
+  const languageIssues = Array.isArray(draft?.language_issues) ? draft.language_issues : [];
+  const issues = [];
+  for (const issue of languageIssues) {
+    issues.push({
+      kind: "language",
+      index: issue.index,
+      category: issue.category,
+      field: issue.field,
+      current_text: issue.current_text || "",
+      reason: issue.reason,
+    });
+  }
+  for (const item of coverage.missing_required) {
+    issues.push({
+      kind: "missing_required_source",
+      refs: Array.isArray(item.refs) ? item.refs : [],
+      short_sha: item.short_sha || "",
+      subject: item.subject || "",
+      reason: item.reason || "important local-plugin release source",
+    });
+  }
+  for (const item of coverage.invalid_item_refs) {
+    issues.push({
+      kind: "invalid_source_ref",
+      ref: item.ref || "",
+      category: item.category || "",
+      text_cn: item.text_cn || "",
+      reason: "release note cites a source_ref that is not present in evidence",
+    });
+  }
+  if (!Array.isArray(draft?.release_items) || draft.release_items.length === 0) {
+    issues.push({
+      kind: "empty_release_items",
+      reason: "release_items must contain at least one evidence-backed item",
+    });
+  }
+
+  const repairableKinds = new Set(["language", "missing_required_source"]);
+  const repairable =
+    issues.length > 0 &&
+    issues.every((issue) => repairableKinds.has(issue.kind)) &&
+    Array.isArray(draft?.release_items) &&
+    draft.release_items.length > 0;
+
+  return {
+    ok: Boolean(draft?.ok) && !draft?.needs_review && issues.length === 0,
+    needs_review: Boolean(draft?.needs_review),
+    repairable,
+    issue_count: issues.length,
+    language_issue_count: languageIssues.length,
+    invalid_item_ref_count: coverage.invalid_item_refs.length,
+    missing_required_count: coverage.missing_required_count,
+    issues,
+    coverage,
+    postprocess: draft?.postprocess || {},
+  };
+}
+
+function repairContextFromValidation({ draft, validationReport, repairAttempt, maxRepairAttempts }) {
+  return {
+    schema: "memos.plugin.release_notes.repair.v1",
+    repair_attempt: repairAttempt,
+    max_repair_attempts: maxRepairAttempts,
+    validation_report: validationReport,
+    previous_release_items: (draft.release_items || []).map((item, index) => ({
+      index,
+      category: item.category,
+      text_cn: item.text_cn,
+      text_en: item.text_en,
+      source_refs: item.source_refs,
+    })),
+    instructions: [
+      "Repair only the issues listed in validation_report. Do not rewrite already valid release-note facts.",
+      "For language issues, edit only the affected text_cn/text_en field: text_cn must contain Chinese, text_en must contain no Chinese/CJK characters.",
+      "Treat text_cn as the canonical wording first; text_en must be a faithful translation of text_cn, not an independently invented summary.",
+      "Keep existing valid category and source_refs unchanged. Do not add source_refs that are not present in the evidence.",
+      "For missing_required_source issues, add a concise product-facing item or attach the listed refs to a semantically matching existing item, using only the listed evidence.",
+      "Return the same release_items schema with category, text_cn, text_en, and source_refs.",
+    ],
+  };
+}
+
+function validationAttemptRecord({ stage, repairAttempt, draft, validationReport }) {
+  return {
+    stage,
+    repair_attempt: repairAttempt,
+    ok: validationReport.ok,
+    needs_review: validationReport.needs_review,
+    repairable: validationReport.repairable,
+    issue_count: validationReport.issue_count,
+    language_issue_count: validationReport.language_issue_count,
+    missing_required_count: validationReport.missing_required_count,
+    invalid_item_ref_count: validationReport.invalid_item_ref_count,
+    coverage: validationReport.coverage,
+    issues: validationReport.issues,
+    postprocess: draft.postprocess || {},
+  };
+}
+
+export async function requestValidatedDraft(
+  evidence,
+  {
+    requestImpl = requestDraft,
+    maxRepairAttempts = MAX_DRAFT_REPAIR_ATTEMPTS,
+  } = {},
+) {
+  let rawDraft = await requestImpl(evidence);
+  const attempts = [];
+  let finalDraft = null;
+
+  for (let repairAttempt = 0; repairAttempt <= maxRepairAttempts; repairAttempt += 1) {
+    const stage = repairAttempt === 0 ? "draft" : "repair";
+    const postprocessed = postprocessDraftFromEvidence(rawDraft, evidence);
+    const validationReport = validationReportFromPostprocessedDraft(postprocessed);
+    attempts.push(validationAttemptRecord({ stage, repairAttempt, draft: postprocessed, validationReport }));
+
+    finalDraft = {
+      ...postprocessed,
+      validation_report: validationReport,
+      repair_attempts: attempts,
+      validation_attempt_count: attempts.length,
+      repair_attempt_count: Math.max(0, attempts.length - 1),
+    };
+
+    if (validationReport.ok) {
+      return finalDraft;
+    }
+    if (!validationReport.repairable || repairAttempt >= maxRepairAttempts) {
+      return finalDraft;
+    }
+
+    const stageLabel =
+      repairAttempt === 0 ? "initial draft validation" : `repair validation attempt ${repairAttempt}`;
+    warn(
+      `Release notes validation failed after ${stageLabel}; requesting draft repair ` +
+        `${repairAttempt + 1}/${maxRepairAttempts}: ${validationReport.issues
+          .map((issue) => issue.kind)
+          .join(", ")}`,
+    );
+    rawDraft = await requestImpl({
+      ...evidence,
+      release_notes_repair_context: repairContextFromValidation({
+        draft: finalDraft,
+        validationReport,
+        repairAttempt: repairAttempt + 1,
+        maxRepairAttempts,
+      }),
+    });
+  }
+
+  return finalDraft;
+}
+
+function embeddedReleaseNotesPayload(items, coverage) {
+  return {
+    schema: "memos.plugin.release_notes.v1",
+    items: items.map((item) => ({
+      category: item.category,
+      text_cn: item.text_cn,
+      text_en: item.text_en,
+      source_refs: item.source_refs,
+    })),
+    coverage: {
+      needs_review: Boolean(coverage.needs_review),
+      required_count: Number(coverage.required_count || 0),
+      covered_required_count: Number(coverage.covered_required_count || 0),
+      missing_required_count: Number(coverage.missing_required_count || 0),
+    },
+  };
+}
+
+function markdownFromReleaseItems(items, coverage) {
+  const lines = ["## Changelog"];
+  for (const category of RELEASE_CATEGORY_ORDER) {
+    const categoryItems = items.filter((item) => item.category === category);
+    if (categoryItems.length === 0) continue;
+    lines.push("");
+    lines.push(`### ${category}`);
+    for (const item of categoryItems) {
+      lines.push(`- ${item.text_cn}`);
+    }
+  }
+  lines.push("");
+  lines.push(`<!-- ${RELEASE_NOTES_MARKER}`);
+  lines.push(JSON.stringify(embeddedReleaseNotesPayload(items, coverage), null, 2));
+  lines.push("-->");
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function postprocessDraftFromEvidence(draft, evidence) {
+  const inputItems = Array.isArray(draft?.release_items)
+    ? draft.release_items.map(normalizeReleaseItem).filter(Boolean)
+    : [];
+  if (inputItems.length === 0) return draft;
+
+  const index = buildSourceRefIndex(evidence);
+  let reclassifiedItems = 0;
+  let items = inputItems.map((item) => {
+    const hintedCategory = bestHintCategoryForItem(item, index);
+    const category = hintedCategory || item.category;
+    if (category !== item.category) reclassifiedItems += 1;
+    return rewriteKnownReleaseItem({ ...item, category }, index);
+  });
+
+  const deduped = dedupeSourceRefsByBestCategory(items, index);
+  items = dedupeReleaseItems(
+    deduped.items.map((item) => {
+      const hintedCategory = bestHintCategoryForItem(item, index);
+      const category = hintedCategory || item.category;
+      if (category !== item.category) reclassifiedItems += 1;
+      return rewriteKnownReleaseItem({ ...item, category }, index);
+    }),
+  );
+
+  const coverage = coverageFromReleaseItems(evidence, draft, items, index);
+  const languageIssues = languageIssuesFromReleaseItems(items);
+  if (languageIssues.length > 0) {
+    coverage.needs_review = true;
+  }
+  const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
+  const postprocess = {
+    applied: true,
+    removed_duplicate_source_refs: deduped.removedDuplicateRefs,
+    dropped_empty_source_items: deduped.droppedItems,
+    reclassified_items: reclassifiedItems,
+    final_item_count: items.length,
+  };
+  const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
+  if (
+    postprocess.removed_duplicate_source_refs > 0 ||
+    postprocess.dropped_empty_source_items > 0 ||
+    postprocess.reclassified_items > 0
+  ) {
+    warnings.push("release notes were postprocessed to dedupe source_refs and apply evidence category hints");
+  }
+  if (languageIssues.length > 0) {
+    warnings.push("release notes language validation failed; manual review is required");
+  }
+
+  return {
+    ...draft,
+    ok: Boolean(items.length) && !coverage.needs_review,
+    needs_review: Boolean(coverage.needs_review),
+    release_items: items,
+    release_categories: releaseCategories,
+    docs_categories: docsCategories,
+    coverage,
+    warnings,
+    language_issues: languageIssues,
+    postprocess,
+    release_notes_markdown: markdownFromReleaseItems(items, coverage),
+  };
+}
+
+export function validateManualNotes(notes) {
+  const text = String(notes || "").trim();
+  if (!/^## Changelog\s*$/m.test(text)) {
+    fail("Manual release notes must contain a '## Changelog' heading.");
+  }
+  const match = text.match(/<!--\s*doc-agent-release-notes-json\s*\n([\s\S]*?)\n-->/);
+  if (!match) {
+    fail("Manual release notes must include the doc-agent-release-notes-json evidence block.");
+  }
+  let payload;
+  try {
+    payload = JSON.parse(match[1]);
+  } catch {
+    fail("Manual release notes contain invalid doc-agent-release-notes-json.");
+  }
+  if (!Array.isArray(payload?.items) || payload.items.length === 0) {
+    fail("Manual release notes evidence block must contain non-empty items.");
+  }
+  if (payload?.coverage?.needs_review !== false) {
+    fail("Manual release notes evidence coverage must explicitly set needs_review=false.");
+  }
+  for (const item of payload.items) {
+    if (!item?.text_cn || !item?.text_en || !Array.isArray(item?.source_refs) || item.source_refs.length === 0) {
+      fail("Every manual release-note item must include text_cn, text_en, and source_refs.");
+    }
+    if (!CJK_RE.test(String(item.text_cn || ""))) {
+      fail("Every manual release-note item text_cn must contain Chinese text.");
+    }
+    if (CJK_RE.test(String(item.text_en || ""))) {
+      fail("Every manual release-note item text_en must not contain Chinese/CJK characters.");
+    }
+  }
+  return text;
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function cleanError(value) {
+  return String(value || "")
+    .replace(/Bearer\s+\S+/gi, "Bearer ***")
+    .replace(/sk-[A-Za-z0-9_-]+/g, "sk-***")
+    .replace(/https?:\/\/[^\s"'<>]+/gi, "https://***")
+    .replace(/\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g, "***")
+    .replace(/\s+/g, " ")
+    .slice(0, 600);
+}
+
+function requiredUrlFromEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) {
+    fail(`${name} secret is required when release_notes input is empty.`);
+  }
+  try {
+    const parsed = new URL(value);
+    if (!/^https?:$/.test(parsed.protocol)) fail(`${name} must be an HTTP(S) URL.`);
+  } catch {
+    fail(`${name} must be an HTTP(S) URL.`);
+  }
+  return value;
+}
+
+function optionalUrlFromEnv(name) {
+  const value = String(process.env[name] || "").trim();
+  if (!value) return "";
+  try {
+    const parsed = new URL(value);
+    if (!/^https?:$/.test(parsed.protocol)) fail(`${name} must be an HTTP(S) URL.`);
+  } catch {
+    fail(`${name} must be an HTTP(S) URL.`);
+  }
+  return value;
+}
+
+export async function reportFailure({ evidence, attempts, finalError, phase = "release-notes", fetchImpl = fetch }) {
+  if (attempts.length < 3) return { skipped: true, reason: "fewer than three attempts" };
+  const token = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN || "";
+  if (!token.trim()) return { skipped: true, reason: "missing configured token" };
+  const url = optionalUrlFromEnv("DOC_AGENT_RELEASE_FAILURE_URL");
+  if (!url) return { skipped: true, reason: "missing configured failure URL" };
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      product_id: PRODUCT_ID,
+      repository: evidence.repo,
+      version: evidence.target_version,
+      phase,
+      run_id: process.env.GITHUB_RUN_ID || `${evidence.current_tag}-local`,
+      run_url: process.env.GITHUB_RUN_ID
+        ? `https://github.com/${evidence.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : "",
+      attempts: attempts.slice(0, 3).map((item, index) => ({
+        attempt: index + 1,
+        error_code: item.error_code || "DRAFT_FAILED",
+        message: cleanError(item.message),
+        retryable: Boolean(item.retryable),
+      })),
+      final_error: cleanError(finalError),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failure-report endpoint returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function reportExternalFailureFromEnv({ fetchImpl = fetch } = {}) {
+  const phase = String(process.env.RELEASE_FAILURE_PHASE || "").trim();
+  const attemptDir = String(process.env.RELEASE_FAILURE_ATTEMPT_DIR || "").trim();
+  if (!phase || !attemptDir) fail("RELEASE_FAILURE_PHASE and RELEASE_FAILURE_ATTEMPT_DIR are required.");
+  const attempts = [1, 2, 3].map((attempt) => {
+    let message = "attempt log is unavailable";
+    try { message = readFileSync(join(attemptDir, `${attempt}.log`), "utf8"); } catch {}
+    return { error_code: phase.toUpperCase().replace(/[^A-Z0-9]+/g, "_"), message: cleanError(message), retryable: true };
+  });
+  return reportFailure({
+    evidence: {
+      repo: process.env.GITHUB_REPOSITORY || "MemTensor/MemOS",
+      target_version: displayVersion(process.env.RELEASE_VERSION),
+      current_tag: process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${cleanVersion(process.env.RELEASE_VERSION)}`,
+    },
+    attempts,
+    finalError: attempts[2].message,
+    phase,
+    fetchImpl,
+  });
+}
+
+export async function requestDraft(
+  evidence,
+  { fetchImpl = fetch, sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) } = {},
+) {
+  const url = requiredUrlFromEnv("DOC_AGENT_RELEASE_NOTES_DRAFT_URL");
+  const token = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN || "";
+  if (!token.trim()) {
+    fail("DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN secret is required when release_notes input is empty.");
+  }
+
+  const attempts = [];
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          ...evidence,
+          workflow_retry_context: {
+            attempt,
+            previous_errors: attempts.map((item) => item.message),
+          },
+        }),
+      });
+      const text = await response.text();
+      let payload = {};
+      try {
+        payload = text ? JSON.parse(text) : {};
+      } catch {
+        throw Object.assign(new Error(`non-JSON response: HTTP ${response.status}`), {
+          retryable: isRetryableStatus(response.status),
+          errorCode: `HTTP_${response.status}`,
+        });
+      }
+      if (!response.ok) {
+        throw Object.assign(
+          new Error(`HTTP ${response.status} ${JSON.stringify(payload).slice(0, 400)}`),
+          { retryable: isRetryableStatus(response.status), errorCode: `HTTP_${response.status}` },
+        );
+      }
+      if (!payload.ok || payload.needs_review) {
+        const serverAttempts = Array.isArray(payload.attempts) ? payload.attempts : [];
+        const coverage = payload.coverage ? JSON.stringify(payload.coverage) : "";
+        const warnings = Array.isArray(payload.warnings) ? payload.warnings.join("; ") : "";
+        const message = `Release notes draft needs review. ${coverage} ${warnings}`.trim();
+        if (serverAttempts.length >= 3) {
+          await reportFailure({
+            evidence,
+            attempts: serverAttempts.map((item) => ({
+              error_code: "DRAFT_VALIDATION",
+              message: item.error || message,
+              retryable: false,
+            })),
+            finalError: message,
+            fetchImpl,
+          });
+        }
+        fail(message);
+      }
+      if (!String(payload.release_notes_markdown || "").trim()) {
+        fail("Release-notes draft service returned an empty release_notes_markdown.");
+      }
+      return payload;
+    } catch (error) {
+      const entry = {
+        error_code: error?.errorCode || "DRAFT_REQUEST",
+        message: cleanError(error?.message || error),
+        retryable: Boolean(error?.retryable),
+      };
+      attempts.push(entry);
+      if (!entry.retryable || attempt === 3) {
+        if (attempts.length === 3) {
+          await reportFailure({ evidence, attempts, finalError: entry.message, fetchImpl });
+        }
+        fail(`Release-notes draft request failed on attempt ${attempt}: ${entry.message}`);
+      }
+      warn(`Release-notes draft attempt ${attempt} failed; retrying: ${entry.message}`);
+      await sleep(250 * 2 ** (attempt - 1));
+    }
+  }
+  fail("Release-notes draft failed after three attempts.");
+}
+
+export async function main() {
+  const targetVersion = cleanVersion(process.env.RELEASE_VERSION);
+  if (!targetVersion) fail("RELEASE_VERSION is required.");
+
+  const currentTag = process.env.RELEASE_TAG || `${CURRENT_TAG_PREFIX}${targetVersion}`;
+  const notesPath =
+    process.env.RELEASE_NOTES_FILE ||
+    join(tmpdir(), `memos-local-plugin-${targetVersion}-release-notes.md`);
+  mkdirSync(dirname(notesPath), { recursive: true });
+
+  const manualNotes = String(process.env.MANUAL_RELEASE_NOTES || "").trim();
+  if (manualNotes) {
+    writeFileSync(notesPath, ensureSourceHint(validateManualNotes(manualNotes)), "utf8");
+    appendOutput("release_notes_file", notesPath);
+    appendOutput("draft_used", "false");
+    console.log(`Using manually provided release notes: ${notesPath}`);
+    return;
+  }
+
+  const previousTag = findPreviousTag(targetVersion, currentTag);
+  if (!previousTag) {
+    fail(`Cannot find a previous local plugin tag before ${currentTag}.`);
+  }
+
+  const currentRef = resolveCurrentRef(currentTag);
+  const evidence = collectEvidence({ targetVersion, currentTag, previousTag, currentRef });
+  const evidencePath = join(tmpdir(), `memos-local-plugin-${targetVersion}-evidence.json`);
+  writeFileSync(evidencePath, JSON.stringify(evidenceForInspection(evidence), null, 2), "utf8");
+
+  const draft = await requestValidatedDraft(evidence);
+  if (!draft.ok || draft.needs_review) {
+    fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
+  }
+  const draftPath = join(tmpdir(), `memos-local-plugin-${targetVersion}-release-notes-draft.json`);
+  writeFileSync(draftPath, JSON.stringify(draftForInspection(draft), null, 2), "utf8");
+  writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");
+
+  appendOutput("release_notes_file", notesPath);
+  appendOutput("evidence_file", evidencePath);
+  appendOutput("draft_file", draftPath);
+  appendOutput("draft_used", "true");
+  appendOutput("previous_tag", previousTag);
+  appendOutput("current_tag", currentTag);
+  appendOutput("current_ref", currentRef);
+  appendOutput("draft_confidence", String(draft.confidence || ""));
+  appendOutput("missing_required_count", String(draft.coverage?.missing_required_count ?? ""));
+  appendOutput("validation_attempt_count", String(draft.validation_attempt_count ?? ""));
+  appendOutput("repair_attempt_count", String(draft.repair_attempt_count ?? ""));
+
+  console.log(`Drafted release notes with configured service: ${notesPath}`);
+  console.log(`Previous tag: ${previousTag}`);
+  console.log(`Current tag: ${currentTag}`);
+  console.log(`Current evidence ref: ${currentRef}`);
+  console.log(`Coverage: ${JSON.stringify(draft.coverage || {})}`);
+  console.log(`Validation attempts: ${draft.validation_attempt_count ?? ""}`);
+  console.log(`Repair attempts: ${draft.repair_attempt_count ?? ""}`);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  const run = process.env.RELEASE_FAILURE_PHASE ? reportExternalFailureFromEnv : main;
+  run().catch((error) => {
+    console.error(`::error::${cleanError(error?.message || String(error))}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -1,0 +1,653 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  cleanVersion,
+  categoryHintsForCommits,
+  draftForInspection,
+  evidenceForInspection,
+  ensureSourceHint,
+  RELEASE_NOTE_GUIDANCE,
+  postprocessDraftFromEvidence,
+  reportExternalFailureFromEnv,
+  requestDraft,
+  requestValidatedDraft,
+  resolveCurrentRef,
+  validateManualNotes,
+  versionFromTag,
+} from "./draft-local-plugin-release-notes.mjs";
+
+const evidence = {
+  repo: "MemTensor/MemOS",
+  current_tag: "memos-local-plugin-v2.0.10",
+  target_version: "v2.0.10",
+};
+
+function response(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    async text() {
+      return JSON.stringify(body);
+    },
+    async json() {
+      return body;
+    },
+  };
+}
+
+test("normalizes only real local-plugin tag families", () => {
+  assert.equal(cleanVersion("v2.0.10"), "2.0.10");
+  assert.equal(versionFromTag("memos-local-plugin-v2.0.10"), "2.0.10");
+  assert.equal(versionFromTag("openclaw-local-plugin-v2.0.9"), "2.0.9");
+  assert.equal(versionFromTag("v2.0.10"), "");
+});
+
+test("uses an existing release tag as the evidence endpoint", () => {
+  const exists = (ref) => ref === "memos-local-plugin-v2.0.10" || ref === "manual-ref";
+  assert.equal(
+    resolveCurrentRef("memos-local-plugin-v2.0.10", { requestedRef: "", refExistsImpl: exists }),
+    "memos-local-plugin-v2.0.10",
+  );
+  assert.equal(
+    resolveCurrentRef("memos-local-plugin-v2.0.11", { requestedRef: "", refExistsImpl: exists }),
+    "HEAD",
+  );
+  assert.equal(
+    resolveCurrentRef("memos-local-plugin-v2.0.11", { requestedRef: "manual-ref", refExistsImpl: exists }),
+    "manual-ref",
+  );
+  assert.throws(
+    () => resolveCurrentRef("memos-local-plugin-v2.0.11", { requestedRef: "missing-ref", refExistsImpl: exists }),
+    /RELEASE_EVIDENCE_REF does not exist/,
+  );
+});
+
+test("documents release-note category guidance for the draft service", () => {
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Added, /configuration/);
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Improved, /performance optimization/);
+  assert.match(RELEASE_NOTE_GUIDANCE.category_policy.Fixed, /broken behavior/);
+  assert.ok(
+    RELEASE_NOTE_GUIDANCE.quality_policy.some((item) =>
+      item.includes("Do not collapse a new configuration capability and a bug fix"),
+    ),
+  );
+  assert.ok(
+    RELEASE_NOTE_GUIDANCE.translation_policy.some((item) =>
+      item.includes("Treat text_cn as the canonical release-note wording first"),
+    ),
+  );
+});
+
+test("adds source-ref category hints from commit subjects", () => {
+  const hints = categoryHintsForCommits([
+    {
+      short_sha: "59c14746",
+      subject: "Fix #2076: local-plugin gateway CPU 100% — synchronous full-table vector scan (#2077)",
+    },
+    {
+      short_sha: "9deb941e",
+      subject: "feat(l3): dedicated l3Llm config slot for abstraction pass (#1959)",
+    },
+    {
+      short_sha: "de03ab29",
+      subject: "Fix #2063: algorithm.lightweightMemory.enabled: true does not actually skip evolution pipeline (#2074)",
+    },
+    {
+      short_sha: "78ae7a53",
+      subject: "fix(memos-local-plugin): handle full endpoint paths in openai_compatible probe",
+    },
+    {
+      short_sha: "c739e9f2",
+      subject: "fix: ruff",
+    },
+    {
+      short_sha: "ca2b3854",
+      subject: "fix(memos): apply Memtensor-AI review feedback to PR #1817",
+    },
+  ]);
+  assert.deepEqual(
+    hints.map((hint) => hint.category),
+    ["Improved", "Added", "Fixed", "Fixed"],
+  );
+  assert.deepEqual(hints[0].source_refs, ["59c14746", "#2076", "#2077"]);
+  assert.deepEqual(hints[2].source_refs, ["de03ab29", "#2063", "#2074"]);
+});
+
+test("redacts full diff and prompt guidance from inspection evidence", () => {
+  const inspection = evidenceForInspection({
+    ...evidence,
+    release_note_guidance: {
+      category_policy: { Added: "private prompt details" },
+      quality_policy: ["private quality prompt"],
+      translation_policy: ["private translation prompt"],
+      source_ref_category_hints: [{ category: "Added", source_refs: ["abc1234"] }],
+    },
+    important_diff: {
+      "apps/memos-local-plugin/**": "diff --git a/private.js b/private.js",
+    },
+  });
+
+  assert.equal("important_diff" in inspection, false);
+  assert.equal(inspection.release_note_guidance.category_policy, undefined);
+  assert.deepEqual(inspection.release_note_guidance.source_ref_category_hints, [
+    { category: "Added", source_refs: ["abc1234"] },
+  ]);
+  assert.match(inspection.redactions.important_diff, /omitted/);
+});
+
+test("redacts server debug fields from inspection draft", () => {
+  const inspection = draftForInspection({
+    ok: true,
+    needs_review: false,
+    confidence: "high",
+    release_items: [{ category: "Added", text_cn: "新增配置", text_en: "Added configuration", source_refs: ["abc1234"] }],
+    coverage: { needs_review: false, required_count: 1, covered_required_count: 1, covered_refs: ["abc1234"] },
+    model: "private-model",
+    prompt: "private prompt",
+    debug: { trace: "private debug" },
+  });
+
+  assert.equal(inspection.model, undefined);
+  assert.equal(inspection.prompt, undefined);
+  assert.equal(inspection.debug, undefined);
+  assert.deepEqual(inspection.release_items[0].source_refs, ["abc1234"]);
+  assert.match(inspection.redactions.model_and_prompt_details, /omitted/);
+});
+
+test("postprocesses duplicate source refs into the best evidence category", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**修复 CPU 占用**：解决同步全表向量扫描导致的 CPU 100%。",
+          text_en: "**CPU Fix**: Fixed CPU usage from synchronous vector scans.",
+          source_refs: ["59c14746", "#2077"],
+        },
+        {
+          category: "Improved",
+          text_cn: "**向量扫描优化**：降低向量扫描 CPU 压力。",
+          text_en: "**Vector scan**: Reduced vector-scan CPU pressure.",
+          source_refs: ["59c14746", "#2077"],
+        },
+        {
+          category: "Fixed",
+          text_cn: "**记忆与 LLM 调用稳定性**：补强空响应重试、错误日志、XML 上下文边界和脏奖励恢复场景处理。",
+          text_en:
+            "**Memory and LLM Stability**: Improved empty-response retry, error logging, XML boundaries, and dirty-reward recovery.",
+          source_refs: ["2c48b496", "#2064", "e5080657", "#2052"],
+        },
+        {
+          category: "Improved",
+          text_cn: "**检索上下文边界优化**：使用 XML 边界组织记忆上下文。",
+          text_en: "**Context boundaries**: Organized memory context with XML boundaries.",
+          source_refs: ["e5080657", "#2052"],
+        },
+      ],
+      coverage: { required_count: 3, covered_required_count: 3, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "59c1474600000000000000000000000000000000",
+          short_sha: "59c14746",
+          subject: "Fix #2076: local-plugin gateway CPU 100% — synchronous full-table vector scan (#2077)",
+        },
+        {
+          sha: "2c48b49600000000000000000000000000000000",
+          short_sha: "2c48b496",
+          subject: "fix(skill-crystallize): retry with context when LLM returns empty response (#2064)",
+        },
+        {
+          sha: "e508065700000000000000000000000000000000",
+          short_sha: "e5080657",
+          subject: "fix: delimit memory context with XML boundary (#2052)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Improved",
+            source_refs: ["59c14746", "#2076", "#2077"],
+            subject: "Fix #2076: local-plugin gateway CPU 100% — synchronous full-table vector scan (#2077)",
+          },
+          {
+            category: "Fixed",
+            source_refs: ["2c48b496", "#2064"],
+            subject: "fix(skill-crystallize): retry with context when LLM returns empty response (#2064)",
+          },
+          {
+            category: "Improved",
+            source_refs: ["e5080657", "#2052"],
+            subject: "fix: delimit memory context with XML boundary (#2052)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.needs_review, false);
+  assert.equal(processed.coverage.covered_required_count, 3);
+  assert.equal(processed.postprocess.removed_duplicate_source_refs, 4);
+  assert.equal(processed.postprocess.dropped_empty_source_items, 1);
+  assert.equal(processed.release_items.length, 3);
+  assert.deepEqual(
+    processed.release_items.map((item) => item.category),
+    ["Improved", "Fixed", "Improved"],
+  );
+  assert.equal(
+    processed.release_items.filter((item) => item.source_refs.includes("59c14746")).length,
+    1,
+  );
+  assert.equal(
+    processed.release_items.find((item) => item.text_cn.includes("记忆恢复"))?.text_cn.includes("XML"),
+    false,
+  );
+  assert.match(processed.release_notes_markdown, /doc-agent-release-notes-json/);
+});
+
+test("postprocesses a single misclassified performance item into Improved", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**修复 CPU 占用**：解决同步全表向量扫描导致的 CPU 100%。",
+          text_en: "**CPU Fix**: Fixed CPU usage from synchronous vector scans.",
+          source_refs: ["59c14746", "#2077"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "59c1474600000000000000000000000000000000",
+          short_sha: "59c14746",
+          subject: "Fix #2076: local-plugin gateway CPU 100% — synchronous full-table vector scan (#2077)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Improved",
+            source_refs: ["59c14746", "#2076", "#2077"],
+            subject: "Fix #2076: local-plugin gateway CPU 100% — synchronous full-table vector scan (#2077)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.release_items[0].category, "Improved");
+  assert.match(processed.release_items[0].text_cn, /向量扫描性能优化/);
+  assert.match(processed.release_notes_markdown, /### Improved/);
+});
+
+test("postprocesses mixed endpoint and auth fixes without dropping either concern", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**桥接与连接稳定性**：优化 RPC 会话豁免和 OpenAI-compatible 端点探测。",
+          text_en: "**Bridge and connection stability**: Improved RPC exemption and endpoint probing.",
+          source_refs: ["4afaa3ce", "78ae7a53"],
+        },
+      ],
+      coverage: { required_count: 2, covered_required_count: 2, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "4afaa3ce00000000000000000000000000000000",
+          short_sha: "4afaa3ce",
+          subject: "fix(auth): restrict /api/v1/rpc session exemption to loopback callers",
+        },
+        {
+          sha: "78ae7a5300000000000000000000000000000000",
+          short_sha: "78ae7a53",
+          subject: "fix(memos-local-plugin): handle full endpoint paths in openai_compatible probe",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Fixed",
+            source_refs: ["4afaa3ce"],
+            subject: "fix(auth): restrict /api/v1/rpc session exemption to loopback callers",
+          },
+          {
+            category: "Fixed",
+            source_refs: ["78ae7a53"],
+            subject: "fix(memos-local-plugin): handle full endpoint paths in openai_compatible probe",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.match(processed.release_items[0].text_cn, /连接与鉴权边界修复/);
+  assert.match(processed.release_items[0].text_cn, /endpoint/);
+  assert.match(processed.release_items[0].text_cn, /RPC/);
+});
+
+test("postprocess fails closed when English and Chinese text cross languages", () => {
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "Plugin health dashboard",
+          text_en: "插件健康看板",
+          source_refs: ["abc1234", "#3001"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    },
+    {
+      commits: [
+        {
+          sha: "abc12340000000000000000000000000000000",
+          short_sha: "abc1234",
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+      release_note_guidance: {
+        source_ref_category_hints: [
+          {
+            category: "Added",
+            source_refs: ["abc1234", "#3001"],
+            subject: "feat: add plugin health dashboard (#3001)",
+          },
+        ],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.equal(processed.language_issues.length, 2);
+});
+
+test("repairs postprocessed language validation issues with exact context", async () => {
+  const repairEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: add plugin health dashboard (#3001)",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234", "#3001"],
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+    },
+  };
+  const requests = [];
+  const requestImpl = async (payload) => {
+    requests.push(payload);
+    if (requests.length === 1) {
+      return {
+        ok: true,
+        needs_review: false,
+        release_items: [
+          {
+            category: "Added",
+            text_cn: "Plugin health dashboard",
+            text_en: "插件健康看板",
+            source_refs: ["abc1234", "#3001"],
+          },
+        ],
+        coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+        warnings: [],
+      };
+    }
+    return {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Added",
+          text_cn: "**插件健康看板**：新增本地插件健康状态展示。",
+          text_en: "**Plugin Health Dashboard**: Added local plugin health status visibility.",
+          source_refs: ["abc1234", "#3001"],
+        },
+      ],
+      coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+      warnings: [],
+    };
+  };
+
+  const result = await requestValidatedDraft(repairEvidence, { requestImpl });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.needs_review, false);
+  assert.equal(result.repair_attempt_count, 1);
+  assert.equal(result.validation_attempt_count, 2);
+  assert.equal(result.validation_report.ok, true);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].release_notes_repair_context.validation_report.language_issue_count, 2);
+  assert.deepEqual(
+    requests[1].release_notes_repair_context.validation_report.issues.map((issue) => issue.field),
+    ["text_cn", "text_en"],
+  );
+  assert.equal(requests[1].release_notes_repair_context.previous_release_items[0].source_refs[0], "abc1234");
+  assert.match(result.release_notes_markdown, /插件健康看板/);
+  assert.match(result.release_notes_markdown, /doc-agent-release-notes-json/);
+});
+
+test("stops release-note repair after two validation repair attempts", async () => {
+  const repairEvidence = {
+    commits: [
+      {
+        sha: "abc12340000000000000000000000000000000",
+        short_sha: "abc1234",
+        subject: "feat: add plugin health dashboard (#3001)",
+      },
+    ],
+    release_note_guidance: {
+      source_ref_category_hints: [
+        {
+          category: "Added",
+          source_refs: ["abc1234", "#3001"],
+          subject: "feat: add plugin health dashboard (#3001)",
+        },
+      ],
+    },
+  };
+  const requests = [];
+  const crossedDraft = {
+    ok: true,
+    needs_review: false,
+    release_items: [
+      {
+        category: "Added",
+        text_cn: "Plugin health dashboard",
+        text_en: "插件健康看板",
+        source_refs: ["abc1234", "#3001"],
+      },
+    ],
+    coverage: { required_count: 1, covered_required_count: 1, missing_required_count: 0 },
+    warnings: [],
+  };
+  const requestImpl = async (payload) => {
+    requests.push(payload);
+    return crossedDraft;
+  };
+
+  const result = await requestValidatedDraft(repairEvidence, { requestImpl, maxRepairAttempts: 2 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.needs_review, true);
+  assert.equal(result.repair_attempt_count, 2);
+  assert.equal(result.validation_attempt_count, 3);
+  assert.equal(result.validation_report.language_issue_count, 2);
+  assert.equal(requests.length, 3);
+  assert.equal(requests[1].release_notes_repair_context.repair_attempt, 1);
+  assert.equal(requests[2].release_notes_repair_context.repair_attempt, 2);
+});
+
+test("reports three external-operation attempt logs with a sanitized phase", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "local-plugin-release-failure-"));
+  const previous = { ...process.env };
+  try {
+    for (const attempt of [1, 2, 3]) writeFileSync(join(directory, `${attempt}.log`), `npm failure ${attempt}`);
+    Object.assign(process.env, {
+      RELEASE_FAILURE_PHASE: "npm-publish",
+      RELEASE_FAILURE_ATTEMPT_DIR: directory,
+      RELEASE_VERSION: "2.0.10",
+      RELEASE_TAG: "memos-local-plugin-v2.0.10",
+      DOC_AGENT_RELEASE_FAILURE_URL: "https://example.invalid/failure",
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: "test-token",
+    });
+    let report;
+    await reportExternalFailureFromEnv({
+      fetchImpl: async (_url, options) => { report = JSON.parse(options.body); return response(200, { ok: true }); },
+    });
+    assert.equal(report.phase, "npm-publish");
+    assert.deepEqual(report.attempts.map((item) => item.message), ["npm failure 1", "npm failure 2", "npm failure 3"]);
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual notes require bilingual evidence refs and passed coverage", () => {
+  const valid = `## Changelog
+
+### Added
+- local memory
+
+<!-- doc-agent-release-notes-json
+{"items":[{"text_cn":"本地记忆","text_en":"Local memory","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`;
+  assert.equal(validateManualNotes(valid), valid);
+  assert.match(ensureSourceHint(valid), /source-id=openclaw-local-plugin/);
+  assert.throws(() => validateManualNotes("## Changelog\n- unsupported"), /evidence block/);
+  assert.throws(
+    () =>
+      validateManualNotes(`## Changelog
+
+### Added
+- local memory
+
+<!-- doc-agent-release-notes-json
+{"items":[{"text_cn":"Local memory","text_en":"本地记忆","source_refs":["abc1234"]}],"coverage":{"needs_review":false}}
+-->`),
+    /text_cn must contain Chinese/,
+  );
+});
+
+test("retries transient draft failures and passes prior error context", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const requests = [];
+    const fetchImpl = async (_url, options) => {
+      requests.push(JSON.parse(options.body));
+      if (requests.length < 3) return response(503, { detail: "busy" });
+      return response(200, {
+        ok: true,
+        needs_review: false,
+        release_notes_markdown: "## Changelog\n\n### Added\n- ok",
+      });
+    };
+    const result = await requestDraft(evidence, { fetchImpl, sleep: async () => {} });
+    assert.equal(result.ok, true);
+    assert.equal(requests.length, 3);
+    assert.equal(requests[1].workflow_retry_context.previous_errors.length, 1);
+    assert.equal(requests[2].workflow_retry_context.previous_errors.length, 2);
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("reports once after three transient failures", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, body: JSON.parse(options.body) });
+      if (url.includes("/failure")) return response(200, { ok: true, sent: true });
+      return response(503, { detail: "busy" });
+    };
+    await assert.rejects(
+      requestDraft(evidence, { fetchImpl, sleep: async () => {} }),
+      /attempt 3/,
+    );
+    const reports = calls.filter((call) => call.url.includes("/failure"));
+    assert.equal(reports.length, 1);
+    assert.deepEqual(reports[0].body.attempts.map((item) => item.attempt), [1, 2, 3]);
+    assert.equal(reports[0].body.repository, "MemTensor/MemOS");
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("requires configured draft URL instead of using a public fallback", async () => {
+  const previous = { ...process.env };
+  try {
+    delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL;
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    await assert.rejects(
+      requestDraft(evidence, { fetchImpl: async () => response(200, { ok: true }), sleep: async () => {} }),
+      /DOC_AGENT_RELEASE_NOTES_DRAFT_URL secret is required/,
+    );
+  } finally {
+    process.env = previous;
+  }
+});
+
+test("sanitizes configured URLs and IPs before failure reporting", async () => {
+  const previous = { ...process.env };
+  try {
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = "https://example.invalid/draft";
+    process.env.DOC_AGENT_RELEASE_FAILURE_URL = "https://example.invalid/failure";
+    process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = "test-token";
+    const calls = [];
+    const fetchImpl = async (url, options) => {
+      calls.push({ url, body: JSON.parse(options.body) });
+      if (url.includes("/failure")) return response(200, { ok: true, sent: true });
+      throw Object.assign(
+        new Error("connect ECONNREFUSED https://example.invalid/redacted-path with Bearer test-token"),
+        { retryable: true },
+      );
+    };
+    await assert.rejects(
+      requestDraft(evidence, { fetchImpl, sleep: async () => {} }),
+      /attempt 3/,
+    );
+    const report = calls.find((call) => call.url.includes("/failure"))?.body;
+    assert.ok(report);
+    assert.doesNotMatch(JSON.stringify(report), /example\.invalid|redacted-path|test-token/);
+    assert.match(JSON.stringify(report), /https:\/\/\*\*\*/);
+  } finally {
+    process.env = previous;
+  }
+});

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+attempts="${RETRY_ATTEMPTS:-3}"
+delay="${RETRY_DELAY_SECONDS:-5}"
+label="command"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --attempts)
+      attempts="$2"
+      shift 2
+      ;;
+    --delay)
+      delay="$2"
+      shift 2
+      ;;
+    --label)
+      label="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::retry.sh requires a command to run." >&2
+  exit 2
+fi
+
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::Invalid retry attempts: ${attempts}" >&2
+  exit 2
+fi
+
+if ! [[ "${delay}" =~ ^[0-9]+$ ]]; then
+  echo "::error::Invalid retry delay: ${delay}" >&2
+  exit 2
+fi
+
+for attempt in $(seq 1 "${attempts}"); do
+  echo "::group::${label} attempt ${attempt}/${attempts}" >&2
+  set +e
+  "$@"
+  status=$?
+  set -e
+  echo "::endgroup::" >&2
+
+  if [ "${status}" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "${attempt}" -eq "${attempts}" ]; then
+    echo "::error::${label} failed after ${attempts} attempts with exit code ${status}." >&2
+    exit "${status}"
+  fi
+
+  sleep_seconds=$((delay * attempt))
+  echo "::warning::${label} failed with exit code ${status}; retrying in ${sleep_seconds}s." >&2
+  sleep "${sleep_seconds}"
+done

--- a/.github/workflows/memos-local-plugin-post-merge-dry-run.yml
+++ b/.github/workflows/memos-local-plugin-post-merge-dry-run.yml
@@ -1,0 +1,29 @@
+name: MemOS Local Plugin — Post-Merge Dry Run
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/memos-local-plugin-publish.yml"
+      - ".github/workflows/memos-local-plugin-post-merge-dry-run.yml"
+      - ".github/scripts/draft-local-plugin-release-notes.mjs"
+      - ".github/scripts/draft-local-plugin-release-notes.test.mjs"
+      - ".github/scripts/retry.sh"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dry-run:
+    if: ${{ github.repository == 'MemTensor/MemOS' }}
+    uses: ./.github/workflows/memos-local-plugin-publish.yml
+    with:
+      version: "2.0.10"
+      tag: "latest"
+      git_ref: ""
+      release_notes: ""
+      dry_run: true
+      recover_existing_npm_release: false
+    secrets: inherit

--- a/.github/workflows/memos-local-plugin-publish.yml
+++ b/.github/workflows/memos-local-plugin-publish.yml
@@ -14,6 +14,51 @@ on:
         description: "Git ref to build from (branch, tag, or SHA). Leave blank to use the branch selected above."
         required: false
         default: ""
+      release_notes:
+        description: "Optional Markdown release notes. Leave blank to let the configured draft service use real git evidence before publish."
+        required: false
+        default: ""
+      dry_run:
+        description: "Draft release notes and build artifacts only. Skip npm publish, tag, GitHub Release, and release PR."
+        required: true
+        type: boolean
+        default: true
+      recover_existing_npm_release:
+        description: "Allow reconstructing a missing tag/Release for an npm version. Keep false for normal releases."
+        required: true
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish or dry-run (e.g. 2.0.10 or 2.0.11-beta.1)"
+        required: true
+        type: string
+      tag:
+        description: "npm dist-tag (latest for production, beta/next/alpha for testing)"
+        required: false
+        type: string
+        default: "latest"
+      git_ref:
+        description: "Git ref to build from. Leave blank to use the caller ref."
+        required: false
+        type: string
+        default: ""
+      release_notes:
+        description: "Optional Markdown release notes. Leave blank to let the configured draft service use evidence."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Draft release notes and build artifacts only. Skip npm publish, tag, GitHub Release, and release PR."
+        required: false
+        type: boolean
+        default: true
+      recover_existing_npm_release:
+        description: "Allow reconstructing a missing tag/Release for an npm version. Keep false for normal releases."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: memos-local-plugin-publish
@@ -34,7 +79,7 @@ jobs:
         include:
           - os: macos-14
             platform: darwin-arm64
-          - os: macos-15
+          - os: macos-15-intel
             platform: darwin-x64
           - os: ubuntu-latest
             platform: linux-x64
@@ -45,24 +90,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref || github.ref }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install dependencies
-        run: npm install
+        shell: bash
+        run: bash ../../.github/scripts/retry.sh --label "npm ci" -- npm ci
 
       - name: Rebuild for x64 under Rosetta (darwin-x64 only)
         if: matrix.platform == 'darwin-x64'
-        run: |
-          arch -x86_64 npm rebuild better-sqlite3
+        shell: bash
+        run: bash ../../.github/scripts/retry.sh --label "npm rebuild better-sqlite3 under Rosetta" -- arch -x86_64 npm rebuild better-sqlite3
 
       - name: Collect prebuild
         shell: bash
         run: |
-          mkdir -p prebuilds/${{ matrix.platform }}
-          cp node_modules/better-sqlite3/build/Release/better_sqlite3.node prebuilds/${{ matrix.platform }}/
+          bash ../../.github/scripts/retry.sh --label "collect ${{ matrix.platform }} prebuild" -- bash -euo pipefail -c '
+            mkdir -p prebuilds/${{ matrix.platform }}
+            cp node_modules/better-sqlite3/build/Release/better_sqlite3.node prebuilds/${{ matrix.platform }}/
+          '
 
       - name: Upload prebuild artifact
         uses: actions/upload-artifact@v4
@@ -77,6 +126,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref || github.ref }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -92,56 +142,382 @@ jobs:
 
       - name: Organize prebuilds
         run: |
-          cd prebuilds
-          for dir in prebuild-*; do
-            platform="${dir#prebuild-}"
-            mkdir -p "$platform"
-            mv "$dir/better_sqlite3.node" "$platform/"
-            rmdir "$dir"
-          done
-          echo "Prebuilds collected:"
-          find . -name "*.node" -exec ls -lh {} \;
+          bash ../../.github/scripts/retry.sh --label "organize prebuild artifacts" -- bash -euo pipefail -c '
+            cd prebuilds
+            for dir in prebuild-*; do
+              platform="${dir#prebuild-}"
+              mkdir -p "$platform"
+              mv "$dir/better_sqlite3.node" "$platform/"
+              rmdir "$dir"
+            done
+            echo "Prebuilds collected:"
+            find . -name "*.node" -exec ls -lh {} \;
+          '
 
       - name: Install dependencies (skip native build)
-        run: npm install --ignore-scripts
+        run: bash ../../.github/scripts/retry.sh --label "npm ci --ignore-scripts" -- npm ci --ignore-scripts
+
+      - name: Install Linux sqlite binding for validation
+        run: |
+          bash ../../.github/scripts/retry.sh --label "install linux sqlite binding for validation" -- bash -euo pipefail -c '
+            test -s prebuilds/linux-x64/better_sqlite3.node
+            mkdir -p node_modules/better-sqlite3/build/Release
+            cp prebuilds/linux-x64/better_sqlite3.node node_modules/better-sqlite3/build/Release/better_sqlite3.node
+          '
 
       - name: Generate telemetry credentials
-        run: node scripts/generate-telemetry-credentials.cjs
+        run: bash ../../.github/scripts/retry.sh --label "generate telemetry credentials" -- node scripts/generate-telemetry-credentials.cjs
         env:
           MEMOS_ARMS_ENDPOINT: ${{ secrets.MEMOS_ARMS_ENDPOINT }}
           MEMOS_ARMS_PID: ${{ secrets.MEMOS_ARMS_PID }}
           MEMOS_ARMS_ENV: ${{ secrets.MEMOS_ARMS_ENV }}
 
       - name: Bump version
-        run: npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "${RELEASE_VERSION}" == v* ]]; then
+            echo "::error::version must not include a leading v."
+            exit 1
+          fi
+          bash ../../.github/scripts/retry.sh --label "bump package version" -- npm version "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+
+      - name: Validate and build package
+        run: |
+          bash ../../.github/scripts/retry.sh --attempts 2 --label "npm run lint" -- npm run lint
+          bash ../../.github/scripts/retry.sh --attempts 2 --label "npm test" -- npm test
+          bash ../../.github/scripts/retry.sh --label "npm pack dry-run" -- bash -euo pipefail -c 'npm pack --dry-run --json > "${RUNNER_TEMP}/memos-local-plugin-pack.json"'
+
+      - name: Draft GitHub Release notes
+        id: release_notes
+        working-directory: .
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: memos-local-plugin-v${{ inputs.version }}
+          MANUAL_RELEASE_NOTES: ${{ inputs.release_notes }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_URL: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_URL }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
+        run: bash .github/scripts/retry.sh --attempts 2 --label "draft GitHub Release notes" -- node .github/scripts/draft-local-plugin-release-notes.mjs
+
+      - name: Prepare release notes inspection artifact
+        working-directory: .
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
+          EVIDENCE_FILE: ${{ steps.release_notes.outputs.evidence_file }}
+          DRAFT_FILE: ${{ steps.release_notes.outputs.draft_file }}
+          DRAFT_USED: ${{ steps.release_notes.outputs.draft_used }}
+          PREVIOUS_TAG: ${{ steps.release_notes.outputs.previous_tag }}
+          CURRENT_TAG: ${{ steps.release_notes.outputs.current_tag }}
+          CURRENT_REF: ${{ steps.release_notes.outputs.current_ref }}
+          DRAFT_CONFIDENCE: ${{ steps.release_notes.outputs.draft_confidence }}
+          MISSING_REQUIRED_COUNT: ${{ steps.release_notes.outputs.missing_required_count }}
+          VALIDATION_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.validation_attempt_count }}
+          REPAIR_ATTEMPT_COUNT: ${{ steps.release_notes.outputs.repair_attempt_count }}
+        run: |
+          set -euo pipefail
+          inspection_dir="${RUNNER_TEMP}/memos-local-plugin-release-notes-inspection"
+          mkdir -p "${inspection_dir}"
+
+          if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
+            echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+
+          cp "${RELEASE_NOTES_FILE}" "${inspection_dir}/release-notes.md"
+          cp "${RUNNER_TEMP}/memos-local-plugin-pack.json" "${inspection_dir}/npm-pack.json"
+          if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
+            cp "${EVIDENCE_FILE}" "${inspection_dir}/evidence.json"
+          fi
+          if [ "${DRAFT_USED:-}" = "true" ]; then
+            if [ -z "${DRAFT_FILE}" ] || [ ! -s "${DRAFT_FILE}" ]; then
+              echo "::error::Draft JSON file was not generated."
+              exit 1
+            fi
+            cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+          elif [ -n "${DRAFT_FILE}" ] && [ -s "${DRAFT_FILE}" ]; then
+            cp "${DRAFT_FILE}" "${inspection_dir}/release-notes-draft.json"
+          fi
+
+          {
+            echo "# MemOS local plugin release notes inspection"
+            echo
+            echo "- dry_run: ${DRY_RUN}"
+            echo "- version: ${RELEASE_VERSION}"
+            echo "- draft_used: ${DRAFT_USED:-unknown}"
+            echo "- previous_tag: ${PREVIOUS_TAG:-n/a}"
+            echo "- current_tag: ${CURRENT_TAG:-n/a}"
+            echo "- current_ref: ${CURRENT_REF:-n/a}"
+            echo "- draft_confidence: ${DRAFT_CONFIDENCE:-n/a}"
+            echo "- missing_required_count: ${MISSING_REQUIRED_COUNT:-n/a}"
+            echo "- validation_attempt_count: ${VALIDATION_ATTEMPT_COUNT:-n/a}"
+            echo "- repair_attempt_count: ${REPAIR_ATTEMPT_COUNT:-n/a}"
+            echo
+            echo "Files:"
+            echo
+            echo "- release-notes.md"
+            echo "- npm-pack.json"
+            if [ -n "${EVIDENCE_FILE}" ] && [ -s "${EVIDENCE_FILE}" ]; then
+              echo "- evidence.json (redacted; no full diff or prompt guidance)"
+            fi
+            if [ -f "${inspection_dir}/release-notes-draft.json" ]; then
+              echo "- release-notes-draft.json"
+            fi
+          } > "${inspection_dir}/README.md"
+
+          {
+            echo "### MemOS local plugin release notes"
+            echo
+            echo "- dry_run: \`${DRY_RUN}\`"
+            echo "- draft_used: \`${DRAFT_USED:-unknown}\`"
+            echo "- previous_tag: \`${PREVIOUS_TAG:-n/a}\`"
+            echo "- current_tag: \`${CURRENT_TAG:-n/a}\`"
+            echo "- current_ref: \`${CURRENT_REF:-n/a}\`"
+            echo "- draft_confidence: \`${DRAFT_CONFIDENCE:-n/a}\`"
+            echo "- missing_required_count: \`${MISSING_REQUIRED_COUNT:-n/a}\`"
+            echo "- validation_attempt_count: \`${VALIDATION_ATTEMPT_COUNT:-n/a}\`"
+            echo "- repair_attempt_count: \`${REPAIR_ATTEMPT_COUNT:-n/a}\`"
+            echo
+            echo "Download the workflow artifact \`memos-local-plugin-release-notes-inspection\` to review release-notes.md, release-notes-draft.json, and redacted evidence.json."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload release notes inspection artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: memos-local-plugin-release-notes-inspection
+          path: ${{ runner.temp }}/memos-local-plugin-release-notes-inspection
+          if-no-files-found: error
+
+      - name: Stop before publish in dry run
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "::notice::dry_run=true; skipped npm publish, tag, GitHub Release, and release PR."
 
       - name: Publish to npm
+        if: ${{ inputs.dry_run != true }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           PACKAGE_NAME: "@memtensor/memos-local-plugin"
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: memos-local-plugin-v${{ inputs.version }}
           NPM_DIST_TAG: ${{ inputs.tag }}
+          RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
+          DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
+          DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
         run: |
-          if npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >/dev/null 2>&1; then
-            echo "${PACKAGE_NAME}@${RELEASE_VERSION} already exists on npm; skipping publish."
+          set -euo pipefail
+          npm_view_log="${RUNNER_TEMP}/memos-local-plugin-npm-view.log"
+          npm_version_exists() {
+            for attempt in 1 2 3; do
+              set +e
+              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >"${npm_view_log}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                sed -n '1,40p' "${npm_view_log}"
+                return 0
+              fi
+              if grep -Eiq "E404|404 Not Found|No match found|is not in this registry" "${npm_view_log}"; then
+                return 1
+              fi
+              sed -n '1,120p' "${npm_view_log}"
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::npm view failed after three attempts; refusing to guess whether ${PACKAGE_NAME}@${RELEASE_VERSION} exists."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          remote_tag_exists() {
+            local release_tag="$1"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${status}" = 2 ]; then
+                return 1
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote tag ${release_tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+
+          if npm_version_exists; then
+            release_tag="memos-local-plugin-v${RELEASE_VERSION}"
+            if remote_tag_exists "${release_tag}"; then
+              echo "${PACKAGE_NAME}@${RELEASE_VERSION} and ${release_tag} already exist; treating this as an idempotent rerun."
+            elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
+              echo "Recovery mode enabled; npm version exists, so publish is skipped."
+            else
+              echo "::error::npm version exists but ${release_tag} does not. Refusing to invent release metadata without explicit recovery mode."
+              exit 1
+            fi
           else
-            npm publish --access public --tag "${NPM_DIST_TAG}"
+            attempt_dir="${RUNNER_TEMP}/memos-local-plugin-npm-publish-attempts"
+            mkdir -p "${attempt_dir}"
+            for attempt in 1 2 3; do
+              set +e
+              npm publish --access public --tag "${NPM_DIST_TAG}" >"${attempt_dir}/${attempt}.log" 2>&1
+              publish_status=$?
+              set -e
+              sed -n '1,160p' "${attempt_dir}/${attempt}.log"
+              if [ "${publish_status}" = 0 ]; then
+                break
+              fi
+              if npm_version_exists; then
+                echo "Publish returned an error, but npm now contains the requested version."
+                break
+              fi
+              if [ "${attempt}" = 3 ]; then
+                RELEASE_FAILURE_PHASE=npm-publish \
+                  RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
+                  node ../../.github/scripts/draft-local-plugin-release-notes.mjs \
+                  || echo "::warning::Failed to send the exhausted-retry notification."
+                echo "::error::npm publish failed after three attempts."
+                exit 1
+              fi
+              sleep "$((attempt * 5))"
+            done
+            if ! npm_version_exists; then
+              echo "::error::npm publish appeared to finish, but ${PACKAGE_NAME}@${RELEASE_VERSION} is still not visible."
+              exit 1
+            fi
           fi
 
       - name: Create release tag and PR
+        if: ${{ inputs.dry_run != true }}
         working-directory: .
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
+          NPM_DIST_TAG: ${{ inputs.tag }}
+          RELEASE_NOTES_FILE: ${{ steps.release_notes.outputs.release_notes_file }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+          if [ -z "${RELEASE_NOTES_FILE}" ] || [ ! -s "${RELEASE_NOTES_FILE}" ]; then
+            echo "::error::Release notes file was not generated."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           release_tag="memos-local-plugin-v${RELEASE_VERSION}"
           release_branch="release/${release_tag}"
           release_title="release: @memtensor/memos-local-plugin v${RELEASE_VERSION}"
+          remote_branch_sha() {
+            local branch="$1"
+            local out="${RUNNER_TEMP}/memos-local-plugin-remote-branch.txt"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --heads origin "${branch}" >"${out}" 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                awk '{print $1}' "${out}"
+                return 0
+              fi
+              sed -n '1,120p' "${out}"
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote branch ${branch} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          remote_tag_exists() {
+            local tag="$1"
+            for attempt in 1 2 3; do
+              set +e
+              git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${status}" = 2 ]; then
+                return 1
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::error::Failed to check remote tag ${tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          create_release_if_missing() {
+            release_flags=()
+            if [[ "${RELEASE_VERSION}" == *-* || "${NPM_DIST_TAG}" != "latest" ]]; then
+              release_flags+=(--prerelease)
+              echo "Marking GitHub Release ${release_tag} as prerelease because version=${RELEASE_VERSION}, npm_dist_tag=${NPM_DIST_TAG}."
+            fi
+            for attempt in 1 2 3; do
+              if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                echo "GitHub Release ${release_tag} already exists; leaving it unchanged."
+                return 0
+              fi
+              set +e
+              gh release create "${release_tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --target "$(git rev-parse HEAD)" \
+                --title "OpenClaw Local Plugin v${RELEASE_VERSION}" \
+                --notes-file "${RELEASE_NOTES_FILE}" \
+                "${release_flags[@]}"
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if [ "${attempt}" = 3 ]; then
+                if gh release view "${release_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                  echo "GitHub Release ${release_tag} exists after a failed create response; treating as success."
+                  return 0
+                fi
+                echo "::error::Failed to create GitHub Release ${release_tag} after three attempts."
+                exit "${status}"
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
+          create_pr_if_missing() {
+            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "Release PR already exists for ${release_branch}."
+              return 0
+            fi
+            for attempt in 1 2 3; do
+              set +e
+              gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base "${DEFAULT_BRANCH}" \
+                --head "${release_branch}" \
+                --title "${release_title}" \
+                --body "Bumps apps/memos-local-plugin/package.json for the published npm release ${RELEASE_VERSION}."
+              status=$?
+              set -e
+              if [ "${status}" = 0 ]; then
+                return 0
+              fi
+              if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                echo "Release PR exists after a failed create response; treating as success."
+                return 0
+              fi
+              if [ "${attempt}" = 3 ]; then
+                echo "::warning::Failed to create release PR automatically after three attempts. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
+                return 0
+              fi
+              sleep "$((attempt * 5))"
+            done
+          }
 
           git add apps/memos-local-plugin/package.json apps/memos-local-plugin/package-lock.json
           created_release_commit=false
@@ -151,33 +527,29 @@ jobs:
           fi
 
           if [ "${created_release_commit}" = "true" ]; then
-            remote_branch_sha="$(git ls-remote --heads origin "${release_branch}" | awk '{print $1}')"
+            remote_branch_sha="$(remote_branch_sha "${release_branch}")"
             if [ -n "${remote_branch_sha}" ]; then
-              git push --force-with-lease="refs/heads/${release_branch}:${remote_branch_sha}" origin "HEAD:refs/heads/${release_branch}"
+              if [ "${remote_branch_sha}" != "$(git rev-parse HEAD)" ]; then
+                echo "::error::Release branch ${release_branch} already exists at a different commit; refusing to overwrite it."
+                exit 1
+              fi
+              echo "Release branch ${release_branch} already points at this commit."
             else
-              git push origin "HEAD:refs/heads/${release_branch}"
+              bash .github/scripts/retry.sh --label "push release branch" -- git push origin "HEAD:refs/heads/${release_branch}"
             fi
           fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+          if remote_tag_exists "${release_tag}"; then
             echo "Tag ${release_tag} already exists on origin; leaving it unchanged."
           else
             git tag "${release_tag}"
-            git push origin "refs/tags/${release_tag}"
+            bash .github/scripts/retry.sh --label "push release tag" -- git push origin "refs/tags/${release_tag}"
           fi
 
+          create_release_if_missing
+
           if [ "${created_release_commit}" = "true" ]; then
-            if gh pr view "${release_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-              echo "Release PR already exists for ${release_branch}."
-            else
-              gh pr create \
-                --repo "${GITHUB_REPOSITORY}" \
-                --base "${DEFAULT_BRANCH}" \
-                --head "${release_branch}" \
-                --title "${release_title}" \
-                --body "Bumps apps/memos-local-plugin/package.json for the published npm release ${RELEASE_VERSION}." \
-                || echo "::warning::Failed to create release PR automatically. Open a PR from ${release_branch} to ${DEFAULT_BRANCH}."
-            fi
+            create_pr_if_missing
           else
             echo "No version bump changes to open as a PR."
           fi

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   deploy:
+    if: startsWith(github.event.release.tag_name, 'v')
 
     runs-on: ubuntu-latest
 

--- a/apps/memos-local-plugin/tests/e2e/v7-full-chain.e2e.test.ts
+++ b/apps/memos-local-plugin/tests/e2e/v7-full-chain.e2e.test.ts
@@ -344,6 +344,13 @@ function buildPipeline(
     ...baseCfg,
     algorithm: {
       ...baseCfg.algorithm,
+      // This suite verifies the complete V7 evolution chain. Lightweight
+      // memory is enabled by default in production and intentionally skips
+      // reward / L2 / L3 / skill, so disable it explicitly for this test.
+      lightweightMemory: {
+        ...baseCfg.algorithm.lightweightMemory,
+        enabled: false,
+      },
       reward: {
         ...baseCfg.algorithm.reward,
         feedbackWindowSec: 0,

--- a/apps/memos-local-plugin/tests/unit/startup-recovery.test.ts
+++ b/apps/memos-local-plugin/tests/unit/startup-recovery.test.ts
@@ -15,20 +15,21 @@ function initBody(): string {
   return source.slice(start, end);
 }
 
-function stripScheduledRecoveryCallbacks(body: string): string {
+function stripBackgroundRecoveryCallback(body: string): string {
   return body.replace(
-    /scheduleStartupRecovery\([\s\S]*?\n        \}\);/g,
-    "scheduleStartupRecovery(<background task>);",
+    /startupRecoveryPromise = \(async \(\) => \{[\s\S]*?\n\s*\}\)\(\);/g,
+    "startupRecoveryPromise = <background task>;",
   );
 }
 
 describe("memory-core startup recovery", () => {
   it("does not block init on stale/dirty episode recovery", () => {
-    const synchronousInitBody = stripScheduledRecoveryCallbacks(initBody());
+    const body = initBody();
+    const synchronousInitBody = stripBackgroundRecoveryCallback(body);
 
     expect(synchronousInitBody).not.toContain("await recoverOpenEpisodesAsSessionEnd(stale)");
     expect(synchronousInitBody).not.toContain("await recoverDirtyClosedEpisodes(dirtyClosed)");
-    expect(initBody()).toContain("scheduleStartupRecovery(\"startup.open_recovery\"");
-    expect(initBody()).toContain("scheduleStartupRecovery(\"startup.dirty_closed_recovery\"");
+    expect(body).toContain("startupRecoveryPromise = (async () => {");
+    expect(body).not.toContain("await startupRecoveryPromise");
   });
 });

--- a/apps/memos-local-plugin/tests/unit/storage/migrator.test.ts
+++ b/apps/memos-local-plugin/tests/unit/storage/migrator.test.ts
@@ -171,15 +171,21 @@ describe("storage/migrator", () => {
     const db = openDb({ filepath: dbPath, agent: "openclaw" });
     try {
       runMigrations(db);
+      db.exec(`
+        INSERT INTO sessions (id, agent, started_at, last_seen_at)
+        VALUES ('session-1', 'openclaw', 1, 1);
+        INSERT INTO episodes (id, session_id, started_at)
+        VALUES ('episode-1', 'session-1', 1);
+      `);
       // Seed test rows: two with NULL share_scope, two with explicit values.
       db.exec(`
         INSERT INTO traces (
-          id, session_id, ts, role, value, priority, embedding, share_scope
+          id, episode_id, session_id, ts, user_text, agent_text, turn_id, share_scope
         ) VALUES
-          ('t-null-a', 'session-1', 10, 'user', 0.0, 0.0, X'', NULL),
-          ('t-null-b', 'session-1', 20, 'assistant', 0.0, 0.0, X'', NULL),
-          ('t-private', 'session-1', 30, 'user', 0.0, 0.0, X'', 'private'),
-          ('t-public', 'session-1', 40, 'assistant', 0.0, 0.0, X'', 'public')
+          ('t-null-a', 'episode-1', 'session-1', 10, 'user a', 'agent a', 10, NULL),
+          ('t-null-b', 'episode-1', 'session-1', 20, 'user b', 'agent b', 20, NULL),
+          ('t-private', 'episode-1', 'session-1', 30, 'user c', 'agent c', 30, 'private'),
+          ('t-public', 'episode-1', 'session-1', 40, 'user d', 'agent d', 40, 'public')
       `);
       const rows = db
         .prepare<unknown, { id: string; share_scope: string | null }>(


### PR DESCRIPTION
## Summary

This PR wires the OpenClaw local plugin publish workflow into the Doc Agent release-notes draft flow.

It adds:

- evidence-backed release notes generation for `apps/memos-local-plugin`
- source-ref coverage checks for important local-plugin commits
- deterministic postprocessing for category/source-ref dedupe
- bilingual validation plus bounded LLM repair attempts
- retry handling for transient release workflow phases
- Linux sqlite prebuild installation for validation after `npm ci --ignore-scripts`
- prerelease GitHub Release marking for beta/next/alpha or semver prerelease versions
- a post-merge dry-run workflow that automatically runs the local-plugin workflow on `main` with `dry_run=true`

## Safety

- `dry_run=true` skips npm publish, tag creation, GitHub Release creation, and release PR creation.
- Formal docs sync remains gated on GitHub `release.published`.
- `release.published` prerelease events are skipped on the 106 Doc Agent side before docs PR creation.
- Production deployment is not part of this PR.

## Validation

- Local Node test: `node --test .github/scripts/draft-local-plugin-release-notes.test.mjs` passed, 14/14.
- GitHub Actions dry-run passed on this branch:
  - https://github.com/MemTensor/MemOS/actions/runs/29729728702
- Final inspection artifact summary:
  - `needs_review=false`
  - `missing_required_count=0`
  - `language_issue_count=0`
  - `validation_attempt_count=1`
  - `repair_attempt_count=0`
  - `item_count=8`

## Follow-up after merge

After this draft PR is reviewed and merged, the new post-merge workflow should automatically run the main-branch local-plugin dry-run using:

- `version=2.0.10`
- `tag=latest`
- `dry_run=true`

A real beta rehearsal should wait until there is an actual next release source; do not publish `2.0.11-beta.1` only for testing.
