### PR TITLE
release: @memtensor/memos-local-plugin v2.0.11

### DIFF
--- a/apps/memos-local-plugin/package-lock.json
+++ b/apps/memos-local-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memtensor/memos-local-plugin",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/memos-local-plugin/package.json
+++ b/apps/memos-local-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memtensor/memos-local-plugin",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Reflect2Evolve memory plugin: layered L1/L2/L3 memory, reflection-weighted value backprop, cross-task policy induction, skill crystallization, three-tier retrieval. Adapters for OpenClaw and Hermes Agent via a shared algorithm core.",
   "type": "module",
   "main": "dist/core/index.js",


### PR DESCRIPTION
Bumps `apps/memos-local-plugin/package.json` and `apps/memos-local-plugin/package-lock.json` for the published npm release `2.0.11`.

- npm: [@memtensor/memos-local-plugin@2.0.11](https://www.npmjs.com/package/@memtensor/memos-local-plugin/v/2.0.11)
- GitHub Release: [memos-local-plugin-v2.0.11](https://github.com/MemTensor/MemOS/releases/tag/memos-local-plugin-v2.0.11)
- Recovery workflow: [Action #36](https://github.com/MemTensor/MemOS/actions/runs/30243297633)