### PR TITLE
Fix #2278: [Bug] memos-local-plugin: --daemon entry never starts the status heartbeat — hea

### DIFF
--- a/apps/memos-local-plugin/bridge.cts
+++ b/apps/memos-local-plugin/bridge.cts
@@ -475,6 +475,11 @@ async function main(): Promise<void> {
         process.stderr.write(
           `bridge: daemon viewer live at ${viewer.url} (agent=${args.agent})\n`,
         );
+        // Daemon is the standalone viewer process: it owns the Hermes
+        // status heartbeat (issue #2278). stdio mode starts the same
+        // heartbeat in its own branch above.
+        bridgeStatus?.markConnected();
+        bridgeHeartbeat = bridgeStatus?.startHeartbeat();
         break;
       } catch (err) {
         const e = err as NodeJS.ErrnoException;
@@ -502,6 +507,7 @@ async function main(): Promise<void> {
 
     const shutdownDaemon = async (sig: string) => {
       process.stderr.write(`bridge: daemon received ${sig}, shutting down\n`);
+      bridgeHeartbeat?.stop();
       removeOwnedPidFile();
       try { await viewer!.close(); } catch { /* best-effort */ }
       try {

--- a/apps/memos-local-plugin/bridge.mts
+++ b/apps/memos-local-plugin/bridge.mts
@@ -385,6 +385,11 @@ async function main(): Promise<void> {
         process.stderr.write(
           `bridge: daemon viewer live at ${viewer.url} (agent=${args.agent})\n`,
         );
+        // Daemon is the standalone viewer process: it owns the Hermes
+        // status heartbeat (issue #2278). stdio mode starts the same
+        // heartbeat in its own branch above.
+        bridgeStatus?.markConnected();
+        bridgeHeartbeat = bridgeStatus?.startHeartbeat();
         break;
       } catch (err) {
         const e = err as NodeJS.ErrnoException;
@@ -412,6 +417,7 @@ async function main(): Promise<void> {
 
     const shutdownDaemon = async (sig: string) => {
       process.stderr.write(`bridge: daemon received ${sig}, shutting down\n`);
+      bridgeHeartbeat?.stop();
       removeOwnedPidFile();
       try { await viewer!.close(); } catch { /* best-effort */ }
       try {

--- a/apps/memos-local-plugin/tests/unit/bridge/bridge-daemon-heartbeat.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/bridge-daemon-heartbeat.test.ts
@@ -1,0 +1,102 @@
+/**
+ * bridge.mts / bridge.cts daemon heartbeat regression guard for issue #2278.
+ *
+ * Issue summary: since PR #1998 the Hermes launcher prefers the pure-ESM
+ * `dist/bridge.mjs` entry (built from `bridge.mts`). In `bridge.mts` the
+ * `bridge-status.json` heartbeat was only started in the **stdio** branch
+ * (`if (!args.daemon)`); the `--daemon` branch never called
+ * `markConnected()` / `startHeartbeat()`. A daemon-spawned bridge therefore
+ * never refreshed the status file, and the health endpoint permanently
+ * reported `status: "disconnected"` / "Hermes bridge heartbeat is stale"
+ * ~20 s after the last (possibly pre-upgrade) write — while RPC kept
+ * working.
+ *
+ * The legacy `bridge.cts` daemon path has the same gap (it was never called
+ * there, even in the original signal-light commit 22ccacbf), so both entries
+ * are guarded here.
+ *
+ * Why source-level (rather than runtime): both `bridge.mts` and `bridge.cts`
+ * are top-level executable scripts; refactoring them into injectable
+ * functions just to runtime-test the heartbeat would be a much larger change
+ * than the invariant deserves. A source-level assertion catches the
+ * regression at the moment a developer removes the daemon-side calls — which
+ * is exactly what the issue asks us to prevent. Same pattern as
+ * `bridge-startup-ordering.test.ts` (#1747).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = resolve(HERE, "..", "..", "..");
+const BRIDGE_MTS_PATH = resolve(PLUGIN_ROOT, "bridge.mts");
+const BRIDGE_CTS_PATH = resolve(PLUGIN_ROOT, "bridge.cts");
+
+/**
+ * Assert that the daemon branch of `src` starts the status heartbeat.
+ *
+ * The stdio branch (`if (!args.daemon)`) textually precedes the daemon
+ * branch (`if (args.daemon)`), so every daemon-side call must sit at an
+ * index AFTER the daemon guard's `if (args.daemon)`. The stdio block's own
+ * `markConnected()` sits before it and must remain in place too.
+ */
+function expectDaemonHeartbeat(src: string, entryName: string): void {
+  const stdioGuardIdx = src.indexOf("if (!args.daemon)");
+  const daemonGuardIdx = src.indexOf("if (args.daemon)");
+
+  expect(
+    stdioGuardIdx,
+    `${entryName}: stdio guard "if (!args.daemon)" not found`,
+  ).toBeGreaterThanOrEqual(0);
+  expect(
+    daemonGuardIdx,
+    `${entryName}: daemon guard "if (args.daemon)" not found`,
+  ).toBeGreaterThanOrEqual(0);
+  expect(
+    daemonGuardIdx,
+    `${entryName}: daemon guard must appear after the stdio guard ` +
+      `(stdioGuardIdx=${stdioGuardIdx} daemonGuardIdx=${daemonGuardIdx}). ` +
+      `If the branch structure changed, re-check the ordering assertion.`,
+  ).toBeGreaterThan(stdioGuardIdx);
+
+  const markIdx = src.indexOf("bridgeStatus?.markConnected();", daemonGuardIdx);
+  const heartbeatIdx = src.indexOf(
+    "bridgeHeartbeat = bridgeStatus?.startHeartbeat();",
+    daemonGuardIdx,
+  );
+
+  expect(
+    markIdx,
+    `${entryName}: bridgeStatus?.markConnected(); must be called inside the ` +
+      `daemon branch (after "if (args.daemon)"). Removing it reopens issue ` +
+      `#2278: a --daemon bridge never refreshes bridge-status.json and the ` +
+      `health endpoint reports "Hermes bridge heartbeat is stale" forever ` +
+      `while RPC still works.`,
+  ).toBeGreaterThanOrEqual(0);
+  expect(
+    heartbeatIdx,
+    `${entryName}: bridgeHeartbeat = bridgeStatus?.startHeartbeat(); must be ` +
+      `called inside the daemon branch. Same issue #2278 rationale as above.`,
+  ).toBeGreaterThanOrEqual(0);
+
+  // The stdio branch keeps its own heartbeat start — the fix must ADD
+  // daemon-side calls, not relocate the stdio ones.
+  const stdioMarkIdx = src.indexOf("bridgeStatus?.markConnected();", stdioGuardIdx);
+  expect(
+    stdioMarkIdx,
+    `${entryName}: the stdio branch (if (!args.daemon)) must keep its own ` +
+      `bridgeStatus?.markConnected(); call`,
+  ).toBeGreaterThanOrEqual(0);
+  expect(stdioMarkIdx).toBeLessThan(daemonGuardIdx);
+}
+
+describe("bridge daemon status heartbeat (regression guard for #2278)", () => {
+  it("bridge.mts starts the status heartbeat in the --daemon branch", () => {
+    expectDaemonHeartbeat(readFileSync(BRIDGE_MTS_PATH, "utf8"), "bridge.mts");
+  });
+
+  it("bridge.cts starts the status heartbeat in the --daemon branch (parity)", () => {
+    expectDaemonHeartbeat(readFileSync(BRIDGE_CTS_PATH, "utf8"), "bridge.cts");
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2278: the memos-local-plugin `--daemon` bridge entry never started the bridge-status heartbeat, so a daemon-spawned bridge never refreshed bridge-status.json and the health endpoint permanently reported "Hermes bridge heartbeat is stale" while RPC kept working.

Root cause: the pure-ESM entry `apps/memos-local-plugin/bridge.mts` (built to `dist/bridge.mjs`, which the Python launcher has preferred since #1998) only called `markConnected()` / `startHeartbeat()` inside its stdio branch (`if (!args.daemon)`); the `--daemon` branch had no status calls at all. A source-level git-history check confirmed the legacy `bridge.cts` daemon path had the same gap (never called there even in the original signal-light commit 22ccacbf), which is why the ESM translation lost it.

Fix: mirror the stdio pattern into the daemon branch of both entries — after the viewer bind-retry loop succeeds, call `bridgeStatus?.markConnected()` and `bridgeHeartbeat = bridgeStatus?.startHeartbeat()`; stop the heartbeat in `shutdownDaemon` (SIGINT/SIGTERM). The bridge core is fully initialized before the daemon block, so "connected" is never claimed prematurely; OpenClaw is unaffected (all calls are `?.`-guarded no-ops since `bridgeStatus` is null for openclaw); the heartbeat timer is unref()ed and does not hold the daemon open. Stdio-mode behavior is unchanged and pinned by the new regression test.

Regression guard: added `apps/memos-local-plugin/tests/unit/bridge/bridge-daemon-heartbeat.test.ts`, a source-level guard following the existing `bridge-startup-ordering.test.ts` pattern (#1747). It asserts both entries start the heartbeat inside the `if (args.daemon)` branch while the stdio branch keeps its own calls. Verified TDD-style: the test fails on the pre-fix code (both entries) and passes after the fix.

Test evidence (real output): `vitest run tests/unit/bridge tests/unit/bridge-status.test.ts` -> 8 files / 39 tests passed; `tsc -p tsconfig.json --noEmit` -> exit 0; `vitest run tests/unit` -> 164 files / 1351 passed, 1 skipped. (An initial full-suite run showed failures in unrelated modules caused by pnpm skipping native build scripts locally — better-sqlite3/esbuild/onnxruntime/sharp; after approving those builds the entire suite is green. The change touches only bridge.mts, bridge.cts, and the new test.)

opsp artifacts archived to the memos-autodev-specs repo (task.md + proposal/spec/design/tasks/test-cases/verification-report) on commit b89a59e.

Related Issue (Required):  Fixes #2278

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@whipser030, @hijzy please review this PR.

## Reviewer Checklist
- [x] closes #2278
- [ ] Made sure Checks passed
- [ ] Tests have been provided
