### PR TITLE
fix(hermes-adapter): widen _ACTIVE_CLIENTS key with owner_id to prevent intra-process bridge fight

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/__init__.py
@@ -514,6 +514,7 @@ class MemTensorProvider(MemoryProvider):
                         MemosBridgeClient(
                             runtime_home=home,
                             extra_env=env,
+                            owner_id=f"provider-{id(self)}",
                         )
                     ),
                     before_spawn=lambda home=runtime_home: _prepare_shared_bridge(home),
@@ -526,6 +527,7 @@ class MemTensorProvider(MemoryProvider):
                 new_bridge = MemosBridgeClient(
                     runtime_home=str(runtime_home),
                     extra_env=runtime_env,
+                    owner_id=f"provider-{id(self)}",
                 )
                 new_bridge.register_host_handler(
                     "host.llm.complete",
@@ -2195,6 +2197,7 @@ class MemTensorProvider(MemoryProvider):
                             MemosBridgeClient(
                                 runtime_home=home,
                                 extra_env=env,
+                                owner_id=f"provider-{id(self)}",
                             )
                         ),
                         before_spawn=lambda home=runtime_home: _prepare_shared_bridge(home),
@@ -2261,6 +2264,7 @@ class MemTensorProvider(MemoryProvider):
                 new_bridge = MemosBridgeClient(
                     runtime_home=str(runtime_home),
                     extra_env=runtime_env,
+                    owner_id=f"provider-{id(self)}",
                 )
                 logger.info(
                     "MemOS: new bridge created (pid=%s)",

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -46,7 +46,7 @@ HOST_HANDLER_QUEUE_CAPACITY = 16
 # This is the Python-side guard against issue #1910 (bridge process leak:
 # every turn spawns new bridge.cjs). Defence in depth on the Node side
 # lives in ``bridge.cts`` via ``bridge-stdio.pid``.
-_ACTIVE_CLIENTS: dict[tuple[str, bool, str], MemosBridgeClient] = {}
+_ACTIVE_CLIENTS: dict[tuple[str, bool, str, str], MemosBridgeClient] = {}
 _ACTIVE_CLIENTS_LOCK = threading.Lock()
 
 
@@ -145,6 +145,13 @@ class MemosBridgeClient:
         self,
         *,
         bridge_path: str | None = None,
+        node_binary: str | None = None,
+        agent: str = "hermes",
+        no_viewer: bool = True,
+        extra_env: dict[str, str] | None = None,
+        runtime_home: str | None = None,
+        owner_id: str | None = None,
+    ) -> None:| None = None,
         node_binary: str | None = None,
         agent: str = "hermes",
         no_viewer: bool = True,
@@ -265,6 +272,10 @@ class MemosBridgeClient:
         self._singleton_agent = agent
         self._singleton_no_viewer = bool(no_viewer)
         self._singleton_runtime_home = str(resolved_runtime_home)
+        # owner-keying: widen the singleton tracker key to (agent, no_viewer, home,
+        # owner_id) so concurrent provider instances in ONE process (gateway
+        # email/cron/subagent sessions) do not reap each other's bridges.
+        self._singleton_owner = owner_id or f"anon-{id(self)}"
         previous = self._register_active()
         if previous is not None and previous is not self:
             prev_pid = getattr(previous, "pid", "?")
@@ -282,6 +293,7 @@ class MemosBridgeClient:
             self._singleton_agent,
             self._singleton_no_viewer,
             self._singleton_runtime_home,
+            self._singleton_owner,
         )
         with _ACTIVE_CLIENTS_LOCK:
             previous = _ACTIVE_CLIENTS.get(key)
@@ -294,6 +306,7 @@ class MemosBridgeClient:
             self._singleton_agent,
             self._singleton_no_viewer,
             self._singleton_runtime_home,
+            self._singleton_owner,
         )
         with _ACTIVE_CLIENTS_LOCK:
             if _ACTIVE_CLIENTS.get(key) is self:

--- a/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
+++ b/apps/memos-local-plugin/adapters/hermes/memos_provider/bridge_client.py
@@ -151,12 +151,6 @@ class MemosBridgeClient:
         extra_env: dict[str, str] | None = None,
         runtime_home: str | None = None,
         owner_id: str | None = None,
-    ) -> None:| None = None,
-        node_binary: str | None = None,
-        agent: str = "hermes",
-        no_viewer: bool = True,
-        extra_env: dict[str, str] | None = None,
-        runtime_home: str | None = None,
     ) -> None:
         self._lock = threading.Lock()
         self._next_id = 1


### PR DESCRIPTION
## Description

When the Hermes gateway runs multiple concurrent sessions (email threads, cron jobs, subagents) in one process, each session gets its own `MemTensorProvider` instance. Every `MemosBridgeClient()` construction closes whatever client holds the per-process `(agent, no_viewer, runtime_home)` singleton slot in `_ACTIVE_CLIENTS` — which belongs to a **different** session's provider.

### Root cause

The module-level singleton tracker `_ACTIVE_CLIENTS` in `bridge_client.py` was keyed by `(agent, no_viewer, runtime_home)` — one slot per process. This was correct as a guard against issue #1910 (bridge process leak where one provider kept spawning new bridges per turn), but **fatal** when N provider instances coexist in one gateway process.

**Evidence chain:**
- Gateway process hosts 2+ `bridge.mjs --no-viewer` children, replacing one every 2-3s (PIDs churn constantly)
- Dashboard (single session, one provider) has one stable bridge, zero churn
- The only difference: provider-instance count
- Daemon (`bridge.cjs --daemon`, systemd, :18800) stable throughout

### Fix

Widen the singleton key to `(agent, no_viewer, runtime_home, owner_id)` so concurrent provider instances in one process coexist instead of fighting.

Changes:
- **bridge_client.py**: key type widened `tuple[str, bool, str]` -> `tuple[str, bool, str, str]`; `owner_id: str | None` parameter added to `__init__`; `_singleton_owner` field set from `owner_id or f"anon-{id(self)}"`; key construction in both `_register_active` and `_unregister_active` updated
- **__init__.py**: both construction sites (`initialize()` and `_reconnect_bridge()`) in both shared-bridge and legacy modes pass `owner_id=f"provider-{id(self)}"`

Expected steady state after fix: daemon + 1 bridge per host process = 3 total; reconnect counts -> ~0.

### Alternatives

- **HTTP transport (#1985)** — the architectural end-state, but needs more design
- **Process-wide shared ref-counted client** — one JSON-RPC per process, sessions multiplexed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test — verifies distinct provider instances coexist in the tracker, same-owner replacement works, unregister only removes self
- [x] Living on production (kiwipaulrob's homelab) since 12 Aug 2026 — zero `bridge client is closed` storms since deployment (was thousands/day)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have linked the issue to this PR (if applicable) — related: #1910, #1927, #1985