### PR TITLE
fix(cli): bound example archive download time

### DIFF
--- a/src/memos/cli.py
+++ b/src/memos/cli.py
@@ -42,7 +42,7 @@ def download_examples(dest: str) -> bool:
     print(f"📥 Downloading examples from {zip_url}...")
 
     try:
-        response = requests.get(zip_url)
+        response = requests.get(zip_url, timeout=30)
         response.raise_for_status()
 
         with zipfile.ZipFile(BytesIO(response.content)) as z:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,8 @@ class TestDownloadExamples:
 
         assert result is True
         mock_requests.assert_called_once_with(
-            "https://github.com/MemTensor/MemOS/archive/refs/heads/main.zip"
+            "https://github.com/MemTensor/MemOS/archive/refs/heads/main.zip",
+            timeout=30,
         )
         mock_response.raise_for_status.assert_called_once()
 


### PR DESCRIPTION
## Description

`memos download_examples` downloaded the GitHub archive without a timeout. A stalled connection could therefore block the CLI indefinitely.

This change applies the same bounded-network behavior used elsewhere in the client: the archive request now times out after 30 seconds. The extraction behavior and destination layout are unchanged.

Related Issue (Required): N/A — regression reproduced on current `main`.

## Type of change

- [x] Bug fix (non-breaking)

## How Has This Been Tested?

- [x] Before: the focused test expected `timeout=30` and failed with actual call `requests.get(url)`.
- [x] After: `.venv/bin/pytest tests/test_cli.py -q` (`6 passed`).
- [x] Ruff check and format pass for both changed files.

## Impact

- Breaking change: no
- Scope: CLI example archive download only
- Dependencies: none