### PR TITLE
Fix #2308: LLM facade drops opts.op before providers — per-op provider switches (e.g. think

### DIFF
--- a/apps/memos-local-plugin/core/llm/client.ts
+++ b/apps/memos-local-plugin/core/llm/client.ts
@@ -282,6 +282,7 @@ export function createLlmClientWithProvider(
       maxTokens: opts?.maxTokens ?? config.maxTokens ?? DEFAULT_MAX_TOKENS,
       jsonMode,
       stop: opts?.stop,
+      op: opts?.op,
     };
   }
 

--- a/apps/memos-local-plugin/core/llm/types.ts
+++ b/apps/memos-local-plugin/core/llm/types.ts
@@ -257,6 +257,14 @@ export interface ProviderCallInput {
   maxTokens: number;
   jsonMode: boolean;
   stop?: string[];
+  /**
+   * Logical call site (e.g. `capture.summarize`, `retrieval.filter`,
+   * `skill.evolve`). Forwarded from `LlmCallOptions.op` so providers
+   * can apply per-op behavior (request-body tweaks, routing overrides,
+   * reasoning kill-switches, per-op budget caps). Optional — providers
+   * must not assume it is set.
+   */
+  op?: string;
 }
 
 /** What providers return — pre-facade post-processing. */

--- a/apps/memos-local-plugin/tests/unit/llm/client.test.ts
+++ b/apps/memos-local-plugin/tests/unit/llm/client.test.ts
@@ -322,6 +322,51 @@ describe("llm/client", () => {
     );
   });
 
+  // ─── op propagation to providers (issue #2308) ────────────────────────
+  //
+  // The facade must forward `opts.op` onto the `ProviderCallInput` handed to
+  // `provider.complete()` / `provider.stream()` so per-op provider behavior
+  // (e.g. request-body tweaks, routing overrides, reasoning kill-switches
+  // keyed on `capture.summarize`) can fire. Dropping it silently makes
+  // those switches unreachable.
+  describe("op propagation (issue #2308)", () => {
+    it("complete forwards opts.op onto the provider input", async () => {
+      const fake = new FakeProvider("openai_compatible", () => ({ text: "ok", durationMs: 1 }));
+      const client = createLlmClientWithProvider(cfg(), fake);
+      await client.complete("hi", { op: "capture.summarize" });
+      expect(fake.lastInput?.op).toBe("capture.summarize");
+    });
+
+    it("completeJson forwards opts.op onto the provider input", async () => {
+      const fake = new FakeProvider("openai_compatible", () => ({
+        text: '{"a":1}',
+        durationMs: 1,
+      }));
+      const client = createLlmClientWithProvider(cfg(), fake);
+      await client.completeJson<{ a: number }>("score", { op: "retrieval.filter" });
+      expect(fake.lastInput?.op).toBe("retrieval.filter");
+    });
+
+    it("stream forwards opts.op onto the provider input (non-streaming provider)", async () => {
+      // FakeProvider has no stream(); the facade wraps complete() in a
+      // single-chunk iterable, which still exercises buildCallInput.
+      const fake = new FakeProvider("openai_compatible", () => ({ text: "one", durationMs: 1 }));
+      const client = createLlmClientWithProvider(cfg(), fake);
+      const parts: string[] = [];
+      for await (const c of client.stream("x", { op: "skill.evolve" })) {
+        if (!c.done) parts.push(c.delta);
+      }
+      expect(fake.lastInput?.op).toBe("skill.evolve");
+    });
+
+    it("omits op field when caller supplies no op (contract stays optional)", async () => {
+      const fake = new FakeProvider("openai_compatible", () => ({ text: "ok", durationMs: 1 }));
+      const client = createLlmClientWithProvider(cfg(), fake);
+      await client.complete("hi");
+      expect(fake.lastInput?.op).toBeUndefined();
+    });
+  });
+
   // ─── Circuit breaker (issue #1897) ──────────────────────────────────────
   describe("circuit breaker", () => {
     function statusSink(): { rows: LlmStatusDetail[]; push: (d: LlmStatusDetail) => void } {


### PR DESCRIPTION
## Description

Fix #2308: the LLM facade in `apps/memos-local-plugin/core/llm/client.ts` no longer drops `opts.op` when it hands `ProviderCallInput` to `provider.complete()` / `provider.stream()`. Two-line change: extend `ProviderCallInput` in `core/llm/types.ts` with an optional `op?: string`, and copy `opts?.op` inside `buildCallInput()`. `op` stays optional so providers must not assume it is set; no public `LlmClient` surface change and no new error codes.

This unblocks the OpenRouter/DeepSeek reasoning kill-switch reported in the issue (`opts.op === "capture.summarize"` inside a provider's request builder can now actually evaluate true). Landing the per-op switch itself — e.g. `body.thinking = { type: "disabled" }` in `providers/openai.ts` — is a routing-policy decision left as a follow-up so operators can review it independently.

Tests: added 4 new unit tests under a new "op propagation (issue #2308)" describe block in `tests/unit/llm/client.test.ts` covering `complete` / `completeJson` / `stream` forwarding plus the "no op supplied" case. Verification: all 84 LLM unit tests green (5 files: client / providers / json-mode / prompts / fetcher), `tsc -p tsconfig.json --noEmit` clean. The 46 pre-existing failing test files in the broader unit suite (memory/l3/subscriber etc.) were verified unchanged against the base branch via `git stash` and are unrelated to this fix.

Confidence: 0.85 — root cause and fix were both explicit in the issue with local verification by the reporter.

Related Issue (Required):  Fixes #2308

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Added four focused unit tests covering `complete`, `completeJson`, streaming fallback, and calls without an explicit `op`. Existing PR checks passed before retargeting and will be rerun against the updated base.

- [x] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@whipser030, @hijzy please review this PR.

## Reviewer Checklist
- [x] closes #2308
- [x] Made sure Checks passed
- [x] Tests have been provided
