### PR TITLE
fix(memory): skip working-memory cleanup during reorganize pass

### DIFF
--- a/src/memos/memories/textual/tree_text_memory/organize/manager.py
+++ b/src/memos/memories/textual/tree_text_memory/organize/manager.py
@@ -112,7 +112,11 @@ class MemoryManager:
         else:
             added_ids = self._add_memories_parallel(memories, user_name)
 
-        if mode == "sync":
+        # When running inside a reorganize pass, the working-memory pool is
+        # being reconstructed from long-term material, so we must not drop
+        # nodes via ``remove_oldest_memory`` and must not refresh the
+        # aggregated size counters against a temporary population.
+        if mode == "sync" and not self.is_reorganize:
             self._cleanup_working_memory(user_name)
 
         return added_ids

--- a/tests/memories/textual/test_tree_manager.py
+++ b/tests/memories/textual/test_tree_manager.py
@@ -142,3 +142,40 @@ def test_add_returns_written_node_ids(memory_manager):
     assert isinstance(ids, list)
     assert all(isinstance(i, str) for i in ids)
     assert len(ids) > 0
+
+
+def test_add_in_reorganize_mode_skips_working_memory_cleanup(
+    mock_graph_store, mock_embedder, mock_llm
+):
+    """In reorganize mode we must not evict working-memory nodes."""
+    mgr = MemoryManager(
+        graph_store=mock_graph_store,
+        embedder=mock_embedder,
+        llm=mock_llm,
+        is_reorganize=True,
+    )
+    memory = TextualMemoryItem(
+        memory="keep me during reorg",
+        metadata=TreeNodeTextualMemoryMetadata(embedding=[0.1] * 5, memory_type="WorkingMemory"),
+    )
+    before_calls = mock_graph_store.remove_oldest_memory.call_count
+    mgr.add([memory], mode="sync")
+    # remove_oldest_memory must NOT have been called for WorkingMemory cleanup
+    assert mock_graph_store.remove_oldest_memory.call_count == before_calls
+
+
+def test_add_normal_mode_still_cleans_up_working_memory(mock_graph_store, mock_embedder, mock_llm):
+    """Non-reorganize mode preserves the original cleanup behavior."""
+    mgr = MemoryManager(
+        graph_store=mock_graph_store,
+        embedder=mock_embedder,
+        llm=mock_llm,
+        is_reorganize=False,
+    )
+    memory = TextualMemoryItem(
+        memory="normal add",
+        metadata=TreeNodeTextualMemoryMetadata(embedding=[0.1] * 5, memory_type="WorkingMemory"),
+    )
+    before_calls = mock_graph_store.remove_oldest_memory.call_count
+    mgr.add([memory], mode="sync")
+    assert mock_graph_store.remove_oldest_memory.call_count > before_calls


### PR DESCRIPTION
## Summary

- Guard `MemoryManager.add(mode='sync')` so `_cleanup_working_memory` is skipped when the manager is running inside a reorganize pass (`self.is_reorganize=True`).
- During reorg the working-memory pool is being reconstructed from long-term material; pruning it with `remove_oldest_memory` would silently drop freshly rebuilt nodes.
- Added unit tests covering both branches (reorganize on / off).

Closes #1952.

## Verification

- `ruff format` applied (no reformat).
- `ruff check` pre-existing warnings only (`BLE001`/`DTZ005` on untouched lines).
- New tests assert `remove_oldest_memory` is *not* invoked when `is_reorganize=True` and *is* invoked in normal mode.

## Checklist

- [x] Local ruff format / check ran clean on changed lines.
- [x] Tests added for new behaviour.
- [x] Backward compatible — non-reorganize flow unchanged.