### PR TITLE
fix: normalize Postgres embedding strings for reorganizer

### DIFF
--- a/src/memos/graph_dbs/postgres.py
+++ b/src/memos/graph_dbs/postgres.py
@@ -26,16 +26,37 @@ from memos.log import get_logger
 logger = get_logger(__name__)
 
 
+def _normalize_embedding_value(embedding: Any) -> list[float] | None:
+    """Coerce pgvector/psycopg2 embedding values into list[float] for GraphDBNode."""
+    if embedding is None:
+        return None
+    if isinstance(embedding, list):
+        return [float(x) for x in embedding]
+    if isinstance(embedding, tuple):
+        return [float(x) for x in embedding]
+    if isinstance(embedding, str):
+        stripped = embedding.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, list):
+            return [float(x) for x in parsed]
+        return None
+    return None
+
+
 def _prepare_node_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     """Ensure metadata has proper datetime fields and normalized types."""
     now = datetime.utcnow().isoformat()
     metadata.setdefault("created_at", now)
     metadata.setdefault("updated_at", now)
 
-    # Normalize embedding type
-    embedding = metadata.get("embedding")
-    if embedding and isinstance(embedding, list):
-        metadata["embedding"] = [float(x) for x in embedding]
+    normalized = _normalize_embedding_value(metadata.get("embedding"))
+    if normalized is not None:
+        metadata["embedding"] = normalized
 
     return metadata
 
@@ -437,6 +458,11 @@ class PostgresGraphDB(BaseGraphDB):
         }
         if include_embedding and len(row) > 5:
             result["metadata"]["embedding"] = row[5]
+        normalized = _normalize_embedding_value(result["metadata"].get("embedding"))
+        if normalized is not None:
+            result["metadata"]["embedding"] = normalized
+        elif "embedding" in result["metadata"]:
+            del result["metadata"]["embedding"]
         return result
 
     @staticmethod

--- a/src/memos/graph_dbs/postgres.py
+++ b/src/memos/graph_dbs/postgres.py
@@ -30,20 +30,23 @@ def _normalize_embedding_value(embedding: Any) -> list[float] | None:
     """Coerce pgvector/psycopg2 embedding values into list[float] for GraphDBNode."""
     if embedding is None:
         return None
-    if isinstance(embedding, list):
-        return [float(x) for x in embedding]
-    if isinstance(embedding, tuple):
-        return [float(x) for x in embedding]
-    if isinstance(embedding, str):
-        stripped = embedding.strip()
-        if not stripped:
+    try:
+        if isinstance(embedding, list):
+            return [float(x) for x in embedding]
+        if isinstance(embedding, tuple):
+            return [float(x) for x in embedding]
+        if isinstance(embedding, str):
+            stripped = embedding.strip()
+            if not stripped:
+                return None
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                return None
+            if isinstance(parsed, list):
+                return [float(x) for x in parsed]
             return None
-        try:
-            parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            return None
-        if isinstance(parsed, list):
-            return [float(x) for x in parsed]
+    except (ValueError, TypeError):
         return None
     return None
 
@@ -458,11 +461,12 @@ class PostgresGraphDB(BaseGraphDB):
         }
         if include_embedding and len(row) > 5:
             result["metadata"]["embedding"] = row[5]
-        normalized = _normalize_embedding_value(result["metadata"].get("embedding"))
-        if normalized is not None:
-            result["metadata"]["embedding"] = normalized
-        elif "embedding" in result["metadata"]:
-            del result["metadata"]["embedding"]
+        if include_embedding:
+            normalized = _normalize_embedding_value(result["metadata"].get("embedding"))
+            if normalized is not None:
+                result["metadata"]["embedding"] = normalized
+            elif "embedding" in result["metadata"]:
+                del result["metadata"]["embedding"]
         return result
 
     @staticmethod

--- a/tests/graph_dbs/test_postgres_embedding_parse.py
+++ b/tests/graph_dbs/test_postgres_embedding_parse.py
@@ -1,0 +1,56 @@
+"""Regression tests for PostgresGraphDB embedding normalization."""
+
+from __future__ import annotations
+
+import json
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from memos.graph_dbs.postgres import PostgresGraphDB, _normalize_embedding_value, _prepare_node_metadata
+
+
+def test_normalize_embedding_value_parses_json_string() -> None:
+    assert _normalize_embedding_value("[0.5, -1.0]") == [0.5, -1.0]
+
+
+def test_normalize_embedding_value_coerces_numeric_list() -> None:
+    assert _normalize_embedding_value([2, 3]) == [2.0, 3.0]
+
+
+def test_normalize_embedding_value_rejects_invalid_string() -> None:
+    assert _normalize_embedding_value("not-json") is None
+
+
+def test_prepare_node_metadata_normalizes_string_embedding() -> None:
+    metadata = _prepare_node_metadata({"embedding": "[0.25, 0.75]"})
+    assert metadata["embedding"] == [0.25, 0.75]
+
+
+def _build_db() -> PostgresGraphDB:
+    with (
+        patch("memos.graph_dbs.postgres.require_python_package", lambda **kwargs: lambda fn: fn),
+        patch("psycopg2.pool.ThreadedConnectionPool", MagicMock()),
+        patch.object(PostgresGraphDB, "_init_schema", lambda self: None),
+    ):
+        config = MagicMock()
+        config.schema_name = "test_schema"
+        config.user_name = "user-1"
+        return PostgresGraphDB(config)
+
+
+def test_parse_row_normalizes_string_embedding_from_vector_column() -> None:
+    db = _build_db()
+    row: tuple[Any, ...] = (
+        "node-1",
+        "memory text",
+        json.dumps({"memory_type": "UserMemory"}),
+        datetime(2026, 8, 22, 12, 0, 0),
+        datetime(2026, 8, 22, 12, 0, 0),
+        "[0.25, 0.75]",
+    )
+
+    parsed = db._parse_row(row, include_embedding=True)
+
+    assert parsed["metadata"]["embedding"] == [0.25, 0.75]

--- a/tests/graph_dbs/test_postgres_embedding_parse.py
+++ b/tests/graph_dbs/test_postgres_embedding_parse.py
@@ -23,6 +23,11 @@ def test_normalize_embedding_value_rejects_invalid_string() -> None:
     assert _normalize_embedding_value("not-json") is None
 
 
+def test_normalize_embedding_value_rejects_non_numeric_elements() -> None:
+    assert _normalize_embedding_value(["a", 0.5]) is None
+    assert _normalize_embedding_value('["a", 0.5]') is None
+
+
 def test_prepare_node_metadata_normalizes_string_embedding() -> None:
     metadata = _prepare_node_metadata({"embedding": "[0.25, 0.75]"})
     assert metadata["embedding"] == [0.25, 0.75]
@@ -54,3 +59,18 @@ def test_parse_row_normalizes_string_embedding_from_vector_column() -> None:
     parsed = db._parse_row(row, include_embedding=True)
 
     assert parsed["metadata"]["embedding"] == [0.25, 0.75]
+
+
+def test_parse_row_preserves_props_embedding_when_not_requested() -> None:
+    db = _build_db()
+    row: tuple[Any, ...] = (
+        "node-1",
+        "memory text",
+        json.dumps({"memory_type": "UserMemory", "embedding": "[0.1, 0.2]"}),
+        datetime(2026, 8, 22, 12, 0, 0),
+        datetime(2026, 8, 22, 12, 0, 0),
+    )
+
+    parsed = db._parse_row(row, include_embedding=False)
+
+    assert parsed["metadata"]["embedding"] == "[0.1, 0.2]"


### PR DESCRIPTION
## Description

`PostgresGraphDB._parse_row()` and `_prepare_node_metadata()` assumed `metadata["embedding"]` is already a `list[float]`. When `include_embedding=True`, psycopg2/pgvector often returns the vector column as a JSON string (for example `'[-0.047..., ...]'`).

The reorganizer loads nodes with `get_node(..., include_embedding=True)` and constructs `GraphDBNode(**raw_node)`. Pydantic then rejects the string embedding, so the reorganizer consumer logs a traceback and skips reorganize work.

This change adds `_normalize_embedding_value()` to coerce list/tuple/JSON-string embeddings into `list[float]`, and uses it in both metadata preparation and row parsing.

Related Issue (Required): Fixes #2270

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

Added regression tests in `tests/graph_dbs/test_postgres_embedding_parse.py`:

- `_normalize_embedding_value()` parses JSON string embeddings
- `_prepare_node_metadata()` normalizes string embeddings in metadata
- `_parse_row(..., include_embedding=True)` normalizes pgvector string column values

Reproduce with:

```bash
pytest tests/graph_dbs/test_postgres_embedding_parse.py -v
```

## Checklist

- [x] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [x] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [x] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人
