### PR TITLE
fix(memos-local-plugin): use POSIX-ERE-compatible pgrep pattern for hermes chat detection (port of #2192 to main)

### DIFF
--- a/apps/memos-local-plugin/bridge/hermes-process.ts
+++ b/apps/memos-local-plugin/bridge/hermes-process.ts
@@ -18,22 +18,16 @@
  * therefore misses any invocation with a global flag (`--skills`,
  * `-m`, `--provider`, …) between them.
  *
- * The current pattern is `hermes(?:\s+\S+)*\s+chat\b`:
+ * The command grammar is `hermes (<token>)* chat (<space>|$)`:
  *
- *   • `hermes`           — the binary basename.
- *   • `(?:\s+\S+)*`      — any complete argv-style tokens between the
- *     binary and the subcommand.
- *   • `\s+chat\b`        — a standalone `chat` token, so it does *not*
- *     match `chatter`, `chat-server`, `--chat-log`, or a flag value
- *     like `--profile=chat`.
+ *   • `hermes`       — the binary basename.
+ *   • `(<token>)*`   — complete argv-style tokens before the subcommand.
+ *   • `chat`         — a complete token, not `chatter` or `chat-server`.
  *
- * `pgrep -f` on Linux uses glibc's ERE engine, which supports
- * `\s`/`\b` as GNU extensions. JavaScript's `RegExp` supports the same
- * tokens natively, so this module also exports
- * `matchesHermesChatCommandLine()` for unit tests — exercising the
- * pattern as a JS regex is a faithful proxy for the pgrep-side
- * behaviour without requiring a real Hermes binary or a fork of the
- * pgrep process in CI.
+ * `pgrep -f` on Linux uses glibc's POSIX ERE engine, so its pattern uses
+ * POSIX character classes and capturing groups only. JavaScript does not
+ * implement POSIX character classes, so the test helper declares the same
+ * grammar with `\s`, `\S`, and non-capturing groups instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as childProcess from "node:child_process";
@@ -45,7 +39,12 @@ import * as childProcess from "node:child_process";
  * string we hand to `pgrep` and confirm we have not silently regressed
  * back to a literal substring match.
  */
-export const HERMES_CHAT_PROCESS_PATTERN = "hermes(?:\\s+\\S+)*\\s+chat\\b";
+export const HERMES_CHAT_PROCESS_PATTERN =
+  "hermes([[:space:]]+[^[:space:]]+)*[[:space:]]+chat([[:space:]]|$)";
+
+// Keep this semantically aligned with HERMES_CHAT_PROCESS_PATTERN. POSIX ERE
+// has no non-capturing groups, while JavaScript can avoid unused captures.
+const HERMES_CHAT_JS_PATTERN = /hermes(?:\s+\S+)*\s+chat(?:\s|$)/;
 
 /**
  * JS-side equivalent of `pgrep -f HERMES_CHAT_PROCESS_PATTERN`.
@@ -56,7 +55,7 @@ export const HERMES_CHAT_PROCESS_PATTERN = "hermes(?:\\s+\\S+)*\\s+chat\\b";
  * `/proc/<pid>/cmdline`-style command-line string.
  */
 export function matchesHermesChatCommandLine(commandLine: string): boolean {
-  return new RegExp(HERMES_CHAT_PROCESS_PATTERN).test(commandLine);
+  return HERMES_CHAT_JS_PATTERN.test(commandLine);
 }
 
 /**

--- a/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
+++ b/apps/memos-local-plugin/tests/unit/bridge/hermes-process.test.ts
@@ -7,9 +7,11 @@
  * subcommand (`hermes --skills memory-routing chat`) was silently
  * missed and the viewer was stuck on `"disconnected"`.
  *
- * The pattern under test is `hermes(?:\s+\S+)*\s+chat\b` — these cases
- * lock in the exact shape of the fix.
+ * The pgrep pattern uses POSIX character classes while the JS helper
+ * uses equivalent `\s` / `\S` tokens. These cases lock in both the
+ * shared command grammar and the exact wire format passed to pgrep.
  */
+import { spawnSync } from "node:child_process";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -23,8 +25,23 @@ describe("HERMES_CHAT_PROCESS_PATTERN", () => {
     // If this string ever changes, audit `bridge.cts` callers and the
     // issue description before adjusting — the constant is the only
     // surface that fixes the substring-detection bug.
-    expect(HERMES_CHAT_PROCESS_PATTERN).toBe("hermes(?:\\s+\\S+)*\\s+chat\\b");
+    expect(HERMES_CHAT_PROCESS_PATTERN).toBe(
+      "hermes([[:space:]]+[^[:space:]]+)*[[:space:]]+chat([[:space:]]|$)",
+    );
   });
+
+  it.skipIf(process.platform !== "linux")(
+    "compiles under the glibc ERE engine used by pgrep",
+    () => {
+      const result = spawnSync("pgrep", ["-f", HERMES_CHAT_PROCESS_PATTERN], {
+        encoding: "utf8",
+        timeout: 2000,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect([0, 1]).toContain(result.status);
+    },
+  );
 });
 
 describe("matchesHermesChatCommandLine", () => {
@@ -53,7 +70,9 @@ describe("matchesHermesChatCommandLine", () => {
 
   it("matches `hermes -m gpt-4 chat` (global short flag before subcommand) — #1915", () => {
     expect(
-      matchesHermesChatCommandLine("/usr/local/bin/hermes -m gpt-4 chat"),
+      matchesHermesChatCommandLine(
+        "/usr/local/lib/hermes-agent/venv/bin/hermes -m gpt-4 chat",
+      ),
     ).toBe(true);
   });
 
@@ -75,6 +94,12 @@ describe("matchesHermesChatCommandLine", () => {
   it("does not match `hermes chatter` (chat must end at a word boundary)", () => {
     expect(
       matchesHermesChatCommandLine("/usr/local/bin/hermes chatter"),
+    ).toBe(false);
+  });
+
+  it("does not match `hermes chat-server` (chat must be a complete token)", () => {
+    expect(
+      matchesHermesChatCommandLine("/usr/local/bin/hermes chat-server"),
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Ports the reviewed pgrep pattern fix from #2192 onto `main`, so release trains that build the local plugin from `main` stop shipping an invalid `pgrep -f` pattern.

#2192 was merged on 24 Aug into `fix-local-plugin-260824`, but `main` (and npm builds published from it, including 2.0.15) still carries the pre-fix pattern. This PR applies the identical reviewed change — POSIX character classes + capturing groups only for the pgrep wire format, with a dedicated JS literal for the unit-test helper.

## Root cause

`HERMES_CHAT_PROCESS_PATTERN` shipped as `hermes(?:\\s+\\S+)*\\s+chat\\b`. The `(?:...)` non-capturing group is PCRE syntax; `pgrep -f` on Linux compiles patterns with **glibc POSIX ERE**, which has no non-capturing groups and rejects the whole pattern:

```
pgrep: regex error: Invalid preceding regular expression   # pgrep exits 2
```

`isHermesChatRunning()` collapses every failure to `false`, so each detection poll errors and the daemon viewer stays stuck on `"disconnected"`. The original #1915 fix passed its unit tests because JavaScript's `RegExp` accepts `(?:...)` — JS matching behaviour is a faithful proxy for *matching*, but not for *pattern validity* under ERE. Observed live on 26 Aug 2026 (plugin 2.0.15): one regex error per poll cycle in the daemon journal across reboots, plus `core.health` timeouts during host load spikes while detection kept silently failing.

## Fix (identical to reviewed #2192)

- pgrep wire pattern rebuilt from POSIX character classes and capturing groups only:
  `hermes([[:space:]]+[^[:space:]]+)*[[:space:]]+chat([[:space:]]|$)`
- JS test helper split into its own literal (`HERMES_CHAT_JS_PATTERN`) so each engine gets a natively valid regex for the same command grammar; `chat` must be a complete argv token (no `chat-server` false positives)
- New Linux-only regression test runs the **real** `pgrep` binary against the wire pattern and requires exit status 0 or 1 — exit 2 means a syntax error slipped back in

## Verification

- Old-pattern reproduction: `pgrep -f 'hermes(?:\\s+\\S+)*\\s+chat\\b'` → exit **2** (`Invalid preceding regular expression`); new pattern → exit **0/1**
- `vitest run tests/unit/bridge/hermes-process.test.ts`: **16/16 passed** (includes the real-pgrep Linux regression)
- Full bridge suites: `vitest run tests/unit/bridge/ tests/unit/bridge-status.test.ts` → **7 files / 39 tests passed**
- Scoped `tsc --noEmit` type-check of `bridge/hermes-process.ts`: clean

## Notes

- No runtime dependencies; no generated `dist/` files added.
- CONTRIBUTING.md suggests PRs against `dev`, but no plain `dev` branch exists upstream; recent plugin fixes (#2192) were merged via feature branches, so this targets `main`. Happy to retarget if maintainers prefer another base.