### PR TITLE
fix: install.ps1 writes Hermes config template to the wrong location

### DIFF
--- a/apps/memos-local-plugin/install.ps1
+++ b/apps/memos-local-plugin/install.ps1
@@ -402,7 +402,7 @@ fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
 function Install-Hermes {
     Write-Host "`n=== Hermes Install ===" -ForegroundColor Cyan
     $Prefix = Join-Path $env:LOCALAPPDATA "hermes\memos-plugin"
-    $HomeDir = $Prefix
+    $HomeDir = Join-Path $env:USERPROFILE ".hermes\memos-plugin"
     $ConfigFile = Join-Path $env:LOCALAPPDATA "hermes\config.yaml"
     $AdapterDir = Join-Path $Prefix "adapters\hermes"
     


### PR DESCRIPTION
## Summary

On a fresh Windows install, the Hermes branch of `install.ps1` writes the template `config.yaml` to the wrong location:

```powershell
$HomeDir = $Prefix   # %LOCALAPPDATA%\hermes\memos-plugin (code dir)
```

The daemon reads its runtime config from `~/.hermes/memos-plugin` (resolved from `Path.home()` in `bridge_client.py` / the bridge), so right after installation the log shows:

```
config file not found at ~/.hermes/memos-plugin/config.yaml; using defaults
```

Result: the LLM summarizer and skill-evolution stay disabled on Windows even though the install reported success. Local embedding still works, which makes the failure easy to miss.

## Changes

Use the same split as the OpenClaw branch (which already sets `$HomeDir = ~/.openclaw\memos-plugin`):

```powershell
$HomeDir = Join-Path $env:USERPROFILE ".hermes\memos-plugin"
```

## Test

- Verified on Windows: after install, the daemon now finds the template config at the runtime home; LLM summarizer / skill-evolution become available.
- The fix is one line and mirrors the existing OpenClaw branch, so behavior for OpenClaw and non-Windows installs is unchanged.

---

Related to #2221 (systemic Hermes home resolution on Windows).

---

**Note (2026-08-05):** #2224 (systemic fix for #2221) covers runtime path resolution; `install.ps1` is outside its scope, so this PR addresses the install-script half of the same bug family.
