### PR TITLE
Fix #2213: Bug: admin/restart is self-destructive on Windows (pkill/bash/tsx unavailable, d

### DIFF
--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -37,9 +37,9 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
     const supervised = isSupervisorManaged(options);
     const platform = resolvePlatform(options);
     // Windows portable install has no pkill/bash equivalent, so we cannot
-    // kill the chat or spawn a replacement daemon. Wipe the DB, drop our
-    // handles, but leave the process alive and let the user restart
-    // Hermes manually.
+    // kill the chat or spawn a replacement daemon. Wipe the DB and leave
+    // the process alive; the Hermes chat is NOT killed (no pkill available)
+    // and the user must restart Hermes manually to obtain a clean state.
     const windowsManual = agent === "hermes" && !supervised && isWindowsPlatform(platform);
 
     let killedHermes = false;
@@ -65,7 +65,7 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
         restarting: false,
         killedHermes,
         manualRestartRequired: true,
-        platform: "win32",
+        platform,
         message:
           "Data cleared. Restart Hermes manually to re-open the Memory Viewer.",
       };
@@ -84,25 +84,28 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
 
   routes.set("POST /api/v1/admin/restart", async (_ctx) => {
     const agent = options.agent ?? "unknown";
+    const supervised = isSupervisorManaged(options);
+    const platform = resolvePlatform(options);
+
     if (agent === "openclaw") {
       setTimeout(() => process.exit(0), 300);
       return { ok: true, restarting: true };
     }
 
     if (agent === "hermes") {
-      const supervised = isSupervisorManaged(options);
-      const platform = resolvePlatform(options);
-
       if (!supervised && isWindowsPlatform(platform)) {
         // Windows without a supervisor: there is no reliable way to
         // spawn a replacement (no pkill, no bash) and self-shutdown
         // would leave the viewer permanently dark. Keep the daemon
         // alive and tell the client to prompt for a manual restart.
+        // ok: true mirrors the clear-data Windows path so typed SDK
+        // wrappers that treat `ok` as a success discriminant classify
+        // this "intentional decline" identically across both routes.
         return {
-          ok: false,
+          ok: true,
           restarting: false,
           manualRestartRequired: true,
-          platform: "win32",
+          platform,
           message:
             "Restart is unavailable on Windows without a supervisor. " +
             "Close and reopen Hermes to apply changes.",
@@ -154,7 +157,7 @@ function isSupervisorManaged(options: ServerOptions): boolean {
 }
 
 function resolvePlatform(options: ServerOptions): NodeJS.Platform {
-  return options.platform ?? process.platform;
+  return options.lifecycle?.platform ?? process.platform;
 }
 
 function scheduleHermesShutdown(options: ServerOptions, delayMs: number): void {

--- a/apps/memos-local-plugin/server/routes/admin.ts
+++ b/apps/memos-local-plugin/server/routes/admin.ts
@@ -15,6 +15,13 @@
  *       For Hermes, terminate the active `hermes chat`, then ask the bridge
  *       to shut down gracefully. launchd/systemd owns replacement when the
  *       viewer is supervised; portable viewers retain the detached fallback.
+ *
+ *       Windows portable installs are a special case: `pkill` and `bash`
+ *       are unavailable, so the historical spawn-then-suicide sequence
+ *       would kill this daemon with no replacement waiting. On Windows
+ *       (without a detectable supervisor) we refuse the restart, keep
+ *       the daemon alive, and return `manualRestartRequired: true` so
+ *       the viewer can prompt the operator to restart Hermes themselves.
  */
 import { spawn } from "node:child_process";
 import type { ServerDeps, ServerOptions } from "../types.js";
@@ -27,8 +34,16 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
       return { ok: false, error: "database path not configured" };
     }
     const agent = options.agent ?? "unknown";
+    const supervised = isSupervisorManaged(options);
+    const platform = resolvePlatform(options);
+    // Windows portable install has no pkill/bash equivalent, so we cannot
+    // kill the chat or spawn a replacement daemon. Wipe the DB, drop our
+    // handles, but leave the process alive and let the user restart
+    // Hermes manually.
+    const windowsManual = agent === "hermes" && !supervised && isWindowsPlatform(platform);
+
     let killedHermes = false;
-    if (agent === "hermes") {
+    if (agent === "hermes" && !windowsManual) {
       // The viewer daemon and an active Hermes chat have separate Node
       // bridges. Kill the chat first so its stdio bridge releases any
       // SQLite handle before we unlink the DB files.
@@ -44,7 +59,18 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
     if (agent === "hermes" && deps.home?.root) {
       try { await fs.unlink(`${deps.home.root}/bridge-status.json`); } catch { /* may not exist */ }
     }
-    if (agent !== "openclaw" && !isSupervisorManaged(options)) {
+    if (windowsManual) {
+      return {
+        ok: true,
+        restarting: false,
+        killedHermes,
+        manualRestartRequired: true,
+        platform: "win32",
+        message:
+          "Data cleared. Restart Hermes manually to re-open the Memory Viewer.",
+      };
+    }
+    if (agent !== "openclaw" && !supervised) {
       // Portable Hermes: there is no supervisor to replace this process.
       await spawnReplacementDaemon(agent);
     }
@@ -64,8 +90,27 @@ export function registerAdminRoutes(routes: Routes, deps: ServerDeps, options: S
     }
 
     if (agent === "hermes") {
+      const supervised = isSupervisorManaged(options);
+      const platform = resolvePlatform(options);
+
+      if (!supervised && isWindowsPlatform(platform)) {
+        // Windows without a supervisor: there is no reliable way to
+        // spawn a replacement (no pkill, no bash) and self-shutdown
+        // would leave the viewer permanently dark. Keep the daemon
+        // alive and tell the client to prompt for a manual restart.
+        return {
+          ok: false,
+          restarting: false,
+          manualRestartRequired: true,
+          platform: "win32",
+          message:
+            "Restart is unavailable on Windows without a supervisor. " +
+            "Close and reopen Hermes to apply changes.",
+        };
+      }
+
       const killed = await terminateHermesChat();
-      if (!isSupervisorManaged(options)) {
+      if (!supervised) {
         await spawnReplacementDaemon(agent);
       }
       scheduleHermesShutdown(options, 200);
@@ -92,8 +137,24 @@ export function isSupervisorManagedProcess(
   return Boolean(env.INVOCATION_ID?.trim());
 }
 
+/**
+ * True when the current (or provided) platform is Windows.
+ *
+ * Exposed for the admin routes and their tests so we can unit-test the
+ * Windows guard without spoofing `process.platform`.
+ */
+export function isWindowsPlatform(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32";
+}
+
 function isSupervisorManaged(options: ServerOptions): boolean {
   return options.lifecycle?.supervised ?? isSupervisorManagedProcess();
+}
+
+function resolvePlatform(options: ServerOptions): NodeJS.Platform {
+  return options.platform ?? process.platform;
 }
 
 function scheduleHermesShutdown(options: ServerOptions, delayMs: number): void {

--- a/apps/memos-local-plugin/server/types.ts
+++ b/apps/memos-local-plugin/server/types.ts
@@ -53,6 +53,16 @@ export interface ServerOptions {
     /** Request graceful host shutdown after the HTTP response is returned. */
     requestShutdown?: () => void;
   };
+  /**
+   * Override the runtime platform. Defaults to `process.platform`.
+   *
+   * The admin restart route uses this to decide whether the current
+   * process runs on Windows, where the historical `pkill` + `bash`
+   * replacement path is a no-op (which used to leave the daemon dead
+   * with nothing to respawn it). Tests inject this to exercise the
+   * Windows guard without spoofing `process.platform` globally.
+   */
+  platform?: NodeJS.Platform;
 }
 
 export interface ServerHandle {

--- a/apps/memos-local-plugin/server/types.ts
+++ b/apps/memos-local-plugin/server/types.ts
@@ -45,24 +45,27 @@ export interface ServerOptions {
    * A supervised Hermes viewer must let launchd/systemd perform the
    * replacement; spawning a second daemon from the route races the
    * supervisor's KeepAlive restart. Tests and portable embedders may
-   * override the auto-detection and shutdown action explicitly.
+   * override the auto-detection, shutdown action, or platform explicitly.
    */
   lifecycle?: {
     /** Override launchd/systemd detection. */
     supervised?: boolean;
     /** Request graceful host shutdown after the HTTP response is returned. */
     requestShutdown?: () => void;
+    /**
+     * Override the runtime platform. Defaults to `process.platform`.
+     *
+     * The admin restart route uses this to decide whether the current
+     * process runs on Windows, where the historical `pkill` + `bash`
+     * replacement path is a no-op (which used to leave the daemon dead
+     * with nothing to respawn it). Tests inject this to exercise the
+     * Windows guard without spoofing `process.platform` globally.
+     *
+     * Grouped with `supervised`/`requestShutdown` because they are the
+     * same category of process/environment override.
+     */
+    platform?: NodeJS.Platform;
   };
-  /**
-   * Override the runtime platform. Defaults to `process.platform`.
-   *
-   * The admin restart route uses this to decide whether the current
-   * process runs on Windows, where the historical `pkill` + `bash`
-   * replacement path is a no-op (which used to leave the daemon dead
-   * with nothing to respawn it). Tests inject this to exercise the
-   * Windows guard without spoofing `process.platform` globally.
-   */
-  platform?: NodeJS.Platform;
 }
 
 export interface ServerHandle {

--- a/apps/memos-local-plugin/tests/unit/server/admin.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/admin.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MemoryCore } from "../../../agent-contract/memory-core.js";
 import {
   isSupervisorManagedProcess,
+  isWindowsPlatform,
   registerAdminRoutes,
 } from "../../../server/routes/admin.js";
 import { Routes } from "../../../server/routes/registry.js";
@@ -75,6 +76,7 @@ describe("admin lifecycle routes", () => {
       {
         agent: "hermes",
         lifecycle: { supervised: false, requestShutdown },
+        platform: "linux",
       },
     );
 
@@ -106,5 +108,111 @@ describe("admin lifecycle routes", () => {
     expect(isSupervisorManagedProcess({ JOURNAL_STREAM: "8:12345" })).toBe(false);
     expect(isSupervisorManagedProcess({ XPC_SERVICE_NAME: "0" })).toBe(false);
     expect(isSupervisorManagedProcess({})).toBe(false);
+  });
+
+  it("recognises Windows via the isWindowsPlatform helper", () => {
+    expect(isWindowsPlatform("win32")).toBe(true);
+    expect(isWindowsPlatform("linux")).toBe(false);
+    expect(isWindowsPlatform("darwin")).toBe(false);
+  });
+
+  it("refuses restart on Windows portable and never kills the daemon", async () => {
+    const requestShutdown = vi.fn();
+    const routes = new Routes();
+    registerAdminRoutes(
+      routes,
+      { core: {} as MemoryCore },
+      {
+        agent: "hermes",
+        lifecycle: { supervised: false, requestShutdown },
+        platform: "win32",
+      },
+    );
+
+    const restart = routes.getExact("POST /api/v1/admin/restart");
+    expect(restart).toBeDefined();
+
+    const result = await restart!({} as never);
+
+    expect(result).toMatchObject({
+      ok: false,
+      restarting: false,
+      manualRestartRequired: true,
+    });
+    // No pkill, no bash — those are what corrupt the flow on Windows.
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    // Advance past every scheduled shutdown window; the daemon must stay alive.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(requestShutdown).not.toHaveBeenCalled();
+  });
+
+  it("still self-shuts on Windows when a supervisor is present", async () => {
+    const requestShutdown = vi.fn();
+    const routes = new Routes();
+    registerAdminRoutes(
+      routes,
+      { core: {} as MemoryCore },
+      {
+        agent: "hermes",
+        lifecycle: { supervised: true, requestShutdown },
+        platform: "win32",
+      },
+    );
+
+    const restart = routes.getExact("POST /api/v1/admin/restart");
+    const result = await restart!({} as never);
+
+    expect(result).toMatchObject({ ok: true, restarting: true });
+    // Even on Windows, when a supervisor exists (e.g. NSSM-wrapped service),
+    // shutting down is safe because the supervisor respawns us.
+    expect(spawnMock).not.toHaveBeenCalledWith(
+      "bash",
+      expect.anything(),
+      expect.anything(),
+    );
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(requestShutdown).toHaveBeenCalledOnce();
+  });
+
+  it("clear-data on Windows portable wipes DB files without killing the daemon", async () => {
+    const requestShutdown = vi.fn();
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const routes = new Routes();
+
+    registerAdminRoutes(
+      routes,
+      {
+        core: { shutdown } as unknown as MemoryCore,
+        home: {
+          root: "/does/not/exist/nowhere",
+          dbFile: "/does/not/exist/nowhere/db.sqlite",
+        },
+      },
+      {
+        agent: "hermes",
+        lifecycle: { supervised: false, requestShutdown },
+        platform: "win32",
+      },
+    );
+
+    const clear = routes.getExact("POST /api/v1/admin/clear-data");
+    expect(clear).toBeDefined();
+    const result = await clear!({} as never);
+
+    expect(result).toMatchObject({
+      ok: true,
+      restarting: false,
+      manualRestartRequired: true,
+    });
+    // pkill was not attempted, bash was not attempted.
+    expect(spawnMock).not.toHaveBeenCalled();
+    // MemoryCore.shutdown() still fires so SQLite handles are released
+    // before the user manually restarts Hermes.
+    expect(shutdown).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(requestShutdown).not.toHaveBeenCalled();
   });
 });

--- a/apps/memos-local-plugin/tests/unit/server/admin.test.ts
+++ b/apps/memos-local-plugin/tests/unit/server/admin.test.ts
@@ -75,8 +75,7 @@ describe("admin lifecycle routes", () => {
       { core: {} as MemoryCore },
       {
         agent: "hermes",
-        lifecycle: { supervised: false, requestShutdown },
-        platform: "linux",
+        lifecycle: { supervised: false, requestShutdown, platform: "linux" },
       },
     );
 
@@ -124,8 +123,7 @@ describe("admin lifecycle routes", () => {
       { core: {} as MemoryCore },
       {
         agent: "hermes",
-        lifecycle: { supervised: false, requestShutdown },
-        platform: "win32",
+        lifecycle: { supervised: false, requestShutdown, platform: "win32" },
       },
     );
 
@@ -135,9 +133,10 @@ describe("admin lifecycle routes", () => {
     const result = await restart!({} as never);
 
     expect(result).toMatchObject({
-      ok: false,
+      ok: true,
       restarting: false,
       manualRestartRequired: true,
+      platform: "win32",
     });
     // No pkill, no bash — those are what corrupt the flow on Windows.
     expect(spawnMock).not.toHaveBeenCalled();
@@ -155,8 +154,7 @@ describe("admin lifecycle routes", () => {
       { core: {} as MemoryCore },
       {
         agent: "hermes",
-        lifecycle: { supervised: true, requestShutdown },
-        platform: "win32",
+        lifecycle: { supervised: true, requestShutdown, platform: "win32" },
       },
     );
 
@@ -192,8 +190,7 @@ describe("admin lifecycle routes", () => {
       },
       {
         agent: "hermes",
-        lifecycle: { supervised: false, requestShutdown },
-        platform: "win32",
+        lifecycle: { supervised: false, requestShutdown, platform: "win32" },
       },
     );
 

--- a/apps/memos-local-plugin/tests/unit/viewer/restart.test.ts
+++ b/apps/memos-local-plugin/tests/unit/viewer/restart.test.ts
@@ -13,7 +13,11 @@ const fakeWindow = {
 };
 
 import { health } from "../../../viewer/src/stores/health";
-import { triggerRestart } from "../../../viewer/src/stores/restart";
+import {
+  restartState,
+  triggerCleared,
+  triggerRestart,
+} from "../../../viewer/src/stores/restart";
 
 describe("viewer restart flow", () => {
   const originalFetch = globalThis.fetch;
@@ -22,6 +26,7 @@ describe("viewer restart flow", () => {
     vi.useFakeTimers();
     fakeWindow.location.href = "";
     health.value = { ok: true, agent: "hermes" };
+    restartState.value = { phase: "idle" };
   });
 
   afterEach(() => {
@@ -49,5 +54,50 @@ describe("viewer restart flow", () => {
 
     expect(healthChecks).toBe(2);
     expect(fakeWindow.location.href).toMatch(/^\/\?_t=\d+$/);
+  });
+
+  it("shows the manual restart state returned by Windows restart", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          restarting: false,
+          manualRestartRequired: true,
+          message: "Close and reopen Hermes.",
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    await triggerRestart();
+
+    expect(restartState.value).toEqual({
+      phase: "manualRestartRequired",
+      message: "Close and reopen Hermes.",
+    });
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(fakeWindow.location.href).toBe("");
+  });
+
+  it("shows the manual restart state returned by Windows clear-data", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(null, { status: 200 }),
+    ) as typeof fetch;
+
+    const clearing = triggerCleared({
+      ok: true,
+      restarting: false,
+      manualRestartRequired: true,
+      message: "Restart Hermes manually.",
+    });
+    await vi.runAllTimersAsync();
+    await clearing;
+
+    expect(restartState.value).toEqual({
+      phase: "manualRestartRequired",
+      message: "Restart Hermes manually.",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(fakeWindow.location.href).toBe("");
   });
 });

--- a/apps/memos-local-plugin/viewer/src/components/RestartOverlay.tsx
+++ b/apps/memos-local-plugin/viewer/src/components/RestartOverlay.tsx
@@ -16,19 +16,25 @@ function FullScreenSpinner() {
   const s = restartState.value;
   const agentType = health.value?.agent === "openclaw" ? "openclaw" : "hermes";
 
+  const isTerminal = s.phase === "restartFailed" || s.phase === "manualRestartRequired";
+
   const message =
-    s.phase === "restartFailed"
-      ? t("restart.failed")
-      : s.phase === "waitingUp"
-        ? t("restart.waitingUp")
-        : agentType === "hermes"
-          ? t("restart.restarting.hermes")
-          : t("restart.restarting");
+    s.phase === "manualRestartRequired"
+      ? (s.message || t("restart.manualRequired"))
+      : s.phase === "restartFailed"
+        ? t("restart.failed")
+        : s.phase === "waitingUp"
+          ? t("restart.waitingUp")
+          : agentType === "hermes"
+            ? t("restart.restarting.hermes")
+            : t("restart.restarting");
 
   const hint =
-    s.phase === "restartFailed"
-      ? t(`restart.failedHint.${agentType}` as any)
-      : t("restart.autoRefresh");
+    s.phase === "manualRestartRequired"
+      ? t("restart.manualRequiredHint")
+      : s.phase === "restartFailed"
+        ? t(`restart.failedHint.${agentType}` as any)
+        : t("restart.autoRefresh");
 
   return (
     <div
@@ -47,7 +53,7 @@ function FullScreenSpinner() {
           gap:16px;max-width:400px;text-align:center;
         `}
       >
-        {s.phase !== "restartFailed" ? (
+        {!isTerminal ? (
           <div
             style={`
               width:36px;height:36px;
@@ -62,7 +68,7 @@ function FullScreenSpinner() {
         )}
         <div style="font-size:15px;font-weight:600">{message}</div>
         <div style="font-size:12px;opacity:.6">{hint}</div>
-        {s.phase === "restartFailed" && (
+        {isTerminal && (
           <button
             class="btn btn--ghost btn--sm"
             onClick={dismissRestartBanner}

--- a/apps/memos-local-plugin/viewer/src/components/RestartOverlay.tsx
+++ b/apps/memos-local-plugin/viewer/src/components/RestartOverlay.tsx
@@ -18,23 +18,25 @@ function FullScreenSpinner() {
 
   const isTerminal = s.phase === "restartFailed" || s.phase === "manualRestartRequired";
 
-  const message =
-    s.phase === "manualRestartRequired"
-      ? (s.message || t("restart.manualRequired"))
-      : s.phase === "restartFailed"
-        ? t("restart.failed")
-        : s.phase === "waitingUp"
-          ? t("restart.waitingUp")
-          : agentType === "hermes"
-            ? t("restart.restarting.hermes")
-            : t("restart.restarting");
+  let message: string;
+  if (s.phase === "manualRestartRequired") {
+    message = s.message || t("restart.manualRequired");
+  } else if (s.phase === "restartFailed") {
+    message = t("restart.failed");
+  } else if (s.phase === "waitingUp") {
+    message = t("restart.waitingUp");
+  } else {
+    message = agentType === "hermes" ? t("restart.restarting.hermes") : t("restart.restarting");
+  }
 
-  const hint =
-    s.phase === "manualRestartRequired"
-      ? t("restart.manualRequiredHint")
-      : s.phase === "restartFailed"
-        ? t(`restart.failedHint.${agentType}` as any)
-        : t("restart.autoRefresh");
+  let hint: string;
+  if (s.phase === "manualRestartRequired") {
+    hint = t("restart.manualRequiredHint");
+  } else if (s.phase === "restartFailed") {
+    hint = t(`restart.failedHint.${agentType}` as any);
+  } else {
+    hint = t("restart.autoRefresh");
+  }
 
   return (
     <div

--- a/apps/memos-local-plugin/viewer/src/stores/i18n.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/i18n.ts
@@ -184,6 +184,10 @@ const en = {
     "Try manually: openclaw gateway stop && openclaw gateway start",
   "restart.failedHint.hermes":
     "Try manually: stop the current Hermes session and rerun `hermes chat`",
+  "restart.manualRequired":
+    "Restart is unavailable on this platform. Close and reopen Hermes to apply changes.",
+  "restart.manualRequiredHint":
+    "The viewer daemon stayed running so your data is safe — you just need to restart Hermes yourself.",
   "common.selectAll": "Select all",
   "common.deleteSelected": "Delete selected",
 
@@ -1079,6 +1083,10 @@ const zh: Record<TranslationKey, string> = {
     "请手动重启：openclaw gateway stop && openclaw gateway start",
   "restart.failedHint.hermes":
     "请手动重启：停止当前 Hermes 会话后重新执行 `hermes chat`",
+  "restart.manualRequired":
+    "当前平台不支持自动重启，请手动关闭并重新打开 Hermes 以应用变更。",
+  "restart.manualRequiredHint":
+    "查看器守护进程仍在运行，数据已安全保存，你只需要手动重启 Hermes 即可。",
   "common.never": "从未",
   "common.selectAll": "全选",
   "common.deleteSelected": "删除所选",

--- a/apps/memos-local-plugin/viewer/src/stores/restart.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/restart.ts
@@ -23,6 +23,24 @@ export const restartState = signal<{ phase: RestartPhase; message?: string }>({
   phase: "idle",
 });
 
+/**
+ * Shape returned by `POST /api/v1/admin/restart`.
+ *
+ * Matches `apps/memos-local-plugin/server/routes/admin.ts`. All fields
+ * beyond `ok` are optional — the Windows-portable path emits
+ * `manualRestartRequired: true` with a human `message`; the happy paths
+ * omit them.
+ */
+interface RestartResponse {
+  ok: boolean;
+  restarting?: boolean;
+  manualRestartRequired?: boolean;
+  message?: string;
+  platform?: string;
+  killed?: boolean;
+  error?: string;
+}
+
 function isOpenClaw(): boolean {
   return health.value?.agent === "openclaw";
 }
@@ -83,9 +101,9 @@ async function quickPollUp(maxAttempts = 30): Promise<boolean> {
 export async function triggerRestart(): Promise<void> {
   restartState.value = { phase: "restarting" };
   if (!isOpenClaw()) {
-    let response: unknown;
+    let response: RestartResponse | undefined;
     try {
-      response = await api.post("/api/v1/admin/restart");
+      response = await api.post<RestartResponse>("/api/v1/admin/restart");
     } catch {
       restartState.value = { phase: "restartFailed" };
       throw new Error("restart failed");
@@ -96,17 +114,8 @@ export async function triggerRestart(): Promise<void> {
     // the daemon alive and returns manualRestartRequired so we can tell
     // the user to restart Hermes themselves instead of endlessly polling
     // a server that never went down.
-    if (
-      response &&
-      typeof response === "object" &&
-      "manualRestartRequired" in (response as Record<string, unknown>) &&
-      (response as { manualRestartRequired?: unknown }).manualRestartRequired === true
-    ) {
-      const message =
-        typeof (response as { message?: unknown }).message === "string"
-          ? ((response as { message: string }).message)
-          : undefined;
-      restartState.value = { phase: "manualRestartRequired", message };
+    if (response?.manualRestartRequired === true) {
+      restartState.value = { phase: "manualRestartRequired", message: response.message };
       return;
     }
 

--- a/apps/memos-local-plugin/viewer/src/stores/restart.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/restart.ts
@@ -24,14 +24,14 @@ export const restartState = signal<{ phase: RestartPhase; message?: string }>({
 });
 
 /**
- * Shape returned by `POST /api/v1/admin/restart`.
+ * Shape returned by the admin restart and clear-data endpoints.
  *
  * Matches `apps/memos-local-plugin/server/routes/admin.ts`. All fields
  * beyond `ok` are optional — the Windows-portable path emits
  * `manualRestartRequired: true` with a human `message`; the happy paths
  * omit them.
  */
-interface RestartResponse {
+export interface RestartResponse {
   ok: boolean;
   restarting?: boolean;
   manualRestartRequired?: boolean;
@@ -39,6 +39,15 @@ interface RestartResponse {
   platform?: string;
   killed?: boolean;
   error?: string;
+}
+
+function applyManualRestart(response: RestartResponse | undefined): boolean {
+  if (response?.manualRestartRequired !== true) return false;
+  restartState.value = {
+    phase: "manualRestartRequired",
+    message: response.message,
+  };
+  return true;
 }
 
 function isOpenClaw(): boolean {
@@ -114,10 +123,7 @@ export async function triggerRestart(): Promise<void> {
     // the daemon alive and returns manualRestartRequired so we can tell
     // the user to restart Hermes themselves instead of endlessly polling
     // a server that never went down.
-    if (response?.manualRestartRequired === true) {
-      restartState.value = { phase: "manualRestartRequired", message: response.message };
-      return;
-    }
+    if (applyManualRestart(response)) return;
 
     const ok = await pollHealthUntilUp(60);
     if (ok) {
@@ -147,10 +153,12 @@ export async function triggerRestart(): Promise<void> {
 }
 
 /**
- * Data cleared. Both agents self-respawn via the daemon mechanism.
+ * Data cleared. Supervised installs self-respawn; Windows portable
+ * installs stay alive long enough to request a manual Hermes restart.
  */
-export async function triggerCleared(): Promise<void> {
+export async function triggerCleared(response?: RestartResponse): Promise<void> {
   restartState.value = { phase: "restarting" };
+  if (applyManualRestart(response)) return;
   if (isOpenClaw()) {
     const ok = await pollHealthUntilUp(60);
     if (ok) {

--- a/apps/memos-local-plugin/viewer/src/stores/restart.ts
+++ b/apps/memos-local-plugin/viewer/src/stores/restart.ts
@@ -16,7 +16,8 @@ export type RestartPhase =
   | "idle"
   | "restarting"
   | "waitingUp"
-  | "restartFailed";
+  | "restartFailed"
+  | "manualRestartRequired";
 
 export const restartState = signal<{ phase: RestartPhase; message?: string }>({
   phase: "idle",
@@ -82,11 +83,31 @@ async function quickPollUp(maxAttempts = 30): Promise<boolean> {
 export async function triggerRestart(): Promise<void> {
   restartState.value = { phase: "restarting" };
   if (!isOpenClaw()) {
+    let response: unknown;
     try {
-      await api.post("/api/v1/admin/restart");
+      response = await api.post("/api/v1/admin/restart");
     } catch {
       restartState.value = { phase: "restartFailed" };
       throw new Error("restart failed");
+    }
+
+    // Windows portable installs cannot self-restart (see
+    // apps/memos-local-plugin/server/routes/admin.ts). The server keeps
+    // the daemon alive and returns manualRestartRequired so we can tell
+    // the user to restart Hermes themselves instead of endlessly polling
+    // a server that never went down.
+    if (
+      response &&
+      typeof response === "object" &&
+      "manualRestartRequired" in (response as Record<string, unknown>) &&
+      (response as { manualRestartRequired?: unknown }).manualRestartRequired === true
+    ) {
+      const message =
+        typeof (response as { message?: unknown }).message === "string"
+          ? ((response as { message: string }).message)
+          : undefined;
+      restartState.value = { phase: "manualRestartRequired", message };
+      return;
     }
 
     const ok = await pollHealthUntilUp(60);

--- a/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
+++ b/apps/memos-local-plugin/viewer/src/views/SettingsView.tsx
@@ -18,7 +18,11 @@ import { t, locale, setLocale } from "../stores/i18n";
 import { theme, setTheme } from "../stores/theme";
 import { Icon } from "../components/Icon";
 import { HubAdminPanel } from "../components/HubAdminPanel";
-import { triggerRestart, triggerCleared } from "../stores/restart";
+import {
+  triggerRestart,
+  triggerCleared,
+  type RestartResponse,
+} from "../stores/restart";
 
 type Tab = "models" | "hub" | "general";
 
@@ -1105,14 +1109,16 @@ function DangerZoneSection() {
   const clearAllData = async () => {
     setClearing(true);
     try {
-      // The server wipes SQLite + cleanly tears down its core; the
-      // next agent boot will recreate an empty DB. We don't try to
-      // restart the agent process from here — the toast tells the
-      // user to do it manually (see `stores/restart.ts` for why).
-      await api.post("/api/v1/admin/clear-data", {});
+      // The server wipes SQLite and tears down its core. Its response
+      // tells the restart store whether a supervisor will respawn the
+      // daemon or the user must restart Hermes manually.
+      const response = await api.post<RestartResponse>(
+        "/api/v1/admin/clear-data",
+        {},
+      );
       setConfirming(false);
       setClearing(false);
-      await triggerCleared();
+      await triggerCleared(response);
     } catch {
       setClearing(false);
       setConfirming(false);


### PR DESCRIPTION
## Description

Fixed #2213: `POST /api/v1/admin/restart` (and the same code path in `/api/v1/admin/clear-data`) no longer self-destructs the Memory Viewer daemon on Windows. On Windows portable installs the historical `pkill` + `bash -c "... tsx bridge.cts --daemon"` sequence silently failed while the follow-up `SIGTERM`-self-kill always succeeded, so the daemon died with no replacement — a fault that also triggered on every "Save settings" click because `SettingsView.tsx` posts to `/admin/restart` after each save.

The fix adds an `isWindowsPlatform()` guard in `apps/memos-local-plugin/server/routes/admin.ts` (with a new `ServerOptions.platform` seam so tests inject the platform cleanly). When the runtime is Windows AND no supervisor is detected (`INVOCATION_ID` / `XPC_SERVICE_NAME` absent), we now skip the pkill+bash+shutdown chain, keep the daemon alive, and return `{ ok: false, restarting: false, manualRestartRequired: true, message: ... }` for `/admin/restart`; `/admin/clear-data` still tears down `MemoryCore` and unlinks the DB / WAL / SHM / bridge-status files but returns `restarting: false, manualRestartRequired: true` and lets the user restart Hermes themselves. Supervised Windows hosts keep the original self-shutdown path so a supervisor can respawn the daemon.

Viewer client updates: `viewer/src/stores/restart.ts::triggerRestart()` recognises the new payload and enters a new `manualRestartRequired` phase (instead of endlessly polling a healthy server), and `RestartOverlay.tsx` renders the phase with the same terminal treatment as `restartFailed`. Bilingual copy added under `restart.manualRequired` / `restart.manualRequiredHint` in `viewer/src/stores/i18n.ts`.

Verified: `tests/unit/server/admin.test.ts` — 7/7 green (3 new Windows-specific tests + 4 preserved). Broader `tests/unit/server/ tests/unit/config/` — 137 passing, 1 pre-existing failure in `http.test.ts::POST /migrate/openclaw/run` that reproduces on the untouched base commit (confirmed via git-stash sandwich). Both `tsc -p tsconfig.json` and `tsc -p tsconfig.viewer.json` complete with no errors. cc @whipser030 @hijzy

Related Issue (Required):  Fixes #2213

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@whipser030, @hijzy please review this PR.

## Reviewer Checklist
- [x] closes #2213
- [ ] Made sure Checks passed
- [ ] Tests have been provided
