### PR TITLE
fix(bridge): use os.homedir() for PID file path so Windows stops creating <drive>:\tmp stray folders

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -29,6 +29,8 @@ const path = require("node:path") as typeof import("node:path");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require("node:fs") as typeof import("node:fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+const { homedir } = require("node:os") as typeof import("node:os");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const childProcess = require("node:child_process") as typeof import("node:child_process");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const url = require("node:url") as typeof import("node:url");
@@ -95,7 +97,7 @@ const STDIO_PID_FILENAME = "bridge-stdio.pid";
 function pidFilePath(agent: string, filename: string = PID_FILENAME): string {
   const agentHome = agent === "hermes" ? ".hermes" : ".openclaw";
   return path.join(
-    process.env.HOME ?? "/tmp",
+    homedir(),
     agentHome,
     "memos-plugin",
     "daemon",

--- a/apps/memos-local-plugin/bridge.mts
+++ b/apps/memos-local-plugin/bridge.mts
@@ -30,6 +30,7 @@
  */
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
+import { homedir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -81,7 +82,7 @@ const PID_FILENAME = "bridge.pid";
 function pidFilePath(agent: string): string {
   const agentHome = agent === "hermes" ? ".hermes" : ".openclaw";
   return path.join(
-    process.env.HOME ?? "/tmp",
+    homedir(),
     agentHome,
     "memos-plugin",
     "daemon",

--- a/apps/memos-local-plugin/tests/unit/bridge/pid-file-path.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/pid-file-path.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("bridge PID file path", () => {
+  for (const entry of ["bridge.cts", "bridge.mts"]) {
+    it(`${entry} resolves the PID directory from the OS home`, () => {
+      const source = readFileSync(resolve(entry), "utf8");
+      const start = source.indexOf("function pidFilePath");
+      const end = source.indexOf("function readPidFile", start);
+
+      expect(start, `${entry}: pidFilePath() not found`).toBeGreaterThanOrEqual(0);
+      expect(end, `${entry}: readPidFile() not found`).toBeGreaterThan(start);
+
+      const pidFilePathSource = source.slice(start, end);
+      expect(pidFilePathSource).toMatch(/\bhomedir\(\)/);
+      expect(pidFilePathSource).not.toMatch(/process\.env\.HOME|["']\/tmp["']/);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

On Windows, every bridge/daemon start creates a stray folder at the root of whichever drive the process happens to run from.

`process.env.HOME` is **not set on Windows** (Windows uses `USERPROFILE`), so `pidFilePath()` falls back to `"/tmp"`:

```ts
return path.join(process.env.HOME ?? "/tmp", agentHome, "memos-plugin", "daemon", PID_FILENAME);
```

Node resolves `/tmp` relative to the **current drive root** of the process cwd. Concretely:

- daemon started with cwd on `C:` → writes `C:\tmp\.hermes\memos-plugin\daemon\bridge.pid`
- daemon started with cwd on `D:` → writes `D:\tmp\.hermes\memos-plugin\daemon\bridge.pid`
- install.ps1 uses `Start-Process` without `-WorkingDirectory`, so the daemon inherits whatever directory the installer was run from — users who install from `D:\` get the PID file on `D:\tmp`

Two consequences:

1. **Stray folders** (`C:\tmp\.hermes\...` and `D:\tmp\.hermes\...`) appear on drive roots after any bridge/daemon start — confusing, and they accumulate.
2. **The singleton guard is broken across entries**: the PID file is written to a drive-dependent path, so a daemon started from `C:` cannot see the PID file written by one started from `D:` (or vice-versa). `killExistingBridge()` then fails to kill the previous holder and two daemons fight over the viewer port (observed: two `server.started` on :18800 from independent processes).

## Fix

Use `os.homedir()` instead of `process.env.HOME ?? "/tmp"`. `homedir()` is cross-platform: on Windows it returns `C:\Users\<user>` (via `USERPROFILE`), on POSIX/macOS it returns the user home. The PID file now always lands at `~/.hermes/memos-plugin/daemon/bridge.pid` regardless of cwd or entry point, restoring the singleton guard.

```ts
import { homedir } from "node:os";

function pidFilePath(agent: string): string {
  const agentHome = agent === "hermes" ? ".hermes" : ".openclaw";
  return path.join(
    homedir(),
    agentHome,
    "memos-plugin",
    "daemon",
    PID_FILENAME,
  );
}
```

## Verification (Windows 10)

- Before: starting the daemon from `C:` created `C:\tmp\.hermes\memos-plugin\daemon\bridge.pid`; from `D:` created `D:\tmp\...`; both stale entries pointed to dead PIDs while a third live daemon wrote to yet another location.
- After: daemon writes PID only to `C:\Users\<user>\.hermes\memos-plugin\daemon\bridge.pid`, matching the actual listener PID. No `C:\tmp` / `D:\tmp` folders are created.

## Notes

- This is the same Windows-path class of bug as #2210 (Hermes home resolution) and #2211 (install.ps1 runtime home); this one is isolated to the PID file location.
- Related: #2213 (admin/restart self-destructive on Windows) also involves daemon lifecycle on Windows.
