### PR TITLE
fix(plugin): remember unsupported reasoning-effort routes per bridge

### DIFF
--- a/apps/memos-local-plugin/adapters/deepseek-harness/host-llm.ts
+++ b/apps/memos-local-plugin/adapters/deepseek-harness/host-llm.ts
@@ -96,6 +96,9 @@ export interface CreateDeepSeekHarnessHostLlmBridgeOptions {
 export function createDeepSeekHarnessHostLlmBridge(
   options: CreateDeepSeekHarnessHostLlmBridgeOptions,
 ): HostLlmBridge {
+  // Per-bridge, not module-global: each runtime owns its route knowledge, so
+  // concurrent bridges stay independent and tests remain hermetic.
+  const effortUnsupportedRoutes: EffortUnsupportedRoutes = new Set();
   return {
     id: HOST_LLM_BRIDGE_ID,
     async complete(input: HostLlmCompleteInput): Promise<HostLlmCompletion> {
@@ -122,6 +125,7 @@ export function createDeepSeekHarnessHostLlmBridge(
           input,
           route,
           callDeadline.signal,
+          effortUnsupportedRoutes,
         );
         const request = createGenerateOptions(input, route, prepared.config);
         request.signal = callDeadline.signal;
@@ -212,6 +216,13 @@ function createGenerateOptions(
   };
 }
 
+/** Routes of one bridge that already rejected the branded `off` effort probe. */
+type EffortUnsupportedRoutes = Set<string>;
+
+function effortRouteKey(route: DeepSeekHarnessLlmRoute): string {
+  return `${route.provider}/${route.model}`;
+}
+
 /**
  * Prepare a registration-bound bounded MemOS helper call.
  *
@@ -223,14 +234,24 @@ function createGenerateOptions(
  * adapter/provider default. prepareCall performs no provider generation I/O
  * and binds that validation to the same registration used for dispatch, even
  * if HMR replaces the route before the returned stream starts.
+ *
+ * A model may advertise no efforts at all (a hand-declared OpenAI-completions
+ * entry, for example), so for such routes the probe itself always fails. Each
+ * bridge remembers the routes that rejected the probe and skips it on later
+ * calls: without that memory every summarize/filter pays one doomed attempt
+ * plus a logged UNSUPPORTED_REASONING_EFFORT error before its real request.
  */
 async function prepareAuxiliaryCall(
   llm: DeepSeekHarnessLlmLike,
   input: HostLlmCompleteInput,
   route: DeepSeekHarnessLlmRoute,
   signal: AbortSignal,
+  effortUnsupportedRoutes: EffortUnsupportedRoutes,
 ): Promise<PreparedLlmCall> {
   const config = createCallConfig(input, route);
+  if (effortUnsupportedRoutes.has(effortRouteKey(route))) {
+    return llm.prepareCall(config, signal);
+  }
   try {
     return await llm.prepareCall(
       { ...config, reasoningEffort: NO_REASONING_EFFORT },
@@ -243,6 +264,7 @@ async function prepareAuxiliaryCall(
     ) {
       throw error;
     }
+    effortUnsupportedRoutes.add(effortRouteKey(route));
     return llm.prepareCall(config, signal);
   }
 }

--- a/apps/memos-local-plugin/tests/unit/adapters/deepseek-harness-host-llm.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/deepseek-harness-host-llm.test.ts
@@ -227,6 +227,86 @@ describe("DeepSeek Harness host LLM bridge", () => {
     expect(result.text).toBe("ok");
   });
 
+  it("remembers an unsupported-effort route and probes it only once per bridge", async () => {
+    const preparations: LlmCallConfig[] = [];
+    const routes = new DeepSeekHarnessLlmRouteContext();
+    const bridge = createDeepSeekHarnessHostLlmBridge({
+      llm: streamFrom([
+        { type: "text-delta", index: 0, text: "ok" },
+        { type: "finish", reason: { kind: "stop" } },
+      ], undefined, [], (config) => {
+        preparations.push(config);
+      }),
+      routes,
+    });
+    const complete = () => bridge.complete({ messages: [{ role: "user", content: "hello" }] });
+
+    const first = await routes.run(
+      { provider: "openai", model: "gpt-test" },
+      complete,
+    );
+    const second = await routes.run(
+      { provider: "openai", model: "gpt-test" },
+      complete,
+    );
+
+    expect(first.text).toBe("ok");
+    expect(second.text).toBe("ok");
+    // The doomed probe runs once per route; later helper calls skip straight
+    // to the effort-less preparation instead of failing again.
+    expect(preparations).toEqual([
+      {
+        provider: "openai",
+        model: "gpt-test",
+        reasoningEffort: ReasoningEffortId("off"),
+      },
+      { provider: "openai", model: "gpt-test" },
+      { provider: "openai", model: "gpt-test" },
+    ]);
+  });
+
+  it("keeps remembered effort routes scoped to a single bridge instance", async () => {
+    const firstPreparations: LlmCallConfig[] = [];
+    const secondPreparations: LlmCallConfig[] = [];
+    const routes = new DeepSeekHarnessLlmRouteContext();
+    const firstBridge = createDeepSeekHarnessHostLlmBridge({
+      llm: streamFrom([
+        { type: "text-delta", index: 0, text: "ok" },
+        { type: "finish", reason: { kind: "stop" } },
+      ], undefined, [], (config) => {
+        firstPreparations.push(config);
+      }),
+      routes,
+    });
+    const secondBridge = createDeepSeekHarnessHostLlmBridge({
+      llm: streamFrom([
+        { type: "text-delta", index: 0, text: "ok" },
+        { type: "finish", reason: { kind: "stop" } },
+      ], undefined, [], (config) => {
+        secondPreparations.push(config);
+      }),
+      routes,
+    });
+    const completeOn = (bridge: typeof firstBridge) => () => bridge.complete({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    await routes.run(
+      { provider: "openai", model: "gpt-test" },
+      completeOn(firstBridge),
+    );
+    await routes.run(
+      { provider: "openai", model: "gpt-test" },
+      completeOn(secondBridge),
+    );
+
+    // A fresh bridge re-probes: route knowledge must not leak across runtimes.
+    expect(secondPreparations[0]).toHaveProperty(
+      "reasoningEffort",
+      ReasoningEffortId("off"),
+    );
+  });
+
   it("does not fall back for errors other than unsupported reasoning effort", async () => {
     const failure = new LlmError("invalid model metadata", "INVALID_MODEL_REASONING");
     const prepareCall = vi.fn<DeepSeekHarnessLlmLike["prepareCall"]>();


### PR DESCRIPTION
## Problem

`prepareAuxiliaryCall` in the DeepSeek Harness adapter probes DSH'"'"'s branded `off` reasoning effort before **every** auxiliary LLM call, and falls back to an effort-less preparation when the exact model rejects it. That fallback is correct — but for models that advertise **no reasoning efforts at all** (e.g. a hand-declared OpenAI-completions entry), the probe fails *every* time, so each summarize / retrieval-filter call pays one doomed `prepareCall`, one logged `UNSUPPORTED_REASONING_EFFORT` error row, and a retry before doing any real work.

Observed in production while running the plugin (2.0.16) against DeepSeek Harness with OpenCode'"'"'s `x-preview-f-free`: the harness-side api log accumulated **1,220 failed** `capture.summarize` preparations vs 191 successes, and **1,267 failed** retrieval filters vs 106 ok — every success reached only through the fallback retry, doubling round trips and flooding the log.

## Fix

Each bridge now remembers the routes that rejected the probe (keyed by `provider/model`) and skips the probe on later calls:

- first call for a route: probe `off` → on `UNSUPPORTED_REASONING_EFFORT`, remember the route, prepare without effort (unchanged behavior);
- later calls for a remembered route: go straight to the effort-less preparation;
- models that *do* support `off` are unaffected — they keep getting the probe;
- non-unsupported errors still propagate untouched and do not poison the cache.

The memory is scoped **per bridge instance** (closure state, not module-global), so concurrent bridges stay independent and unit tests remain hermetic across cases.

## Tests

- new: `"remembers an unsupported-effort route and probes it only once per bridge"` — asserts the exact preparation sequence `[off, plain, plain]` across two completes;
- new: `"keeps remembered effort routes scoped to a single bridge instance"` — guards against reintroducing module-global state;
- existing suite passes unchanged (`20/20` in `tests/unit/adapters/deepseek-harness-host-llm.test.ts`);
- `tsc -p tsconfig.json --noEmit` clean.