### PR TITLE
fix: resolve Hermes native memory import path on Windows

### DIFF
--- a/apps/memos-local-plugin/server/routes/import-export.ts
+++ b/apps/memos-local-plugin/server/routes/import-export.ts
@@ -333,8 +333,16 @@ function parseMultipartBundle(contentType: string, body: Buffer): string | null 
   return null;
 }
 
+function hermesHome(): string {
+  if (process.env.HERMES_HOME) return process.env.HERMES_HOME;
+  if (process.platform === "win32") {
+    return join(process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local"), "hermes");
+  }
+  return join(homedir(), ".hermes");
+}
+
 function hermesNativeMemoryPath(): string {
-  return join(homedir(), ".hermes", "memories", "MEMORY.md");
+  return join(hermesHome(), "memories", "MEMORY.md");
 }
 
 function openClawHome(): string {


### PR DESCRIPTION
## Summary

On Windows, the "Import Hermes native memory" flow always reports the file as missing because `hermesNativeMemoryPath()` hardcodes the home directory via `os.homedir()`:

```ts
return join(homedir(), ".hermes", "memories", "MEMORY.md");
```

Hermes on Windows stores its memory files under `%LOCALAPPDATA%\hermes\memories\` (its `HERMES_HOME`), not `~/.hermes`. The viewer UI shows the resolved path and offers no way to edit it, so the import is unusable on Windows.

## Changes

Resolve the Hermes home directory in order:

1. `HERMES_HOME` env var — set by Hermes at runtime on all platforms
2. Windows: `%LOCALAPPDATA%\hermes`
3. Other platforms: `~/.hermes` (previous behavior, unchanged)

## Test

- Verified on Windows: `GET /api/v1/import/hermes-native/scan` now locates `MEMORY.md`.
- Non-Windows behavior is unchanged (same fallback as before).

---

Related to #2221 (systemic Hermes home resolution on Windows).