### PR TITLE
fix(skill): auto-generate crystallizer summary/steps instead of rejecting

### DIFF
--- a/apps/memos-local-plugin/core/skill/crystallize.ts
+++ b/apps/memos-local-plugin/core/skill/crystallize.ts
@@ -470,11 +470,34 @@ function capString(s: string, cap: number): string {
 
 /**
  * A sensible default validator used both in production and in tests.
- * Throws if the draft is structurally unusable (no name, no steps, no summary).
+ * Throws only when the draft is structurally unusable (no name). Missing
+ * summary/steps are repaired from the remaining fields instead — LLMs (e.g.
+ * deepseek-v4-flash) routinely return valid JSON drafts that omit `summary`
+ * or the `steps` array, and rejecting those stalls the crystallizer queue
+ * (see issue #2143).
  */
 export function defaultDraftValidator(draft: SkillCrystallizationDraft): void {
   if (!draft.name) throw new Error("skill.crystallize.invalid: missing name");
-  if (!draft.summary) throw new Error("skill.crystallize.invalid: missing summary");
-  if (draft.steps.length === 0)
-    throw new Error("skill.crystallize.invalid: missing steps");
+  if (!draft.summary) {
+    // Auto-generate a summary from the richest available field. Use `||` not
+    // `??`: LLM JSON emits empty strings, and `??` only falls through on
+    // null/undefined.
+    const autoSummary =
+      draft.steps?.[0]?.body ||
+      draft.steps?.[0]?.title ||
+      draft.displayTitle ||
+      draft.name ||
+      "skill procedure";
+    draft.summary = autoSummary.slice(0, 200);
+  }
+  if (!draft.steps || draft.steps.length === 0) {
+    // Auto-generate a single step when the LLM omits the steps array
+    // (mirror of the summary fallback chain above).
+    const autoBody = draft.summary || draft.displayTitle || draft.name || "";
+    if (autoBody) {
+      draft.steps = [{ title: "Execute the fix", body: autoBody.slice(0, 2000) }];
+    } else {
+      throw new Error("skill.crystallize.invalid: missing steps");
+    }
+  }
 }

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize-validator.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize-validator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultDraftValidator } from "../../../core/skill/crystallize.js";
+import { makeDraft } from "./_helpers.js";
+
+describe("defaultDraftValidator", () => {
+  it("passes a complete draft through unchanged", () => {
+    const draft = makeDraft();
+    expect(() => defaultDraftValidator(draft)).not.toThrow();
+    expect(draft.summary).toBe("Ensure system libs exist before pip install on alpine.");
+    expect(draft.steps).toHaveLength(3);
+  });
+
+  it("never throws for a missing summary (issue #2143)", () => {
+    const draft = makeDraft({ summary: "" });
+    expect(() => defaultDraftValidator(draft)).not.toThrow();
+  });
+
+  it("auto-generates summary from the first step body when omitted", () => {
+    const draft = makeDraft({ summary: "" });
+    defaultDraftValidator(draft);
+    expect(draft.summary).toBe("inspect the pip error for missing .so names");
+  });
+
+  it("falls back through step title, displayTitle, then name for the summary", () => {
+    const draft = makeDraft({ summary: "", steps: [] });
+    defaultDraftValidator(draft);
+    expect(draft.summary).toBe("Alpine pip install with system deps");
+  });
+
+  it("caps the auto-generated summary at 200 chars", () => {
+    const longBody = "x".repeat(500);
+    const draft = makeDraft({
+      summary: "",
+      steps: [{ title: "t", body: longBody }],
+    });
+    defaultDraftValidator(draft);
+    expect(draft.summary).toBe("x".repeat(200));
+  });
+
+  it("uses || not ?? — an empty-string summary still triggers the fallback", () => {
+    const draft = makeDraft({ summary: "", steps: [] });
+    defaultDraftValidator(draft);
+    expect(draft.summary).not.toBe("");
+  });
+
+  it("auto-generates a single step when the steps array is empty", () => {
+    const draft = makeDraft({ steps: [] });
+    defaultDraftValidator(draft);
+    expect(draft.steps).toEqual([
+      {
+        title: "Execute the fix",
+        body: "Ensure system libs exist before pip install on alpine.",
+      },
+    ]);
+  });
+
+  it("still rejects a draft with no name", () => {
+    const draft = makeDraft({ name: "" });
+    expect(() => defaultDraftValidator(draft)).toThrow(/missing name/);
+  });
+});

--- a/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
+++ b/apps/memos-local-plugin/tests/unit/skill/crystallize.test.ts
@@ -230,7 +230,10 @@ describe("skill/crystallize", () => {
     expect(r.modelRefusal?.content).toContain("I cannot process this request");
   });
 
-  it("rejects drafts that the validator flags as invalid", async () => {
+  it("repairs drafts the strict validator would have rejected (issue #2143)", async () => {
+    // A draft with an empty summary AND no steps used to be rejected with
+    // skill.crystallize.invalid: missing summary / missing steps. The lenient
+    // validator auto-generates both, so the same draft now crystallizes.
     const llm = fakeLlm({
       completeJson: {
         "skill.crystallize": makeDraft({ steps: [], summary: "" }) as unknown,
@@ -240,6 +243,10 @@ describe("skill/crystallize", () => {
       { policy: mkPolicy(), evidence: [mkTrace("tr_1", "x")], namingSpace: [] },
       { llm, log, config: makeSkillConfig(), validate: defaultDraftValidator },
     );
-    expect(r.ok).toBe(false);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.draft.summary).not.toBe("");
+      expect(r.draft.steps.length).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
## Summary

`defaultDraftValidator` in `core/skill/crystallize.ts` throws `skill.crystallize.invalid: missing summary` / `missing steps` whenever the LLM returns valid JSON that omits those fields. With deepseek-v4-flash this happens routinely, flooding bridge logs with 10+ `ERROR skill.crystallize.failed` messages per minute and stalling the crystallizer queue (which in turn delays other RPCs like `memory.search` waiting on the queue to drain).

This PR makes the validator **repair** such drafts instead of rejecting them:

- **Missing summary** → auto-generated from the richest available field, in priority order: first step body → first step title → `displayTitle` → `name` → static placeholder `"skill procedure"`. Capped at 200 chars. Never throws for a missing/empty summary.
- **Missing/empty steps** → a single `"Execute the fix"` step generated from the summary (`title` + `body`, capped at 2000 chars). Only throws when nothing at all can be derived.
- **Missing name** → still rejected (`skill.crystallize.invalid: missing name`). On the LLM path this is unreachable anyway — `normaliseDraft()` already substitutes `skill_<policy_id>` — so the check remains purely a guard for direct validator use.

## Change

- `core/skill/crystallize.ts` — `defaultDraftValidator` rewritten: strict → lenient repair (uses `||` not `??` — LLM JSON emits empty strings, and `??` only falls through on null/undefined).
- `tests/unit/skill/crystallize.test.ts` — the old "rejects drafts that the validator flags as invalid" test used `{ steps: [], summary: "" }`, which is exactly the case this PR now repairs; converted into an end-to-end regression asserting the draft crystallizes with auto-generated summary + steps.
- `tests/unit/skill/crystallize-validator.test.ts` — new focused suite (8 tests): full-draft passthrough, never-throws-for-missing-summary, summary fallback chain (step body → displayTitle → name), 200-char cap, empty-string (`||`) semantics, single-step auto-generation, missing-name rejection.

## Tests

- `npx vitest run tests/unit/skill` → **54 passed (10 files)**
- `npx tsc -p tsconfig.json --noEmit` → clean (exit 0)
- The repair logic is the same shape already proven in production (local Hermes CT100 ran this validator for ~2 weeks; crystallizer backlog drained, zero `missing summary` rejections since).

## Related

- **Fixes #2143** — the tracked issue for this failure mode (filed 2026-07-22).
- PR #2064 (v2.0.23) addressed the separate empty-response mode; this PR covers the valid-JSON-without-summary mode it did not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests (`npx vitest run tests/unit/skill` — 54 passed)
- [x] Type-check (`tsc --noEmit` clean)
- [x] Production-proven shape (the lenient fallback chain has run on Hermes CT100 since ~1 Aug 2026; `skill.crystallize.failed` missing-summary floods dropped to zero)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally