### PR TITLE
fix: publish local plugin release notes in English

### DIFF
--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -760,7 +760,7 @@ function categoriesFromReleaseItems(items) {
   for (const category of RELEASE_CATEGORY_ORDER) {
     const categoryItems = items.filter((item) => item.category === category);
     if (categoryItems.length === 0) continue;
-    releaseCategories[category] = categoryItems.map((item) => item.text_cn);
+    releaseCategories[category] = categoryItems.map((item) => item.text_en);
     const docCategory = RELEASE_TO_DOC_CATEGORY[category];
     docsCategories.cn[docCategory] = categoryItems.map((item) => item.text_cn);
     docsCategories.en[docCategory] = categoryItems.map((item) => item.text_en);
@@ -1039,7 +1039,7 @@ function markdownFromReleaseItems(items, coverage) {
     lines.push("");
     lines.push(`### ${category}`);
     for (const item of categoryItems) {
-      lines.push(`- ${item.text_cn}`);
+      lines.push(`- ${item.text_en}`);
     }
   }
   lines.push("");
@@ -1237,7 +1237,9 @@ export function manualDraftFromNotes(notes, evidence) {
     validation_report: validationReport,
     validation_attempt_count: 1,
     repair_attempt_count: 0,
-    release_notes_markdown: ensureSourceHint(text),
+    release_notes_markdown: ensureSourceHint(
+      markdownFromReleaseItems(draft.release_items, draft.coverage),
+    ),
   };
 }
 

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -392,9 +392,9 @@ test("postprocesses a single misclassified performance item into Improved", () =
   assert.equal(processed.release_items[0].category, "Improved");
   assert.match(processed.release_items[0].text_cn, /向量扫描性能优化/);
   assert.match(processed.release_notes_markdown, /### Improved/);
-  assert.doesNotMatch(processed.release_categories.Improved[0], /[\u3400-\u9fff]/u);
-  assert.match(processed.docs_categories.cn.Improvements[0], /[\u3400-\u9fff]/u);
-  assert.doesNotMatch(processed.docs_categories.en.Improvements[0], /[\u3400-\u9fff]/u);
+  assert.doesNotMatch(processed.release_categories.Improved[0], /\p{Script=Han}/u);
+  assert.match(processed.docs_categories.cn.Improvements[0], /\p{Script=Han}/u);
+  assert.doesNotMatch(processed.docs_categories.en.Improvements[0], /\p{Script=Han}/u);
 });
 
 test("postprocesses mixed endpoint and auth fixes without dropping either concern", () => {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -392,6 +392,9 @@ test("postprocesses a single misclassified performance item into Improved", () =
   assert.equal(processed.release_items[0].category, "Improved");
   assert.match(processed.release_items[0].text_cn, /向量扫描性能优化/);
   assert.match(processed.release_notes_markdown, /### Improved/);
+  assert.doesNotMatch(processed.release_categories.Improved[0], /[\u3400-\u9fff]/u);
+  assert.match(processed.docs_categories.cn.Improvements[0], /[\u3400-\u9fff]/u);
+  assert.doesNotMatch(processed.docs_categories.en.Improvements[0], /[\u3400-\u9fff]/u);
 });
 
 test("postprocesses mixed endpoint and auth fixes without dropping either concern", () => {
@@ -554,6 +557,9 @@ test("repairs postprocessed language validation issues with exact context", asyn
     ["text_cn", "text_en"],
   );
   assert.equal(requests[1].release_notes_repair_context.previous_release_items[0].source_refs[0], "abc1234");
+  const visibleNotes = result.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0];
+  assert.match(visibleNotes, /Plugin Health Dashboard/);
+  assert.doesNotMatch(visibleNotes, /插件健康看板/);
   assert.match(result.release_notes_markdown, /插件健康看板/);
   assert.match(result.release_notes_markdown, /doc-agent-release-notes-json/);
 });
@@ -618,6 +624,9 @@ test("standalone latest draft validation allows one initial response plus three 
   assert.equal(result.needs_review, false);
   assert.equal(result.validation_attempt_count, 4);
   assert.equal(result.repair_attempt_count, 3);
+  const visibleNotes = result.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0];
+  assert.match(visibleNotes, /Plugin Health Dashboard/);
+  assert.doesNotMatch(visibleNotes, /插件健康看板/);
   assert.match(result.release_notes_markdown, /插件健康看板/);
 });
 
@@ -750,6 +759,10 @@ test("manual stable notes are revalidated against collected evidence", () => {
   const draft = manualDraftFromNotes(notes, evidence);
   assert.equal(draft.ok, true);
   assert.equal(draft.release_items[0].category, "Fixed");
+  const visibleNotes = draft.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0];
+  assert.match(visibleNotes, /Restores Hermes bridge state/);
+  assert.doesNotMatch(visibleNotes, /修复 Hermes/);
+  assert.match(draft.release_notes_markdown, /修复 Hermes/);
   assert.match(draft.release_notes_markdown, /source-id=openclaw-local-plugin/);
 
   assert.throws(

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -762,7 +762,14 @@ test("manual stable notes are revalidated against collected evidence", () => {
   const visibleNotes = draft.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0];
   assert.match(visibleNotes, /Restores Hermes bridge state/);
   assert.doesNotMatch(visibleNotes, /修复 Hermes/);
-  assert.match(draft.release_notes_markdown, /修复 Hermes/);
+  const embeddedJson = draft.release_notes_markdown.match(
+    /<!--\s*doc-agent-release-notes-json\s*\n([\s\S]*?)\n-->/,
+  )?.[1];
+  assert.ok(embeddedJson, "release notes should retain the hidden bilingual payload");
+  const embeddedPayload = JSON.parse(embeddedJson);
+  assert.equal(embeddedPayload.items[0].text_cn, "修复 Hermes 桥接状态恢复。");
+  assert.equal(embeddedPayload.items[0].text_en, "Restores Hermes bridge state.");
+  assert.deepEqual(embeddedPayload.items[0].source_refs, ["abc1234"]);
   assert.match(draft.release_notes_markdown, /source-id=openclaw-local-plugin/);
 
   assert.throws(


### PR DESCRIPTION
## Summary

- render the visible MemOS local-plugin GitHub Release changelog in English
- keep the hidden bilingual Doc Agent payload, `source_refs`, and CN/EN docs previews unchanged
- normalize manually supplied stable notes through the same English public rendering path

This is a focused follow-up to merged PR #2249. Both the standalone stable publisher and the paired weekly publisher use this shared generator. Prerelease package-only behavior is unchanged.

## Verification

- `155` local-plugin release and MemOS paired-release tests passed
- verified public Release categories contain no CJK while CN docs categories retain Chinese
- `git diff --check` passed
- sensitive-value scan passed

## Historical releases

This fixes future Releases only. Existing `v2.0.16` and `v2.0.17` docs gaps require controlled webhook recovery after their historical evidence is checked; this PR does not redeliver webhooks or publish anything.
