### PR TITLE
fix(ci): tolerate npm registry propagation delay

### DIFF
--- a/.github/scripts/publish-local-plugin.sh
+++ b/.github/scripts/publish-local-plugin.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required.}"
+: "${PACKAGE_NAME:?PACKAGE_NAME is required.}"
+: "${RELEASE_VERSION:?RELEASE_VERSION is required.}"
+: "${RELEASE_TAG:?RELEASE_TAG is required.}"
+: "${NPM_DIST_TAG:?NPM_DIST_TAG is required.}"
+
+npm_visibility_attempts="${NPM_VISIBILITY_ATTEMPTS:-10}"
+npm_ambiguous_visibility_attempts="${NPM_AMBIGUOUS_VISIBILITY_ATTEMPTS:-3}"
+npm_visibility_delay_seconds="${NPM_VISIBILITY_DELAY_SECONDS:-5}"
+
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::${name} must be a positive integer; received ${value}."
+    exit 2
+  fi
+}
+
+validate_non_negative_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+    echo "::error::${name} must be a non-negative integer; received ${value}."
+    exit 2
+  fi
+}
+
+validate_positive_integer "NPM_VISIBILITY_ATTEMPTS" "${npm_visibility_attempts}"
+validate_positive_integer "NPM_AMBIGUOUS_VISIBILITY_ATTEMPTS" "${npm_ambiguous_visibility_attempts}"
+validate_non_negative_integer "NPM_VISIBILITY_DELAY_SECONDS" "${npm_visibility_delay_seconds}"
+
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+npm_view_log="${RUNNER_TEMP}/memos-local-plugin-npm-view.log"
+
+npm_version_exists() {
+  local attempt
+  local status
+
+  for attempt in 1 2 3; do
+    set +e
+    npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version --prefer-online >"${npm_view_log}" 2>&1
+    status=$?
+    set -e
+    if [ "${status}" = 0 ]; then
+      sed -n '1,40p' "${npm_view_log}"
+      return 0
+    fi
+    if grep -Eiq "E404|404 Not Found|No match found|is not in this registry" "${npm_view_log}"; then
+      return 1
+    fi
+    sed -n '1,120p' "${npm_view_log}"
+    if [ "${attempt}" = 3 ]; then
+      echo "::error::npm view failed after three attempts; refusing to guess whether ${PACKAGE_NAME}@${RELEASE_VERSION} exists."
+      exit "${status}"
+    fi
+    sleep "$((attempt * 5))"
+  done
+}
+
+wait_for_npm_version() {
+  local attempts="$1"
+  local attempt
+  local delay
+
+  for attempt in $(seq 1 "${attempts}"); do
+    if npm_version_exists; then
+      echo "${PACKAGE_NAME}@${RELEASE_VERSION} became visible on attempt ${attempt}/${attempts}."
+      return 0
+    fi
+    if [ "${attempt}" = "${attempts}" ]; then
+      return 1
+    fi
+
+    delay=$((npm_visibility_delay_seconds * attempt))
+    if [ "${delay}" -gt 30 ]; then
+      delay=30
+    fi
+    echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} is not visible yet; retrying in ${delay}s."
+    if [ "${delay}" -gt 0 ]; then
+      sleep "${delay}"
+    fi
+  done
+
+  return 1
+}
+
+remote_tag_exists() {
+  local release_tag="$1"
+  local attempt
+  local status
+
+  for attempt in 1 2 3; do
+    set +e
+    git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1
+    status=$?
+    set -e
+    if [ "${status}" = 0 ]; then
+      return 0
+    fi
+    if [ "${status}" = 2 ]; then
+      return 1
+    fi
+    if [ "${attempt}" = 3 ]; then
+      echo "::error::Failed to check remote tag ${release_tag} after three attempts."
+      exit "${status}"
+    fi
+    sleep "$((attempt * 5))"
+  done
+}
+
+if npm_version_exists; then
+  if remote_tag_exists "${RELEASE_TAG}"; then
+    echo "${PACKAGE_NAME}@${RELEASE_VERSION} and ${RELEASE_TAG} already exist; treating this as an idempotent rerun."
+  elif [ "${RECOVER_EXISTING_NPM_RELEASE:-false}" = "true" ]; then
+    echo "Recovery mode enabled; npm version exists, so publish is skipped."
+  else
+    echo "::error::npm version exists but ${RELEASE_TAG} does not. Refusing to invent release metadata without explicit recovery mode."
+    exit 1
+  fi
+else
+  attempt_directory="${RUNNER_TEMP}/memos-local-plugin-npm-publish-attempts"
+  mkdir -p "${attempt_directory}"
+  publish_accepted=false
+
+  for attempt in 1 2 3; do
+    set +e
+    npm publish --access public --tag "${NPM_DIST_TAG}" >"${attempt_directory}/${attempt}.log" 2>&1
+    publish_status=$?
+    set -e
+    sed -n '1,160p' "${attempt_directory}/${attempt}.log"
+
+    if [ "${publish_status}" = 0 ]; then
+      publish_accepted=true
+      break
+    fi
+
+    if wait_for_npm_version "${npm_ambiguous_visibility_attempts}"; then
+      echo "Publish returned an error, but npm now contains the requested version."
+      publish_accepted=true
+      break
+    fi
+
+    if [ "${attempt}" = 3 ]; then
+      RELEASE_FAILURE_PHASE=npm-publish \
+        RELEASE_FAILURE_ATTEMPT_DIR="${attempt_directory}" \
+        node "${script_directory}/draft-local-plugin-release-notes.mjs" \
+        || echo "::warning::Failed to send the exhausted-retry notification."
+      echo "::error::npm publish failed after three attempts."
+      exit 1
+    fi
+
+    delay=$((npm_visibility_delay_seconds * attempt))
+    if [ "${delay}" -gt 0 ]; then
+      sleep "${delay}"
+    fi
+  done
+
+  if ! wait_for_npm_version "${npm_visibility_attempts}"; then
+    if [ "${publish_accepted}" = "true" ]; then
+      echo "::warning::npm publish succeeded, but ${PACKAGE_NAME}@${RELEASE_VERSION} is not visible after propagation retries; continuing with tag, Release, and PR creation."
+    else
+      echo "::error::npm publish did not succeed and ${PACKAGE_NAME}@${RELEASE_VERSION} is still absent."
+      exit 1
+    fi
+  fi
+fi

--- a/.github/scripts/publish-local-plugin.test.mjs
+++ b/.github/scripts/publish-local-plugin.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const publishScript = join(scriptDirectory, "publish-local-plugin.sh");
+
+const mockNpm = `#!/usr/bin/env bash
+set -euo pipefail
+
+increment_counter() {
+  local name="$1"
+  local counter_file="\${NPM_MOCK_STATE_DIR}/\${name}"
+  local count=0
+  if [ -f "\${counter_file}" ]; then
+    count="$(cat "\${counter_file}")"
+  fi
+  count=$((count + 1))
+  printf '%s' "\${count}" > "\${counter_file}"
+  printf '%s' "\${count}"
+}
+
+case "\${1:-}" in
+  view)
+    view_count="$(increment_counter view)"
+    if [ "\${NPM_MOCK_SCENARIO}" = "eventually-visible" ] && [ "\${view_count}" -ge 4 ]; then
+      printf '%s\\n' "\${RELEASE_VERSION}"
+      exit 0
+    fi
+    echo "npm error code E404" >&2
+    echo "npm error 404 Not Found - \${PACKAGE_NAME}@\${RELEASE_VERSION}" >&2
+    exit 1
+    ;;
+  publish)
+    increment_counter publish >/dev/null
+    if [ "\${NPM_MOCK_SCENARIO}" = "publish-fails" ]; then
+      echo "npm error code E500" >&2
+      exit 1
+    fi
+    echo "+ \${PACKAGE_NAME}@\${RELEASE_VERSION}"
+    exit 0
+    ;;
+  *)
+    echo "Unexpected npm command: $*" >&2
+    exit 2
+    ;;
+esac
+`;
+
+function readCounter(stateDirectory, name) {
+  try {
+    return Number(readFileSync(join(stateDirectory, name), "utf8"));
+  } catch {
+    return 0;
+  }
+}
+
+function runScenario(scenario, overrides = {}) {
+  const fixtureDirectory = mkdtempSync(join(tmpdir(), "memos-local-plugin-publish-"));
+  const binDirectory = join(fixtureDirectory, "bin");
+  const stateDirectory = join(fixtureDirectory, "state");
+  mkdirSync(binDirectory);
+  mkdirSync(stateDirectory);
+
+  const npmPath = join(binDirectory, "npm");
+  writeFileSync(npmPath, mockNpm, "utf8");
+  chmodSync(npmPath, 0o755);
+
+  const result = spawnSync("bash", [publishScript], {
+    cwd: fixtureDirectory,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDirectory}:${process.env.PATH}`,
+      RUNNER_TEMP: fixtureDirectory,
+      PACKAGE_NAME: "@memtensor/memos-local-plugin",
+      RELEASE_VERSION: "2.0.12",
+      RELEASE_TAG: "memos-local-plugin-v2.0.12",
+      NPM_DIST_TAG: "latest",
+      RECOVER_EXISTING_NPM_RELEASE: "false",
+      DOC_AGENT_RELEASE_FAILURE_URL: "",
+      DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: "",
+      NPM_MOCK_SCENARIO: scenario,
+      NPM_MOCK_STATE_DIR: stateDirectory,
+      NPM_VISIBILITY_ATTEMPTS: "3",
+      NPM_AMBIGUOUS_VISIBILITY_ATTEMPTS: "2",
+      NPM_VISIBILITY_DELAY_SECONDS: "0",
+      ...overrides,
+    },
+  });
+
+  const outcome = {
+    ...result,
+    viewCount: readCounter(stateDirectory, "view"),
+    publishCount: readCounter(stateDirectory, "publish"),
+  };
+  rmSync(fixtureDirectory, { recursive: true, force: true });
+  return outcome;
+}
+
+test("waits through two post-publish 404 responses before the version becomes visible", () => {
+  const result = runScenario("eventually-visible");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.publishCount, 1);
+  assert.equal(result.viewCount, 4);
+  assert.match(result.stdout, /became visible on attempt 3/);
+});
+
+test("continues release metadata creation when publish succeeds but visibility remains delayed", () => {
+  const result = runScenario("always-missing");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.publishCount, 1);
+  assert.equal(result.viewCount, 4);
+  assert.match(result.stdout, /npm publish succeeded.*continuing with tag, Release, and PR creation/s);
+});
+
+test("fails when publish fails and the requested version remains absent", () => {
+  const result = runScenario("publish-fails");
+
+  assert.notEqual(result.status, 0);
+  assert.equal(result.publishCount, 3);
+  assert.match(result.stdout + result.stderr, /npm publish failed after three attempts/);
+});

--- a/.github/workflows/memos-local-plugin-post-merge-dry-run.yml
+++ b/.github/workflows/memos-local-plugin-post-merge-dry-run.yml
@@ -9,6 +9,8 @@ on:
       - ".github/workflows/memos-local-plugin-post-merge-dry-run.yml"
       - ".github/scripts/draft-local-plugin-release-notes.mjs"
       - ".github/scripts/draft-local-plugin-release-notes.test.mjs"
+      - ".github/scripts/publish-local-plugin.sh"
+      - ".github/scripts/publish-local-plugin.test.mjs"
       - ".github/scripts/retry.sh"
 
 permissions:

--- a/.github/workflows/memos-local-plugin-publish.yml
+++ b/.github/workflows/memos-local-plugin-publish.yml
@@ -133,6 +133,10 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Test npm publish helper
+        working-directory: .
+        run: node --test .github/scripts/publish-local-plugin.test.mjs
+
       - name: Download all prebuilds
         uses: actions/download-artifact@v4
         with:
@@ -306,92 +310,7 @@ jobs:
           RECOVER_EXISTING_NPM_RELEASE: ${{ inputs.recover_existing_npm_release }}
           DOC_AGENT_RELEASE_FAILURE_URL: ${{ secrets.DOC_AGENT_RELEASE_FAILURE_URL }}
           DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN: ${{ secrets.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN }}
-        run: |
-          set -euo pipefail
-          npm_view_log="${RUNNER_TEMP}/memos-local-plugin-npm-view.log"
-          npm_version_exists() {
-            for attempt in 1 2 3; do
-              set +e
-              npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >"${npm_view_log}" 2>&1
-              status=$?
-              set -e
-              if [ "${status}" = 0 ]; then
-                sed -n '1,40p' "${npm_view_log}"
-                return 0
-              fi
-              if grep -Eiq "E404|404 Not Found|No match found|is not in this registry" "${npm_view_log}"; then
-                return 1
-              fi
-              sed -n '1,120p' "${npm_view_log}"
-              if [ "${attempt}" = 3 ]; then
-                echo "::error::npm view failed after three attempts; refusing to guess whether ${PACKAGE_NAME}@${RELEASE_VERSION} exists."
-                exit "${status}"
-              fi
-              sleep "$((attempt * 5))"
-            done
-          }
-          remote_tag_exists() {
-            local release_tag="$1"
-            for attempt in 1 2 3; do
-              set +e
-              git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1
-              status=$?
-              set -e
-              if [ "${status}" = 0 ]; then
-                return 0
-              fi
-              if [ "${status}" = 2 ]; then
-                return 1
-              fi
-              if [ "${attempt}" = 3 ]; then
-                echo "::error::Failed to check remote tag ${release_tag} after three attempts."
-                exit "${status}"
-              fi
-              sleep "$((attempt * 5))"
-            done
-          }
-
-          if npm_version_exists; then
-            release_tag="memos-local-plugin-v${RELEASE_VERSION}"
-            if remote_tag_exists "${release_tag}"; then
-              echo "${PACKAGE_NAME}@${RELEASE_VERSION} and ${release_tag} already exist; treating this as an idempotent rerun."
-            elif [ "${RECOVER_EXISTING_NPM_RELEASE}" = "true" ]; then
-              echo "Recovery mode enabled; npm version exists, so publish is skipped."
-            else
-              echo "::error::npm version exists but ${release_tag} does not. Refusing to invent release metadata without explicit recovery mode."
-              exit 1
-            fi
-          else
-            attempt_dir="${RUNNER_TEMP}/memos-local-plugin-npm-publish-attempts"
-            mkdir -p "${attempt_dir}"
-            for attempt in 1 2 3; do
-              set +e
-              npm publish --access public --tag "${NPM_DIST_TAG}" >"${attempt_dir}/${attempt}.log" 2>&1
-              publish_status=$?
-              set -e
-              sed -n '1,160p' "${attempt_dir}/${attempt}.log"
-              if [ "${publish_status}" = 0 ]; then
-                break
-              fi
-              if npm_version_exists; then
-                echo "Publish returned an error, but npm now contains the requested version."
-                break
-              fi
-              if [ "${attempt}" = 3 ]; then
-                RELEASE_FAILURE_PHASE=npm-publish \
-                  RELEASE_FAILURE_ATTEMPT_DIR="${attempt_dir}" \
-                  node ../../.github/scripts/draft-local-plugin-release-notes.mjs \
-                  || echo "::warning::Failed to send the exhausted-retry notification."
-                echo "::error::npm publish failed after three attempts."
-                exit 1
-              fi
-              sleep "$((attempt * 5))"
-            done
-            if ! npm_version_exists; then
-              echo "::error::npm publish appeared to finish, but ${PACKAGE_NAME}@${RELEASE_VERSION} is still not visible."
-              exit 1
-            fi
-          fi
+        run: bash ../../.github/scripts/publish-local-plugin.sh
 
       - name: Create release tag and PR
         if: ${{ inputs.dry_run != true }}


### PR DESCRIPTION
## Description

Fixes false failures in the MemOS local-plugin npm release workflow when the npm Registry has not propagated a newly published version to `npm view` yet.

The publish logic is extracted into `.github/scripts/publish-local-plugin.sh` so it can be tested independently. The helper now:

- keeps the immediate pre-publish lookup for duplicate detection;
- waits for post-publish visibility with bounded, capped backoff;
- continues Tag, GitHub Release, and release PR creation when `npm publish` succeeded but registry visibility is still delayed;
- still fails after three publish failures when the requested version remains absent.

No new dependencies are required.

Related Issue (Required): N/A - follow-up to [failed Action #35](https://github.com/MemTensor/MemOS/actions/runs/30242511664)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script Or Test Steps (please provide)

Commands run:

```bash
node --test .github/scripts/publish-local-plugin.test.mjs .github/scripts/draft-local-plugin-release-notes.test.mjs
bash -n .github/scripts/publish-local-plugin.sh
shellcheck .github/scripts/publish-local-plugin.sh
actionlint .github/workflows/memos-local-plugin-publish.yml .github/workflows/memos-local-plugin-post-merge-dry-run.yml
git diff --check
```

The Node test suite passed 21/21 tests, including these regression scenarios:

- two post-publish `404` responses followed by successful visibility;
- successful publish with continued registry invisibility;
- failed publish with the requested version remaining absent.

`make format` could not run locally because Poetry is not installed in this checkout; this PR does not change Python files.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | N/A: no documentation behavior changed
- [x] I have linked the issue to this PR (if applicable) | N/A: linked the failed release run above
- [x] I have mentioned the person who will review this PR | @hijzy @whipser030

## Reviewer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided
