### PR TITLE
fix(plugin): retry crystallization after validation failure

### DIFF
--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -110,6 +110,7 @@ export async function crystallizeDraft(
     input.policy.procedure,
     ...input.evidence.flatMap((t) => [t.userText, t.agentText, t.reflection]),
   ]);
+  let lastRaw: string | null = null;
 
   try {
     const rsp = await llm.completeJson<Record<string, unknown>>(
@@ -125,6 +126,7 @@ export async function crystallizeDraft(
         schemaHint: "skill-crystallize.v2",
       },
     );
+    lastRaw = rsp.raw;
     const rawRefusal = detectModelRefusal(rsp.raw);
     if (rawRefusal) {
       const modelRefusal = {
@@ -158,7 +160,7 @@ export async function crystallizeDraft(
     return { ok: true, draft };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const rawPreview = rawPreviewFromError(err);
+    const rawPreview = rawPreviewFromError(err) ?? lastRaw;
     const refusal = rawPreview ? detectModelRefusal(rawPreview) : null;
     if (refusal) {
       const modelRefusal = {

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -242,4 +242,43 @@ describe("skill/crystallize", () => {
     );
     expect(r.ok).toBe(false);
   });
+
+  it("retries drafts that fail validation after JSON parsing", async () => {
+    const invalidDraft = makeDraft({ summary: "" });
+    const correctedDraft = makeDraft({ summary: "Install system libraries before pip" });
+    let attempts = 0;
+    let correctionInput: unknown = null;
+    const llm = fakeLlm({
+      completeJson: {
+        "skill.crystallize": (input) => {
+          attempts += 1;
+          if (attempts === 1) return invalidDraft;
+          correctionInput = input;
+          return correctedDraft;
+        },
+      },
+    });
+
+    const r = await crystallizeDraft(
+      { policy: mkPolicy(), evidence: [mkTrace("tr_1", "x")], namingSpace: [] },
+      { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
+    );
+
+    expect(attempts).toBe(2);
+    expect(correctionInput).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: JSON.stringify(invalidDraft),
+        }),
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringContaining("missing summary"),
+        }),
+      ]),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.draft.summary).toBe(correctedDraft.summary);
+  });
 });


### PR DESCRIPTION
## Summary

- retain the first parsed crystallization response until structural validation completes
- reuse that response as correction context when a validator rejects an otherwise valid JSON draft
- add a regression test covering a missing-summary response that succeeds on correction

## Root cause

The correction retry only had access to raw output carried by `MemosError.details.rawPreview`. Post-parse draft validation throws a plain `Error`, so a valid JSON response that omitted a required field lost its raw output and skipped the existing correction path.

## Impact

Skill crystallization can now ask the model to repair structurally incomplete drafts instead of failing immediately after successful JSON parsing.

## Validation

- `npm test -- tests/unit/skill/crystallize.test.ts`
- `npm run lint`
- `npm run build`

The full unit suite was also exercised on Windows: 1,278 tests passed, while 19 unrelated path, locale, WSL, and sparse-checkout-sensitive tests failed. The focused crystallization suite passed all 8 tests.
