### PR TITLE
ci: make local plugin release notes resilient to large releases

### DIFF
--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -37,6 +37,8 @@ const CURRENT_TAG_PREFIX = "memos-local-plugin-v";
 const TAG_PREFIXES = [CURRENT_TAG_PREFIX, "openclaw-local-plugin-v"];
 const RELEASE_NOTES_MARKER = "doc-agent-release-notes-json";
 const RELEASE_CATEGORY_ORDER = ["Added", "Improved", "Fixed"];
+const MIN_RELEASE_TOPICS = 12;
+const MAX_RELEASE_TOPICS = 18;
 const MAX_DRAFT_REPAIR_ATTEMPTS = 3;
 const RELEASE_TO_DOC_CATEGORY = {
   Added: "New Features",
@@ -51,6 +53,11 @@ function fail(message) {
 
 function warn(message) {
   console.error(`::warning::${message}`);
+}
+
+export function releaseTopicLimitForRequiredCount(requiredCount) {
+  const count = Math.max(0, Number(requiredCount) || 0);
+  return Math.min(MAX_RELEASE_TOPICS, Math.max(MIN_RELEASE_TOPICS, Math.ceil(count / 2)));
 }
 
 function sh(args, options = {}) {
@@ -203,22 +210,90 @@ export function findPreviousTag(targetVersion, currentTag, options = {}) {
   return selectPreviousTag(listProductTags(), targetVersion, currentTag, options);
 }
 
+function commitIdentity(commit) {
+  return String(commit?.sha || commit?.short_sha || "").toLowerCase();
+}
+
+function revertTargetSha(commit) {
+  return `${commit?.subject || ""}\n${commit?.body || ""}`.match(
+    /This reverts commit ([0-9a-f]{7,40})\b/i,
+  )?.[1]?.toLowerCase() || "";
+}
+
+function revertedSubject(commit) {
+  return String(commit?.subject || "").match(/^Revert\s+"(.+)"(?:\s+\(#\d+\))?$/i)?.[1] || "";
+}
+
+function commitMatchesSha(commit, targetSha) {
+  const identity = commitIdentity(commit);
+  return Boolean(identity && targetSha && (identity.startsWith(targetSha) || targetSha.startsWith(identity)));
+}
+
+export function filterNetEffectiveCommits(commits) {
+  const chronological = [...commits].reverse();
+  const seen = [];
+  const active = new Map();
+  const effectRoot = new Map();
+  const resolvedReverts = new Set();
+
+  for (const commit of chronological) {
+    const identity = commitIdentity(commit);
+    if (!identity) continue;
+
+    const isRevert = /^revert\b/i.test(String(commit.subject || ""));
+    let target = null;
+    if (isRevert) {
+      const targetSha = revertTargetSha(commit);
+      if (targetSha) {
+        target = [...seen].reverse().find((candidate) => commitMatchesSha(candidate, targetSha)) || null;
+      } else {
+        const targetSubject = revertedSubject(commit).toLowerCase();
+        if (targetSubject) {
+          target =
+            [...seen]
+              .reverse()
+              .find((candidate) => String(candidate.subject || "").toLowerCase() === targetSubject) || null;
+        }
+      }
+    }
+
+    if (target) {
+      const targetIdentity = commitIdentity(target);
+      const root = effectRoot.get(targetIdentity) || targetIdentity;
+      active.set(root, !active.get(root));
+      effectRoot.set(identity, root);
+      resolvedReverts.add(identity);
+    } else {
+      active.set(identity, true);
+      effectRoot.set(identity, identity);
+    }
+    seen.push(commit);
+  }
+
+  return commits.filter((commit) => {
+    const identity = commitIdentity(commit);
+    return identity && !resolvedReverts.has(identity) && active.get(identity) === true;
+  });
+}
+
 function parseCommits(previousTag, currentRef) {
   const text = sh([
     "log",
-    "--format=%H%x09%h%x09%s",
+    "--format=%H%x1f%h%x1f%s%x1f%b%x1e",
     "--no-merges",
     `${previousTag}..${currentRef}`,
     "--",
     PRODUCT_PATH,
   ]);
-  return text
-    .split("\n")
+  const commits = text
+    .split("\x1e")
+    .map((record) => record.trim())
     .filter(Boolean)
-    .map((line) => {
-      const [sha = "", shortSha = "", subject = ""] = line.split("\t");
-      return { sha, short_sha: shortSha, subject };
+    .map((record) => {
+      const [sha = "", shortSha = "", subject = "", body = ""] = record.split("\x1f");
+      return { sha, short_sha: shortSha, subject, body };
     });
+  return filterNetEffectiveCommits(commits).map(({ body: _body, ...commit }) => commit);
 }
 
 function parseChangedFiles(previousTag, currentRef) {
@@ -271,10 +346,17 @@ function categoryHintForSubject(subject) {
   const lower = value.toLowerCase();
   if (
     lower.startsWith("release:") ||
+    /^(ci|chore|docs|test|style|build)(\([^)]+\))?:/i.test(value) ||
     /^fix(\([^)]+\))?:\s*ruff\b/i.test(value) ||
     /review feedback/i.test(value)
   ) {
     return null;
+  }
+  if (/^revert\b/i.test(value)) {
+    return {
+      category: "Fixed",
+      reason: "user-visible rollback of behavior introduced before this release range",
+    };
   }
   if (/^(feat|feature|add)(\([^)]+\))?:|^add\s+/i.test(value)) {
     return {
@@ -314,7 +396,10 @@ function categoryHintForSubject(subject) {
       reason: "specific bug fix",
     };
   }
-  return null;
+  return {
+    category: "Improved",
+    reason: "path-scoped local-plugin change requiring product-facing classification",
+  };
 }
 
 export function categoryHintsForCommits(commits) {
@@ -332,13 +417,151 @@ export function categoryHintsForCommits(commits) {
     .filter(Boolean);
 }
 
+const RELEASE_TOPIC_DEFINITIONS = [
+  {
+    key: "hermes-runtime",
+    category: "Fixed",
+    title_hint: "Hermes runtime and bridge reliability",
+    pattern: /hermes|bridge|pgrep|pid|utf-?8|ensure_ascii|world_model/i,
+  },
+  {
+    key: "idle-skill-archival",
+    category: "Improved",
+    title_hint: "Idle skill archival efficiency and safety",
+    pattern: /idle skill|skill archival|archive idle|idle archive/i,
+  },
+  {
+    key: "configuration-secrets",
+    category: "Fixed",
+    title_hint: "Configuration paths and secret fallback handling",
+    pattern: /config path|secret|environment fallback|env resolver|masked apiKey/i,
+  },
+  {
+    key: "llm-slots",
+    category: "Fixed",
+    title_hint: "LLM and Skill Evolver slot configuration",
+    pattern: /l3llm|l3 llm|skillEvolver|maxTokens|headers|dedicated-slot|llm\./i,
+  },
+  {
+    key: "startup-recovery",
+    category: "Fixed",
+    title_hint: "Startup, installer, recovery, and shutdown reliability",
+    pattern: /startup|installer|gateway after|recovery wait|shutdown/i,
+  },
+  {
+    key: "crystallizer",
+    category: "Fixed",
+    title_hint: "Crystallizer draft and summary recovery",
+    pattern: /crystallizer|crystallize|summary\/steps/i,
+  },
+  {
+    key: "trace-storage",
+    category: "Improved",
+    title_hint: "Trace indexing and storage migration reliability",
+    pattern: /trace index|newest-trace|idx_traces|storage|migrator/i,
+  },
+  {
+    key: "reasoning-capabilities",
+    category: "Fixed",
+    title_hint: "Auxiliary reasoning capability reliability",
+    pattern: /auxiliary reasoning|reasoning capabilities/i,
+  },
+  {
+    key: "release-automation",
+    category: "Improved",
+    title_hint: "Local plugin release automation",
+    pattern: /paired local plugin releases|release automation|package inspection/i,
+  },
+];
+
+function releaseTopicDefinition(hint) {
+  const subject = String(hint?.subject || "");
+  const matched = RELEASE_TOPIC_DEFINITIONS.find((definition) => definition.pattern.test(subject));
+  if (matched) return matched;
+  const category = normalizeReleaseCategory(hint?.category) || "Fixed";
+  return {
+    key: `other-${category.toLowerCase()}`,
+    category,
+    title_hint: `${category} local plugin behavior`,
+  };
+}
+
+export function releaseTopicsForCommits(commits) {
+  const topics = new Map();
+  for (const hint of categoryHintsForCommits(commits)) {
+    const definition = releaseTopicDefinition(hint);
+    const existing = topics.get(definition.key) || {
+      key: definition.key,
+      category: definition.category,
+      title_hint: definition.title_hint,
+      reason: "aggregate related user-visible changes into one evidence-backed release item",
+      source_refs: [],
+      subjects: [],
+    };
+    for (const ref of hint.source_refs || []) {
+      if (!existing.source_refs.includes(ref)) existing.source_refs.push(ref);
+    }
+    if (hint.subject && !existing.subjects.includes(hint.subject)) {
+      existing.subjects.push(hint.subject);
+    }
+    topics.set(definition.key, existing);
+  }
+  return compactReleaseTopics(
+    [...topics.values()],
+    releaseTopicLimitForRequiredCount(commits.length),
+  );
+}
+
+export function compactReleaseTopics(
+  rawTopics,
+  maxTopics = releaseTopicLimitForRequiredCount(rawTopics.length),
+) {
+  const topics = rawTopics.map((topic) => ({
+    ...topic,
+    source_refs: [...new Set(topic.source_refs || [])],
+    subjects: [...new Set(topic.subjects || [])],
+  }));
+  let consolidationIndex = 0;
+
+  while (topics.length > maxTopics) {
+    let bestPair = null;
+    for (let left = 0; left < topics.length; left += 1) {
+      for (let right = left + 1; right < topics.length; right += 1) {
+        if (topics[left].category !== topics[right].category) continue;
+        const score = (topics[left].source_refs.length + topics[right].source_refs.length) * 1000 + left + right;
+        if (!bestPair || score < bestPair.score) bestPair = { left, right, score };
+      }
+    }
+    if (!bestPair) {
+      fail(`Cannot compact ${topics.length} local-plugin release topics without mixing categories.`);
+    }
+
+    const first = topics[bestPair.left];
+    const second = topics[bestPair.right];
+    topics.splice(bestPair.right, 1);
+    topics.splice(bestPair.left, 1, {
+      key: `consolidated-${first.category.toLowerCase()}-${consolidationIndex}`,
+      category: first.category,
+      title_hint: `${first.category} local plugin behavior`,
+      reason: "consolidate related user-visible changes while preserving complete evidence coverage",
+      source_refs: [...new Set([...first.source_refs, ...second.source_refs])],
+      subjects: [...new Set([...first.subjects, ...second.subjects])],
+    });
+    consolidationIndex += 1;
+  }
+  return topics;
+}
+
 export function releaseNoteGuidanceForCommits(commits) {
   return {
     ...RELEASE_NOTE_GUIDANCE,
     source_ref_category_hints: categoryHintsForCommits(commits),
+    release_topics: releaseTopicsForCommits(commits),
     source_ref_hint_policy:
       "Treat source_ref_category_hints as advisory classification hints grounded in evidence. " +
-      "Use them to avoid moving performance/compatibility work into Fixed merely because the commit subject starts with fix.",
+      "Use them to avoid moving performance/compatibility work into Fixed merely because the commit subject starts with fix. " +
+      "Treat release_topics as the required coverage units: write at most one concise release item per topic, " +
+      "and preserve every topic source_ref on that item.",
   };
 }
 
@@ -362,9 +585,10 @@ export function collectEvidence({ targetVersion, currentTag, previousTag, curren
     release_note_quality_request: {
       candidate_count: 3,
       max_repair_attempts: MAX_DRAFT_REPAIR_ATTEMPTS,
+      max_items: releaseTopicLimitForRequiredCount(commits.length),
       selection_policy: [
         "Preserve complete evidence coverage and valid source_refs before optimizing readability.",
-        "Prefer 6-10 concise product-facing bullets and never exceed 12 bullets.",
+        "Prefer 6-10 concise product-facing bullets when possible; for larger releases do not exceed max_items.",
       ],
     },
     repo,
@@ -402,6 +626,7 @@ export function evidenceForInspection(evidence) {
       source_ref_category_hints: Array.isArray(guidance.source_ref_category_hints)
         ? guidance.source_ref_category_hints
         : [],
+      release_topics: Array.isArray(guidance.release_topics) ? guidance.release_topics : [],
     },
     redactions: {
       important_diff: "omitted from public workflow artifacts; sent only to the configured draft service",
@@ -477,7 +702,6 @@ function normalizeReleaseCategory(value) {
 
 function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
-  if (/^\d{2,}$/.test(text)) return `#${text}`;
   if (/^#\d+$/.test(text)) return text;
   if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
   return "";
@@ -530,20 +754,27 @@ function buildSourceRefIndex(evidence) {
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
 
-  for (const hint of evidence?.release_note_guidance?.source_ref_category_hints || []) {
+  const topics = evidence?.release_note_guidance?.release_topics || [];
+  const sourceGroups = topics.length > 0
+    ? topics
+    : evidence?.release_note_guidance?.source_ref_category_hints || [];
+  for (const [position, hint] of sourceGroups.entries()) {
     const refs = normalizeSourceRefs(hint.source_refs);
     const category = normalizeReleaseCategory(hint.category);
     if (refs.length === 0 || !category) continue;
-    const groupKey = refs[0];
+    const groupKey = topics.length > 0
+      ? `topic:${String(hint.key || position)}`
+      : refs[0];
     for (const ref of refs) {
-      knownRefs.add(ref);
       refToGroup.set(ref, groupKey);
     }
     groups.set(groupKey, {
       key: groupKey,
       category,
       refs,
-      subject: String(hint.subject || ""),
+      subjects: Array.isArray(hint.subjects)
+        ? hint.subjects.map((value) => String(value || "")).filter(Boolean)
+        : [String(hint.subject || "")].filter(Boolean),
       reason: String(hint.reason || ""),
     });
   }
@@ -576,7 +807,7 @@ function bestHintCategoryForItem(item, index) {
 
 function subjectsForItem(item, index) {
   return groupKeysForItem(item, index.refToGroup)
-    .map((key) => index.groups.get(key)?.subject || "")
+    .flatMap((key) => index.groups.get(key)?.subjects || [])
     .filter(Boolean)
     .join(" ");
 }
@@ -720,13 +951,20 @@ function dedupeSourceRefsByBestCategory(items, index) {
   const filtered = [];
   for (const item of items) {
     const refs = [];
+    const ownedGroups = new Set();
     for (const ref of item.source_refs) {
       const groupKey = groupKeyForRef(ref, index.refToGroup);
       const owner = ownerByGroup.get(groupKey);
       if (!owner || owner === item) {
         if (!refs.includes(ref)) refs.push(ref);
+        if (owner === item && index.groups.has(groupKey)) ownedGroups.add(groupKey);
       } else {
         removedDuplicateRefs += 1;
+      }
+    }
+    for (const groupKey of ownedGroups) {
+      for (const ref of index.groups.get(groupKey)?.refs || []) {
+        if (!refs.includes(ref)) refs.push(ref);
       }
     }
     if (refs.length === 0) {
@@ -792,7 +1030,7 @@ function coverageFromReleaseItems(evidence, draft, items, index) {
     .filter((group) => !coveredGroups.has(group.key))
     .map((group) => ({
       short_sha: group.refs.find((ref) => /^[a-f0-9]{7,40}$/.test(ref)) || "",
-      subject: group.subject,
+      subject: (group.subjects || []).join("; "),
       refs: group.refs,
       reason: group.reason || "important local-plugin release source",
     }));
@@ -817,7 +1055,7 @@ function coverageFromReleaseItems(evidence, draft, items, index) {
     covered_refs: coveredRefs.sort(),
     policy:
       previousCoverage.policy ||
-      "important feat/fix/perf/refactor commits must be referenced by at least one bullet source_ref",
+      "every deterministic local-plugin release topic must be referenced by one evidence-backed bullet; all topic source_refs are preserved",
   };
 }
 

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -10,12 +10,16 @@ import {
   draftForInspection,
   evidenceForInspection,
   ensureSourceHint,
+  filterNetEffectiveCommits,
   isLegacyPackageOnlyRelease,
   legacyPackageDraftFromEvidence,
   manualDraftFromNotes,
   parseSemver,
   RELEASE_NOTE_GUIDANCE,
   postprocessDraftFromEvidence,
+  releaseTopicsForCommits,
+  compactReleaseTopics,
+  releaseTopicLimitForRequiredCount,
   reportExternalFailureFromEnv,
   requestDraft,
   requestValidatedDraft,
@@ -191,13 +195,203 @@ test("adds source-ref category hints from commit subjects", () => {
       short_sha: "ca2b3854",
       subject: "fix(memos): apply Memtensor-AI review feedback to PR #1817",
     },
+    {
+      short_sha: "ab12cd34",
+      subject: "adjust session checkpoint ownership for local plugin hosts",
+    },
   ]);
   assert.deepEqual(
     hints.map((hint) => hint.category),
-    ["Improved", "Added", "Fixed", "Fixed"],
+    ["Improved", "Added", "Fixed", "Fixed", "Improved"],
   );
   assert.deepEqual(hints[0].source_refs, ["59c14746", "#2076", "#2077"]);
   assert.deepEqual(hints[2].source_refs, ["de03ab29", "#2063", "#2074"]);
+});
+
+test("removes net-zero reverts while preserving reapplications and revert-of-revert effects", () => {
+  const original = {
+    sha: "1111111111111111111111111111111111111111",
+    short_sha: "11111111",
+    subject: "feat(plugin): add session checkpoint recovery",
+    body: "",
+  };
+  const revert = {
+    sha: "2222222222222222222222222222222222222222",
+    short_sha: "22222222",
+    subject: 'Revert "feat(plugin): add session checkpoint recovery"',
+    body: `This reverts commit ${original.sha}.`,
+  };
+  const reapply = {
+    sha: "3333333333333333333333333333333333333333",
+    short_sha: "33333333",
+    subject: "feat(plugin): restore session checkpoint recovery safely",
+    body: "",
+  };
+  const revertOfRevert = {
+    sha: "4444444444444444444444444444444444444444",
+    short_sha: "44444444",
+    subject: 'Revert "Revert session checkpoint recovery"',
+    body: `This reverts commit ${revert.sha}.`,
+  };
+
+  assert.deepEqual(filterNetEffectiveCommits([revert, original]), []);
+  assert.deepEqual(filterNetEffectiveCommits([reapply, revert, original]), [reapply]);
+  assert.deepEqual(filterNetEffectiveCommits([revertOfRevert, revert, original]), [original]);
+});
+
+test("uses subject fallback for in-range reverts but keeps rollbacks of older releases", () => {
+  const original = {
+    sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    short_sha: "aaaaaaaa",
+    subject: "fix(plugin): retain host input during recall",
+    body: "",
+  };
+  const subjectOnlyRevert = {
+    sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    short_sha: "bbbbbbbb",
+    subject: 'Revert "fix(plugin): retain host input during recall"',
+    body: "",
+  };
+  const priorReleaseRollback = {
+    sha: "cccccccccccccccccccccccccccccccccccccccc",
+    short_sha: "cccccccc",
+    subject: 'Revert "feat(plugin): legacy behavior from an older release"',
+    body: "This reverts commit dddddddddddddddddddddddddddddddddddddddd.",
+  };
+
+  assert.deepEqual(filterNetEffectiveCommits([subjectOnlyRevert, original]), []);
+  assert.deepEqual(filterNetEffectiveCommits([priorReleaseRollback]), [priorReleaseRollback]);
+  assert.deepEqual(categoryHintsForCommits([priorReleaseRollback])[0].category, "Fixed");
+});
+
+test("aggregates the v2.0.18 high-commit release into evidence-complete user topics", () => {
+  const commits = [
+    ["602f60ff", "fix(plugin): make free-form config paths explicit"],
+    ["e1530908", "fix(plugin): scope secret environment fallbacks"],
+    ["c6aaf9d3", "fix(plugin): use OS home for bridge PID fallback"],
+    ["060859d0", "fix(plugin): run idle skill archival in background"],
+    ["117b2a2d", "fix(plugin): recover gateway after installer failures"],
+    ["fa4bb36b", "fix(hermes-adapter): pass ensure_ascii=False in handle_tool_call json.dumps (#2255)"],
+    ["763ca1fc", "fix(skill): auto-generate crystallizer summary/steps instead of rejecting"],
+    ["2b726985", "fix(plugin): default headers {} on l3Llm/skillEvolver slots; maxTokens floor 100"],
+    ["5fd49171", "fix(core): bound startup recovery wait in shutdown to 15s"],
+    ["10786401", "fix(plugin): wire l3Llm/skillEvolver maxTokens+headers; raise dedicated-slot defaults to 4096"],
+    ["d59fe83a", "fix(plugin): add l3Llm.maxTokens default (shares SkillEvolverSchema)"],
+    ["70646de3", "fix(plugin): declare llm.maxTokens and llm.headers as first-class config keys"],
+    ["1f28c8c5", "fix(config): apply OCR review to secret env resolver"],
+    ["d38dfacb", "fix(config): resolve masked apiKey from env on load"],
+    ["10cda282", "perf(plugin): batch idle skill archival"],
+    ["0dad4af3", "fix(plugin): archive idle skills atomically"],
+    ["02aa0d8b", "refactor(plugin): clarify Hermes regex variants"],
+    ["d985d076", "refactor(plugin): avoid JS regex captures"],
+    ["211dd165", "fix(plugin): harden Hermes pgrep pattern"],
+    ["0ff0a72d", "fix(plugin): bound idle archive batches"],
+    ["c5c0d0cd", "fix(plugin): address idle archive review"],
+    ["411406dd", "fix(plugin): archive idle low-eta skills"],
+    ["213665dd", "fix(memos-local-plugin): use POSIX-ERE-compatible pgrep pattern for hermes chat detection"],
+    ["d76c78aa", "fix(plugin): resolve auxiliary reasoning capabilities"],
+    ["b90b5c91", "fix(plugin): harden newest-trace index rollout"],
+    ["f0f35c77", "fix(storage): add idx_traces_ts to unblock event loop on newest-first trace reads (#2284)"],
+    ["068a701a", "fix(plugin): reconcile stale Hermes bridge status"],
+    ["0d9503a1", "Fix #2255: memos_search returns Chinese text as unicode escapes (#2256)"],
+    ["7b35fcd8", "fix(plugin): harden crystallizer draft recovery"],
+  ].map(([short_sha, subject]) => ({
+    short_sha,
+    sha: short_sha.padEnd(40, "0"),
+    subject,
+  }));
+
+  const topics = releaseTopicsForCommits(commits);
+  assert.ok(topics.length > 1);
+  assert.ok(topics.length <= 15);
+  assert.equal(releaseTopicLimitForRequiredCount(commits.length), 15);
+  assert.equal(
+    topics.flatMap((topic) => topic.source_refs).includes("#10786401"),
+    false,
+    "a numeric hexadecimal SHA must not be rewritten as a PR number",
+  );
+  assert.ok(topics.flatMap((topic) => topic.source_refs).includes("10786401"));
+
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: topics.map((topic, index) => ({
+        category: topic.category,
+        text_cn: `**主题 ${index + 1}**：汇总同一用户影响下的本地插件改进。`,
+        text_en: `**Topic ${index + 1}**: Groups related local-plugin changes by user impact.`,
+        source_refs: [topic.source_refs[0]],
+      })),
+      coverage: {},
+      warnings: [],
+    },
+    {
+      commits,
+      release_note_guidance: { release_topics: topics },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.needs_review, false);
+  assert.equal(processed.coverage.required_count, topics.length);
+  assert.equal(processed.coverage.missing_required_count, 0);
+  assert.ok(processed.release_items.length > 0);
+  assert.ok(
+    processed.release_items.length <= topics.length,
+    "topics with identical user impact may share one release-note item",
+  );
+  assert.deepEqual(
+    new Set(processed.coverage.covered_refs),
+    new Set(topics.flatMap((topic) => topic.source_refs)),
+  );
+
+  const omittedTopicRefs = new Set(topics[0].source_refs);
+  const missingTopic = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: processed.release_items.map((item) => ({
+        ...item,
+        source_refs: item.source_refs.filter((ref) => !omittedTopicRefs.has(ref)),
+      })),
+      coverage: {},
+      warnings: [],
+    },
+    {
+      commits,
+      release_note_guidance: { release_topics: topics },
+    },
+  );
+  assert.equal(missingTopic.ok, false);
+  assert.equal(missingTopic.needs_review, true);
+  assert.equal(missingTopic.coverage.missing_required_count, 1);
+});
+
+test("compacts future topic growth below the hard item limit without losing evidence", () => {
+  const topics = Array.from({ length: 40 }, (_, index) => ({
+    key: `future-topic-${index}`,
+    category: ["Added", "Improved", "Fixed"][index % 3],
+    title_hint: `Future topic ${index}`,
+    reason: "future release topic",
+    source_refs: [`${(0xabc0000 + index).toString(16)}`],
+    subjects: [`future local-plugin change ${index}`],
+  }));
+
+  const compacted = compactReleaseTopics(topics);
+  assert.equal(releaseTopicLimitForRequiredCount(2), 12);
+  assert.equal(releaseTopicLimitForRequiredCount(29), 15);
+  assert.equal(releaseTopicLimitForRequiredCount(40), 18);
+  assert.equal(compacted.length, 18);
+  assert.equal(new Set(compacted.map((topic) => topic.key)).size, compacted.length);
+  assert.deepEqual(
+    new Set(compacted.flatMap((topic) => topic.source_refs)),
+    new Set(topics.flatMap((topic) => topic.source_refs)),
+  );
+  assert.deepEqual(
+    new Set(compacted.flatMap((topic) => topic.subjects)),
+    new Set(topics.flatMap((topic) => topic.subjects)),
+  );
+  assert.ok(compacted.every((topic) => ["Added", "Improved", "Fixed"].includes(topic.category)));
 });
 
 test("redacts full diff and prompt guidance from inspection evidence", () => {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -199,6 +199,14 @@ test("adds source-ref category hints from commit subjects", () => {
       short_sha: "ab12cd34",
       subject: "adjust session checkpoint ownership for local plugin hosts",
     },
+    {
+      short_sha: "31976918",
+      subject: "test(plugin): format Hermes UTF-8 regression",
+    },
+    {
+      short_sha: "492bc844",
+      subject: "test(hermes-adapter): add world_model coverage and drop fragile \\u check",
+    },
   ]);
   assert.deepEqual(
     hints.map((hint) => hint.category),
@@ -206,6 +214,11 @@ test("adds source-ref category hints from commit subjects", () => {
   );
   assert.deepEqual(hints[0].source_refs, ["59c14746", "#2076", "#2077"]);
   assert.deepEqual(hints[2].source_refs, ["de03ab29", "#2063", "#2074"]);
+  assert.equal(
+    hints.some((hint) => hint.source_refs.includes("31976918") || hint.source_refs.includes("492bc844")),
+    false,
+    "test-only Hermes commits must not become required user-facing release topics",
+  );
 });
 
 test("removes net-zero reverts while preserving reapplications and revert-of-revert effects", () => {
@@ -295,6 +308,8 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
     ["068a701a", "fix(plugin): reconcile stale Hermes bridge status"],
     ["0d9503a1", "Fix #2255: memos_search returns Chinese text as unicode escapes (#2256)"],
     ["7b35fcd8", "fix(plugin): harden crystallizer draft recovery"],
+    ["31976918", "test(plugin): format Hermes UTF-8 regression"],
+    ["492bc844", "test(hermes-adapter): add world_model coverage and drop fragile \\u check"],
   ].map(([short_sha, subject]) => ({
     short_sha,
     sha: short_sha.padEnd(40, "0"),
@@ -304,7 +319,14 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
   const topics = releaseTopicsForCommits(commits);
   assert.ok(topics.length > 1);
   assert.ok(topics.length <= 15);
-  assert.equal(releaseTopicLimitForRequiredCount(commits.length), 15);
+  assert.equal(releaseTopicLimitForRequiredCount(29), 15);
+  assert.equal(
+    topics.some((topic) =>
+      topic.source_refs.some((ref) => ref === "31976918" || ref === "492bc844"),
+    ),
+    false,
+    "the v2.0.18 test-only commits must not be required release-note evidence",
+  );
   assert.equal(
     topics.flatMap((topic) => topic.source_refs).includes("#10786401"),
     false,

--- a/.github/scripts/prepare-memos-release.mjs
+++ b/.github/scripts/prepare-memos-release.mjs
@@ -28,7 +28,8 @@ export const RELEASE_TO_DOC_CATEGORY = {
 };
 export const MAX_REPAIR_ATTEMPTS = 3;
 export const MAX_DRAFT_ATTEMPTS = MAX_REPAIR_ATTEMPTS + 1;
-const MAX_RELEASE_ITEMS = 12;
+const MIN_RELEASE_ITEMS = 12;
+const MAX_RELEASE_ITEMS = 18;
 const MAX_TEXT_CN_CHARS = 180;
 const MAX_TEXT_EN_CHARS = 220;
 const CJK_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
@@ -82,6 +83,11 @@ function fail(message) {
 
 function warn(message) {
   console.error(`::warning::${message}`);
+}
+
+export function releaseItemLimitForRequiredCount(requiredCount) {
+  const count = Math.max(0, Number(requiredCount) || 0);
+  return Math.min(MAX_RELEASE_ITEMS, Math.max(MIN_RELEASE_ITEMS, Math.ceil(count / 2)));
 }
 
 function sh(args, options = {}) {
@@ -1181,6 +1187,7 @@ export function collectLocalPluginEvidence({
     release_note_quality_request: {
       candidate_count: 3,
       max_repair_attempts: MAX_REPAIR_ATTEMPTS,
+      max_items: releaseItemLimitForRequiredCount(importantCommits.length),
       methodology: RELEASE_NOTE_METHODS,
       require_source_refs: true,
       require_bilingual_output: true,
@@ -1584,10 +1591,13 @@ export function validateDraft(draft, evidence) {
   if (!draft.release_items.length && evidence.has_user_facing_product_changes) {
     issues.push({ kind: "empty_release_items", message: "release_items is required when product files changed" });
   }
-  if (draft.release_items.length > MAX_RELEASE_ITEMS) {
+  const maxReleaseItems = releaseItemLimitForRequiredCount(
+    evidence.required_source_refs?.length || evidence.important_commits?.length || 0,
+  );
+  if (draft.release_items.length > maxReleaseItems) {
     issues.push({
       kind: "too_many_release_items",
-      message: `release_items must be concise for the Plugin tab; got ${draft.release_items.length}, max ${MAX_RELEASE_ITEMS}`,
+      message: `release_items must be concise for the Plugin tab; got ${draft.release_items.length}, max ${maxReleaseItems}`,
     });
   }
 

--- a/.github/scripts/prepare-memos-release.mjs
+++ b/.github/scripts/prepare-memos-release.mjs
@@ -1433,26 +1433,80 @@ function dedupeFallbackItems(items) {
   return [...byKey.values()];
 }
 
+function fallbackItemTitle(text) {
+  return String(text || "")
+    .match(/^\*\*([^*]+)\*\*/)?.[1]
+    ?.trim() || "local-plugin behavior";
+}
+
+function combinedFallbackCopy(category, first, second, sequence) {
+  const cnTitles = [fallbackItemTitle(first.text_cn), fallbackItemTitle(second.text_cn)]
+    .filter(Boolean)
+    .join("、")
+    .slice(0, 72);
+  const enTitles = [fallbackItemTitle(first.text_en), fallbackItemTitle(second.text_en)]
+    .filter(Boolean)
+    .join(" and ")
+    .slice(0, 100);
+  const copy = {
+    Added: {
+      text_cn: `**本地插件组合新能力 ${sequence}**：第 ${sequence} 组统一呈现 ${cnTitles} 相关的新能力与使用场景，并保留完整发布依据。`,
+      text_en: `**Combined local-plugin capabilities ${sequence}**: Group ${sequence} covers new capabilities and usage scenarios related to ${enTitles} while preserving complete release evidence.`,
+    },
+    Improved: {
+      text_cn: `**本地插件组合改进 ${sequence}**：第 ${sequence} 组统一呈现 ${cnTitles} 相关的体验与性能改进，并保留完整发布依据。`,
+      text_en: `**Combined local-plugin improvements ${sequence}**: Group ${sequence} covers experience and performance improvements related to ${enTitles} while preserving complete release evidence.`,
+    },
+    Fixed: {
+      text_cn: `**本地插件组合修复 ${sequence}**：第 ${sequence} 组统一呈现 ${cnTitles} 相关的问题修复与稳定性改进，并保留完整发布依据。`,
+      text_en: `**Combined local-plugin fixes ${sequence}**: Group ${sequence} covers fixes and reliability improvements related to ${enTitles} while preserving complete release evidence.`,
+    },
+  };
+  return copy[category] || copy.Improved;
+}
+
+export function compactFallbackItems(rawItems, maxItems) {
+  const items = rawItems.map((item) => ({
+    ...item,
+    source_refs: [...new Set(item.source_refs || [])],
+  }));
+  let sequence = 1;
+
+  while (items.length > maxItems) {
+    let bestPair = null;
+    for (let left = 0; left < items.length; left += 1) {
+      for (let right = left + 1; right < items.length; right += 1) {
+        if (items[left].category !== items[right].category) continue;
+        const score = (items[left].source_refs.length + items[right].source_refs.length) * 1000 + left + right;
+        if (!bestPair || score < bestPair.score) bestPair = { left, right, score };
+      }
+    }
+    if (!bestPair) {
+      fail(`Cannot compact ${items.length} offline release-note items without mixing categories.`);
+    }
+
+    const first = items[bestPair.left];
+    const second = items[bestPair.right];
+    const combinedCopy = combinedFallbackCopy(first.category, first, second, sequence);
+    items.splice(bestPair.right, 1);
+    items.splice(bestPair.left, 1, {
+      category: first.category,
+      ...combinedCopy,
+      source_refs: [...new Set([...first.source_refs, ...second.source_refs])],
+    });
+    sequence += 1;
+  }
+  return items;
+}
+
 function localFallbackDraft(evidence) {
-  const revertedKeys = new Set((evidence.reverted_change_keys || []).map((item) => String(item).toLowerCase()));
-  const aggregateItems = (evidence.release_aggregate_items || [])
-    .filter((item) => !/^revert\b/i.test(item.text))
-    .filter((item) => !revertedKeys.has(String(item.text || "").toLowerCase()));
-  const sourceItems = aggregateItems.length
-    ? aggregateItems.map((item) => {
-        const prRefs = (item.source_refs || []).filter((ref) => String(ref).startsWith("#"));
-        return {
-          ...item,
-          source_refs: prRefs.length ? prRefs : [item.source_commit].filter(Boolean),
-        };
-      })
-    : evidence.important_commits.map((commit) => ({
-        text: commit.subject,
-        source_refs: [commit.short_sha],
-      }));
+  const sourceItems = evidence.important_commits.map((commit) => ({
+    text: commit.subject,
+    source_refs: [commit.short_sha],
+  }));
   let items = dedupeFallbackItems(sourceItems
     .map((sourceItem) => {
-      const topic = fallbackTopicForText(sourceItem.text, { allowGeneric: aggregateItems.length === 0 });
+      const topic = fallbackTopicForText(sourceItem.text, { allowGeneric: true });
       if (!topic) return null;
       return {
         category: topic.category,
@@ -1461,7 +1515,7 @@ function localFallbackDraft(evidence) {
         source_refs: sourceItem.source_refs?.length ? sourceItem.source_refs : [evidence.important_commits[0]?.short_sha].filter(Boolean),
       };
     })
-    .filter(Boolean)).slice(0, 10);
+    .filter(Boolean));
   if (!items.length && evidence.important_commits.length) {
     items = dedupeFallbackItems(evidence.important_commits.map((commit) => {
       const topic = fallbackTopicForText(commit.subject, { allowGeneric: true });
@@ -1471,8 +1525,16 @@ function localFallbackDraft(evidence) {
         text_en: topic.text_en,
         source_refs: [commit.short_sha],
       };
-    })).slice(0, 10);
+    }));
   }
+  items = compactFallbackItems(
+    items,
+    releaseItemLimitForRequiredCount(evidence.required_source_refs.length),
+  );
+  const coveredRefs = new Set(items.flatMap((item) => item.source_refs));
+  const coveredRequiredCount = evidence.required_source_refs.filter((required) =>
+    required.accepted_refs.some((ref) => coveredRefs.has(ref)),
+  ).length;
   return {
     ok: true,
     needs_review: false,
@@ -1481,8 +1543,8 @@ function localFallbackDraft(evidence) {
     release_items: items,
     coverage: {
       required_count: evidence.required_source_refs.length,
-      covered_required_count: Math.min(items.length, evidence.required_source_refs.length),
-      missing_required_count: Math.max(0, evidence.required_source_refs.length - items.length),
+      covered_required_count: coveredRequiredCount,
+      missing_required_count: Math.max(0, evidence.required_source_refs.length - coveredRequiredCount),
     },
     validation_attempt_count: 1,
     repair_attempt_count: 0,

--- a/.github/scripts/prepare-memos-release.test.mjs
+++ b/.github/scripts/prepare-memos-release.test.mjs
@@ -15,6 +15,7 @@ import {
   compareSemver,
   cleanLocalPluginVersion,
   cleanVersion,
+  compactFallbackItems,
   deriveReleaseVersionFromMergedPrHead,
   docsPreviewMarkdown,
   existingReleaseTagState,
@@ -1403,6 +1404,70 @@ test("allows a larger evidence-complete draft for a high-commit local-plugin rel
   assert.equal(result.ok, true, JSON.stringify(result.issues));
   assert.equal(result.coverage.missing_required_count, 0);
   assert.equal(result.issues.some((issue) => issue.kind === "too_many_release_items"), false);
+});
+
+test("offline preview dynamically compacts 29 commits without dropping required refs", async () => {
+  const required = Array.from({ length: 29 }, (_item, index) => {
+    const shortSha = (0xdef0000 + index).toString(16);
+    return {
+      sha: shortSha.padEnd(40, "0"),
+      short_sha: shortSha,
+      subject: `fix(plugin): repair user-visible runtime scenario ${index + 1}`,
+      accepted_refs: [shortSha],
+    };
+  });
+  const dynamicEvidence = {
+    ...evidence,
+    dry_run: true,
+    commits: required,
+    important_commits: required,
+    required_source_refs: required,
+    pull_requests: [],
+    release_aggregate_items: [],
+  };
+  const originalUrl = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL;
+  const originalToken = process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN;
+  const originalOffline = process.env.ALLOW_OFFLINE_DOCS_PREVIEW;
+
+  try {
+    delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL;
+    delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN;
+    process.env.ALLOW_OFFLINE_DOCS_PREVIEW = "true";
+
+    const draft = await requestDocAgentDraft(dynamicEvidence);
+    const result = validateDraft(draft, dynamicEvidence);
+
+    assert.equal(draft.release_items.length, 15);
+    assert.equal(result.ok, true, JSON.stringify(result.issues));
+    assert.equal(result.coverage.required_count, 29);
+    assert.equal(result.coverage.covered_required_count, 29);
+    assert.equal(result.coverage.missing_required_count, 0);
+    assert.equal(new Set(draft.release_items.flatMap((item) => item.source_refs)).size, 29);
+  } finally {
+    if (originalUrl === undefined) delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL;
+    else process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN;
+    else process.env.DOC_AGENT_RELEASE_NOTES_DRAFT_TOKEN = originalToken;
+    if (originalOffline === undefined) delete process.env.ALLOW_OFFLINE_DOCS_PREVIEW;
+    else process.env.ALLOW_OFFLINE_DOCS_PREVIEW = originalOffline;
+  }
+});
+
+test("offline compaction keeps categories separate and retains every source ref", () => {
+  const items = Array.from({ length: 20 }, (_item, index) => ({
+    category: index % 2 ? "Fixed" : "Improved",
+    text_cn: `**场景 ${index + 1}**：提升本地插件在用户场景 ${index + 1} 下的处理稳定性。`,
+    text_en: `**Scenario ${index + 1}**: Improves local-plugin reliability for user scenario ${index + 1}.`,
+    source_refs: [`${(0xfed0000 + index).toString(16)}`],
+  }));
+  const compacted = compactFallbackItems(items, 12);
+
+  assert.equal(compacted.length, 12);
+  assert.deepEqual(
+    new Set(compacted.flatMap((item) => item.source_refs)),
+    new Set(items.flatMap((item) => item.source_refs)),
+  );
+  assert.ok(compacted.every((item) => ["Improved", "Fixed"].includes(item.category)));
 });
 
 test("rejects plugin docs bullets that are too long to render well", () => {

--- a/.github/scripts/prepare-memos-release.test.mjs
+++ b/.github/scripts/prepare-memos-release.test.mjs
@@ -26,6 +26,7 @@ import {
   localPluginTagForVersion,
   npmVersionLookupResult,
   prependRepositoryReleaseNotes,
+  releaseItemLimitForRequiredCount,
   requestDocAgentDraft,
   repositoryReleaseNotesPath,
   resolveRef,
@@ -1364,6 +1365,44 @@ test("rejects plugin docs drafts that are too fragmented for the changelog page"
   const result = validateDraft({ ...validDraft, release_items: noisyItems }, evidence);
   assert.equal(result.ok, false);
   assert.ok(result.issues.some((issue) => issue.kind === "too_many_release_items"));
+});
+
+test("allows a larger evidence-complete draft for a high-commit local-plugin release", () => {
+  const required = Array.from({ length: 29 }, (_item, index) => {
+    const shortSha = (0xabc0000 + index).toString(16);
+    return {
+      sha: shortSha.padEnd(40, "0"),
+      short_sha: shortSha,
+      subject: `fix(plugin): user-visible reliability change ${index + 1}`,
+      accepted_refs: [shortSha],
+    };
+  });
+  const dynamicEvidence = {
+    ...evidence,
+    commits: required,
+    important_commits: required,
+    required_source_refs: required,
+    pull_requests: [],
+  };
+  const releaseItems = Array.from({ length: 15 }, (_item, index) => ({
+    category: "Improved",
+    text_cn: `**本地插件可靠性 ${index + 1}**：汇总第 ${index + 1} 类用户场景下的运行改进。`,
+    text_en: `**Local-plugin reliability ${index + 1}**: Groups runtime improvements for user scenario ${index + 1}.`,
+    source_refs: required
+      .filter((_commit, commitIndex) => commitIndex % 15 === index)
+      .map((commit) => commit.short_sha),
+  }));
+
+  assert.equal(releaseItemLimitForRequiredCount(2), 12);
+  assert.equal(releaseItemLimitForRequiredCount(29), 15);
+  assert.equal(releaseItemLimitForRequiredCount(40), 18);
+  const result = validateDraft(
+    { ...validDraft, release_items: releaseItems },
+    dynamicEvidence,
+  );
+  assert.equal(result.ok, true, JSON.stringify(result.issues));
+  assert.equal(result.coverage.missing_required_count, 0);
+  assert.equal(result.issues.some((issue) => issue.kind === "too_many_release_items"), false);
 });
 
 test("rejects plugin docs bullets that are too long to render well", () => {


### PR DESCRIPTION
## Summary

- aggregate local-plugin commits into deterministic user-facing release topics while preserving every source ref
- align standalone and weekly release-note item limits with the Doc Agent dynamic 12-18 policy
- handle net-zero reverts and numeric hexadecimal commit refs correctly
- make the read-only offline preview compact large evidence sets without truncating required refs
- add v2.0.18 and future high-commit regression coverage

## Why

The v2.0.18 release had 29 important local-plugin commits. The old drafting path produced 12 items that referenced only 12 of those commits, so strict evidence validation stopped the workflow before npm, tag, and GitHub Release side effects.

The Doc Agent already supports a dynamic item budget, but these caller-side MemOS changes had not been committed or submitted. This PR makes both sides use the same rule and groups related commits before drafting, so concise notes can still retain complete evidence coverage.

## Policy

- item budget: `min(18, max(12, ceil(required_count / 2)))`
- 29 required commits therefore allow up to 15 items
- related commits may share one release item, but all of their `source_refs` are preserved
- missing or invented refs, uncovered important commits, mixed-language copy, duplicate copy, and invalid release binding still fail closed

## Safety

- no workflow permissions, secrets, npm publish behavior, tag behavior, or GitHub Release ordering changed
- no package runtime source changed
- both the weekly MemOS release path and standalone local-plugin path use the same evidence policy
- small releases retain the existing 12-item limit
- the PR dry-run fallback remains side-effect-free and now preserves complete evidence instead of slicing to 10 items

## Verification

- `node --check` passed for both changed scripts
- `git diff --check` passed
- full local-plugin release automation suite: 162/162 tests passed
- GitHub `MemOS Release — Pre-Merge Dry Run` passed in run 33365598362
- real inspection result: 28 effective important commits, 14 items, 28/28 covered refs, 0 validation issues
