### PR TITLE
feat(plugin): add OrcaRouter as a named summarizer provider

### DIFF
--- a/apps/memos-local-openclaw/README.md
+++ b/apps/memos-local-openclaw/README.md
@@ -192,6 +192,9 @@ Add the plugin config to `~/.openclaw/openclaw.json`:
 | Anthropic | `anthropic` | `claude-3-haiku-20240307` |
 | Gemini | `gemini` | `gemini-1.5-flash` |
 | AWS Bedrock | `bedrock` | `anthropic.claude-3-haiku-20240307-v1:0` |
+| OrcaRouter | `orcarouter` | `anthropic/claude-haiku-4.5` |
+
+For [OrcaRouter](https://www.orcarouter.ai), use `provider: "orcarouter"` with `endpoint: "https://api.orcarouter.ai/v1"` and an `sk-orca-`-prefixed API key.
 
 > **No summarizer config?** The plugin automatically falls back to the OpenClaw native model (auto-detected from `~/.openclaw/openclaw.json`). If that is also unavailable, a rule-based fallback generates summaries from the first sentence + key entities. Good enough to start.
 

--- a/apps/memos-local-openclaw/src/ingest/providers/index.ts
+++ b/apps/memos-local-openclaw/src/ingest/providers/index.ts
@@ -36,6 +36,7 @@ function detectProvider(
     return "gemini";
   }
   if (key.includes("bedrock") || url.includes("bedrock")) return "bedrock";
+  if (key.includes("orcarouter") || url.includes("orcarouter.ai")) return "orcarouter";
   return "openai_compatible";
 }
 
@@ -553,6 +554,7 @@ function callSummarize(cfg: SummarizerConfig, text: string, log: Logger): Promis
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -578,6 +580,7 @@ function callSummarizeTask(cfg: SummarizerConfig, text: string, log: Logger): Pr
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -603,6 +606,7 @@ function callGenerateTaskTitle(cfg: SummarizerConfig, text: string, log: Logger)
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -628,6 +632,7 @@ function callTopicJudge(cfg: SummarizerConfig, currentContext: string, newMessag
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -653,6 +658,7 @@ function callFilterRelevant(cfg: SummarizerConfig, query: string, candidates: Ar
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -678,6 +684,7 @@ function callJudgeDedup(cfg: SummarizerConfig, newSummary: string, candidates: A
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -703,6 +710,7 @@ function callTopicClassifier(cfg: SummarizerConfig, taskState: string, newMessag
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":
@@ -728,6 +736,7 @@ function callTopicArbitration(cfg: SummarizerConfig, taskState: string, newMessa
   switch (cfg.provider) {
     case "openai":
     case "openai_compatible":
+    case "orcarouter":
     case "azure_openai":
     case "zhipu":
     case "siliconflow":

--- a/apps/memos-local-openclaw/src/shared/llm-call.ts
+++ b/apps/memos-local-openclaw/src/shared/llm-call.ts
@@ -28,6 +28,7 @@ function detectProvider(providerKey: string | undefined, baseUrl: string): Summa
     return "gemini";
   }
   if (key.includes("bedrock") || url.includes("bedrock")) return "bedrock";
+  if (key.includes("orcarouter") || url.includes("orcarouter.ai")) return "orcarouter";
   return "openai_compatible";
 }
 

--- a/apps/memos-local-openclaw/src/types.ts
+++ b/apps/memos-local-openclaw/src/types.ts
@@ -144,6 +144,7 @@ export interface RankedCandidate {
 export type SummaryProvider =
   | "openai"
   | "openai_compatible"
+  | "orcarouter"
   | "anthropic"
   | "gemini"
   | "azure_openai"

--- a/apps/memos-local-openclaw/tests/llm-call.test.ts
+++ b/apps/memos-local-openclaw/tests/llm-call.test.ts
@@ -107,4 +107,33 @@ describe("shared/llm-call", () => {
     const body = JSON.parse(cap.init!.body as string);
     expect("provider" in body).toBe(false);
   });
+
+  it("calls OrcaRouter for the orcarouter provider", async () => {
+    const cap: { url?: string; init?: RequestInit } = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: unknown, init?: unknown) => {
+        cap.url = String(url);
+        cap.init = init as RequestInit;
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: "ok" } }] }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    const cfg: SummarizerConfig = {
+      provider: "orcarouter",
+      endpoint: "https://api.orcarouter.ai/v1",
+      apiKey: "sk-orca-test",
+      model: "anthropic/claude-haiku-4.5",
+    };
+
+    const result = await callLLMOnce(cfg, "summarize this");
+
+    expect(result).toBe("ok");
+    expect(cap.url).toBe("https://api.orcarouter.ai/v1/chat/completions");
+    const body = JSON.parse(cap.init!.body as string);
+    expect(body.model).toBe("anthropic/claude-haiku-4.5");
+  });
 });


### PR DESCRIPTION
## Description

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats named OpenAI-compatible providers such as `deepseek`/`siliconflow`. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind one API key (keys start with `sk-orca-`), and it also provides gateway-level security controls for AI agents.

The `memos-local-openclaw` plugin models several OpenAI-compatible endpoints as named `provider` values (`deepseek`, `siliconflow`, `zhipu`, `moonshot`, ...). This PR registers `orcarouter` the same way, so the summarizer config, auto-detection and docs stay consistent:

- `src/types.ts` — add `"orcarouter"` to the `SummaryProvider` union.
- `src/shared/llm-call.ts` — `detectProvider` now recognizes the `orcarouter` provider key / `orcarouter.ai` base URL.
- `src/ingest/providers/index.ts` — route `orcarouter` through the OpenAI-compatible summarize dispatch (8 switches) and the OpenClaw fallback-config loader.
- `apps/memos-local-openclaw/README.md` — document the provider (`endpoint: "https://api.orcarouter.ai/v1"`, `sk-orca-` keys).
- `tests/llm-call.test.ts` — unit test covering the `orcarouter` provider call.

Related Issue (Required): N/A — feature addition; no existing issue tracks this.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test — `npx vitest run tests/llm-call.test.ts` → 5/5 pass, including the new `orcarouter` case. Full suite: 377 passed / 14 skipped; the 10 failing tests are pre-existing on `main` (module-format + plugin-impl-access suites, unrelated to this change — verified by running the suite on a clean checkout).
- [x] Test Script Or Test Steps (please provide) — L3 live test against the real gateway through the new code path (`callLLMOnce` with `provider: "orcarouter"`, endpoint `https://api.orcarouter.ai/v1`, model `anthropic/claude-haiku-4.5`):

```text
LIVE_RESULT="ORCA_OK"
LIVE_OK
```

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

I'm an engineer on the OrcaRouter team.
