### PR TITLE
fix(search): bound external provider requests

### DIFF
--- a/src/memos/memories/textual/tree_text_memory/retrieve/bochasearch.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/bochasearch.py
@@ -23,6 +23,8 @@ from memos.memories.textual.item import (
 
 logger = get_logger(__name__)
 
+_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class BochaAISearchAPI:
     """BochaAI Search API Client"""
@@ -102,7 +104,12 @@ class BochaAISearchAPI:
     def _post(self, url: str, body: dict) -> list[dict]:
         """Send POST request and parse BochaAI search results."""
         try:
-            resp = requests.post(url, headers=self.headers, json=body)
+            resp = requests.post(
+                url,
+                headers=self.headers,
+                json=body,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
             resp.raise_for_status()
             raw_data = resp.json()
 

--- a/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever.py
+++ b/src/memos/memories/textual/tree_text_memory/retrieve/internet_retriever.py
@@ -14,6 +14,9 @@ from memos.memories.textual.item import (
 )
 
 
+_REQUEST_TIMEOUT_SECONDS = 30
+
+
 class GoogleCustomSearchAPI:
     """Google Custom Search API Client"""
 
@@ -59,7 +62,11 @@ class GoogleCustomSearchAPI:
         }
 
         try:
-            response = requests.get(self.base_url, params=params)
+            response = requests.get(
+                self.base_url,
+                params=params,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/tests/memories/textual/test_internet_search_timeouts.py
+++ b/tests/memories/textual/test_internet_search_timeouts.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+from memos.memories.textual.tree_text_memory.retrieve.bochasearch import BochaAISearchAPI
+from memos.memories.textual.tree_text_memory.retrieve.internet_retriever import (
+    GoogleCustomSearchAPI,
+)
+
+
+@patch("memos.memories.textual.tree_text_memory.retrieve.bochasearch.requests.post")
+def test_bocha_search_uses_bounded_request_timeout(mock_post):
+    response = MagicMock()
+    response.json.return_value = {"data": {"webPages": {"value": []}}}
+    mock_post.return_value = response
+
+    BochaAISearchAPI("api-key").search_web("query")
+
+    mock_post.assert_called_once_with(
+        "https://api.bochaai.com/v1/web-search",
+        headers={
+            "Authorization": "Bearer api-key",
+            "Content-Type": "application/json",
+        },
+        json={
+            "query": "query",
+            "summary": True,
+            "freshness": "noLimit",
+            "count": 20,
+        },
+        timeout=30,
+    )
+
+
+@patch("memos.memories.textual.tree_text_memory.retrieve.internet_retriever.requests.get")
+def test_google_search_uses_bounded_request_timeout(mock_get):
+    response = MagicMock()
+    response.json.return_value = {"items": []}
+    mock_get.return_value = response
+
+    GoogleCustomSearchAPI("api-key", "engine-id").search("query")
+
+    mock_get.assert_called_once_with(
+        "https://www.googleapis.com/customsearch/v1",
+        params={
+            "key": "api-key",
+            "cx": "engine-id",
+            "q": "query",
+            "num": 10,
+            "start": 1,
+        },
+        timeout=30,
+    )


### PR DESCRIPTION
## Description

The Google Custom Search and Bocha search clients issued external HTTP requests without a timeout. A stalled provider could therefore hold a retrieval worker indefinitely and delay or exhaust the search pipeline.

This change applies a 30-second request timeout to both provider clients. Existing error handling remains unchanged: request failures still return the providers current empty-result fallback.

Related Issue (Required): N/A — network-boundary regression reproduced on current `main`.

## Type of change

- [x] Bug fix (non-breaking)

## How Has This Been Tested?

- [x] Before: both new tests failed because the actual `requests.get/post` calls omitted `timeout`.
- [x] After: `.venv/bin/pytest tests/memories/textual/test_internet_search_timeouts.py -q` (`2 passed`).
- [x] Ruff check and format pass for all three changed files.

## Impact

- Breaking change: no
- Affected modules: Google Custom Search and Bocha search clients
- Dependencies/API schema: unchanged