### PR TITLE
fix(memos-local-plugin): use POSIX-ERE-compatible pgrep pattern for hermes chat detection

### DIFF
--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -39,8 +39,12 @@ import * as childProcess from "node:child_process";
  * string we hand to `pgrep` and confirm we have not silently regressed
  * back to a literal substring match.
  */
-function buildHermesChatPattern(space: string, nonSpace: string): string {
-  return `hermes(${space}+${nonSpace}+)*${space}+chat(${space}|$)`;
+function buildHermesChatPattern(
+  space: string,
+  nonSpace: string,
+  groupStart = "(",
+): string {
+  return `hermes${groupStart}${space}+${nonSpace}+)*${space}+chat${groupStart}${space}|$)`;
 }
 
 export const HERMES_CHAT_PROCESS_PATTERN = buildHermesChatPattern(
@@ -49,7 +53,7 @@ export const HERMES_CHAT_PROCESS_PATTERN = buildHermesChatPattern(
 );
 
 const HERMES_CHAT_JS_PATTERN = new RegExp(
-  buildHermesChatPattern("\\s", "\\S"),
+  buildHermesChatPattern("\\s", "\\S", "(?:"),
 );
 
 /**

--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -18,22 +18,25 @@
  * therefore misses any invocation with a global flag (`--skills`,
  * `-m`, `--provider`, …) between them.
  *
- * The current pattern is `hermes(?:\s+\S+)*\s+chat\b`:
+ * The current pattern is `hermes(\s+\S+)*\s+chat\b`:
  *
  *   • `hermes`           — the binary basename.
- *   • `(?:\s+\S+)*`      — any complete argv-style tokens between the
+ *   • `(\s+\S+)*`       — any complete argv-style tokens between the
  *     binary and the subcommand.
  *   • `\s+chat\b`        — a standalone `chat` token, so it does *not*
  *     match `chatter`, `chat-server`, `--chat-log`, or a flag value
  *     like `--profile=chat`.
  *
  * `pgrep -f` on Linux uses glibc's ERE engine, which supports
- * `\s`/`\b` as GNU extensions. JavaScript's `RegExp` supports the same
- * tokens natively, so this module also exports
- * `matchesHermesChatCommandLine()` for unit tests — exercising the
- * pattern as a JS regex is a faithful proxy for the pgrep-side
- * behaviour without requiring a real Hermes binary or a fork of the
- * pgrep process in CI.
+ * `\s`/`\b` as GNU extensions. ⚠️ The pattern MUST stay within POSIX
+ * ERE — in particular it must NOT use `(?:…)` non-capturing groups,
+ * which are PCRE-only: glibc ERE rejects the whole pattern with
+ * "Invalid preceding regular expression", `pgrep` exits 2, and
+ * `isHermesChatRunning()` silently reports `false`, leaving the
+ * viewer stuck on `"disconnected"`. A plain capturing group `(…)`
+ * is valid in both ERE and JavaScript's `RegExp`, so
+ * `matchesHermesChatCommandLine()` can still proxy the pattern for
+ * unit tests without a real Hermes binary or a fork of pgrep in CI.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as childProcess from "node:child_process";
@@ -45,7 +48,7 @@ import * as childProcess from "node:child_process";
  * string we hand to `pgrep` and confirm we have not silently regressed
  * back to a literal substring match.
  */
-export const HERMES_CHAT_PROCESS_PATTERN = "hermes(?:\\s+\\S+)*\\s+chat\\b";
+export const HERMES_CHAT_PROCESS_PATTERN = "hermes(\\s+\\S+)*\\s+chat\\b";
 
 /**
  * JS-side equivalent of `pgrep -f HERMES_CHAT_PROCESS_PATTERN`.

--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -26,8 +26,8 @@
  *
  * `pgrep -f` on Linux uses glibc's POSIX ERE engine, so its pattern uses
  * POSIX character classes and capturing groups only. JavaScript does not
- * implement POSIX character classes, so the test helper builds the same
- * grammar with `\s` and `\S` tokens instead.
+ * implement POSIX character classes, so the test helper declares the same
+ * grammar with `\s`, `\S`, and non-capturing groups instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as childProcess from "node:child_process";
@@ -39,22 +39,12 @@ import * as childProcess from "node:child_process";
  * string we hand to `pgrep` and confirm we have not silently regressed
  * back to a literal substring match.
  */
-function buildHermesChatPattern(
-  space: string,
-  nonSpace: string,
-  groupStart = "(",
-): string {
-  return `hermes${groupStart}${space}+${nonSpace}+)*${space}+chat${groupStart}${space}|$)`;
-}
+export const HERMES_CHAT_PROCESS_PATTERN =
+  "hermes([[:space:]]+[^[:space:]]+)*[[:space:]]+chat([[:space:]]|$)";
 
-export const HERMES_CHAT_PROCESS_PATTERN = buildHermesChatPattern(
-  "[[:space:]]",
-  "[^[:space:]]",
-);
-
-const HERMES_CHAT_JS_PATTERN = new RegExp(
-  buildHermesChatPattern("\\s", "\\S", "(?:"),
-);
+// Keep this semantically aligned with HERMES_CHAT_PROCESS_PATTERN. POSIX ERE
+// has no non-capturing groups, while JavaScript can avoid unused captures.
+const HERMES_CHAT_JS_PATTERN = /hermes(?:\s+\S+)*\s+chat(?:\s|$)/;
 
 /**
  * JS-side equivalent of `pgrep -f HERMES_CHAT_PROCESS_PATTERN`.

--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -18,25 +18,16 @@
  * therefore misses any invocation with a global flag (`--skills`,
  * `-m`, `--provider`, …) between them.
  *
- * The current pattern is `hermes(\s+\S+)*\s+chat\b`:
+ * The command grammar is `hermes (<token>)* chat (<space>|$)`:
  *
- *   • `hermes`           — the binary basename.
- *   • `(\s+\S+)*`       — any complete argv-style tokens between the
- *     binary and the subcommand.
- *   • `\s+chat\b`        — a standalone `chat` token, so it does *not*
- *     match `chatter`, `chat-server`, `--chat-log`, or a flag value
- *     like `--profile=chat`.
+ *   • `hermes`       — the binary basename.
+ *   • `(<token>)*`   — complete argv-style tokens before the subcommand.
+ *   • `chat`         — a complete token, not `chatter` or `chat-server`.
  *
- * `pgrep -f` on Linux uses glibc's ERE engine, which supports
- * `\s`/`\b` as GNU extensions. ⚠️ The pattern MUST stay within POSIX
- * ERE — in particular it must NOT use `(?:…)` non-capturing groups,
- * which are PCRE-only: glibc ERE rejects the whole pattern with
- * "Invalid preceding regular expression", `pgrep` exits 2, and
- * `isHermesChatRunning()` silently reports `false`, leaving the
- * viewer stuck on `"disconnected"`. A plain capturing group `(…)`
- * is valid in both ERE and JavaScript's `RegExp`, so
- * `matchesHermesChatCommandLine()` can still proxy the pattern for
- * unit tests without a real Hermes binary or a fork of pgrep in CI.
+ * `pgrep -f` on Linux uses glibc's POSIX ERE engine, so its pattern uses
+ * POSIX character classes and capturing groups only. JavaScript does not
+ * implement POSIX character classes, so the test helper builds the same
+ * grammar with `\s` and `\S` tokens instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as childProcess from "node:child_process";
@@ -48,7 +39,18 @@ import * as childProcess from "node:child_process";
  * string we hand to `pgrep` and confirm we have not silently regressed
  * back to a literal substring match.
  */
-export const HERMES_CHAT_PROCESS_PATTERN = "hermes(\\s+\\S+)*\\s+chat\\b";
+function buildHermesChatPattern(space: string, nonSpace: string): string {
+  return `hermes(${space}+${nonSpace}+)*${space}+chat(${space}|$)`;
+}
+
+export const HERMES_CHAT_PROCESS_PATTERN = buildHermesChatPattern(
+  "[[:space:]]",
+  "[^[:space:]]",
+);
+
+const HERMES_CHAT_JS_PATTERN = new RegExp(
+  buildHermesChatPattern("\\s", "\\S"),
+);
 
 /**
  * JS-side equivalent of `pgrep -f HERMES_CHAT_PROCESS_PATTERN`.
@@ -59,7 +61,7 @@ export const HERMES_CHAT_PROCESS_PATTERN = "hermes(\\s+\\S+)*\\s+chat\\b";
  * `/proc/<pid>/cmdline`-style command-line string.
  */
 export function matchesHermesChatCommandLine(commandLine: string): boolean {
-  return new RegExp(HERMES_CHAT_PROCESS_PATTERN).test(commandLine);
+  return HERMES_CHAT_JS_PATTERN.test(commandLine);
 }
 
 /**

--- a/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
@@ -7,10 +7,14 @@
  * subcommand (`hermes --skills memory-routing chat`) was silently
  * missed and the viewer was stuck on `"disconnected"`.
  *
- * The pattern under test is `hermes(?:\s+\S+)*\s+chat\b` — these cases
- * lock in the exact shape of the fix.
+ * The pattern under test is `hermes(\s+\S+)*\s+chat\b` — these cases
+ * lock in the exact shape of the fix. It must stay valid POSIX ERE
+ * (no `(?:…)` groups): glibc ERE rejects non-capturing groups, so a
+ * PCRE-ism in the pattern makes every `pgrep -f` call fail with a
+ * regex error and `isHermesChatRunning()` return `false` forever.
  */
 import { describe, expect, it, vi } from "vitest";
+import { spawnSync } from "node:child_process";
 
 import {
   HERMES_CHAT_PROCESS_PATTERN,
@@ -23,7 +27,20 @@ describe("HERMES_CHAT_PROCESS_PATTERN", () => {
     // If this string ever changes, audit `bridge.cts` callers and the
     // issue description before adjusting — the constant is the only
     // surface that fixes the substring-detection bug.
-    expect(HERMES_CHAT_PROCESS_PATTERN).toBe("hermes(?:\\s+\\S+)*\\s+chat\\b");
+    expect(HERMES_CHAT_PROCESS_PATTERN).toBe("hermes(\\s+\\S+)*\\s+chat\\b");
+  });
+
+  it("compiles under glibc POSIX ERE — pgrep must not exit 2 (regex error)", () => {
+    // Regression for the `(?:…)` non-capturing group: JS RegExp accepts
+    // it, but glibc ERE (what `pgrep -f` uses on Linux) rejects the
+    // whole pattern with "Invalid preceding regular expression". Run the
+    // real binary so a PCRE-ism can never silently sneak back in.
+    // exit 0 = match, 1 = no match (both fine), 2 = regex syntax error.
+    const result = spawnSync("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
+      encoding: "utf8",
+      timeout: 2000,
+    });
+    expect(result.status).not.toBe(2);
   });
 });
 

--- a/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
@@ -7,14 +7,12 @@
  * subcommand (`hermes --skills memory-routing chat`) was silently
  * missed and the viewer was stuck on `"disconnected"`.
  *
- * The pattern under test is `hermes(\s+\S+)*\s+chat\b` — these cases
- * lock in the exact shape of the fix. It must stay valid POSIX ERE
- * (no `(?:…)` groups): glibc ERE rejects non-capturing groups, so a
- * PCRE-ism in the pattern makes every `pgrep -f` call fail with a
- * regex error and `isHermesChatRunning()` return `false` forever.
+ * The pgrep pattern uses POSIX character classes while the JS helper
+ * uses equivalent `\s` / `\S` tokens. These cases lock in both the
+ * shared command grammar and the exact wire format passed to pgrep.
  */
-import { describe, expect, it, vi } from "vitest";
 import { spawnSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   HERMES_CHAT_PROCESS_PATTERN,
@@ -27,21 +25,23 @@ describe("HERMES_CHAT_PROCESS_PATTERN", () => {
     // If this string ever changes, audit `bridge.cts` callers and the
     // issue description before adjusting — the constant is the only
     // surface that fixes the substring-detection bug.
-    expect(HERMES_CHAT_PROCESS_PATTERN).toBe("hermes(\\s+\\S+)*\\s+chat\\b");
+    expect(HERMES_CHAT_PROCESS_PATTERN).toBe(
+      "hermes([[:space:]]+[^[:space:]]+)*[[:space:]]+chat([[:space:]]|$)",
+    );
   });
 
-  it("compiles under glibc POSIX ERE — pgrep must not exit 2 (regex error)", () => {
-    // Regression for the `(?:…)` non-capturing group: JS RegExp accepts
-    // it, but glibc ERE (what `pgrep -f` uses on Linux) rejects the
-    // whole pattern with "Invalid preceding regular expression". Run the
-    // real binary so a PCRE-ism can never silently sneak back in.
-    // exit 0 = match, 1 = no match (both fine), 2 = regex syntax error.
-    const result = spawnSync("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
-      encoding: "utf8",
-      timeout: 2000,
-    });
-    expect(result.status).not.toBe(2);
-  });
+  it.skipIf(process.platform !== "linux")(
+    "compiles under the glibc ERE engine used by pgrep",
+    () => {
+      const result = spawnSync("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
+        encoding: "utf8",
+        timeout: 2000,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect([0, 1]).toContain(result.status);
+    },
+  );
 });
 
 describe("matchesHermesChatCommandLine", () => {
@@ -92,6 +92,12 @@ describe("matchesHermesChatCommandLine", () => {
   it("does not match `hermes chatter` (chat must end at a word boundary)", () => {
     expect(
       matchesHermesChatCommandLine("/usr/local/bin/hermes chatter"),
+    ).toBe(false);
+  });
+
+  it("does not match `hermes chat-server` (chat must be a complete token)", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes chat-server"),
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Fixes the Hermes chat process detection regex in the memos-local-plugin. The pattern introduced for #1915 used a JavaScript/PCRE non-capturing group, but `pgrep -f` on Linux compiles patterns with glibc's POSIX ERE engine. The invalid pattern made every detection call fail and left the daemon viewer stuck on `"disconnected"`.

## Root cause

The unit helper compiled the same string with JavaScript's `RegExp`, which accepts `(?:...)`. That verified matching behavior but not whether the pattern passed to `pgrep` was valid ERE.

## Fix

- Build the runtime pattern with POSIX `[[:space:]]` character classes and capturing groups only.
- Build the JavaScript test pattern from the same command grammar using equivalent `\\s` / `\\S` tokens.
- Require `chat` to be a complete argv token, preventing false positives such as `hermes chat-server`.
- Run the real `pgrep` binary on Linux and require an exit status of 0 or 1, so syntax errors and missing executables cannot pass silently.
- Merge the latest `main` into the contributor branch.

## Verification

- Old pattern reproduction: `pgrep` exits 2 with a regex compilation error.
- `vitest run tests/unit/bridge/hermes-process.test.ts tests/unit/bridge-status.test.ts`: 18 passed, 1 Linux-only test skipped on macOS.
- `npm run lint`: passed.
- `npm run test:unit`: 155 files passed; 1297 tests passed, 2 skipped.
- `npm run build`: passed.

## Notes

The Linux-only `pgrep` regression executes in CI. No runtime dependencies or generated `dist/` files are added.