### PR TITLE
test(log): cover search result summary redaction

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -126,6 +126,43 @@ def test_summarize_search_results_only_counts_buckets_and_items():
     assert len(rendered) <= len(str(results)) * 0.2
 
 
+def test_search_result_summary_log_excludes_embedding_payload(caplog):
+    logger = logging.getLogger("tests.search_results")
+    results = {
+        "text_mem": [
+            {
+                "cube_id": "cube-a",
+                "memories": [
+                    {
+                        "memory": "private memory payload",
+                        "metadata": {
+                            "embedding": [0.123456, 0.654321, 0.999999],
+                            "properties": {"secret": "do-not-log"},
+                        },
+                    }
+                ],
+            }
+        ],
+        "pref_note": "private preference note",
+    }
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        logger.info("Search result summary: %s", log.summarize_search_results(results))
+
+    summary_logs = [
+        record.message for record in caplog.records if "Search result summary" in record.message
+    ]
+    assert len(summary_logs) == 1
+    rendered = summary_logs[0]
+    assert "bucket_counts" in rendered
+    assert "item_counts" in rendered
+    assert "private memory payload" not in rendered
+    assert "private preference note" not in rendered
+    assert "embedding" not in rendered
+    assert "0.123456" not in rendered
+    assert "do-not-log" not in rendered
+
+
 def test_summarize_textual_memories_only_counts_types():
     memories = [
         SimpleNamespace(


### PR DESCRIPTION
## Summary
- add regression coverage for search result summary logging so memory payloads, preference notes, embeddings, and secrets are not rendered
- keep the replacement for #2110 scoped to #2103, without the unrelated API/client/local-plugin changes
- rely on the existing dev-v2.0.29 behavior that logs summarize_search_results(memories_result) instead of serializing result payloads

Refs #2103.
Supersedes #2110.

## Verification
- make format: failed because poetry is not installed in this environment
- uv run --with ruff ruff check --fix tests/test_log.py: All checks passed
- uv run --with ruff ruff format tests/test_log.py: 1 file left unchanged
- uv run --with pytest pytest tests/test_log.py -q: 8 passed, 1 warning