### PR TITLE
fix(plugin): preserve V7 session defaults

### DIFF
--- a/apps/memos-local-plugin/tests/e2e/v7-full-chain.e2e.test.ts
+++ b/apps/memos-local-plugin/tests/e2e/v7-full-chain.e2e.test.ts
@@ -781,8 +781,8 @@ describe("V7 full-chain E2E (Python programming task)", () => {
       algorithm: {
         ...DEFAULT_CONFIG.algorithm,
         session: {
+          ...DEFAULT_CONFIG.algorithm.session,
           followUpMode: "episode_per_turn",
-          mergeMaxGapMs: DEFAULT_CONFIG.algorithm.session.mergeMaxGapMs,
         },
       },
     };


### PR DESCRIPTION
## Description

Fixes the local plugin npm release gate blocked by a timeout in the V7 `episode_per_turn` E2E test.

The strict test fixture replaced the complete `algorithm.session` object and dropped the newer `bgLlmConcurrency` default. That produced a `NaN` semaphore limit, leaving background LLM work queued until both the test and cleanup hook timed out. This change preserves all session defaults before overriding `followUpMode`.

No new dependencies.

Related Issue: N/A. Release-blocking failure: [Actions run #30111697641](https://github.com/MemTensor/MemOS/actions/runs/30111697641/job/89542779124).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Validated with Node.js v22.23.1:

- [x] Unit Test
- [x] Test Script Or Test Steps
- [ ] Pipeline Automated API Test

```bash
npm exec vitest run tests/e2e/v7-full-chain.e2e.test.ts -- --reporter=verbose
npm run lint
npm test
npm pack --dry-run --json
```

The focused V7 test now completes in 1.42s. The full suite passes 148 test files with 1,204 tests passed and 2 skipped, and the package dry run succeeds.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释 (no new production code or complex logic)
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常 (existing V7 E2E test reproduces and verifies the fix)
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 MemOS-Docs 中创建了相关的文档 issue/PR（如果适用） (not applicable)
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用） (linked the failing release run above)
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人: @hijzy

## Reviewer Checklist

- [ ] closes #xxxx (N/A: no issue)
- [ ] Made sure Checks passed
- [ ] Tests have been provided