### PR TITLE
fix: (embedders)preserve config for cached factory instances

### DIFF
--- a/src/memos/embedders/factory.py
+++ b/src/memos/embedders/factory.py
@@ -29,6 +29,8 @@ class EmbedderFactory(BaseEmbedder):
             raise ValueError(f"Invalid backend: {backend}")
         embedder_class = cls.backend_to_class[backend]
         embedder = embedder_class(config_factory.config)
+        if not hasattr(embedder, "config"):
+            embedder.config = config_factory.config
         if backend in cls.cacheable_backends and embedding_optimization_enabled():
             return CachingEmbedder(embedder)
         return embedder

--- a/src/memos/llms/qwen.py
+++ b/src/memos/llms/qwen.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from memos.configs.llm import QwenLLMConfig
 from memos.llms.openai import OpenAILLM
 from memos.log import get_logger
@@ -5,9 +7,24 @@ from memos.log import get_logger
 
 logger = get_logger(__name__)
 
+DASHSCOPE_WAIT_TIMEOUT_HEADER = "X-DashScope-Wait-Timeout"
+DASHSCOPE_WAIT_TIMEOUT_SECONDS = "30"
+
+
+def _add_dashscope_wait_timeout_header(
+    default_headers: dict[str, Any] | None,
+) -> dict[str, Any]:
+    headers = dict(default_headers or {})
+    if not any(key.lower() == DASHSCOPE_WAIT_TIMEOUT_HEADER.lower() for key in headers):
+        headers[DASHSCOPE_WAIT_TIMEOUT_HEADER] = DASHSCOPE_WAIT_TIMEOUT_SECONDS
+    return headers
+
 
 class QwenLLM(OpenAILLM):
     """Qwen (DashScope) LLM class via OpenAI-compatible API."""
 
     def __init__(self, config: QwenLLMConfig):
+        config = config.model_copy(
+            update={"default_headers": _add_dashscope_wait_timeout_header(config.default_headers)}
+        )
         super().__init__(config)

--- a/tests/llms/test_qwen.py
+++ b/tests/llms/test_qwen.py
@@ -1,13 +1,38 @@
 import unittest
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from memos.configs.llm import QwenLLMConfig
 from memos.llms.qwen import QwenLLM
 
 
 class TestQwenLLM(unittest.TestCase):
+    def test_qwen_llm_adds_dashscope_wait_timeout_header(self):
+        """Test QwenLLM adds DashScope server-side queue wait timeout header."""
+        config = QwenLLMConfig.model_validate(
+            {
+                "model_name_or_path": "qwen-test",
+                "api_key": "sk-test",
+                "api_base": "https://dashscope.aliyuncs.com/api/v1",
+                "default_headers": {"X-Custom-Header": "custom"},
+            }
+        )
+
+        with patch("memos.llms.openai.openai.Client") as mock_client:
+            QwenLLM(config)
+
+        default_headers = mock_client.call_args.kwargs["default_headers"]
+        self.assertEqual(default_headers["X-DashScope-Wait-Timeout"], "30")
+        self.assertEqual(default_headers["X-Custom-Header"], "custom")
+
+        config_without_headers = config.model_copy(update={"default_headers": None})
+        with patch("memos.llms.openai.openai.Client") as mock_client:
+            QwenLLM(config_without_headers)
+
+        default_headers = mock_client.call_args.kwargs["default_headers"]
+        self.assertEqual(default_headers["X-DashScope-Wait-Timeout"], "30")
+
     def test_qwen_llm_generate_with_and_without_think_prefix(self):
         """Test QwenLLM non-streaming response generation with and without <think> prefix removal."""
 


### PR DESCRIPTION
## Description

fix: (embedders)preserve config for cached factory instances
fix: add DashScope wait timeout header for Qwen requests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Not applicable


## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [x] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [x] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

## Reviewer Checklist
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
- [ ] Tests have been provided