### PR TITLE
fix(plugin): derive missing crystallization summaries

### DIFF
--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -353,11 +353,24 @@ function normaliseDraft(
   const displayTitle =
     sanitizeDerivedText(raw.display_title ?? raw.displayTitle ?? input.policy.title ?? name) ||
     name;
-  const summary = sanitizeDerivedText(raw.summary);
 
   const parameters = asArray(raw.parameters).map(coerceParameter).filter(Boolean) as SkillParameterDraft[];
   const preconditions = sanitizeDerivedMarkdownList(asStringArray(raw.preconditions));
   const steps = asArray(raw.steps).map(coerceStep).filter(Boolean) as SkillStepDraft[];
+  const summary =
+    sanitizeDerivedText(raw.summary) ||
+    [
+      raw.retrieval_blurb,
+      raw.retrievalBlurb,
+      steps[0]?.body,
+      steps[0]?.title,
+      displayTitle,
+      name,
+    ]
+      .map(sanitizeDerivedText)
+      .find((candidate) => candidate.length > 0)
+      ?.slice(0, 200) ||
+    "skill procedure";
   const examples = asArray(raw.examples).map(coerceExample).filter(Boolean) as SkillExampleDraft[];
   const tags = dedupeLc(sanitizeDerivedList(asStringArray(raw.tags)));
   // V7 §2.4.6 — coerce both `decision_guidance` (preferred LLM key)

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -357,20 +357,14 @@ function normaliseDraft(
   const parameters = asArray(raw.parameters).map(coerceParameter).filter(Boolean) as SkillParameterDraft[];
   const preconditions = sanitizeDerivedMarkdownList(asStringArray(raw.preconditions));
   const steps = asArray(raw.steps).map(coerceStep).filter(Boolean) as SkillStepDraft[];
-  const summary =
+  const summarySource =
     sanitizeDerivedText(raw.summary) ||
-    [
-      raw.retrieval_blurb,
-      raw.retrievalBlurb,
-      steps[0]?.body,
-      steps[0]?.title,
-      displayTitle,
-      name,
-    ]
-      .map(sanitizeDerivedText)
-      .find((candidate) => candidate.length > 0)
-      ?.slice(0, 200) ||
-    "skill procedure";
+    sanitizeDerivedText(raw.retrieval_blurb) ||
+    sanitizeDerivedText(raw.retrievalBlurb) ||
+    sanitizeDerivedText(steps[0]?.body) ||
+    sanitizeDerivedText(steps[0]?.title) ||
+    displayTitle;
+  const summary = summarySource.slice(0, 200);
   const examples = asArray(raw.examples).map(coerceExample).filter(Boolean) as SkillExampleDraft[];
   const tags = dedupeLc(sanitizeDerivedList(asStringArray(raw.tags)));
   // V7 §2.4.6 — coerce both `decision_guidance` (preferred LLM key)

--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -35,6 +35,8 @@ import type {
   SkillStepDraft,
 } from "./types.js";
 
+const MAX_SUMMARY_LENGTH = 200;
+
 export interface CrystallizeInput {
   policy: PolicyRow;
   evidence: TraceRow[];
@@ -364,7 +366,7 @@ function normaliseDraft(
     sanitizeDerivedText(steps[0]?.body) ||
     sanitizeDerivedText(steps[0]?.title) ||
     displayTitle;
-  const summary = summarySource.slice(0, 200);
+  const summary = summarySource.slice(0, MAX_SUMMARY_LENGTH);
   const examples = asArray(raw.examples).map(coerceExample).filter(Boolean) as SkillExampleDraft[];
   const tags = dedupeLc(sanitizeDerivedList(asStringArray(raw.tags)));
   // V7 §2.4.6 — coerce both `decision_guidance` (preferred LLM key)

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -161,6 +161,23 @@ describe("skill/crystallize", () => {
     );
   });
 
+  it("caps an explicit summary at 200 characters", async () => {
+    const llm = fakeLlm({
+      completeJson: {
+        "skill.crystallize": makeDraft({ summary: "x".repeat(250) }),
+      },
+    });
+
+    const r = await crystallizeDraft(
+      { policy: mkPolicy(), evidence: [mkTrace("tr_1", "pip fails")], namingSpace: [] },
+      { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
+    );
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.draft.summary).toBe("x".repeat(200));
+  });
+
   it("cleans unsafe markup from LLM-derived skill fields", async () => {
     const policy = mkPolicy();
     const llm = fakeLlm({

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -178,6 +178,24 @@ describe("skill/crystallize", () => {
     expect(r.draft.summary).toBe("x".repeat(200));
   });
 
+  it("caps a derived retrieval blurb at 200 characters", async () => {
+    const draft = makeDraft() as unknown as Record<string, unknown>;
+    delete draft.summary;
+    draft.retrieval_blurb = "y".repeat(250);
+    const llm = fakeLlm({
+      completeJson: { "skill.crystallize": draft },
+    });
+
+    const r = await crystallizeDraft(
+      { policy: mkPolicy(), evidence: [mkTrace("tr_1", "pip fails")], namingSpace: [] },
+      { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
+    );
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.draft.summary).toBe("y".repeat(200));
+  });
+
   it("cleans unsafe markup from LLM-derived skill fields", async () => {
     const policy = mkPolicy();
     const llm = fakeLlm({

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -120,6 +120,47 @@ describe("skill/crystallize", () => {
     expect(r.draft.tools).toEqual(["shell", "pip.install"]);
   });
 
+  it("derives a summary from the first step when the LLM omits it", async () => {
+    const draft = makeDraft({
+      steps: [{ title: "Inspect failure", body: "Read the package install error." }],
+    }) as unknown as Record<string, unknown>;
+    delete draft.summary;
+    const llm = fakeLlm({
+      completeJson: { "skill.crystallize": draft },
+    });
+
+    const r = await crystallizeDraft(
+      { policy: mkPolicy(), evidence: [mkTrace("tr_1", "pip fails")], namingSpace: [] },
+      { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
+    );
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.draft.summary).toBe("Read the package install error.");
+  });
+
+  it("prefers a retrieval blurb when deriving a missing summary", async () => {
+    const draft = makeDraft({
+      steps: [{ title: "Inspect failure", body: "Read the package install error." }],
+    }) as unknown as Record<string, unknown>;
+    delete draft.summary;
+    draft.retrieval_blurb = "Use this skill for Alpine package installation failures.";
+    const llm = fakeLlm({
+      completeJson: { "skill.crystallize": draft },
+    });
+
+    const r = await crystallizeDraft(
+      { policy: mkPolicy(), evidence: [mkTrace("tr_1", "pip fails")], namingSpace: [] },
+      { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
+    );
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.draft.summary).toBe(
+      "Use this skill for Alpine package installation failures.",
+    );
+  });
+
   it("cleans unsafe markup from LLM-derived skill fields", async () => {
     const policy = mkPolicy();
     const llm = fakeLlm({


### PR DESCRIPTION
## Description

Fixes #2143.

When the crystallization LLM returns a structurally useful draft but omits
`summary`, normalization currently produces an empty string and the default
validator rejects the entire draft.

This change derives a sanitized fallback summary in this order:

1. `retrieval_blurb` / `retrievalBlurb`, when provided by older or alternate models
2. The first normalized step body or title
3. The normalized display title or skill name
4. A final static fallback

Existing non-empty summaries are unchanged. Missing steps remain invalid, so
this does not weaken the structural validator.

Related Issue (Required): Fixes #2143

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
- [x] Test Script Or Test Steps

Evidence:

- Before the fix, the two new regressions failed with
  `skill.crystallize.invalid: missing summary`.
- `npm test -- tests/unit/skill/crystallize.test.ts` -> 9 passed.
- `npm run lint` -> TypeScript project check passed.
- `npm run build` -> plugin build passed.
- The broader `tests/unit/skill` run passed 35 tests; 13 database-backed tests
  could not start because the local Node 26 install lacks the
  `better-sqlite3` native binding after an `--ignore-scripts` install.

## Impact

- Breaking change: no
- Scope: skill draft normalization only
- Dependencies: none
- Existing valid summaries and validation of missing steps are unchanged

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove the fix is effective
- [x] I have linked the issue to this PR
- [x] No documentation update is required for this internal recovery path
- [x] Review requested from @hijzy and @whipser030

## Reviewer Checklist

- [x] closes #2143
- [ ] Made sure Checks passed
- [x] Tests have been provided
