### PR TITLE
fix(plugin): resolve DSH Viewer assets in clean builds

### DIFF
--- a/apps/memos-local-plugin/adapters/deepseek-harness/index.ts
+++ b/apps/memos-local-plugin/adapters/deepseek-harness/index.ts
@@ -132,14 +132,15 @@ export function deepSeekHarnessAutoRecoveryEnabled(config: ResolvedConfig): bool
     config.algorithm.lightweightMemory.enabled;
 }
 
-/** Locate the prebuilt Viewer assets in source and packed-package layouts. */
-export function resolveDeepSeekHarnessViewerStaticRoot(): string {
-  const adapterDir = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    resolve(adapterDir, "..", "..", "..", "viewer", "dist"),
-    resolve(adapterDir, "..", "..", "viewer", "dist"),
-  ];
-  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]!;
+/** Locate Viewer assets without depending on whether they are built yet. */
+export function resolveDeepSeekHarnessViewerStaticRoot(
+  adapterDir: string = dirname(fileURLToPath(import.meta.url)),
+): string {
+  const runtimeRoot = resolve(adapterDir, "..", "..");
+  const pluginRoot = existsSync(resolve(runtimeRoot, "package.json"))
+    ? runtimeRoot
+    : dirname(runtimeRoot);
+  return resolve(pluginRoot, "viewer", "dist");
 }
 
 /** Keep the unauthenticated first-run Viewer strictly on local interfaces. */

--- a/apps/memos-local-plugin/tests/unit/adapters/deepseek-harness-viewer.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/deepseek-harness-viewer.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -231,6 +233,36 @@ describe("DeepSeek Harness Viewer lifecycle", () => {
     expect(runtime.isDeepSeekHarnessViewerLoopbackHost("localhost")).toBe(true);
     expect(runtime.isDeepSeekHarnessViewerLoopbackHost("0.0.0.0")).toBe(false);
     expect(runtime.isDeepSeekHarnessViewerLoopbackHost("192.168.1.20")).toBe(false);
+  });
+
+  it("resolves Viewer assets deterministically in source and packed layouts", async () => {
+    const runtime = await loadAdapter();
+    const fixtureRoot = mkdtempSync(resolve(tmpdir(), "memos-dsh-viewer-layout-"));
+    // A package root may itself be named `dist`; package.json is the stable
+    // layout marker. Deliberately leave viewer/dist unbuilt, as in clean CI.
+    const packageRoot = resolve(fixtureRoot, "dist");
+    mkdirSync(resolve(packageRoot, "adapters/deepseek-harness"), {
+      recursive: true,
+    });
+    mkdirSync(resolve(packageRoot, "dist/adapters/deepseek-harness"), {
+      recursive: true,
+    });
+    writeFileSync(resolve(packageRoot, "package.json"), "{}\n", "utf8");
+
+    try {
+      expect(
+        runtime.resolveDeepSeekHarnessViewerStaticRoot(
+          resolve(packageRoot, "adapters/deepseek-harness"),
+        ),
+      ).toBe(resolve(packageRoot, "viewer/dist"));
+      expect(
+        runtime.resolveDeepSeekHarnessViewerStaticRoot(
+          resolve(packageRoot, "dist/adapters/deepseek-harness"),
+        ),
+      ).toBe(resolve(packageRoot, "viewer/dist"));
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("starts the bundled Viewer on the DSH-owned loopback endpoint", async () => {


### PR DESCRIPTION
## Description

Fix the DSH Viewer static-root resolution exposed by the 2.0.16 release dry run. In a clean checkout, the test job runs before `prepack` builds `viewer/dist`; the previous existence-based fallback therefore selected `apps/viewer/dist` instead of the plugin-owned Viewer directory.

The resolver now identifies the package root through its stable `package.json` marker, so both source (`adapters/deepseek-harness`) and packed (`dist/adapters/deepseek-harness`) layouts resolve to `<package>/viewer/dist` even before Viewer assets are built. A regression test covers both clean layouts, including a package root itself named `dist`.

Failed dry-run evidence: https://github.com/MemTensor/MemOS/actions/runs/31927133607

Related Issue (Required): Follow-up fix for #2254

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test: `npx vitest run tests/unit/adapters/deepseek-harness-viewer.test.ts` (11 passed)
- [x] Test Script Or Test Steps: `npm run lint`
- [x] Test Script Or Test Steps: `npx vitest run --silent` (175 files passed; 1448 passed, 2 skipped)
- [x] Test Script Or Test Steps: `npm pack --pack-destination tmp/dsh-viewer-static-root-pack` and verified the tarball contains the compiled DSH adapter plus `viewer/dist/index.html`

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [x] Documentation update is not applicable for this packaging-path fix
- [x] I have linked the originating PR and failed release run

## Reviewer Checklist

- [ ] Made sure Checks passed
- [x] Tests have been provided