### PR TITLE
ci: skip release dry run for version-only PRs

### DIFF
--- a/.github/workflows/memos-release-pre-merge-dry-run.yml
+++ b/.github/workflows/memos-release-pre-merge-dry-run.yml
@@ -19,8 +19,6 @@ on:
       - ".github/scripts/publish-paired-local-plugin-release.mjs"
       - ".github/scripts/retry.sh"
       - "apps/memos-local-plugin/package.json"
-      - "pyproject.toml"
-      - "src/memos/__init__.py"
 
 concurrency:
   group: memos-release-pre-merge-dry-run-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- stop triggering MemOS Release — Pre-Merge Dry Run when a PR only changes the two MemOS package version declarations
- keep release-automation and local-plugin package changes covered by the dry run
- leave publish, npm, tag, GitHub Release, Doc Agent, and deployment workflows unchanged

## Why
Version-only release PRs were invoking a read-only release inspection that calls GitHub release-note generation and could fail even though the version changes and Python tests were valid. This check is not required by the main branch ruleset.

## Verification
- TAP version 13
# Subtest: accepts only stable MemOS versions without a leading v
ok 1 - accepts only stable MemOS versions without a leading v
  ---
  duration_ms: 1.500667
  type: 'test'
  ...
# Subtest: compares stable MemOS versions without numeric precision loss
ok 2 - compares stable MemOS versions without numeric precision loss
  ---
  duration_ms: 16.9325
  type: 'test'
  ...
# Subtest: updates both MemOS version declarations and preserves surrounding content
ok 3 - updates both MemOS version declarations and preserves surrounding content
  ---
  duration_ms: 0.38975
  type: 'test'
  ...
# Subtest: updates only the version in the pyproject project section
ok 4 - updates only the version in the pyproject project section
  ---
  duration_ms: 0.082417
  type: 'test'
  ...
# Subtest: is idempotent when both declarations already match
ok 5 - is idempotent when both declarations already match
  ---
  duration_ms: 0.142416
  type: 'test'
  ...
# Subtest: fails closed for mismatched, malformed, duplicate, or downgraded versions
ok 6 - fails closed for mismatched, malformed, duplicate, or downgraded versions
  ---
  duration_ms: 0.164625
  type: 'test'
  ...
# Subtest: updates the repository files as one version pair
ok 7 - updates the repository files as one version pair
  ---
  duration_ms: 1.374292
  type: 'test'
  ...
# Subtest: runs from a trusted copy reached through a symbolic path
ok 8 - runs from a trusted copy reached through a symbolic path
  ---
  duration_ms: 46.6925
  type: 'test'
  ...
# Subtest: prepare workflow creates a guarded release branch and manual PR handoff without touching dev
ok 9 - prepare workflow creates a guarded release branch and manual PR handoff without touching dev
  ---
  duration_ms: 0.697625
  type: 'test'
  ...
# Subtest: publish inspection fails closed unless the target ref contains the requested package version
ok 10 - publish inspection fails closed unless the target ref contains the requested package version
  ---
  duration_ms: 0.495792
  type: 'test'
  ...
# Subtest: compares prerelease versions with SemVer precedence
ok 11 - compares prerelease versions with SemVer precedence
  ---
  duration_ms: 7.929125
  type: 'test'
  ...
# Subtest: adds optional repository-authored notes without replacing generated notes
ok 12 - adds optional repository-authored notes without replacing generated notes
  ---
  duration_ms: 0.500208
  type: 'test'
  ...
# Subtest: rejects unsafe repository-authored release notes
ok 13 - rejects unsafe repository-authored release notes
  ---
  duration_ms: 0.294
  type: 'test'
  ...
# Subtest: selects the previous MemOS stable tag for release evidence
ok 14 - selects the previous MemOS stable tag for release evidence
  ---
  duration_ms: 0.201875
  type: 'test'
  ...
# Subtest: extracts PR refs from GitHub release note wording
ok 15 - extracts PR refs from GitHub release note wording
  ---
  duration_ms: 0.632833
  type: 'test'
  ...
# Subtest: rejects leading v in manual version input
ok 16 - rejects leading v in manual version input
  ---
  duration_ms: 0.098958
  type: 'test'
  ...
# Subtest: derives automatic weekly release versions from supported merged release branches
ok 17 - derives automatic weekly release versions from supported merged release branches
  ---
  duration_ms: 0.200167
  type: 'test'
  ...
# Subtest: quality report exposes the validated MemOS project version
ok 18 - quality report exposes the validated MemOS project version
  ---
  duration_ms: 0.309917
  type: 'test'
  ...
# Subtest: auto mode publishes the next local-plugin patch when the version guard is blank
ok 19 - auto mode publishes the next local-plugin patch when the version guard is blank
  ---
  duration_ms: 0.28625
  type: 'test'
  ...
# Subtest: auto mode treats local_plugin_version as a strict guard
ok 20 - auto mode treats local_plugin_version as a strict guard
  ---
  duration_ms: 0.292458
  type: 'test'
  ...
# Subtest: skip mode leaves local-plugin publishing disabled even when changes exist
ok 21 - skip mode leaves local-plugin publishing disabled even when changes exist
  ---
  duration_ms: 0.096625
  type: 'test'
  ...
# Subtest: accepts only the next unused stable patch for a weekly local-plugin release
ok 22 - accepts only the next unused stable patch for a weekly local-plugin release
  ---
  duration_ms: 0.08525
  type: 'test'
  ...
# Subtest: fails when a weekly local-plugin version is supplied without publishable evidence
ok 23 - fails when a weekly local-plugin version is supplied without publishable evidence
  ---
  duration_ms: 0.056083
  type: 'test'
  ...
# Subtest: used npm/tag versions fail closed unless npm-backed recovery is explicit
ok 24 - used npm/tag versions fail closed unless npm-backed recovery is explicit
  ---
  duration_ms: 0.12075
  type: 'test'
  ...
# Subtest: only reuses an exact unpublished weekly local-plugin Draft on automatic retry
ok 25 - only reuses an exact unpublished weekly local-plugin Draft on automatic retry
  ---
  duration_ms: 0.775292
  type: 'test'
  ...
# Subtest: resolves stable local-plugin tag baselines independently from MemOS tags
ok 26 - resolves stable local-plugin tag baselines independently from MemOS tags
  ---
  duration_ms: 0.189292
  type: 'test'
  ...
# Subtest: accepts only a fully published stable local-plugin baseline
ok 27 - accepts only a fully published stable local-plugin baseline
  ---
  duration_ms: 0.068125
  type: 'test'
  ...
# Subtest: accepts stable local-plugin tags on target history or a direct metadata-only release child
ok 28 - accepts stable local-plugin tags on target history or a direct metadata-only release child
  ---
  duration_ms: 0.078708
  type: 'test'
  ...
# Subtest: rejects detached or mismatched stable local-plugin release tags
ok 29 - rejects detached or mismatched stable local-plugin release tags
  ---
  duration_ms: 0.074917
  type: 'test'
  ...
# Subtest: rejects incomplete or inconsistent stable local-plugin baselines
ok 30 - rejects incomplete or inconsistent stable local-plugin baselines
  ---
  duration_ms: 0.110667
  type: 'test'
  ...
# Subtest: requires an exact publish confirmation for non-dry-run releases
ok 31 - requires an exact publish confirmation for non-dry-run releases
  ---
  duration_ms: 0.102333
  type: 'test'
  ...
# Subtest: publish workflow defaults real releases to draft before release.published
ok 32 - publish workflow defaults real releases to draft before release.published
  ---
  duration_ms: 0.876833
  type: 'test'
  ...
# Subtest: paired local-plugin publisher is release-triggered, idempotent, and has explicit recovery
ok 33 - paired local-plugin publisher is release-triggered, idempotent, and has explicit recovery
  ---
  duration_ms: 0.30875
  type: 'test'
  ...
# Subtest: legacy standalone local-plugin publisher requires an extra non-dry-run confirmation
ok 34 - legacy standalone local-plugin publisher requires an extra non-dry-run confirmation
  ---
  duration_ms: 2.673959
  type: 'test'
  ...
# Subtest: legacy standalone local-plugin post-merge dry run is not push-triggered
ok 35 - legacy standalone local-plugin post-merge dry run is not push-triggered
  ---
  duration_ms: 0.256166
  type: 'test'
  ...
# Subtest: read-only dry-run workflows declare bounded fallback behavior
ok 36 - read-only dry-run workflows declare bounded fallback behavior
  ---
  duration_ms: 0.428
  type: 'test'
  ...
# Subtest: inspection artifact contract includes generic aliases and side-effect proof
ok 37 - inspection artifact contract includes generic aliases and side-effect proof
  ---
  duration_ms: 0.606833
  type: 'test'
  ...
# Subtest: allows flexible target refs only for dry runs
ok 38 - allows flexible target refs only for dry runs
  ---
  duration_ms: 0.06075
  type: 'test'
  ...
# Subtest: validates both MemOS package versions at the exact release target
ok 39 - validates both MemOS package versions at the exact release target
  ---
  duration_ms: 179.047
  type: 'test'
  ...
# Subtest: local dry runs prefer the fetched origin branch over a stale local branch
ok 40 - local dry runs prefer the fetched origin branch over a stale local branch
  ---
  duration_ms: 100.0885
  type: 'test'
  ...
# Subtest: reports absent, matching, and conflicting manual release tags
ok 41 - reports absent, matching, and conflicting manual release tags
  ---
  duration_ms: 119.859959
  type: 'test'
  ...
# Subtest: validates a bilingual source-referenced plugin docs draft
ok 42 - validates a bilingual source-referenced plugin docs draft
  ---
  duration_ms: 0.600625
  type: 'test'
  ...
# Subtest: release note methodology records the sources used for quality policy
ok 43 - release note methodology records the sources used for quality policy
  ---
  duration_ms: 0.041542
  type: 'test'
  ...
# Subtest: collects no local-plugin evidence from non-plugin-only release noise
ok 44 - collects no local-plugin evidence from non-plugin-only release noise
  ---
  duration_ms: 133.607875
  type: 'test'
  ...
# Subtest: filters mixed MemOS release evidence down to local-plugin paths
ok 45 - filters mixed MemOS release evidence down to local-plugin paths
  ---
  duration_ms: 179.084875
  type: 'test'
  ...
# Subtest: filters standalone local-plugin release metadata from docs evidence
ok 46 - filters standalone local-plugin release metadata from docs evidence
  ---
  duration_ms: 241.816708
  type: 'test'
  ...
# Subtest: keeps release merge aggregate items tied to local-plugin path refs
ok 47 - keeps release merge aggregate items tied to local-plugin path refs
  ---
  duration_ms: 215.209375
  type: 'test'
  ...
# Subtest: drops reverted release merge aggregate items from local-plugin evidence
ok 48 - drops reverted release merge aggregate items from local-plugin evidence
  ---
  duration_ms: 283.805834
  type: 'test'
  ...
# Subtest: keeps a reapplied local-plugin change after an earlier commit was reverted
ok 49 - keeps a reapplied local-plugin change after an earlier commit was reverted
  ---
  duration_ms: 240.581625
  type: 'test'
  ...
# Subtest: fallback topic rewrites V7 session default fixes into user-facing docs copy
ok 50 - fallback topic rewrites V7 session default fixes into user-facing docs copy
  ---
  duration_ms: 0.235792
  type: 'test'
  ...
# Subtest: fallback topic rewrites recall and host input work without raw commit prefixes
ok 51 - fallback topic rewrites recall and host input work without raw commit prefixes
  ---
  duration_ms: 0.274083
  type: 'test'
  ...
# Subtest: generic fallback strips Conventional Commit prefixes before validation
ok 52 - generic fallback strips Conventional Commit prefixes before validation
  ---
  duration_ms: 0.273042
  type: 'test'
  ...
# Subtest: GitHub release notes fallback stays whole-repo when API access is unavailable
ok 53 - GitHub release notes fallback stays whole-repo when API access is unavailable
  ---
  duration_ms: 108.677125
  type: 'test'
  ...
# Subtest: rejects English text that still contains Chinese
ok 54 - rejects English text that still contains Chinese
  ---
  duration_ms: 0.217375
  type: 'test'
  ...
# Subtest: rejects missing or invented source refs
ok 55 - rejects missing or invented source refs
  ---
  duration_ms: 0.25
  type: 'test'
  ...
# Subtest: rejects drafts that drop important commits
ok 56 - rejects drafts that drop important commits
  ---
  duration_ms: 0.0425
  type: 'test'
  ...
# Subtest: rejects plugin docs drafts that are too fragmented for the changelog page
ok 57 - rejects plugin docs drafts that are too fragmented for the changelog page
  ---
  duration_ms: 0.17475
  type: 'test'
  ...
# Subtest: rejects plugin docs bullets that are too long to render well
ok 58 - rejects plugin docs bullets that are too long to render well
  ---
  duration_ms: 0.060792
  type: 'test'
  ...
# Subtest: rejects generic Chinese plugin docs copy
ok 59 - rejects generic Chinese plugin docs copy
  ---
  duration_ms: 0.038084
  type: 'test'
  ...
# Subtest: rejects generic English plugin docs copy
ok 60 - rejects generic English plugin docs copy
  ---
  duration_ms: 0.035166
  type: 'test'
  ...
# Subtest: rejects raw Conventional Commit subjects copied into docs copy
ok 61 - rejects raw Conventional Commit subjects copied into docs copy
  ---
  duration_ms: 0.037083
  type: 'test'
  ...
# Subtest: rejects duplicate plugin docs bullets that should be merged
ok 62 - rejects duplicate plugin docs bullets that should be merged
  ---
  duration_ms: 0.034208
  type: 'test'
  ...
# Subtest: accepts concise impact-oriented Chinese plugin docs copy
ok 63 - accepts concise impact-oriented Chinese plugin docs copy
  ---
  duration_ms: 0.030792
  type: 'test'
  ...
# Subtest: allows the draft service one initial response plus three repair attempts
ok 64 - allows the draft service one initial response plus three repair attempts
  ---
  duration_ms: 0.313292
  type: 'test'
  ...
# Subtest: real weekly release skips Doc Agent drafting when local-plugin publishing is not requested
ok 65 - real weekly release skips Doc Agent drafting when local-plugin publishing is not requested
  ---
  duration_ms: 0.057917
  type: 'test'
  ...
# Subtest: fails closed when the draft service exhausts all repair attempts
ok 66 - fails closed when the draft service exhausts all repair attempts
  ---
  duration_ms: 0.175542
  type: 'test'
  ...
# Subtest: builds Plugin tab previews without exposing source refs in page content
ok 67 - builds Plugin tab previews without exposing source refs in page content
  ---
  duration_ms: 0.199416
  type: 'test'
  ...
# Subtest: allows an empty Plugin tab draft when a MemOS release has no local-plugin changes
ok 68 - allows an empty Plugin tab draft when a MemOS release has no local-plugin changes
  ---
  duration_ms: 0.11825
  type: 'test'
  ...
# Subtest: skips Plugin tab docs when local-plugin changes are maintenance-only
ok 69 - skips Plugin tab docs when local-plugin changes are maintenance-only
  ---
  duration_ms: 166.395083
  type: 'test'
  ...
# Subtest: skips feat-labeled commits when the final diff only changes local-plugin tests
ok 70 - skips feat-labeled commits when the final diff only changes local-plugin tests
  ---
  duration_ms: 154.756959
  type: 'test'
  ...
# Subtest: does not combine a test-only feat with unrelated runtime maintenance into a release
ok 71 - does not combine a test-only feat with unrelated runtime maintenance into a release
  ---
  duration_ms: 202.78275
  type: 'test'
  ...
# Subtest: skips local-plugin package metadata only changes even when package version changes
ok 72 - skips local-plugin package metadata only changes even when package version changes
  ---
  duration_ms: 151.996208
  type: 'test'
  ...
# Subtest: skips broad build and refactor noise inside local-plugin runtime paths
ok 73 - skips broad build and refactor noise inside local-plugin runtime paths
  ---
  duration_ms: 201.850708
  type: 'test'
  ...
# Subtest: keeps refactors that state a concrete local-plugin user impact
ok 74 - keeps refactors that state a concrete local-plugin user impact
  ---
  duration_ms: 154.259333
  type: 'test'
  ...
1..74
# tests 74
# suites 0
# pass 74
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 2935.970542 (74 passed)
- workflow YAML parsed successfully
- 
