### PR TITLE
chore: change version number to v2.0.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 ##############################################################################
 
 name = "MemoryOS"
-version = "2.0.27"
+version = "2.0.29"
 description = "Intelligence Begins with Memory"
 license = {text = "Apache-2.0"}
 readme = "README.md"

--- a/src/memos/__init__.py
+++ b/src/memos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.27"
+__version__ = "2.0.29"
 
 from memos.configs.mem_cube import GeneralMemCubeConfig
 from memos.configs.mem_os import MOSConfig


### PR DESCRIPTION
## Description

Update the package version to v2.0.29 in `pyproject.toml` and `src/memos/__init__.py`. No runtime behavior or dependencies change.

Related Issue: N/A

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

- `make format` could not run because Poetry is not installed in the current environment.
- No unit tests were added because this is a version-only metadata change.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | N/A: metadata-only change
- [x] I have added tests that prove my fix is effective or that my feature works | N/A: metadata-only change
- [x] I have created related documentation issue/PR in MemOS-Docs (if applicable) | N/A
- [x] I have linked the issue to this PR (if applicable) | N/A
- [ ] I have mentioned the person who will review this PR | Reviewer not yet assigned

## Reviewer Checklist

- [ ] Made sure checks passed
- [ ] Tests have been provided