### PR TITLE
feat: automate MemOS release preparation

### DIFF
--- a/.github/scripts/memos-version.mjs
+++ b/.github/scripts/memos-version.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MEMOS_PYPROJECT_PATH = "pyproject.toml";
+export const MEMOS_PACKAGE_INIT_PATH = "src/memos/__init__.py";
+
+const STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const PYPROJECT_SECTION_RE = /^\[project\][ \t]*$/gm;
+const TOML_SECTION_RE = /^\[\[?[^\]\r\n]+\]\]?[ \t]*$/gm;
+const PYPROJECT_VERSION_RE = /^version = "([^"]+)"$/gm;
+const PACKAGE_VERSION_RE = /^__version__ = "([^"]+)"$/gm;
+const PYPROJECT_VERSION_ASSIGNMENT_RE = /^[ \t]*version[ \t]*=/gm;
+const PACKAGE_VERSION_ASSIGNMENT_RE =
+  /(?:^|;)[ \t]*__version__(?:[ \t]*:[^=;\n]+)?[ \t]*=/gm;
+const PACKAGE_VERSION_IDENTIFIER_RE = /\b__version__\b/g;
+
+function fail(message) {
+  throw new Error(String(message));
+}
+
+export function normalizeStableMemOSVersion(raw) {
+  const version = String(raw || "").trim();
+  if (!version) fail("MemOS version is required.");
+  if (version.startsWith("v"))
+    fail("MemOS version must not include a leading v.");
+  if (!STABLE_VERSION_RE.test(version)) {
+    fail("MemOS version must be a stable X.Y.Z version without metadata.");
+  }
+  return version;
+}
+
+function compareNumericIdentifier(left, right) {
+  if (left.length !== right.length) return left.length - right.length;
+  return left.localeCompare(right);
+}
+
+export function compareStableMemOSVersions(leftRaw, rightRaw) {
+  const left = normalizeStableMemOSVersion(leftRaw).split(".");
+  const right = normalizeStableMemOSVersion(rightRaw).split(".");
+  for (let index = 0; index < left.length; index += 1) {
+    const comparison = compareNumericIdentifier(left[index], right[index]);
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}
+
+export function expectedReleaseBranches(rawVersion) {
+  const version = normalizeStableMemOSVersion(rawVersion);
+  return {
+    sourceBranch: `dev-v${version}`,
+    releaseBranch: `release/v${version}`,
+  };
+}
+
+function extractSingleVersion(text, pattern, assignmentPattern, path) {
+  const assignments = [...String(text).matchAll(assignmentPattern)];
+  if (assignments.length !== 1) {
+    fail(
+      `${path} must contain exactly one version assignment; found ${assignments.length}.`,
+    );
+  }
+  const matches = [...String(text).matchAll(pattern)];
+  if (matches.length !== 1) {
+    fail(
+      `${path} must contain exactly one canonical version declaration; found ${matches.length}.`,
+    );
+  }
+  return normalizeStableMemOSVersion(matches[0][1]);
+}
+
+function projectSectionBounds(pyprojectText) {
+  const text = String(pyprojectText);
+  const sections = [...text.matchAll(PYPROJECT_SECTION_RE)];
+  if (sections.length !== 1) {
+    fail(
+      `${MEMOS_PYPROJECT_PATH} must contain exactly one [project] section; found ${sections.length}.`,
+    );
+  }
+  const start = sections[0].index + sections[0][0].length;
+  TOML_SECTION_RE.lastIndex = start;
+  const nextSection = TOML_SECTION_RE.exec(text);
+  return { start, end: nextSection?.index ?? text.length };
+}
+
+function inspectPyprojectVersion(pyprojectText) {
+  const bounds = projectSectionBounds(pyprojectText);
+  return extractSingleVersion(
+    String(pyprojectText).slice(bounds.start, bounds.end),
+    PYPROJECT_VERSION_RE,
+    PYPROJECT_VERSION_ASSIGNMENT_RE,
+    `${MEMOS_PYPROJECT_PATH} [project]`,
+  );
+}
+
+function inspectPackageVersion(packageInitText) {
+  const identifiers = [
+    ...String(packageInitText).matchAll(PACKAGE_VERSION_IDENTIFIER_RE),
+  ];
+  if (identifiers.length !== 1) {
+    fail(
+      `${MEMOS_PACKAGE_INIT_PATH} must contain exactly one __version__ identifier; found ${identifiers.length}.`,
+    );
+  }
+  return extractSingleVersion(
+    packageInitText,
+    PACKAGE_VERSION_RE,
+    PACKAGE_VERSION_ASSIGNMENT_RE,
+    MEMOS_PACKAGE_INIT_PATH,
+  );
+}
+
+function replacePyprojectVersion(pyprojectText, expectedVersion) {
+  const text = String(pyprojectText);
+  const bounds = projectSectionBounds(text);
+  const section = text.slice(bounds.start, bounds.end);
+  const nextSection = section.replace(
+    /^version = "[^"]+"$/m,
+    `version = "${expectedVersion}"`,
+  );
+  return `${text.slice(0, bounds.start)}${nextSection}${text.slice(bounds.end)}`;
+}
+
+export function inspectMemOSVersionTexts({ pyprojectText, packageInitText }) {
+  const pyprojectVersion = inspectPyprojectVersion(pyprojectText);
+  const packageVersion = inspectPackageVersion(packageInitText);
+  if (pyprojectVersion !== packageVersion) {
+    fail(
+      `MemOS package versions do not match: ${MEMOS_PYPROJECT_PATH}=${pyprojectVersion}, ` +
+        `${MEMOS_PACKAGE_INIT_PATH}=${packageVersion}.`,
+    );
+  }
+  return { pyprojectVersion, packageVersion, version: pyprojectVersion };
+}
+
+export function assertMemOSVersionTexts({
+  expectedVersion,
+  pyprojectText,
+  packageInitText,
+}) {
+  const expected = normalizeStableMemOSVersion(expectedVersion);
+  const inspected = inspectMemOSVersionTexts({
+    pyprojectText,
+    packageInitText,
+  });
+  if (inspected.version !== expected) {
+    fail(
+      `MemOS package version mismatch: expected ${expected}, but both package files contain ` +
+        `${inspected.version}. Run MemOS Release — Prepare and merge its PR before publishing.`,
+    );
+  }
+  return inspected;
+}
+
+export function updateMemOSVersionTexts({
+  expectedVersion,
+  pyprojectText,
+  packageInitText,
+}) {
+  const expected = normalizeStableMemOSVersion(expectedVersion);
+  const inspected = inspectMemOSVersionTexts({
+    pyprojectText,
+    packageInitText,
+  });
+  const comparison = compareStableMemOSVersions(expected, inspected.version);
+  if (comparison < 0) {
+    fail(
+      `Requested MemOS version ${expected} must be newer than the current version ${inspected.version}.`,
+    );
+  }
+  if (comparison === 0) {
+    return {
+      ...inspected,
+      previousVersion: inspected.version,
+      changed: false,
+      pyprojectText,
+      packageInitText,
+    };
+  }
+
+  const nextPyprojectText = replacePyprojectVersion(pyprojectText, expected);
+  const nextPackageInitText = String(packageInitText).replace(
+    /^__version__ = "[^"]+"$/m,
+    `__version__ = "${expected}"`,
+  );
+  assertMemOSVersionTexts({
+    expectedVersion: expected,
+    pyprojectText: nextPyprojectText,
+    packageInitText: nextPackageInitText,
+  });
+
+  return {
+    pyprojectVersion: expected,
+    packageVersion: expected,
+    version: expected,
+    previousVersion: inspected.version,
+    changed: true,
+    pyprojectText: nextPyprojectText,
+    packageInitText: nextPackageInitText,
+  };
+}
+
+export function updateMemOSVersionFiles({
+  root = process.cwd(),
+  expectedVersion,
+}) {
+  const pyprojectPath = resolve(root, MEMOS_PYPROJECT_PATH);
+  const packageInitPath = resolve(root, MEMOS_PACKAGE_INIT_PATH);
+  const result = updateMemOSVersionTexts({
+    expectedVersion,
+    pyprojectText: readFileSync(pyprojectPath, "utf8"),
+    packageInitText: readFileSync(packageInitPath, "utf8"),
+  });
+  if (result.changed) {
+    writeFileSync(pyprojectPath, result.pyprojectText, "utf8");
+    writeFileSync(packageInitPath, result.packageInitText, "utf8");
+  }
+  return result;
+}
+
+function appendOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  writeFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`, {
+    flag: "a",
+  });
+}
+
+function readMemOSVersionFiles(root) {
+  return {
+    pyprojectText: readFileSync(resolve(root, MEMOS_PYPROJECT_PATH), "utf8"),
+    packageInitText: readFileSync(
+      resolve(root, MEMOS_PACKAGE_INIT_PATH),
+      "utf8",
+    ),
+  };
+}
+
+function escapeWorkflowCommand(value) {
+  return String(value)
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+}
+
+export function run(mode = process.argv[2] || "update") {
+  const root = process.env.MEMOS_VERSION_ROOT || process.cwd();
+  if (mode === "inspect") {
+    const inspected = inspectMemOSVersionTexts(readMemOSVersionFiles(root));
+    appendOutput("version", inspected.version);
+    console.log(`MemOS package version is ${inspected.version}.`);
+    return inspected;
+  }
+
+  const version = normalizeStableMemOSVersion(process.env.RELEASE_VERSION);
+  const branches = expectedReleaseBranches(version);
+  if (mode === "plan") {
+    appendOutput("version", version);
+    appendOutput("source_branch", branches.sourceBranch);
+    appendOutput("release_branch", branches.releaseBranch);
+    console.log(`Prepared release request for MemOS v${version}.`);
+    return { version, ...branches };
+  }
+  if (mode === "require-newer") {
+    const currentVersion = normalizeStableMemOSVersion(
+      process.env.CURRENT_MEMOS_VERSION,
+    );
+    if (compareStableMemOSVersions(version, currentVersion) <= 0) {
+      fail(
+        `Requested MemOS version ${version} must be newer than main package version ${currentVersion}.`,
+      );
+    }
+    console.log(
+      `Requested MemOS version ${version} is newer than main package version ${currentVersion}.`,
+    );
+    return { version, currentVersion, ...branches };
+  }
+  if (mode === "assert") {
+    const inspected = assertMemOSVersionTexts({
+      expectedVersion: version,
+      ...readMemOSVersionFiles(root),
+    });
+    console.log(`MemOS package version matches ${version}.`);
+    return inspected;
+  }
+  if (mode !== "update") fail(`Unsupported memos-version mode: ${mode}`);
+
+  const result = updateMemOSVersionFiles({ root, expectedVersion: version });
+  appendOutput("version", version);
+  appendOutput("source_branch", branches.sourceBranch);
+  appendOutput("release_branch", branches.releaseBranch);
+  appendOutput("previous_version", result.previousVersion);
+  appendOutput("changed", result.changed);
+  console.log(
+    result.changed
+      ? `Updated MemOS package version ${result.previousVersion} -> ${version}.`
+      : `MemOS package version is already ${version}.`,
+  );
+  return result;
+}
+
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))
+) {
+  try {
+    run();
+  } catch (error) {
+    console.error(`::error::${escapeWorkflowCommand(error?.message || error)}`);
+    process.exit(1);
+  }
+}

--- a/.github/scripts/memos-version.test.mjs
+++ b/.github/scripts/memos-version.test.mjs
@@ -1,0 +1,327 @@
+import assert from "node:assert/strict";
+import {
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  MEMOS_PACKAGE_INIT_PATH,
+  MEMOS_PYPROJECT_PATH,
+  assertMemOSVersionTexts,
+  compareStableMemOSVersions,
+  expectedReleaseBranches,
+  inspectMemOSVersionTexts,
+  normalizeStableMemOSVersion,
+  updateMemOSVersionFiles,
+  updateMemOSVersionTexts,
+} from "./memos-version.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const workflowsDir = join(__dirname, "../workflows");
+
+function versionTexts(version = "2.0.29") {
+  return {
+    pyprojectText: `[project]\nname = "MemoryOS"\nversion = "${version}"\ndescription = "test"\n`,
+    packageInitText: `__version__ = "${version}"\n\nfrom memos.example import Example\n`,
+  };
+}
+
+test("accepts only stable MemOS versions without a leading v", () => {
+  assert.equal(normalizeStableMemOSVersion("2.0.30"), "2.0.30");
+  assert.deepEqual(expectedReleaseBranches("2.0.30"), {
+    sourceBranch: "dev-v2.0.30",
+    releaseBranch: "release/v2.0.30",
+  });
+
+  for (const invalid of [
+    "",
+    "v2.0.30",
+    "2.0",
+    "2.0.30-beta.1",
+    "2.0.30+build.1",
+    "02.0.30",
+    "2.0.30; echo unsafe",
+  ]) {
+    assert.throws(
+      () => normalizeStableMemOSVersion(invalid),
+      /stable X\.Y\.Z|leading v|required/,
+    );
+  }
+});
+
+test("compares stable MemOS versions without numeric precision loss", () => {
+  assert.ok(compareStableMemOSVersions("2.0.30", "2.0.29") > 0);
+  assert.ok(compareStableMemOSVersions("10.0.0", "2.99.99") > 0);
+  assert.ok(
+    compareStableMemOSVersions(
+      "2.0.10000000000000000000",
+      "2.0.9999999999999999999",
+    ) > 0,
+  );
+  assert.equal(compareStableMemOSVersions("2.0.30", "2.0.30"), 0);
+});
+
+test("updates both MemOS version declarations and preserves surrounding content", () => {
+  const current = versionTexts();
+  const result = updateMemOSVersionTexts({
+    expectedVersion: "2.0.30",
+    ...current,
+  });
+
+  assert.equal(result.previousVersion, "2.0.29");
+  assert.equal(result.version, "2.0.30");
+  assert.equal(result.changed, true);
+  assert.equal(
+    result.pyprojectText,
+    `[project]\nname = "MemoryOS"\nversion = "2.0.30"\ndescription = "test"\n`,
+  );
+  assert.equal(
+    result.packageInitText,
+    `__version__ = "2.0.30"\n\nfrom memos.example import Example\n`,
+  );
+});
+
+test("updates only the version in the pyproject project section", () => {
+  const result = updateMemOSVersionTexts({
+    expectedVersion: "2.0.30",
+    pyprojectText: `[project]\nversion = "2.0.29"\n\n[example]\nversion = "9.9.9"\n\n[[example.index]]\nversion = "8.8.8"\n`,
+    packageInitText: `__version__ = "2.0.29"\n`,
+  });
+
+  assert.equal(
+    result.pyprojectText,
+    `[project]\nversion = "2.0.30"\n\n[example]\nversion = "9.9.9"\n\n[[example.index]]\nversion = "8.8.8"\n`,
+  );
+});
+
+test("is idempotent when both declarations already match", () => {
+  const current = versionTexts("2.0.30");
+  const result = updateMemOSVersionTexts({
+    expectedVersion: "2.0.30",
+    ...current,
+  });
+
+  assert.equal(result.changed, false);
+  assert.equal(result.previousVersion, "2.0.30");
+  assert.deepEqual(inspectMemOSVersionTexts(current), {
+    pyprojectVersion: "2.0.30",
+    packageVersion: "2.0.30",
+    version: "2.0.30",
+  });
+});
+
+test("fails closed for mismatched, malformed, duplicate, or downgraded versions", () => {
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        packageInitText: `__version__ = "2.0.28"\n`,
+      }),
+    /do not match/,
+  );
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        pyprojectText: `[project]\nversion = "2.0.29"\nversion = "2.0.30"\n`,
+      }),
+    /exactly one/,
+  );
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        pyprojectText: `[project]\nversion = "2.0.29"\nversion='2.0.30'\n`,
+      }),
+    /exactly one version assignment/,
+  );
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        packageInitText: `__version__ = "2.0.29"\n__version__='1.0.0'\n`,
+      }),
+    /exactly one __version__ identifier/,
+  );
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        packageInitText: `__version__ = "2.0.29"; __version__ = "1.0.0"\n`,
+      }),
+    /exactly one __version__ identifier/,
+  );
+  assert.throws(
+    () =>
+      inspectMemOSVersionTexts({
+        ...versionTexts(),
+        packageInitText: `__version__ = "2.0.29"\nif True: __version__ = "1.0.0"\n`,
+      }),
+    /exactly one __version__ identifier/,
+  );
+  assert.throws(
+    () =>
+      updateMemOSVersionTexts({ expectedVersion: "2.0.28", ...versionTexts() }),
+    /must be newer/,
+  );
+  assert.throws(
+    () =>
+      assertMemOSVersionTexts({ expectedVersion: "2.0.30", ...versionTexts() }),
+    /expected 2\.0\.30/,
+  );
+});
+
+test("updates the repository files as one version pair", () => {
+  const root = mkdtempSync(join(tmpdir(), "memos-version-test-"));
+  const current = versionTexts();
+  const pyprojectPath = join(root, MEMOS_PYPROJECT_PATH);
+  const packageInitPath = join(root, MEMOS_PACKAGE_INIT_PATH);
+  mkdirSync(dirname(packageInitPath), { recursive: true });
+  writeFileSync(pyprojectPath, current.pyprojectText);
+  writeFileSync(packageInitPath, current.packageInitText);
+
+  const result = updateMemOSVersionFiles({ root, expectedVersion: "2.0.30" });
+
+  assert.equal(result.changed, true);
+  assert.match(readFileSync(pyprojectPath, "utf8"), /^version = "2\.0\.30"$/m);
+  assert.match(
+    readFileSync(packageInitPath, "utf8"),
+    /^__version__ = "2\.0\.30"$/m,
+  );
+});
+
+test("runs from a trusted copy reached through a symbolic path", () => {
+  const root = mkdtempSync(join(tmpdir(), "memos-version-cli-test-"));
+  const realDirectory = join(root, "real");
+  const linkedDirectory = join(root, "linked");
+  const outputPath = join(root, "output.txt");
+  mkdirSync(realDirectory);
+  symlinkSync(realDirectory, linkedDirectory, "dir");
+  copyFileSync(
+    join(__dirname, "memos-version.mjs"),
+    join(realDirectory, "memos-version.mjs"),
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [join(linkedDirectory, "memos-version.mjs"), "plan"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        RELEASE_VERSION: "2.0.30",
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(readFileSync(outputPath, "utf8"), /^version=2\.0\.30$/m);
+  assert.match(
+    readFileSync(outputPath, "utf8"),
+    /^source_branch=dev-v2\.0\.30$/m,
+  );
+  assert.match(
+    readFileSync(outputPath, "utf8"),
+    /^release_branch=release\/v2\.0\.30$/m,
+  );
+});
+
+test("prepare workflow creates a guarded release branch and manual PR handoff without touching dev", () => {
+  const workflow = readFileSync(
+    join(workflowsDir, "memos-release-prepare.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /name: MemOS Release — Prepare/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(
+    workflow,
+    /permissions:\n\s+contents: write\n\s+pull-requests: read/,
+  );
+  assert.match(workflow, /concurrency:/);
+  assert.match(workflow, /SELECTED_BRANCH: \$\{\{ github\.ref_name \}\}/);
+  assert.match(workflow, /SELECTED_REF: \$\{\{ github\.ref \}\}/);
+  assert.match(workflow, /SELECTED_REF_TYPE: \$\{\{ github\.ref_type \}\}/);
+  assert.match(workflow, /expected_ref="refs\/heads\/\$\{DEFAULT_BRANCH\}"/);
+  assert.match(
+    workflow,
+    /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/,
+  );
+  assert.match(workflow, /RELEASE_VERSION: \$\{\{ inputs\.version \}\}/);
+  assert.match(workflow, /node "\$\{RUNNER_TEMP\}\/memos-version\.mjs"/);
+  assert.match(workflow, /refs\/heads\/\$\{SOURCE_BRANCH\}/);
+  assert.match(workflow, /refs\/heads\/\$\{RELEASE_BRANCH\}/);
+  assert.match(workflow, /merge-base --is-ancestor/);
+  assert.match(workflow, /merged_branch_deleted/);
+  assert.match(workflow, /require-newer/);
+  assert.match(workflow, /assert_release_matches_trusted_update/);
+  assert.match(workflow, /cmp -s/);
+  assert.match(workflow, /git diff --name-only/);
+  assert.match(workflow, /pyproject\.toml/);
+  assert.match(workflow, /src\/memos\/__init__\.py/);
+  assert.match(
+    workflow,
+    /chore: change version number to v\$\{RELEASE_VERSION\}/,
+  );
+  assert.match(workflow, /gh pr list/);
+  assert.match(workflow, /The PR is intentionally opened by a maintainer/);
+  assert.doesNotMatch(workflow, /gh pr create/);
+  assert.match(
+    workflow,
+    /compare\/\$\{DEFAULT_BRANCH\}\.\.\.\$\{RELEASE_BRANCH\}/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /git push[^\n]*refs\/heads\/\$\{SOURCE_BRANCH\}/,
+  );
+  assert.doesNotMatch(workflow, /--force/);
+  assert.doesNotMatch(workflow, /run:[^\n]*\$\{\{ inputs\./);
+});
+
+test("publish inspection fails closed unless the target ref contains the requested package version", () => {
+  const publishScript = readFileSync(
+    join(__dirname, "prepare-memos-release.mjs"),
+    "utf8",
+  );
+  const publishWorkflow = readFileSync(
+    join(workflowsDir, "memos-release-publish-main.yml"),
+    "utf8",
+  );
+
+  assert.match(publishScript, /assertMemOSVersionTexts/);
+  assert.match(publishScript, /target\.sha/);
+  assert.match(publishScript, /MEMOS_PYPROJECT_PATH/);
+  assert.match(publishScript, /MEMOS_PACKAGE_INIT_PATH/);
+  assert.match(publishWorkflow, /memos-version\.test\.mjs/);
+  assert.match(publishScript, /"refs\/remotes\/origin\/main"/);
+  assert.equal(
+    existsSync(join(workflowsDir, "memos-release-publish.yml")),
+    false,
+    "the legacy path must remain absent so old dev workflow revisions cannot be dispatched",
+  );
+  assert.match(
+    publishWorkflow,
+    /SELECTED_BRANCH: \$\{\{ github\.ref_name \}\}/,
+  );
+  assert.match(publishWorkflow, /SELECTED_REF: \$\{\{ github\.ref \}\}/);
+  assert.match(
+    publishWorkflow,
+    /SELECTED_REF_TYPE: \$\{\{ github\.ref_type \}\}/,
+  );
+  assert.match(
+    publishWorkflow,
+    /DEFAULT_BRANCH: \$\{\{ github\.event\.repository\.default_branch \}\}/,
+  );
+});

--- a/.github/scripts/prepare-memos-release.mjs
+++ b/.github/scripts/prepare-memos-release.mjs
@@ -6,6 +6,11 @@ import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 import { buildLocalPluginReleaseIntent } from "./append-local-plugin-release-intent.mjs";
+import {
+  MEMOS_PACKAGE_INIT_PATH,
+  MEMOS_PYPROJECT_PATH,
+  assertMemOSVersionTexts,
+} from "./memos-version.mjs";
 
 export const PRODUCT_ID = "openclaw-local-plugin";
 export const PRODUCT_PATH = "apps/memos-local-plugin";
@@ -277,6 +282,20 @@ function resolveRef(ref) {
     if (sha) return { ref: candidate, sha };
   }
   fail(`Cannot resolve target ref to a commit: ${value}`);
+}
+
+export function assertMemOSVersionAtRef(expectedVersion, targetRef) {
+  const ref = String(targetRef || "").trim();
+  if (!ref) fail("A target ref is required to validate the MemOS package version.");
+  let pyprojectText;
+  let packageInitText;
+  try {
+    pyprojectText = sh(["show", `${ref}:${MEMOS_PYPROJECT_PATH}`]);
+    packageInitText = sh(["show", `${ref}:${MEMOS_PACKAGE_INIT_PATH}`]);
+  } catch {
+    fail(`Cannot read both MemOS package version files from release target ${ref}.`);
+  }
+  return assertMemOSVersionTexts({ expectedVersion, pyprojectText, packageInitText });
 }
 
 export function existingReleaseTagState(currentTag, targetSha) {
@@ -1521,7 +1540,8 @@ export async function run() {
   const repo = process.env.GITHUB_REPOSITORY || "MemTensor/MemOS";
   const targetRefInput = process.env.TARGET_REF || "main";
   validateReleaseTarget({ dryRun, targetRef: targetRefInput });
-  const target = resolveRef(targetRefInput);
+  const target = resolveRef(dryRun === "true" ? targetRefInput : "refs/remotes/origin/main");
+  const memosPackageVersion = assertMemOSVersionAtRef(version, target.sha);
   const allTags = listTags();
   const previousTag = process.env.PREVIOUS_TAG || findPreviousMemOSTag(version, currentTag, allTags);
   if (!previousTag) fail(`Cannot find previous MemOS v* tag before ${currentTag}.`);
@@ -1819,6 +1839,7 @@ export async function run() {
   appendOutput("publish_block_reason", existingTag.publish_blocked ? existingTag.message : "");
   appendOutput("target_ref", target.ref);
   appendOutput("target_sha", target.sha);
+  appendOutput("memos_package_version", memosPackageVersion.version);
   appendOutput("has_product_changes", String(evidence.has_product_changes));
   appendOutput("has_user_facing_product_changes", String(evidence.has_user_facing_product_changes));
   appendOutput("docs_action", preview.docs_action);

--- a/.github/scripts/prepare-memos-release.test.mjs
+++ b/.github/scripts/prepare-memos-release.test.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import {
   PRODUCT_ID,
   RELEASE_NOTE_METHODS,
+  assertMemOSVersionAtRef,
   buildDocsPreview,
   collectLocalPluginEvidence,
   compareSemver,
@@ -322,7 +323,7 @@ test("requires an exact publish confirmation for non-dry-run releases", () => {
 });
 
 test("publish workflow defaults real releases to draft before release.published", () => {
-  const workflow = readFileSync(join(workflowsDir, "memos-release-publish.yml"), "utf8");
+  const workflow = readFileSync(join(workflowsDir, "memos-release-publish-main.yml"), "utf8");
   assert.match(workflow, /create_draft_release:/);
   assert.match(workflow, /default:\s+true/);
   assert.match(workflow, /CREATE_DRAFT_RELEASE/);
@@ -494,6 +495,9 @@ test("read-only dry-run workflows declare bounded fallback behavior", () => {
     assert.match(workflow, /ALLOW_OFFLINE_DOCS_PREVIEW: true/);
     assert.match(workflow, /offline_docs_preview: true/);
     assert.match(workflow, /production publish does not set ALLOW_OFFLINE_DOCS_PREVIEW/);
+    assert.match(workflow, /TARGET_REF: \$\{\{ github\.sha \}\}/);
+    assert.match(workflow, /\.github\/workflows\/memos-release-publish\.yml/);
+    assert.doesNotMatch(workflow, /TARGET_REF: origin\/main|TARGET_REF: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
   }
 });
 
@@ -522,6 +526,23 @@ test("allows flexible target refs only for dry runs", () => {
   assert.doesNotThrow(() => validateReleaseTarget({ dryRun: "false", targetRef: "main" }));
   assert.throws(() => validateReleaseTarget({ dryRun: "false", targetRef: "origin/main" }), /exactly main/);
   assert.throws(() => validateReleaseTarget({ dryRun: "false", targetRef: "feature/test" }), /exactly main/);
+});
+
+test("validates both MemOS package versions at the exact release target", () => {
+  withFixtureRepo(() => {
+    writeRepoFile("pyproject.toml", `[project]\nname = "MemoryOS"\nversion = "9.9.1"\n`);
+    writeRepoFile("src/memos/__init__.py", `__version__ = "9.9.1"\n`);
+    commitAll("chore: prepare package version");
+    const target = git(["rev-parse", "HEAD"]).trim();
+
+    assert.equal(assertMemOSVersionAtRef("9.9.1", target).version, "9.9.1");
+    assert.throws(() => assertMemOSVersionAtRef("9.9.2", target), /expected 9\.9\.2/);
+
+    writeRepoFile("src/memos/__init__.py", `__version__ = "9.9.0"\n`);
+    commitAll("test: create mismatched package version");
+    const mismatchedTarget = git(["rev-parse", "HEAD"]).trim();
+    assert.throws(() => assertMemOSVersionAtRef("9.9.1", mismatchedTarget), /do not match/);
+  });
 });
 
 test("reports absent, matching, and conflicting manual release tags", () => {

--- a/.github/workflows/memos-release-post-merge-dry-run.yml
+++ b/.github/workflows/memos-release-post-merge-dry-run.yml
@@ -6,11 +6,17 @@ on:
       - main
     paths:
       - ".github/workflows/memos-release-publish.yml"
+      - ".github/workflows/memos-release-publish-main.yml"
+      - ".github/workflows/memos-release-prepare.yml"
       - ".github/workflows/memos-release-pre-merge-dry-run.yml"
       - ".github/workflows/memos-release-post-merge-dry-run.yml"
+      - ".github/scripts/memos-version.mjs"
+      - ".github/scripts/memos-version.test.mjs"
       - ".github/scripts/prepare-memos-release.mjs"
       - ".github/scripts/prepare-memos-release.test.mjs"
       - ".github/scripts/retry.sh"
+      - "pyproject.toml"
+      - "src/memos/__init__.py"
 
 concurrency:
   group: memos-release-post-merge-dry-run-main
@@ -40,11 +46,19 @@ jobs:
           git fetch --tags --force origin
           git fetch origin '+refs/heads/*:refs/remotes/origin/*'
 
-      - name: Infer next stable release version for preview
+      - name: Read stable package version for preview
         id: version
         shell: bash
         run: |
           set -euo pipefail
+          version_output="${RUNNER_TEMP}/memos-package-version.out"
+          : > "${version_output}"
+          GITHUB_OUTPUT="${version_output}" node .github/scripts/memos-version.mjs inspect
+          version="$(sed -n 's/^version=//p' "${version_output}")"
+          if [ -z "${version}" ]; then
+            echo "::error::Cannot read the stable MemOS package version."
+            exit 1
+          fi
           latest="$(
             git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --merged origin/main --sort=-v:refname |
               grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
@@ -54,22 +68,19 @@ jobs:
             echo "::error::Cannot infer the latest MemOS stable tag from origin/main."
             exit 1
           fi
-          version="${latest#v}"
-          IFS=. read -r major minor patch <<< "${version}"
-          next_version="${major}.${minor}.$((patch + 1))"
-          echo "version=${next_version}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "latest_tag=${latest}" >> "${GITHUB_OUTPUT}"
 
       - name: Run release workflow tests
         shell: bash
-        run: node --test .github/scripts/prepare-memos-release.test.mjs
+        run: node --test .github/scripts/memos-version.test.mjs .github/scripts/prepare-memos-release.test.mjs
 
       - name: Prepare offline release inspection
         id: prepare
         shell: bash
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          TARGET_REF: origin/main
+          TARGET_REF: ${{ github.sha }}
           DRY_RUN: true
           GITHUB_TOKEN: ${{ github.token }}
           # Post-merge smoke check fallback. Manual publish still requires GitHub/Doc Agent validation.

--- a/.github/workflows/memos-release-pre-merge-dry-run.yml
+++ b/.github/workflows/memos-release-pre-merge-dry-run.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     paths:
       - ".github/workflows/memos-release-publish.yml"
+      - ".github/workflows/memos-release-publish-main.yml"
+      - ".github/workflows/memos-release-prepare.yml"
       - ".github/workflows/memos-release-pre-merge-dry-run.yml"
       - ".github/workflows/memos-release-post-merge-dry-run.yml"
+      - ".github/scripts/memos-version.mjs"
+      - ".github/scripts/memos-version.test.mjs"
       - ".github/scripts/prepare-memos-release.mjs"
       - ".github/scripts/prepare-memos-release.test.mjs"
       - ".github/scripts/retry.sh"
+      - "pyproject.toml"
+      - "src/memos/__init__.py"
 
 concurrency:
   group: memos-release-pre-merge-dry-run-${{ github.event.pull_request.number || github.ref }}
@@ -38,11 +44,19 @@ jobs:
           git fetch --tags --force origin
           git fetch origin '+refs/heads/*:refs/remotes/origin/*'
 
-      - name: Infer next stable release version for preview
+      - name: Read stable package version for preview
         id: version
         shell: bash
         run: |
           set -euo pipefail
+          version_output="${RUNNER_TEMP}/memos-package-version.out"
+          : > "${version_output}"
+          GITHUB_OUTPUT="${version_output}" node .github/scripts/memos-version.mjs inspect
+          version="$(sed -n 's/^version=//p' "${version_output}")"
+          if [ -z "${version}" ]; then
+            echo "::error::Cannot read the stable MemOS package version."
+            exit 1
+          fi
           latest="$(
             git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --merged origin/main --sort=-v:refname |
               grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
@@ -52,22 +66,19 @@ jobs:
             echo "::error::Cannot infer the latest MemOS stable tag from origin/main."
             exit 1
           fi
-          version="${latest#v}"
-          IFS=. read -r major minor patch <<< "${version}"
-          next_version="${major}.${minor}.$((patch + 1))"
-          echo "version=${next_version}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
           echo "latest_tag=${latest}" >> "${GITHUB_OUTPUT}"
 
       - name: Run release workflow tests
         shell: bash
-        run: node --test .github/scripts/prepare-memos-release.test.mjs
+        run: node --test .github/scripts/memos-version.test.mjs .github/scripts/prepare-memos-release.test.mjs
 
       - name: Prepare offline release inspection
         id: prepare
         shell: bash
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          TARGET_REF: origin/main
+          TARGET_REF: ${{ github.sha }}
           DRY_RUN: true
           GITHUB_TOKEN: ${{ github.token }}
           # PR-only local fallback. Production publish requires GitHub/Doc Agent validation.

--- a/.github/workflows/memos-release-prepare.yml
+++ b/.github/workflows/memos-release-prepare.yml
@@ -1,0 +1,366 @@
+name: MemOS Release — Prepare
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Stable MemOS version without leading v (for example 2.0.30)"
+        required: true
+        type: string
+
+concurrency:
+  group: memos-release-prepare
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  prepare:
+    if: ${{ github.repository == 'MemTensor/MemOS' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Require the default-branch workflow
+        shell: bash
+        env:
+          SELECTED_REF: ${{ github.ref }}
+          SELECTED_REF_TYPE: ${{ github.ref_type }}
+          SELECTED_BRANCH: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/${DEFAULT_BRANCH}"
+          if [ "${SELECTED_REF_TYPE}" != branch ] || [ "${SELECTED_REF}" != "${expected_ref}" ] || [ "${SELECTED_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+            echo "::error::Use workflow from must be branch ${expected_ref}; received ${SELECTED_REF}."
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Test version automation
+        run: node --test .github/scripts/memos-version.test.mjs
+
+      - name: Preserve trusted version automation
+        shell: bash
+        run: cp .github/scripts/memos-version.mjs "${RUNNER_TEMP}/memos-version.mjs"
+
+      - name: Validate release request and fetch source
+        id: request
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          output_file="${RUNNER_TEMP}/memos-version-request.out"
+          : > "${output_file}"
+          RELEASE_VERSION="${RELEASE_VERSION}" GITHUB_OUTPUT="${output_file}" \
+            node "${RUNNER_TEMP}/memos-version.mjs" plan
+
+          version="$(sed -n 's/^version=//p' "${output_file}")"
+          source_branch="$(sed -n 's/^source_branch=//p' "${output_file}")"
+          release_branch="$(sed -n 's/^release_branch=//p' "${output_file}")"
+          if [ -z "${version}" ] || [ -z "${source_branch}" ] || [ -z "${release_branch}" ]; then
+            echo "::error::Version automation did not return the expected release request."
+            exit 1
+          fi
+          {
+            echo "version=${version}"
+            echo "source_branch=${source_branch}"
+            echo "release_branch=${release_branch}"
+          } >> "${GITHUB_OUTPUT}"
+
+          git fetch --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}" \
+            "+refs/heads/${source_branch}:refs/remotes/origin/${source_branch}"
+          if git ls-remote --exit-code --heads origin "refs/heads/${release_branch}" >/dev/null 2>&1; then
+            git fetch --no-tags origin \
+              "+refs/heads/${release_branch}:refs/remotes/origin/${release_branch}"
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
+            echo "::error::Tag v${version} already exists; refusing to prepare an already tagged release."
+            exit 1
+          fi
+
+      - name: Create or verify release branch
+        id: branch
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.request.outputs.version }}
+          SOURCE_BRANCH: ${{ steps.request.outputs.source_branch }}
+          RELEASE_BRANCH: ${{ steps.request.outputs.release_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          source_ref="refs/remotes/origin/${SOURCE_BRANCH}"
+          release_ref="refs/remotes/origin/${RELEASE_BRANCH}"
+          main_ref="refs/remotes/origin/${DEFAULT_BRANCH}"
+          source_sha="$(git rev-parse --verify "${source_ref}^{commit}")"
+          main_sha="$(git rev-parse --verify "${main_ref}^{commit}")"
+          expected_files="$(printf '%s\n' pyproject.toml src/memos/__init__.py)"
+          expected_commit="chore: change version number to v${RELEASE_VERSION}"
+          already_merged=false
+          branch_status=missing
+          release_exists=false
+          release_is_ancestor_main=false
+
+          materialize_ref_version() {
+            local ref="$1"
+            local root="${2:-${RUNNER_TEMP}/memos-version-assert}"
+            mkdir -p "${root}/src/memos"
+            git show "${ref}:pyproject.toml" > "${root}/pyproject.toml"
+            git show "${ref}:src/memos/__init__.py" > "${root}/src/memos/__init__.py"
+          }
+
+          inspect_ref_version() {
+            local ref="$1"
+            local output="${RUNNER_TEMP}/memos-version-inspect.out"
+            materialize_ref_version "${ref}"
+            : > "${output}"
+            MEMOS_VERSION_ROOT="${RUNNER_TEMP}/memos-version-assert" GITHUB_OUTPUT="${output}" \
+              node "${RUNNER_TEMP}/memos-version.mjs" inspect >&2
+            sed -n 's/^version=//p' "${output}"
+          }
+
+          assert_ref_version() {
+            local ref="$1"
+            materialize_ref_version "${ref}"
+            MEMOS_VERSION_ROOT="${RUNNER_TEMP}/memos-version-assert" RELEASE_VERSION="${RELEASE_VERSION}" \
+              node "${RUNNER_TEMP}/memos-version.mjs" assert
+          }
+
+          assert_release_matches_trusted_update() {
+            local release_sha="$1"
+            local expected_root="${RUNNER_TEMP}/memos-version-expected"
+            local actual_root="${RUNNER_TEMP}/memos-version-actual"
+            local expected_output="${RUNNER_TEMP}/memos-version-expected.out"
+            materialize_ref_version "${source_sha}" "${expected_root}"
+            : > "${expected_output}"
+            MEMOS_VERSION_ROOT="${expected_root}" RELEASE_VERSION="${RELEASE_VERSION}" GITHUB_OUTPUT="${expected_output}" \
+              node "${RUNNER_TEMP}/memos-version.mjs" update
+            materialize_ref_version "${release_sha}" "${actual_root}"
+            if ! cmp -s "${expected_root}/pyproject.toml" "${actual_root}/pyproject.toml" || \
+              ! cmp -s "${expected_root}/src/memos/__init__.py" "${actual_root}/src/memos/__init__.py"; then
+              echo "::error::${RELEASE_BRANCH} version files do not exactly match the trusted update of ${SOURCE_BRANCH}."
+              exit 1
+            fi
+          }
+
+          if git rev-parse --verify "${release_ref}^{commit}" >/dev/null 2>&1; then
+            release_exists=true
+            branch_status=existing
+            release_sha="$(git rev-parse --verify "${release_ref}^{commit}")"
+            if ! git merge-base --is-ancestor "${source_sha}" "${release_sha}"; then
+              echo "::error::${RELEASE_BRANCH} does not contain the current ${SOURCE_BRANCH} tip. Refusing to rewrite it."
+              exit 1
+            fi
+            release_commit_count="$(git rev-list --count "${source_sha}..${release_sha}")"
+            changed_files="$(git diff --name-only "${source_sha}..${release_sha}")"
+            if [ "${release_commit_count}" = 0 ]; then
+              if [ -n "${changed_files}" ]; then
+                echo "::error::${RELEASE_BRANCH} has an invalid zero-commit diff."
+                exit 1
+              fi
+            elif [ "${release_commit_count}" = 1 ]; then
+              if [ "${changed_files}" != "${expected_files}" ]; then
+                echo "::error::${RELEASE_BRANCH} must change exactly the two MemOS version files."
+                printf 'Expected:\n%s\nActual:\n%s\n' "${expected_files}" "${changed_files}"
+                exit 1
+              fi
+              actual_commit="$(git show -s --format=%s "${release_sha}")"
+              if [ "${actual_commit}" != "${expected_commit}" ]; then
+                echo "::error::${RELEASE_BRANCH} has an unexpected release commit."
+                exit 1
+              fi
+            else
+              echo "::error::${RELEASE_BRANCH} contains ${release_commit_count} commits beyond ${SOURCE_BRANCH}; expected at most one version commit."
+              exit 1
+            fi
+            assert_ref_version "${release_sha}"
+            assert_release_matches_trusted_update "${release_sha}"
+            if git merge-base --is-ancestor "${release_sha}" "${main_sha}"; then
+              release_is_ancestor_main=true
+            fi
+          fi
+
+          main_version="$(inspect_ref_version "${main_sha}")"
+          if [ "${main_version}" = "${RELEASE_VERSION}" ]; then
+            if [ "${release_exists}" = true ] && [ "${release_is_ancestor_main}" = true ]; then
+              already_merged=true
+              branch_status=merged
+            elif [ "${release_exists}" = false ] && git merge-base --is-ancestor "${source_sha}" "${main_sha}"; then
+              release_sha="${main_sha}"
+              already_merged=true
+              branch_status=merged_branch_deleted
+            else
+              echo "::error::${DEFAULT_BRANCH} already declares v${RELEASE_VERSION}, but it does not contain the validated release source. Review repository history before publishing."
+              exit 1
+            fi
+          else
+            CURRENT_MEMOS_VERSION="${main_version}" RELEASE_VERSION="${RELEASE_VERSION}" \
+              node "${RUNNER_TEMP}/memos-version.mjs" require-newer
+            if [ "${release_is_ancestor_main}" = true ]; then
+              echo "::error::${RELEASE_BRANCH} is already merged, but ${DEFAULT_BRANCH} now declares ${main_version} instead of ${RELEASE_VERSION}."
+              exit 1
+            fi
+          fi
+
+          if [ "${release_exists}" = false ] && [ "${already_merged}" = false ]; then
+            git switch --detach "${source_sha}"
+            update_output="${RUNNER_TEMP}/memos-version-update.out"
+            : > "${update_output}"
+            RELEASE_VERSION="${RELEASE_VERSION}" GITHUB_OUTPUT="${update_output}" \
+              node "${RUNNER_TEMP}/memos-version.mjs" update
+            changed="$(sed -n 's/^changed=//p' "${update_output}")"
+            changed_files="$(git diff --name-only)"
+            if [ "${changed}" = true ]; then
+              if [ "${changed_files}" != "${expected_files}" ]; then
+                echo "::error::Version preparation must change exactly the two MemOS version files."
+                printf 'Expected:\n%s\nActual:\n%s\n' "${expected_files}" "${changed_files}"
+                exit 1
+              fi
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git add pyproject.toml src/memos/__init__.py
+              git commit -m "${expected_commit}"
+            elif [ "${changed}" = false ]; then
+              if [ -n "${changed_files}" ]; then
+                echo "::error::Version automation reported no change but left a dirty worktree."
+                exit 1
+              fi
+            else
+              echo "::error::Version automation returned an invalid changed state."
+              exit 1
+            fi
+            release_sha="$(git rev-parse HEAD)"
+
+            remote_source_sha="$(git ls-remote --heads origin "refs/heads/${SOURCE_BRANCH}" | awk '{print $1}')"
+            if [ "${remote_source_sha}" != "${source_sha}" ]; then
+              echo "::error::${SOURCE_BRANCH} moved while the release was being prepared. Rerun to include its latest commit."
+              exit 1
+            fi
+            git push origin "HEAD:refs/heads/${RELEASE_BRANCH}"
+            remote_release_sha="$(git ls-remote --heads origin "refs/heads/${RELEASE_BRANCH}" | awk '{print $1}')"
+            if [ "${remote_release_sha}" != "${release_sha}" ]; then
+              echo "::error::Remote ${RELEASE_BRANCH} does not match the validated release commit."
+              exit 1
+            fi
+            branch_status=created
+          fi
+
+          remote_source_sha="$(git ls-remote --heads origin "refs/heads/${SOURCE_BRANCH}" | awk '{print $1}')"
+          if [ "${remote_source_sha}" != "${source_sha}" ]; then
+            echo "::error::${SOURCE_BRANCH} moved during validation. Rerun to include its latest commit."
+            exit 1
+          fi
+          if [ "${release_exists}" = true ]; then
+            remote_release_sha="$(git ls-remote --heads origin "refs/heads/${RELEASE_BRANCH}" | awk '{print $1}')"
+            if [ "${remote_release_sha}" != "${release_sha}" ]; then
+              echo "::error::${RELEASE_BRANCH} moved during validation. Rerun before creating or reviewing its PR."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "source_sha=${source_sha}"
+            echo "release_sha=${release_sha}"
+            echo "already_merged=${already_merged}"
+            echo "branch_status=${branch_status}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Locate existing release PR
+        if: ${{ steps.branch.outputs.already_merged != 'true' }}
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.request.outputs.version }}
+          SOURCE_BRANCH: ${{ steps.request.outputs.source_branch }}
+          RELEASE_BRANCH: ${{ steps.request.outputs.release_branch }}
+          RELEASE_SHA: ${{ steps.branch.outputs.release_sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          pr_url="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${RELEASE_BRANCH}" \
+            --json url,headRefOid,headRepositoryOwner \
+            --jq '[.[] | select(.headRepositoryOwner.login == "MemTensor")][0].url // ""')"
+          pr_head_sha="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state open \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${RELEASE_BRANCH}" \
+            --json headRefOid,headRepositoryOwner \
+            --jq '[.[] | select(.headRepositoryOwner.login == "MemTensor")][0].headRefOid // ""')"
+          closed_url="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --state closed \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${RELEASE_BRANCH}" \
+            --json url,mergedAt,headRepositoryOwner \
+            --jq '[.[] | select(.mergedAt == null and .headRepositoryOwner.login == "MemTensor")][0].url // ""')"
+          if [ -n "${pr_url}" ] && [ "${pr_head_sha}" != "${RELEASE_SHA}" ]; then
+            echo "::error::The open release PR head ${pr_head_sha} does not match validated branch ${RELEASE_SHA}."
+            exit 1
+          fi
+          if [ -z "${pr_url}" ] && [ -n "${closed_url}" ]; then
+            echo "::error::A release PR for ${RELEASE_BRANCH} was closed without merging (${closed_url}). Review it before retrying."
+            exit 1
+          fi
+          if [ -z "${pr_url}" ]; then
+            compare_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${RELEASE_BRANCH}?expand=1"
+          else
+            compare_url=""
+          fi
+          {
+            echo "url=${pr_url}"
+            echo "compare_url=${compare_url}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Summarize release preparation
+        if: ${{ steps.branch.outcome == 'success' && (steps.branch.outputs.already_merged == 'true' || steps.pr.outcome == 'success') }}
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.request.outputs.version }}
+          SOURCE_BRANCH: ${{ steps.request.outputs.source_branch }}
+          RELEASE_BRANCH: ${{ steps.request.outputs.release_branch }}
+          SOURCE_SHA: ${{ steps.branch.outputs.source_sha }}
+          RELEASE_SHA: ${{ steps.branch.outputs.release_sha }}
+          ALREADY_MERGED: ${{ steps.branch.outputs.already_merged }}
+          BRANCH_STATUS: ${{ steps.branch.outputs.branch_status }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          COMPARE_URL: ${{ steps.pr.outputs.compare_url }}
+        run: |
+          {
+            echo "## MemOS v${RELEASE_VERSION} prepared"
+            echo
+            echo "- Source: \`${SOURCE_BRANCH}\` at \`${SOURCE_SHA}\`"
+            if [ "${BRANCH_STATUS}" = merged_branch_deleted ]; then
+              echo "- Release commit: \`${RELEASE_SHA}\` (the merged release branch was automatically deleted)"
+            else
+              echo "- Release branch: \`${RELEASE_BRANCH}\` at \`${RELEASE_SHA}\`"
+            fi
+            if [ "${ALREADY_MERGED}" = true ]; then
+              echo "- Status: already merged into the default branch"
+            elif [ -n "${PR_URL}" ]; then
+              echo "- Release PR: ${PR_URL}"
+            else
+              echo "- Create release PR: ${COMPARE_URL}"
+              echo "- PR title: \`chore: prepare release v${RELEASE_VERSION}\`"
+              echo "- The PR is intentionally opened by a maintainer so GitHub runs the required pull-request checks."
+            fi
+            echo
+            echo "After review, required checks, and merge, run **MemOS Release — Publish** from main."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/memos-release-publish-main.yml
+++ b/.github/workflows/memos-release-publish-main.yml
@@ -62,6 +62,21 @@ jobs:
       publish_blocked: ${{ steps.prepare.outputs.publish_blocked }}
       publish_block_reason: ${{ steps.prepare.outputs.publish_block_reason }}
     steps:
+      - name: Require the default-branch workflow
+        shell: bash
+        env:
+          SELECTED_REF: ${{ github.ref }}
+          SELECTED_REF_TYPE: ${{ github.ref_type }}
+          SELECTED_BRANCH: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/${DEFAULT_BRANCH}"
+          if [ "${SELECTED_REF_TYPE}" != branch ] || [ "${SELECTED_REF}" != "${expected_ref}" ] || [ "${SELECTED_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+            echo "::error::Use workflow from must be branch ${expected_ref}; received ${SELECTED_REF}."
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
@@ -82,6 +97,7 @@ jobs:
         shell: bash
         run: |
           node --test \
+            .github/scripts/memos-version.test.mjs \
             .github/scripts/prepare-memos-release.test.mjs \
             .github/scripts/append-local-plugin-release-intent.test.mjs \
             .github/scripts/local-plugin-release-contract.test.mjs \


### PR DESCRIPTION
## Description

Add a guarded two-stage MemOS release flow:

- `MemOS Release — Prepare` derives `dev-vX.Y.Z` and `release/vX.Y.Z`, updates only `pyproject.toml` and `src/memos/__init__.py`, verifies the source and generated blobs, and pushes the release branch.
- The Action provides a maintainer-owned compare link instead of opening the PR with `GITHUB_TOKEN`, so the protected branch's required pull-request checks run normally.
- `MemOS Release — Publish` moves to a main-only workflow path, resolves the exact `origin/main` commit, and refuses to tag unless both package version declarations equal the requested release.
- Pre/post-merge dry runs use the package version and the immutable event SHA.

The workflow is idempotent for a newly created branch, an existing valid release branch, and a merged release branch that GitHub has automatically deleted. It fails closed for source drift, branch tampering, ambiguous refs, an existing tag, or mismatched versions.

Related Issue (Required): N/A — release automation requested for v2.0.30

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit Test
  - `node --test .github/scripts/memos-version.test.mjs .github/scripts/prepare-memos-release.test.mjs .github/scripts/append-local-plugin-release-intent.test.mjs .github/scripts/local-plugin-release-contract.test.mjs .github/scripts/create-local-plugin-github-release.test.mjs .github/scripts/publish-paired-local-plugin-release.test.mjs` (75 passed)
- [x] Test Script Or Test Steps
  - `actionlint` 1.7.12 on all four affected release workflows
  - YAML parsing and `bash -n` for every affected workflow script
  - `uvx --from ruff==0.11.13 ruff check .`
  - `uvx --from ruff==0.11.13 ruff format --check .`
  - Local bare-remote Git simulation: first run, idempotent rerun, merged/deleted branch, and tampered-branch rejection
  - Real `dev-v2.0.30` fixture: `2.0.29 -> 2.0.30`, then exact-version assertion
- [x] Pipeline Automated API Test
  - Existing protected-branch checks will run on this PR.

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] Documentation issue/PR is not applicable; the Action job summary contains the operator handoff.
- [x] Related issue is not applicable for this release-automation change.
- [ ] A MemOS maintainer has been assigned for review.

## Reviewer Checklist

- [ ] Made sure Checks passed
- [ ] Tests have been provided
- [ ] Confirm the main-only publish workflow and manual PR handoff match the release policy
