### PR TITLE
fix: normalize numeric local-plugin source refs

### DIFF
--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -1533,9 +1533,13 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     finalItemCount: items.length,
   });
   const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
+  if (postprocess.dropped_invalid_items > 0) {
+    warnings.push(
+      `${postprocess.dropped_invalid_items} release item(s) were dropped as structurally invalid`,
+    );
+  }
   if (
     postprocess.normalized_evidence_backed_source_refs > 0 ||
-    postprocess.dropped_invalid_items > 0 ||
     postprocess.removed_duplicate_source_refs > 0 ||
     postprocess.dropped_empty_source_items > 0 ||
     postprocess.reclassified_items > 0

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -700,18 +700,40 @@ function normalizeReleaseCategory(value) {
   return RELEASE_CATEGORY_ORDER.includes(text) ? text : "";
 }
 
+function sourceRefFromRepositoryUrl(text) {
+  let parsed;
+  try {
+    parsed = new URL(text);
+  } catch {
+    return "";
+  }
+  if (!/^https?:$/.test(parsed.protocol) || parsed.hostname.toLowerCase() !== "github.com") return "";
+  const expectedRepo = String(process.env.GITHUB_REPOSITORY || "MemTensor/MemOS")
+    .split("/")
+    .filter(Boolean)
+    .map((part) => part.toLowerCase());
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  if (
+    expectedRepo.length !== 2 ||
+    parts.length < 4 ||
+    parts[0].toLowerCase() !== expectedRepo[0] ||
+    parts[1].toLowerCase() !== expectedRepo[1]
+  ) {
+    return "";
+  }
+  if (parts[2].toLowerCase() === "pull" && /^\d+$/.test(parts[3])) return `pr:#${parts[3]}`;
+  if (parts[2].toLowerCase() === "commit" && /^[a-fA-F0-9]{7,40}$/.test(parts[3])) {
+    return `sha:${parts[3].toLowerCase()}`;
+  }
+  return "";
+}
+
 function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
   let match = text.match(/^#\s*(\d+)$/);
   if (match) return `#${match[1]}`;
-  match = text.match(
-    /^https?:\/\/github\.com\/MemTensor\/MemOS\/pull\/(\d+)(?:[/?#].*)?$/i,
-  );
-  if (match) return `pr:#${match[1]}`;
-  match = text.match(
-    /^https?:\/\/github\.com\/MemTensor\/MemOS\/commit\/([a-fA-F0-9]{7,40})(?:[/?#].*)?$/i,
-  );
-  if (match) return `sha:${match[1].toLowerCase()}`;
+  const urlRef = sourceRefFromRepositoryUrl(text);
+  if (urlRef) return urlRef;
   match = text.match(/^(?:pr|pull request)\s*:?[\s#]*(\d+)$/i);
   if (match) return `pr:#${match[1]}`;
   match = text.match(/^(?:commit|sha)\s*:?[\s#]*([a-fA-F0-9]{7,40})$/i);
@@ -823,6 +845,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
       if (explicitPrRef) canonicalRef = explicitPrRef;
       if (explicitShaRef) canonicalRef = explicitShaRef;
       const exactEvidenceRef = index.knownRefs.has(canonicalRef);
+      // The draft service can render an all-numeric SHA as #digits. Repair that ambiguous
+      // form only when it is not a real evidence PR and exactly one evidence SHA matches.
       const numericSha = !explicitPrRef && !exactEvidenceRef
         ? /^#(\d{7,40})$/.exec(canonicalRef)?.[1] || ""
         : "";
@@ -1651,7 +1675,7 @@ export function writeDraftFailureInspection({ evidence, payload, error }) {
   return directory;
 }
 
-// Rejection always records a redacted artifact; callers must expect this filesystem side effect.
+// Rejection always writes a sanitized failure inspection artifact; callers must expect this side effect.
 export function requireValidatedDraft({ evidence, draft }) {
   if (draft?.ok && !draft?.needs_review) return draft;
   const error = new Error(

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -730,6 +730,11 @@ function sourceRefFromRepositoryUrl(text) {
   return "";
 }
 
+function normalizeShaRef(value) {
+  const text = String(value || "").trim().toLowerCase();
+  return /^[a-f0-9]{7,40}$/.test(text) ? text : "";
+}
+
 function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
   let match = text.match(/^#\s*(\d+)$/);
@@ -740,7 +745,8 @@ function normalizeSourceRef(value) {
   if (match) return `pr:#${match[1]}`;
   match = text.match(/^(?:commit|sha)\s*:?[\s#]*([a-fA-F0-9]{7,40})$/i);
   if (match) return `sha:${match[1].toLowerCase()}`;
-  if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
+  const shaRef = normalizeShaRef(text);
+  if (shaRef) return shaRef;
   return "";
 }
 
@@ -757,7 +763,7 @@ function normalizeSourceRefs(raw) {
 function refsForCommit(commit) {
   const refs = [];
   for (const ref of [commit?.short_sha, commit?.sha]) {
-    const normalized = normalizeSourceRef(ref);
+    const normalized = normalizeShaRef(ref);
     if (normalized && !refs.includes(normalized)) refs.push(normalized);
   }
   for (const match of String(commit?.subject || "").matchAll(/#(\d+)/g)) {
@@ -789,10 +795,8 @@ function buildSourceRefIndex(evidence) {
   const shaEntries = [];
 
   for (const commit of evidence?.commits || []) {
-    const shortRef = normalizeSourceRef(commit?.short_sha);
-    const fullRef = normalizeSourceRef(commit?.sha);
-    // Both aliases intentionally remain bare hexadecimal values. Prefix resolution
-    // below depends on fullRef starting with the model-provided SHA candidate.
+    const shortRef = normalizeShaRef(commit?.short_sha);
+    const fullRef = normalizeShaRef(commit?.sha);
     if (shortRef && fullRef) shaEntries.push({ shortRef, fullRef });
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
@@ -840,7 +844,7 @@ function groupKeysForItem(item, refToGroup) {
 
 function canonicalizeEvidenceBackedSourceRefs(items, index) {
   let normalizedRefs = 0;
-  const ambiguousShaRefs = [];
+  const ambiguousShaRefs = new Set();
   const canonicalizedItems = items.map((item) => {
     const sourceRefs = [];
     for (const ref of item.source_refs || []) {
@@ -850,8 +854,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
       if (explicitPrRef) canonicalRef = explicitPrRef;
       if (explicitShaRef) canonicalRef = explicitShaRef;
       const exactEvidenceRef = index.knownRefs.has(canonicalRef);
-      // The draft service can render an all-numeric SHA as #digits. Repair that ambiguous
-      // form only when it is not a real evidence PR and exactly one evidence SHA matches.
+      // The draft service can render an all-numeric short SHA as #digits. Repair that
+      // ambiguous form only when it exactly equals an evidence SHA alias, never a prefix.
       const numericSha = !explicitPrRef && !exactEvidenceRef
         ? /^#(\d{7,40})$/.exec(canonicalRef)?.[1] || ""
         : "";
@@ -859,14 +863,16 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
         || numericSha
         || (/^[a-f0-9]{7,40}$/.test(canonicalRef) ? canonicalRef : "");
       if (shaCandidate) {
-        const matches = index.shaEntries.filter((entry) => entry.fullRef.startsWith(shaCandidate));
+        const matches = index.shaEntries.filter((entry) => numericSha
+          ? entry.shortRef === numericSha || entry.fullRef === numericSha
+          : entry.fullRef.startsWith(shaCandidate));
         // Zero or multiple matches intentionally remain unresolved and fail coverage validation.
         if (matches.length === 1) {
           const entry = matches[0];
           canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
             || (exactEvidenceRef ? canonicalRef : entry.shortRef);
-        } else if (matches.length > 1 && !ambiguousShaRefs.includes(ref)) {
-          ambiguousShaRefs.push(ref);
+        } else if (matches.length > 1) {
+          ambiguousShaRefs.add(ref);
         }
       }
       if (canonicalRef !== ref) normalizedRefs += 1;
@@ -874,7 +880,28 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
     }
     return { ...item, source_refs: sourceRefs };
   });
-  return { items: canonicalizedItems, normalizedRefs, ambiguousShaRefs };
+  return { items: canonicalizedItems, normalizedRefs, ambiguousShaRefs: [...ambiguousShaRefs] };
+}
+
+function releaseNotesPostprocess({
+  normalizedRefs = 0,
+  ambiguousShaRefs = [],
+  droppedInvalidItems = 0,
+  removedDuplicateRefs = 0,
+  droppedEmptyItems = 0,
+  reclassifiedItems = 0,
+  finalItemCount = 0,
+} = {}) {
+  return {
+    applied: true,
+    normalized_evidence_backed_source_refs: normalizedRefs,
+    ambiguous_sha_refs: ambiguousShaRefs,
+    dropped_invalid_items: droppedInvalidItems,
+    removed_duplicate_source_refs: removedDuplicateRefs,
+    dropped_empty_source_items: droppedEmptyItems,
+    reclassified_items: reclassifiedItems,
+    final_item_count: finalItemCount,
+  };
 }
 
 function bestHintCategoryForItem(item, index) {
@@ -1433,16 +1460,7 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   const droppedInvalidItems = rawItems.length - inputItems.length;
   if (inputItems.length === 0) {
     const coverage = coverageFromReleaseItems(evidence, draft || {}, [], index);
-    const postprocess = {
-      applied: true,
-      normalized_evidence_backed_source_refs: 0,
-      ambiguous_sha_refs: [],
-      dropped_invalid_items: droppedInvalidItems,
-      removed_duplicate_source_refs: 0,
-      dropped_empty_source_items: 0,
-      reclassified_items: 0,
-      final_item_count: 0,
-    };
+    const postprocess = releaseNotesPostprocess({ droppedInvalidItems });
     return {
       ...(draft || {}),
       ok: false,
@@ -1486,16 +1504,15 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     coverage.needs_review = true;
   }
   const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
-  const postprocess = {
-    applied: true,
-    normalized_evidence_backed_source_refs: canonicalized.normalizedRefs,
-    ambiguous_sha_refs: canonicalized.ambiguousShaRefs,
-    dropped_invalid_items: droppedInvalidItems,
-    removed_duplicate_source_refs: deduped.removedDuplicateRefs,
-    dropped_empty_source_items: deduped.droppedItems,
-    reclassified_items: reclassifiedItems,
-    final_item_count: items.length,
-  };
+  const postprocess = releaseNotesPostprocess({
+    normalizedRefs: canonicalized.normalizedRefs,
+    ambiguousShaRefs: canonicalized.ambiguousShaRefs,
+    droppedInvalidItems,
+    removedDuplicateRefs: deduped.removedDuplicateRefs,
+    droppedEmptyItems: deduped.droppedItems,
+    reclassifiedItems,
+    finalItemCount: items.length,
+  });
   const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
   if (
     postprocess.normalized_evidence_backed_source_refs > 0 ||
@@ -1702,7 +1719,7 @@ export function requireValidatedDraft({ evidence, draft }) {
   try {
     writeDraftFailureInspection({ evidence, payload: draft || {}, error });
   } catch {
-    // Diagnostic artifact failures must never hide the release-note validation error.
+    // Intentional: diagnostic artifact failures must never hide the validation error.
   }
   throw error;
 }

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -799,6 +799,12 @@ function buildSourceRefIndex(evidence, repository = "") {
     const fullRef = normalizeShaRef(commit?.sha);
     if (shortRef && fullRef && !shaEntriesByFullRef.has(fullRef)) {
       shaEntriesByFullRef.set(fullRef, { shortRef, fullRef });
+    } else if (
+      shortRef
+      && fullRef
+      && shaEntriesByFullRef.get(fullRef)?.shortRef !== shortRef
+    ) {
+      warn(`Evidence contains duplicate SHA ${fullRef} with different short refs; using the first.`);
     }
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
@@ -861,18 +867,18 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
       // ambiguous form only when it exactly equals an evidence SHA alias, never a prefix.
       // A known #digits PR ref must stay a PR. Only an otherwise unknown numeric
       // reference is eligible for the exact numeric-SHA recovery path.
-      const numericSha = !explicitPrRef && !exactEvidenceRef
+      const ambiguousNumericRef = !explicitPrRef && !exactEvidenceRef
         ? /^#(\d{7,40})$/.exec(canonicalRef)?.[1] || ""
         : "";
       const shaCandidate = explicitShaRef
-        || numericSha
+        || ambiguousNumericRef
         || (/^[a-f0-9]{7,40}$/.test(canonicalRef) ? canonicalRef : "");
       if (shaCandidate) {
         // Numeric #refs require exact aliases. The fullRef arm intentionally covers
         // the rare but valid case of an all-decimal 40-character Git SHA.
-        const matches = index.shaEntries.filter((entry) => numericSha
-          ? entry.shortRef === numericSha || entry.fullRef === numericSha
-          : entry.fullRef.startsWith(shaCandidate));
+        const matches = index.shaEntries.filter((entry) => ambiguousNumericRef
+          ? entry.shortRef === ambiguousNumericRef || entry.fullRef === ambiguousNumericRef
+          : entry.fullRef.startsWith(shaCandidate) || entry.shortRef === shaCandidate);
         // Zero or multiple matches intentionally remain unresolved and fail coverage validation.
         if (matches.length === 1) {
           const entry = matches[0];

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -708,7 +708,9 @@ function sourceRefFromRepositoryUrl(text) {
     return "";
   }
   if (!/^https?:$/.test(parsed.protocol) || parsed.hostname.toLowerCase() !== "github.com") return "";
-  const expectedRepo = String(process.env.GITHUB_REPOSITORY || "MemTensor/MemOS")
+  const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
+  if (!repository) return "";
+  const expectedRepo = repository
     .split("/")
     .filter(Boolean)
     .map((part) => part.toLowerCase());
@@ -789,6 +791,8 @@ function buildSourceRefIndex(evidence) {
   for (const commit of evidence?.commits || []) {
     const shortRef = normalizeSourceRef(commit?.short_sha);
     const fullRef = normalizeSourceRef(commit?.sha);
+    // Both aliases intentionally remain bare hexadecimal values. Prefix resolution
+    // below depends on fullRef starting with the model-provided SHA candidate.
     if (shortRef && fullRef) shaEntries.push({ shortRef, fullRef });
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
@@ -836,6 +840,7 @@ function groupKeysForItem(item, refToGroup) {
 
 function canonicalizeEvidenceBackedSourceRefs(items, index) {
   let normalizedRefs = 0;
+  const ambiguousShaRefs = [];
   const canonicalizedItems = items.map((item) => {
     const sourceRefs = [];
     for (const ref of item.source_refs || []) {
@@ -860,6 +865,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
           const entry = matches[0];
           canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
             || (exactEvidenceRef ? canonicalRef : entry.shortRef);
+        } else if (matches.length > 1 && !ambiguousShaRefs.includes(ref)) {
+          ambiguousShaRefs.push(ref);
         }
       }
       if (canonicalRef !== ref) normalizedRefs += 1;
@@ -867,7 +874,7 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
     }
     return { ...item, source_refs: sourceRefs };
   });
-  return { items: canonicalizedItems, normalizedRefs };
+  return { items: canonicalizedItems, normalizedRefs, ambiguousShaRefs };
 }
 
 function bestHintCategoryForItem(item, index) {
@@ -1429,6 +1436,7 @@ export function postprocessDraftFromEvidence(draft, evidence) {
     const postprocess = {
       applied: true,
       normalized_evidence_backed_source_refs: 0,
+      ambiguous_sha_refs: [],
       dropped_invalid_items: droppedInvalidItems,
       removed_duplicate_source_refs: 0,
       dropped_empty_source_items: 0,
@@ -1481,6 +1489,7 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   const postprocess = {
     applied: true,
     normalized_evidence_backed_source_refs: canonicalized.normalizedRefs,
+    ambiguous_sha_refs: canonicalized.ambiguousShaRefs,
     dropped_invalid_items: droppedInvalidItems,
     removed_duplicate_source_refs: deduped.removedDuplicateRefs,
     dropped_empty_source_items: deduped.droppedItems,
@@ -1501,6 +1510,11 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   }
   if (languageIssues.length > 0) {
     warnings.push("release notes language validation failed; manual review is required");
+  }
+  if (canonicalized.ambiguousShaRefs.length > 0) {
+    warnings.push(
+      `ambiguous SHA source_refs were left unresolved: ${canonicalized.ambiguousShaRefs.join(", ")}`,
+    );
   }
 
   return {
@@ -1675,13 +1689,21 @@ export function writeDraftFailureInspection({ evidence, payload, error }) {
   return directory;
 }
 
-// Rejection always writes a sanitized failure inspection artifact; callers must expect this side effect.
+// Rejection makes a best-effort sanitized inspection write without masking validation failures.
 export function requireValidatedDraft({ evidence, draft }) {
   if (draft?.ok && !draft?.needs_review) return draft;
-  const error = new Error(
-    `Postprocessed release notes require review: ${JSON.stringify(draft?.validation_report || draft?.coverage || {})}`,
-  );
-  writeDraftFailureInspection({ evidence, payload: draft || {}, error });
+  let summary = "{}";
+  try {
+    summary = JSON.stringify(draft?.validation_report || draft?.coverage || {});
+  } catch {
+    summary = "{\"summary_unavailable\":true}";
+  }
+  const error = new Error(`Postprocessed release notes require review: ${summary}`);
+  try {
+    writeDraftFailureInspection({ evidence, payload: draft || {}, error });
+  } catch {
+    // Diagnostic artifact failures must never hide the release-note validation error.
+  }
   throw error;
 }
 

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -795,6 +795,25 @@ function groupKeysForItem(item, refToGroup) {
   return keys;
 }
 
+function canonicalizeAmbiguousNumericShaRefs(items, index) {
+  let normalizedRefs = 0;
+  const canonicalizedItems = items.map((item) => {
+    const sourceRefs = [];
+    for (const ref of item.source_refs || []) {
+      const match = /^#(\d{7,40})$/.exec(ref);
+      const numericSha = match?.[1] || "";
+      const canonicalRef =
+        numericSha && !index.knownRefs.has(ref) && index.knownRefs.has(numericSha)
+          ? numericSha
+          : ref;
+      if (canonicalRef !== ref) normalizedRefs += 1;
+      if (!sourceRefs.includes(canonicalRef)) sourceRefs.push(canonicalRef);
+    }
+    return { ...item, source_refs: sourceRefs };
+  });
+  return { items: canonicalizedItems, normalizedRefs };
+}
+
 function bestHintCategoryForItem(item, index) {
   const categories = [];
   for (const key of groupKeysForItem(item, index.refToGroup)) {
@@ -1351,8 +1370,9 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   if (inputItems.length === 0) return draft;
 
   const index = buildSourceRefIndex(evidence);
+  const canonicalized = canonicalizeAmbiguousNumericShaRefs(inputItems, index);
   let reclassifiedItems = 0;
-  let items = inputItems.map((item) => {
+  let items = canonicalized.items.map((item) => {
     const hintedCategory = bestHintCategoryForItem(item, index);
     const category = hintedCategory || item.category;
     if (category !== item.category) reclassifiedItems += 1;
@@ -1377,6 +1397,7 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
   const postprocess = {
     applied: true,
+    normalized_ambiguous_numeric_sha_refs: canonicalized.normalizedRefs,
     removed_duplicate_source_refs: deduped.removedDuplicateRefs,
     dropped_empty_source_items: deduped.droppedItems,
     reclassified_items: reclassifiedItems,
@@ -1384,11 +1405,14 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   };
   const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
   if (
+    postprocess.normalized_ambiguous_numeric_sha_refs > 0 ||
     postprocess.removed_duplicate_source_refs > 0 ||
     postprocess.dropped_empty_source_items > 0 ||
     postprocess.reclassified_items > 0
   ) {
-    warnings.push("release notes were postprocessed to dedupe source_refs and apply evidence category hints");
+    warnings.push(
+      "release notes were postprocessed to normalize evidence-backed numeric SHA refs, dedupe source_refs, and apply evidence category hints",
+    );
   }
   if (languageIssues.length > 0) {
     warnings.push("release notes language validation failed; manual review is required");

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -1649,7 +1649,7 @@ export function manualDraftFromNotes(notes, evidence) {
     validation_report: validationReport,
     validation_attempt_count: 1,
     repair_attempt_count: 0,
-    release_notes_markdown: ensureSourceHint(text),
+    release_notes_markdown: ensureSourceHint(draft.release_notes_markdown),
   };
 }
 

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -705,13 +705,13 @@ function normalizeSourceRef(value) {
   let match = text.match(/^#\s*(\d+)$/);
   if (match) return `#${match[1]}`;
   match = text.match(/\/(?:pull|pulls)\/(\d+)(?:[/?#]|$)/i);
-  if (match) return `#${match[1]}`;
+  if (match) return `pr:#${match[1]}`;
   match = text.match(/\/commit\/([a-fA-F0-9]{7,40})(?:[/?#]|$)/i);
-  if (match) return match[1].toLowerCase();
+  if (match) return `sha:${match[1].toLowerCase()}`;
   match = text.match(/^(?:pr|pull request)\s*:?[\s#]*(\d+)$/i);
-  if (match) return `#${match[1]}`;
+  if (match) return `pr:#${match[1]}`;
   match = text.match(/^(?:commit|sha)\s*:?[\s#]*([a-fA-F0-9]{7,40})$/i);
-  if (match) return match[1].toLowerCase();
+  if (match) return `sha:${match[1].toLowerCase()}`;
   if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
   return "";
 }
@@ -814,15 +814,23 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
     const sourceRefs = [];
     for (const ref of item.source_refs || []) {
       let canonicalRef = ref;
-      const exactEvidenceRef = index.knownRefs.has(ref);
-      const numericSha = !exactEvidenceRef ? /^#(\d{7,40})$/.exec(ref)?.[1] || "" : "";
-      const shaCandidate = numericSha || (/^[a-f0-9]{7,40}$/.test(ref) ? ref : "");
+      const explicitPrRef = /^pr:(#\d+)$/.exec(ref)?.[1] || "";
+      const explicitShaRef = /^sha:([a-f0-9]{7,40})$/.exec(ref)?.[1] || "";
+      if (explicitPrRef) canonicalRef = explicitPrRef;
+      if (explicitShaRef) canonicalRef = explicitShaRef;
+      const exactEvidenceRef = index.knownRefs.has(canonicalRef);
+      const numericSha = !explicitPrRef && !exactEvidenceRef
+        ? /^#(\d{7,40})$/.exec(canonicalRef)?.[1] || ""
+        : "";
+      const shaCandidate = explicitShaRef
+        || numericSha
+        || (/^[a-f0-9]{7,40}$/.test(canonicalRef) ? canonicalRef : "");
       if (shaCandidate) {
         const matches = index.shaEntries.filter((entry) => entry.fullRef.startsWith(shaCandidate));
         if (matches.length === 1) {
           const entry = matches[0];
           canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
-            || (exactEvidenceRef ? ref : entry.shortRef);
+            || (exactEvidenceRef ? canonicalRef : entry.shortRef);
         }
       }
       if (canonicalRef !== ref) normalizedRefs += 1;

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -845,6 +845,7 @@ function groupKeysForItem(item, refToGroup) {
 function canonicalizeEvidenceBackedSourceRefs(items, index) {
   let normalizedRefs = 0;
   const ambiguousShaRefs = new Set();
+  const unresolvedShaRefs = new Set();
   const canonicalizedItems = items.map((item) => {
     const sourceRefs = [];
     for (const ref of item.source_refs || []) {
@@ -863,6 +864,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
         || numericSha
         || (/^[a-f0-9]{7,40}$/.test(canonicalRef) ? canonicalRef : "");
       if (shaCandidate) {
+        // Numeric #refs require exact aliases. The fullRef arm intentionally covers
+        // the rare but valid case of an all-decimal 40-character Git SHA.
         const matches = index.shaEntries.filter((entry) => numericSha
           ? entry.shortRef === numericSha || entry.fullRef === numericSha
           : entry.fullRef.startsWith(shaCandidate));
@@ -873,6 +876,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
             || (exactEvidenceRef ? canonicalRef : entry.shortRef);
         } else if (matches.length > 1) {
           ambiguousShaRefs.add(ref);
+        } else {
+          unresolvedShaRefs.add(ref);
         }
       }
       if (canonicalRef !== ref) normalizedRefs += 1;
@@ -880,12 +885,18 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
     }
     return { ...item, source_refs: sourceRefs };
   });
-  return { items: canonicalizedItems, normalizedRefs, ambiguousShaRefs: [...ambiguousShaRefs] };
+  return {
+    items: canonicalizedItems,
+    normalizedRefs,
+    ambiguousShaRefs: [...ambiguousShaRefs],
+    unresolvedShaRefs: [...unresolvedShaRefs],
+  };
 }
 
 function releaseNotesPostprocess({
   normalizedRefs = 0,
   ambiguousShaRefs = [],
+  unresolvedShaRefs = [],
   droppedInvalidItems = 0,
   removedDuplicateRefs = 0,
   droppedEmptyItems = 0,
@@ -896,6 +907,7 @@ function releaseNotesPostprocess({
     applied: true,
     normalized_evidence_backed_source_refs: normalizedRefs,
     ambiguous_sha_refs: ambiguousShaRefs,
+    unresolved_sha_refs: unresolvedShaRefs,
     dropped_invalid_items: droppedInvalidItems,
     removed_duplicate_source_refs: removedDuplicateRefs,
     dropped_empty_source_items: droppedEmptyItems,
@@ -1507,6 +1519,7 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   const postprocess = releaseNotesPostprocess({
     normalizedRefs: canonicalized.normalizedRefs,
     ambiguousShaRefs: canonicalized.ambiguousShaRefs,
+    unresolvedShaRefs: canonicalized.unresolvedShaRefs,
     droppedInvalidItems,
     removedDuplicateRefs: deduped.removedDuplicateRefs,
     droppedEmptyItems: deduped.droppedItems,
@@ -1531,6 +1544,11 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   if (canonicalized.ambiguousShaRefs.length > 0) {
     warnings.push(
       `ambiguous SHA source_refs were left unresolved: ${canonicalized.ambiguousShaRefs.join(", ")}`,
+    );
+  }
+  if (canonicalized.unresolvedShaRefs.length > 0) {
+    warnings.push(
+      `SHA-like source_refs did not resolve to collected evidence: ${canonicalized.unresolvedShaRefs.join(", ")}`,
     );
   }
 
@@ -1720,6 +1738,7 @@ export function requireValidatedDraft({ evidence, draft }) {
     writeDraftFailureInspection({ evidence, payload: draft || {}, error });
   } catch {
     // Intentional: diagnostic artifact failures must never hide the validation error.
+    warn("Failed to write release-note failure diagnostics; preserving the original validation error.");
   }
   throw error;
 }

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -704,9 +704,13 @@ function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
   let match = text.match(/^#\s*(\d+)$/);
   if (match) return `#${match[1]}`;
-  match = text.match(/\/(?:pull|pulls)\/(\d+)(?:[/?#]|$)/i);
+  match = text.match(
+    /^https?:\/\/github\.com\/MemTensor\/MemOS\/pull\/(\d+)(?:[/?#].*)?$/i,
+  );
   if (match) return `pr:#${match[1]}`;
-  match = text.match(/\/commit\/([a-fA-F0-9]{7,40})(?:[/?#]|$)/i);
+  match = text.match(
+    /^https?:\/\/github\.com\/MemTensor\/MemOS\/commit\/([a-fA-F0-9]{7,40})(?:[/?#].*)?$/i,
+  );
   if (match) return `sha:${match[1].toLowerCase()}`;
   match = text.match(/^(?:pr|pull request)\s*:?[\s#]*(\d+)$/i);
   if (match) return `pr:#${match[1]}`;
@@ -827,6 +831,7 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
         || (/^[a-f0-9]{7,40}$/.test(canonicalRef) ? canonicalRef : "");
       if (shaCandidate) {
         const matches = index.shaEntries.filter((entry) => entry.fullRef.startsWith(shaCandidate));
+        // Zero or multiple matches intentionally remain unresolved and fail coverage validation.
         if (matches.length === 1) {
           const entry = matches[0];
           canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
@@ -1646,6 +1651,7 @@ export function writeDraftFailureInspection({ evidence, payload, error }) {
   return directory;
 }
 
+// Rejection always records a redacted artifact; callers must expect this filesystem side effect.
 export function requireValidatedDraft({ evidence, draft }) {
   if (draft?.ok && !draft?.needs_review) return draft;
   const error = new Error(

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -751,7 +751,14 @@ function normalizeSourceRef(value, repository = "") {
 }
 
 function normalizeSourceRefs(raw, repository = "") {
-  const values = Array.isArray(raw) ? raw : String(raw || "").match(/#\d+|[a-fA-F0-9]{7,40}/g) || [];
+  const values = Array.isArray(raw)
+    ? raw
+    : (() => {
+        const text = String(raw || "").trim();
+        return normalizeSourceRef(text, repository)
+          ? [text]
+          : text.match(/#\d+|[a-fA-F0-9]{7,40}/g) || [];
+      })();
   const refs = [];
   for (const value of values) {
     const ref = normalizeSourceRef(value, repository);
@@ -797,14 +804,22 @@ function buildSourceRefIndex(evidence, repository = "") {
   for (const commit of evidence?.commits || []) {
     const shortRef = normalizeShaRef(commit?.short_sha);
     const fullRef = normalizeShaRef(commit?.sha);
-    if (shortRef && fullRef && !shaEntriesByFullRef.has(fullRef)) {
-      shaEntriesByFullRef.set(fullRef, { shortRef, fullRef });
+    const canonicalShortRef = shortRef || fullRef;
+    const identityRef = fullRef || (canonicalShortRef ? `short:${canonicalShortRef}` : "");
+    if (canonicalShortRef && identityRef && !shaEntriesByFullRef.has(identityRef)) {
+      shaEntriesByFullRef.set(identityRef, {
+        shortRef: canonicalShortRef,
+        fullRef: fullRef || canonicalShortRef,
+      });
     } else if (
-      shortRef
-      && fullRef
-      && shaEntriesByFullRef.get(fullRef)?.shortRef !== shortRef
+      canonicalShortRef
+      && identityRef
+      && shaEntriesByFullRef.get(identityRef)?.shortRef !== canonicalShortRef
     ) {
-      warn(`Evidence contains duplicate SHA ${fullRef} with different short refs; using the first.`);
+      warn(
+        `Evidence contains duplicate SHA ${fullRef || canonicalShortRef} ` +
+          "with different short refs; using the first.",
+      );
     }
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -700,7 +700,7 @@ function normalizeReleaseCategory(value) {
   return RELEASE_CATEGORY_ORDER.includes(text) ? text : "";
 }
 
-function sourceRefFromRepositoryUrl(text) {
+function sourceRefFromRepositoryUrl(text, repository) {
   let parsed;
   try {
     parsed = new URL(text);
@@ -708,9 +708,9 @@ function sourceRefFromRepositoryUrl(text) {
     return "";
   }
   if (!/^https?:$/.test(parsed.protocol) || parsed.hostname.toLowerCase() !== "github.com") return "";
-  const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
-  if (!repository) return "";
-  const expectedRepo = repository
+  const trustedRepository = String(repository || "").trim();
+  if (!trustedRepository) return "";
+  const expectedRepo = trustedRepository
     .split("/")
     .filter(Boolean)
     .map((part) => part.toLowerCase());
@@ -735,11 +735,11 @@ function normalizeShaRef(value) {
   return /^[a-f0-9]{7,40}$/.test(text) ? text : "";
 }
 
-function normalizeSourceRef(value) {
+function normalizeSourceRef(value, repository = "") {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
   let match = text.match(/^#\s*(\d+)$/);
   if (match) return `#${match[1]}`;
-  const urlRef = sourceRefFromRepositoryUrl(text);
+  const urlRef = sourceRefFromRepositoryUrl(text, repository);
   if (urlRef) return urlRef;
   match = text.match(/^(?:pr|pull request)\s*:?[\s#]*(\d+)$/i);
   if (match) return `pr:#${match[1]}`;
@@ -750,11 +750,11 @@ function normalizeSourceRef(value) {
   return "";
 }
 
-function normalizeSourceRefs(raw) {
+function normalizeSourceRefs(raw, repository = "") {
   const values = Array.isArray(raw) ? raw : String(raw || "").match(/#\d+|[a-fA-F0-9]{7,40}/g) || [];
   const refs = [];
   for (const value of values) {
-    const ref = normalizeSourceRef(value);
+    const ref = normalizeSourceRef(value, repository);
     if (ref && !refs.includes(ref)) refs.push(ref);
   }
   return refs;
@@ -773,12 +773,12 @@ function refsForCommit(commit) {
   return refs;
 }
 
-function normalizeReleaseItem(raw) {
+function normalizeReleaseItem(raw, repository = "") {
   if (!raw || typeof raw !== "object") return null;
   const category = normalizeReleaseCategory(raw.category);
   const textCn = String(raw.text_cn || "").trim().replace(/^-+\s*/, "");
   const textEn = String(raw.text_en || "").trim().replace(/^-+\s*/, "");
-  const sourceRefs = normalizeSourceRefs(raw.source_refs);
+  const sourceRefs = normalizeSourceRefs(raw.source_refs, repository);
   if (!category || !textCn || !textEn || sourceRefs.length === 0) return null;
   return {
     category,
@@ -788,16 +788,18 @@ function normalizeReleaseItem(raw) {
   };
 }
 
-function buildSourceRefIndex(evidence) {
+function buildSourceRefIndex(evidence, repository = "") {
   const refToGroup = new Map();
   const groups = new Map();
   const knownRefs = new Set();
-  const shaEntries = [];
+  const shaEntriesByFullRef = new Map();
 
   for (const commit of evidence?.commits || []) {
     const shortRef = normalizeShaRef(commit?.short_sha);
     const fullRef = normalizeShaRef(commit?.sha);
-    if (shortRef && fullRef) shaEntries.push({ shortRef, fullRef });
+    if (shortRef && fullRef && !shaEntriesByFullRef.has(fullRef)) {
+      shaEntriesByFullRef.set(fullRef, { shortRef, fullRef });
+    }
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
 
@@ -806,7 +808,7 @@ function buildSourceRefIndex(evidence) {
     ? topics
     : evidence?.release_note_guidance?.source_ref_category_hints || [];
   for (const [position, hint] of sourceGroups.entries()) {
-    const refs = normalizeSourceRefs(hint.source_refs);
+    const refs = normalizeSourceRefs(hint.source_refs, repository);
     const category = normalizeReleaseCategory(hint.category);
     if (refs.length === 0 || !category) continue;
     const groupKey = topics.length > 0
@@ -826,7 +828,7 @@ function buildSourceRefIndex(evidence) {
     });
   }
 
-  return { refToGroup, groups, knownRefs, shaEntries };
+  return { refToGroup, groups, knownRefs, shaEntries: [...shaEntriesByFullRef.values()] };
 }
 
 function groupKeyForRef(ref, refToGroup) {
@@ -857,6 +859,8 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
       const exactEvidenceRef = index.knownRefs.has(canonicalRef);
       // The draft service can render an all-numeric short SHA as #digits. Repair that
       // ambiguous form only when it exactly equals an evidence SHA alias, never a prefix.
+      // A known #digits PR ref must stay a PR. Only an otherwise unknown numeric
+      // reference is eligible for the exact numeric-SHA recovery path.
       const numericSha = !explicitPrRef && !exactEvidenceRef
         ? /^#(\d{7,40})$/.exec(canonicalRef)?.[1] || ""
         : "";
@@ -872,15 +876,16 @@ function canonicalizeEvidenceBackedSourceRefs(items, index) {
         // Zero or multiple matches intentionally remain unresolved and fail coverage validation.
         if (matches.length === 1) {
           const entry = matches[0];
-          canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
-            || (exactEvidenceRef ? canonicalRef : entry.shortRef);
+          const groupedAlias = [entry.shortRef, entry.fullRef]
+            .find((alias) => index.refToGroup.has(alias));
+          canonicalRef = groupedAlias || (exactEvidenceRef ? canonicalRef : entry.shortRef);
         } else if (matches.length > 1) {
           ambiguousShaRefs.add(ref);
         } else {
           unresolvedShaRefs.add(ref);
         }
       }
-      if (canonicalRef !== ref) normalizedRefs += 1;
+      if (canonicalRef !== ref && index.knownRefs.has(canonicalRef)) normalizedRefs += 1;
       if (!sourceRefs.includes(canonicalRef)) sourceRefs.push(canonicalRef);
     }
     return { ...item, source_refs: sourceRefs };
@@ -1466,9 +1471,10 @@ export function legacyPackageDraftFromEvidence(evidence, { npmDistTag = "" } = {
 }
 
 export function postprocessDraftFromEvidence(draft, evidence) {
+  const repository = String(process.env.GITHUB_REPOSITORY || "").trim();
   const rawItems = Array.isArray(draft?.release_items) ? draft.release_items : [];
-  const inputItems = rawItems.map(normalizeReleaseItem).filter(Boolean);
-  const index = buildSourceRefIndex(evidence);
+  const inputItems = rawItems.map((item) => normalizeReleaseItem(item, repository)).filter(Boolean);
+  const index = buildSourceRefIndex(evidence, repository);
   const droppedInvalidItems = rawItems.length - inputItems.length;
   if (inputItems.length === 0) {
     const coverage = coverageFromReleaseItems(evidence, draft || {}, [], index);

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -1409,7 +1409,7 @@ function markdownFromReleaseItems(items, coverage) {
     lines.push("");
     lines.push(`### ${category}`);
     for (const item of categoryItems) {
-      lines.push(`- ${item.text_cn}`);
+      lines.push(`- ${item.text_en}`);
     }
   }
   lines.push("");
@@ -1703,9 +1703,10 @@ function draftReviewSummary(payload) {
 }
 
 export function writeDraftFailureInspection({ evidence, payload, error }) {
+  const runnerTemp = String(process.env.RUNNER_TEMP || "").trim();
   const directory =
     String(process.env.RELEASE_NOTES_FAILURE_DIR || "").trim() ||
-    join(tmpdir(), "memos-local-plugin-release-notes-failure");
+    join(runnerTemp || tmpdir(), "memos-local-plugin-release-notes-failure");
   mkdirSync(directory, { recursive: true });
   const safeDraft = draftForInspection(payload || {});
   const summary = draftReviewSummary(payload || {});

--- a/.github/scripts/draft-local-plugin-release-notes.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.mjs
@@ -702,7 +702,16 @@ function normalizeReleaseCategory(value) {
 
 function normalizeSourceRef(value) {
   const text = String(value || "").trim().replace(/^[`[(\s]+|[`)\],.;\s]+$/g, "");
-  if (/^#\d+$/.test(text)) return text;
+  let match = text.match(/^#\s*(\d+)$/);
+  if (match) return `#${match[1]}`;
+  match = text.match(/\/(?:pull|pulls)\/(\d+)(?:[/?#]|$)/i);
+  if (match) return `#${match[1]}`;
+  match = text.match(/\/commit\/([a-fA-F0-9]{7,40})(?:[/?#]|$)/i);
+  if (match) return match[1].toLowerCase();
+  match = text.match(/^(?:pr|pull request)\s*:?[\s#]*(\d+)$/i);
+  if (match) return `#${match[1]}`;
+  match = text.match(/^(?:commit|sha)\s*:?[\s#]*([a-fA-F0-9]{7,40})$/i);
+  if (match) return match[1].toLowerCase();
   if (/^[a-fA-F0-9]{7,40}$/.test(text)) return text.toLowerCase();
   return "";
 }
@@ -749,8 +758,12 @@ function buildSourceRefIndex(evidence) {
   const refToGroup = new Map();
   const groups = new Map();
   const knownRefs = new Set();
+  const shaEntries = [];
 
   for (const commit of evidence?.commits || []) {
+    const shortRef = normalizeSourceRef(commit?.short_sha);
+    const fullRef = normalizeSourceRef(commit?.sha);
+    if (shortRef && fullRef) shaEntries.push({ shortRef, fullRef });
     for (const ref of refsForCommit(commit)) knownRefs.add(ref);
   }
 
@@ -779,7 +792,7 @@ function buildSourceRefIndex(evidence) {
     });
   }
 
-  return { refToGroup, groups, knownRefs };
+  return { refToGroup, groups, knownRefs, shaEntries };
 }
 
 function groupKeyForRef(ref, refToGroup) {
@@ -795,17 +808,23 @@ function groupKeysForItem(item, refToGroup) {
   return keys;
 }
 
-function canonicalizeAmbiguousNumericShaRefs(items, index) {
+function canonicalizeEvidenceBackedSourceRefs(items, index) {
   let normalizedRefs = 0;
   const canonicalizedItems = items.map((item) => {
     const sourceRefs = [];
     for (const ref of item.source_refs || []) {
-      const match = /^#(\d{7,40})$/.exec(ref);
-      const numericSha = match?.[1] || "";
-      const canonicalRef =
-        numericSha && !index.knownRefs.has(ref) && index.knownRefs.has(numericSha)
-          ? numericSha
-          : ref;
+      let canonicalRef = ref;
+      const exactEvidenceRef = index.knownRefs.has(ref);
+      const numericSha = !exactEvidenceRef ? /^#(\d{7,40})$/.exec(ref)?.[1] || "" : "";
+      const shaCandidate = numericSha || (/^[a-f0-9]{7,40}$/.test(ref) ? ref : "");
+      if (shaCandidate) {
+        const matches = index.shaEntries.filter((entry) => entry.fullRef.startsWith(shaCandidate));
+        if (matches.length === 1) {
+          const entry = matches[0];
+          canonicalRef = [entry.shortRef, entry.fullRef].find((alias) => index.refToGroup.has(alias))
+            || (exactEvidenceRef ? ref : entry.shortRef);
+        }
+      }
       if (canonicalRef !== ref) normalizedRefs += 1;
       if (!sourceRefs.includes(canonicalRef)) sourceRefs.push(canonicalRef);
     }
@@ -1364,13 +1383,40 @@ export function legacyPackageDraftFromEvidence(evidence, { npmDistTag = "" } = {
 }
 
 export function postprocessDraftFromEvidence(draft, evidence) {
-  const inputItems = Array.isArray(draft?.release_items)
-    ? draft.release_items.map(normalizeReleaseItem).filter(Boolean)
-    : [];
-  if (inputItems.length === 0) return draft;
-
+  const rawItems = Array.isArray(draft?.release_items) ? draft.release_items : [];
+  const inputItems = rawItems.map(normalizeReleaseItem).filter(Boolean);
   const index = buildSourceRefIndex(evidence);
-  const canonicalized = canonicalizeAmbiguousNumericShaRefs(inputItems, index);
+  const droppedInvalidItems = rawItems.length - inputItems.length;
+  if (inputItems.length === 0) {
+    const coverage = coverageFromReleaseItems(evidence, draft || {}, [], index);
+    const postprocess = {
+      applied: true,
+      normalized_evidence_backed_source_refs: 0,
+      dropped_invalid_items: droppedInvalidItems,
+      removed_duplicate_source_refs: 0,
+      dropped_empty_source_items: 0,
+      reclassified_items: 0,
+      final_item_count: 0,
+    };
+    return {
+      ...(draft || {}),
+      ok: false,
+      needs_review: true,
+      release_items: [],
+      release_categories: {},
+      docs_categories: { cn: {}, en: {} },
+      coverage,
+      warnings: [
+        ...(Array.isArray(draft?.warnings) ? draft.warnings : []),
+        "no valid evidence-backed release items remained after deterministic normalization",
+      ],
+      language_issues: [],
+      postprocess,
+      release_notes_markdown: markdownFromReleaseItems([], coverage),
+    };
+  }
+
+  const canonicalized = canonicalizeEvidenceBackedSourceRefs(inputItems, index);
   let reclassifiedItems = 0;
   let items = canonicalized.items.map((item) => {
     const hintedCategory = bestHintCategoryForItem(item, index);
@@ -1397,7 +1443,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   const { releaseCategories, docsCategories } = categoriesFromReleaseItems(items);
   const postprocess = {
     applied: true,
-    normalized_ambiguous_numeric_sha_refs: canonicalized.normalizedRefs,
+    normalized_evidence_backed_source_refs: canonicalized.normalizedRefs,
+    dropped_invalid_items: droppedInvalidItems,
     removed_duplicate_source_refs: deduped.removedDuplicateRefs,
     dropped_empty_source_items: deduped.droppedItems,
     reclassified_items: reclassifiedItems,
@@ -1405,7 +1452,8 @@ export function postprocessDraftFromEvidence(draft, evidence) {
   };
   const warnings = Array.isArray(draft.warnings) ? [...draft.warnings] : [];
   if (
-    postprocess.normalized_ambiguous_numeric_sha_refs > 0 ||
+    postprocess.normalized_evidence_backed_source_refs > 0 ||
+    postprocess.dropped_invalid_items > 0 ||
     postprocess.removed_duplicate_source_refs > 0 ||
     postprocess.dropped_empty_source_items > 0 ||
     postprocess.reclassified_items > 0
@@ -1588,6 +1636,15 @@ export function writeDraftFailureInspection({ evidence, payload, error }) {
     "utf8",
   );
   return directory;
+}
+
+export function requireValidatedDraft({ evidence, draft }) {
+  if (draft?.ok && !draft?.needs_review) return draft;
+  const error = new Error(
+    `Postprocessed release notes require review: ${JSON.stringify(draft?.validation_report || draft?.coverage || {})}`,
+  );
+  writeDraftFailureInspection({ evidence, payload: draft || {}, error });
+  throw error;
 }
 
 function requiredUrlFromEnv(name) {
@@ -1847,9 +1904,7 @@ export async function main() {
     });
     throw error;
   }
-  if (!draft.ok || draft.needs_review) {
-    fail(`Postprocessed release notes require review: ${JSON.stringify(draft.validation_report || draft.coverage || {})}`);
-  }
+  draft = requireValidatedDraft({ evidence, draft });
   const draftPath = join(tmpdir(), `memos-local-plugin-${targetVersion}-release-notes-draft.json`);
   writeFileSync(draftPath, JSON.stringify(draftForInspection(draft), null, 2), "utf8");
   writeFileSync(notesPath, ensureSourceHint(draft.release_notes_markdown), "utf8");

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -829,7 +829,7 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
           category: "Fixed",
           text_cn: "**记忆恢复**：修复异常数据恢复问题。",
           text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-          source_refs: ["https://github.com/ForkOwner/ForkRepo/pull/1234"],
+          source_refs: "https://github.com/ForkOwner/ForkRepo/pull/1234",
         }],
         coverage: {},
       },
@@ -980,6 +980,38 @@ test("resolves an exact evidence short SHA even when it is not a full SHA prefix
   const commit = {
     short_sha: "abcdef12",
     sha: "12345678".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: [commit.short_sha],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, []);
+});
+
+test("resolves an evidence short SHA when a producer omits the full SHA", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "",
     subject: "fix(plugin): stabilize memory recovery",
   };
   const topic = {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -658,6 +658,43 @@ test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
   }
 });
 
+test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
+  const previousRepository = process.env.GITHUB_REPOSITORY;
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  try {
+    process.env.GITHUB_REPOSITORY = "ForkOwner/ForkRepo";
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [`https://github.com/ForkOwner/ForkRepo/commit/${commit.sha}`],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(processed.ok, true);
+    assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
+  } finally {
+    if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = previousRepository;
+  }
+});
+
 test("keeps ambiguous SHA prefixes fail-closed", () => {
   const commits = [
     { short_sha: "1078640a", sha: "1078640a".padEnd(40, "0"), subject: "fix(plugin): recovery A" },

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -516,9 +516,21 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     subjects: [commit.subject],
   };
   const variants = [
+    "10786401",
+    "#10786401",
+    "# 10786401",
+    "`#10786401`",
+    "[10786401]",
+    "(10786401)",
+    "1078640",
+    "commit 10786401",
     "commit: 1078640",
+    "sha 10786401",
+    "SHA: 10786401",
+    "PR #10786401",
+    "pull request: 10786401",
     "https://github.com/MemTensor/MemOS/commit/10786401abcdef0123456789abcdef0123456789",
-    "`# 10786401`",
+    "https://github.com/MemTensor/MemOS/pull/10786401",
   ];
 
   for (const sourceRef of variants) {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -527,10 +527,7 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     "commit: 1078640",
     "sha 10786401",
     "SHA: 10786401",
-    "PR #10786401",
-    "pull request: 10786401",
     "https://github.com/MemTensor/MemOS/commit/10786401abcdef0123456789abcdef0123456789",
-    "https://github.com/MemTensor/MemOS/pull/10786401",
   ];
 
   for (const sourceRef of variants) {
@@ -551,6 +548,75 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     assert.equal(processed.ok, true, sourceRef);
     assert.deepEqual(processed.release_items[0].source_refs, ["10786401"], sourceRef);
   }
+});
+
+test("keeps explicit PR references strict instead of coercing them to numeric SHAs", () => {
+  const commit = {
+    short_sha: "10786401",
+    sha: "10786401abcdef0123456789abcdef0123456789",
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+
+  for (const sourceRef of [
+    "PR #10786401",
+    "pull request: 10786401",
+    "https://github.com/MemTensor/MemOS/pull/10786401",
+  ]) {
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [sourceRef],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(processed.ok, false, sourceRef);
+    assert.equal(processed.coverage.invalid_item_refs.length, 1, sourceRef);
+  }
+});
+
+test("accepts an explicit PR reference only when that PR is present in evidence", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery (#10786401)",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha, "#10786401"],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["https://github.com/MemTensor/MemOS/pull/10786401"],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
+  assert.ok(processed.release_items[0].source_refs.includes("abcdef12"));
 });
 
 test("keeps ambiguous SHA prefixes fail-closed", () => {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -20,6 +20,7 @@ import {
   releaseTopicsForCommits,
   compactReleaseTopics,
   releaseTopicLimitForRequiredCount,
+  requireValidatedDraft,
   reportExternalFailureFromEnv,
   requestDraft,
   requestValidatedDraft,
@@ -457,7 +458,7 @@ test("repairs a numeric SHA that the draft formats as a PR reference", () => {
   assert.deepEqual(processed.release_items[0].source_refs, ["10786401"]);
   assert.equal(processed.coverage.invalid_item_refs.length, 0);
   assert.equal(processed.coverage.missing_required_count, 0);
-  assert.equal(processed.postprocess.normalized_ambiguous_numeric_sha_refs, 1);
+  assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 1);
 });
 
 test("preserves an evidence-backed numeric PR reference", () => {
@@ -499,7 +500,115 @@ test("preserves an evidence-backed numeric PR reference", () => {
   assert.equal(processed.ok, true);
   assert.equal(processed.needs_review, false);
   assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
-  assert.equal(processed.postprocess.normalized_ambiguous_numeric_sha_refs, 0);
+  assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 0);
+});
+
+test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () => {
+  const commit = {
+    short_sha: "10786401",
+    sha: "10786401abcdef0123456789abcdef0123456789",
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const variants = [
+    "commit: 1078640",
+    "https://github.com/MemTensor/MemOS/commit/10786401abcdef0123456789abcdef0123456789",
+    "`# 10786401`",
+  ];
+
+  for (const sourceRef of variants) {
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [sourceRef],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(processed.ok, true, sourceRef);
+    assert.deepEqual(processed.release_items[0].source_refs, ["10786401"], sourceRef);
+  }
+});
+
+test("keeps ambiguous SHA prefixes fail-closed", () => {
+  const commits = [
+    { short_sha: "1078640a", sha: "1078640a".padEnd(40, "0"), subject: "fix(plugin): recovery A" },
+    { short_sha: "1078640b", sha: "1078640b".padEnd(40, "0"), subject: "fix(plugin): recovery B" },
+  ];
+  const topics = commits.map((commit, index) => ({
+    key: `recovery-${index}`,
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  }));
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["#1078640"],
+      }],
+      coverage: {},
+    },
+    { commits, release_note_guidance: { release_topics: topics } },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.equal(processed.coverage.invalid_item_refs.length, 1);
+  assert.equal(processed.coverage.missing_required_count, 2);
+});
+
+test("fails closed when every draft item is malformed", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["not-a-source-ref"],
+      }],
+      coverage: {},
+    },
+    {
+      commits: [commit],
+      release_note_guidance: {
+        release_topics: [{
+          key: "memory-recovery",
+          category: "Fixed",
+          source_refs: [commit.short_sha],
+          subjects: [commit.subject],
+        }],
+      },
+    },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
+  assert.deepEqual(processed.release_items, []);
+  assert.equal(processed.coverage.missing_required_count, 1);
+  assert.equal(processed.postprocess.dropped_invalid_items, 1);
 });
 
 test("redacts full diff and prompt guidance from inspection evidence", () => {
@@ -1172,6 +1281,48 @@ test("writes a redacted failure artifact without endpoint or token details", () 
     assert.match(report, /too many release items: 16 > 12/);
     assert.doesNotMatch(report, /private\.example|secret-token/);
     assert.doesNotMatch(redactedEvidence, /private diff/);
+  } finally {
+    process.env = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("writes failure diagnostics when final postprocessing remains invalid", () => {
+  const previous = { ...process.env };
+  const directory = mkdtempSync(join(tmpdir(), "local-plugin-postprocess-failure-"));
+  try {
+    process.env.RELEASE_NOTES_FAILURE_DIR = directory;
+    const invalidDraft = {
+      ok: false,
+      needs_review: true,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "修复记忆恢复问题。",
+        text_en: "Fixed memory recovery.",
+        source_refs: ["#10786401"],
+      }],
+      coverage: {
+        needs_review: true,
+        required_count: 1,
+        covered_required_count: 1,
+        missing_required_count: 0,
+        invalid_item_refs: [{ ref: "#10786401" }],
+      },
+      validation_report: {
+        ok: false,
+        needs_review: true,
+        invalid_item_ref_count: 1,
+      },
+    };
+
+    assert.throws(
+      () => requireValidatedDraft({ evidence, draft: invalidDraft }),
+      /Postprocessed release notes require review/,
+    );
+    const report = JSON.parse(readFileSync(join(directory, "quality-report.json"), "utf8"));
+    assert.equal(report.ok, false);
+    assert.equal(report.invalid_item_ref_count, 1);
+    assert.match(readFileSync(join(directory, "release-notes-draft.json"), "utf8"), /#10786401/);
   } finally {
     process.env = previous;
     rmSync(directory, { recursive: true, force: true });

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -38,6 +38,7 @@ const evidence = {
   target_version: "v2.0.10",
 };
 
+// URL trust tests use the canonical repository when run outside GitHub Actions.
 process.env.GITHUB_REPOSITORY ||= evidence.repo;
 
 function response(status, body) {
@@ -422,7 +423,7 @@ test("compacts future topic growth below the hard item limit without losing evid
 test("repairs a numeric SHA that the draft formats as a PR reference", () => {
   const commit = {
     short_sha: "10786401",
-    sha: "10786401".padEnd(40, "0"),
+    sha: "10786401abcdef0123456789abcdef0123456789",
     subject: "fix(plugin): stabilize memory recovery",
   };
   const topic = {
@@ -462,6 +463,38 @@ test("repairs a numeric SHA that the draft formats as a PR reference", () => {
   assert.equal(processed.coverage.invalid_item_refs.length, 0);
   assert.equal(processed.coverage.missing_required_count, 0);
   assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 1);
+});
+
+test("does not coerce a numeric PR-like prefix into an evidence SHA", () => {
+  const commit = {
+    short_sha: "12345678",
+    sha: "12345678abcdef0123456789abcdef0123456789",
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["#1234567"],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.coverage.invalid_item_refs.length, 1);
+  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, []);
 });
 
 test("preserves an evidence-backed numeric PR reference", () => {
@@ -773,7 +806,7 @@ test("keeps ambiguous SHA prefixes fail-closed", () => {
         category: "Fixed",
         text_cn: "**记忆恢复**：修复异常数据恢复问题。",
         text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-        source_refs: ["#1078640"],
+        source_refs: ["1078640"],
       }],
       coverage: {},
     },
@@ -784,7 +817,7 @@ test("keeps ambiguous SHA prefixes fail-closed", () => {
   assert.equal(processed.needs_review, true);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.equal(processed.coverage.missing_required_count, 2);
-  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["#1078640"]);
+  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["1078640"]);
   assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/);
 });
 
@@ -818,6 +851,8 @@ test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
   assert.equal(processed.needs_review, true);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.equal(processed.coverage.missing_required_count, 2);
+  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["abcdef1"]);
+  assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/);
 });
 
 test("fails closed when every draft item is malformed", () => {
@@ -1617,7 +1652,7 @@ test("preserves the validation error when its summary is not serializable", () =
   coverage.circular = coverage;
   assert.throws(
     () => requireValidatedDraft({ evidence, draft: { ok: false, needs_review: true, coverage } }),
-    /summary_unavailable/,
+    /Postprocessed release notes require review:.*summary_unavailable/,
   );
 });
 

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -1686,6 +1686,15 @@ test("manual stable notes are revalidated against collected evidence", () => {
   const draft = manualDraftFromNotes(notes, evidence);
   assert.equal(draft.ok, true);
   assert.equal(draft.release_items[0].category, "Fixed");
+  assert.match(
+    draft.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /Restores Hermes bridge state/,
+  );
+  assert.doesNotMatch(
+    draft.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /修复 Hermes 桥接状态恢复/,
+  );
+  assert.match(draft.release_notes_markdown, /修复 Hermes 桥接状态恢复/);
   assert.match(draft.release_notes_markdown, /source-id=openclaw-local-plugin/);
 
   assert.throws(

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -37,6 +37,8 @@ const evidence = {
   current_tag: "memos-local-plugin-v2.0.10",
   target_version: "v2.0.10",
 };
+
+process.env.GITHUB_REPOSITORY ||= evidence.repo;
 
 function response(status, body) {
   return {
@@ -456,6 +458,7 @@ test("repairs a numeric SHA that the draft formats as a PR reference", () => {
   assert.equal(processed.ok, true);
   assert.equal(processed.needs_review, false);
   assert.deepEqual(processed.release_items[0].source_refs, ["10786401"]);
+  assert.ok(Array.isArray(processed.coverage.invalid_item_refs));
   assert.equal(processed.coverage.invalid_item_refs.length, 0);
   assert.equal(processed.coverage.missing_required_count, 0);
   assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 1);
@@ -617,9 +620,11 @@ test("accepts an evidence PR URL and retains its linked commit alias", () => {
   );
 
   assert.equal(processed.ok, true);
-  assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
-  // A topic is evidence-complete only when its linked commit alias is retained too.
-  assert.ok(processed.release_items[0].source_refs.includes("abcdef12"));
+  // The URL is replaced, not retained alongside the canonical evidence aliases.
+  assert.deepEqual(
+    [...processed.release_items[0].source_refs].sort(),
+    ["#10786401", "abcdef12"].sort(),
+  );
 });
 
 test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
@@ -689,6 +694,60 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
     );
     assert.equal(processed.ok, true);
     assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
+
+    const rejected = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [`https://github.com/MemTensor/MemOS/commit/${commit.sha}`],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(rejected.ok, false);
+    assert.equal(rejected.postprocess.dropped_invalid_items, 1);
+  } finally {
+    if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = previousRepository;
+  }
+});
+
+test("fails closed for repository URLs when GITHUB_REPOSITORY is unavailable", () => {
+  const previousRepository = process.env.GITHUB_REPOSITORY;
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  try {
+    delete process.env.GITHUB_REPOSITORY;
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [`https://github.com/MemTensor/MemOS/commit/${commit.sha}`],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(processed.ok, false);
+    assert.equal(processed.postprocess.dropped_invalid_items, 1);
   } finally {
     if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
     else process.env.GITHUB_REPOSITORY = previousRepository;
@@ -725,6 +784,8 @@ test("keeps ambiguous SHA prefixes fail-closed", () => {
   assert.equal(processed.needs_review, true);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.equal(processed.coverage.missing_required_count, 2);
+  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["#1078640"]);
+  assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/);
 });
 
 test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
@@ -1519,8 +1580,45 @@ test("writes failure diagnostics when final postprocessing remains invalid", () 
 });
 
 test("returns a fully validated draft without writing failure diagnostics", () => {
-  const validDraft = { ok: true, needs_review: false, release_items: [] };
-  assert.strictEqual(requireValidatedDraft({ evidence, draft: validDraft }), validDraft);
+  const previousFailureDir = process.env.RELEASE_NOTES_FAILURE_DIR;
+  const directory = mkdtempSync(join(tmpdir(), "local-plugin-valid-draft-"));
+  try {
+    process.env.RELEASE_NOTES_FAILURE_DIR = directory;
+    const validDraft = { ok: true, needs_review: false, release_items: [] };
+    assert.strictEqual(requireValidatedDraft({ evidence, draft: validDraft }), validDraft);
+    assert.deepEqual(readdirSync(directory), []);
+  } finally {
+    if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves the validation error when failure diagnostics cannot be written", () => {
+  const previousFailureDir = process.env.RELEASE_NOTES_FAILURE_DIR;
+  const directory = mkdtempSync(join(tmpdir(), "local-plugin-unwritable-diagnostics-"));
+  const filePath = join(directory, "not-a-directory");
+  try {
+    writeFileSync(filePath, "blocks directory creation", "utf8");
+    process.env.RELEASE_NOTES_FAILURE_DIR = filePath;
+    assert.throws(
+      () => requireValidatedDraft({ evidence, draft: { ok: false, needs_review: true } }),
+      /Postprocessed release notes require review/,
+    );
+  } finally {
+    if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves the validation error when its summary is not serializable", () => {
+  const coverage = { needs_review: true };
+  coverage.circular = coverage;
+  assert.throws(
+    () => requireValidatedDraft({ evidence, draft: { ok: false, needs_review: true, coverage } }),
+    /summary_unavailable/,
+  );
 });
 
 test("reports once after three transient failures", async () => {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -41,7 +41,7 @@ const evidence = {
 function withGitHubRepository(repository, callback) {
   const previousRepository = process.env.GITHUB_REPOSITORY;
   try {
-    if (repository) process.env.GITHUB_REPOSITORY = repository;
+    if (repository !== undefined && repository !== null) process.env.GITHUB_REPOSITORY = repository;
     else delete process.env.GITHUB_REPOSITORY;
     return callback();
   } finally {
@@ -498,7 +498,7 @@ test("does not coerce a numeric PR-like prefix into an evidence SHA", () => {
         category: "Fixed",
         text_cn: "**记忆恢复**：修复异常数据恢复问题。",
         text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-        // This 7-digit prefix intentionally differs from the 8-character evidence SHA.
+        // The # sigil makes this a PR ref. It must not be treated as a SHA prefix.
         source_refs: ["#1234567"],
       }],
       coverage: {},
@@ -765,6 +765,8 @@ test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
     for (const sourceRef of [
       `https://github.com/another/repository/commit/${commit.sha}`,
       "https://github.com/another/repository/pull/1234",
+      "https://github.com/MemTensor/MemOS-fork/pull/1234",
+      "https://github.com/NotMemTensor/MemOS/pull/1234",
     ]) {
       const processed = postprocessDraftFromEvidence(
         {
@@ -971,6 +973,38 @@ test("deduplicates repeated evidence commits before resolving SHA prefixes", () 
   assert.equal(processed.ok, true);
   assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
   assert.deepEqual(processed.postprocess.ambiguous_sha_refs, []);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, []);
+});
+
+test("resolves an exact evidence short SHA even when it is not a full SHA prefix", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "12345678".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: [commit.short_sha],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
   assert.deepEqual(processed.postprocess.unresolved_sha_refs, []);
 });
 

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -38,9 +38,17 @@ const evidence = {
   target_version: "v2.0.10",
 };
 
-// URL trust tests use the canonical repository outside Actions. Production reads
-// this variable lazily per call so individual tests can still remove or replace it.
-process.env.GITHUB_REPOSITORY ||= evidence.repo;
+function withGitHubRepository(repository, callback) {
+  const previousRepository = process.env.GITHUB_REPOSITORY;
+  try {
+    if (repository) process.env.GITHUB_REPOSITORY = repository;
+    else delete process.env.GITHUB_REPOSITORY;
+    return callback();
+  } finally {
+    if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = previousRepository;
+  }
+}
 
 function response(status, body) {
   return {
@@ -347,7 +355,7 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
         category: topic.category,
         text_cn: `**主题 ${index + 1}**：汇总同一用户影响下的本地插件改进。`,
         text_en: `**Topic ${index + 1}**: Groups related local-plugin changes by user impact.`,
-        source_refs: [topic.source_refs[0]],
+        source_refs: [topic.source_refs.includes("10786401") ? "#10786401" : topic.source_refs[0]],
       })),
       coverage: {},
       warnings: [],
@@ -362,6 +370,7 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
   assert.equal(processed.needs_review, false);
   assert.equal(processed.coverage.required_count, topics.length);
   assert.equal(processed.coverage.missing_required_count, 0);
+  assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 1);
   assert.ok(processed.release_items.length > 0);
   assert.ok(
     processed.release_items.length <= topics.length,
@@ -590,6 +599,8 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     );
     assert.equal(processed.ok, true, sourceRef);
     assert.deepEqual(processed.release_items[0].source_refs, ["10786401"], sourceRef);
+    assert.deepEqual(processed.postprocess.ambiguous_sha_refs, [], sourceRef);
+    assert.deepEqual(processed.postprocess.unresolved_sha_refs, [], sourceRef);
   }
 });
 
@@ -626,10 +637,10 @@ test("rejects a well-formed short SHA absent from collected evidence", () => {
   assert.match(processed.warnings.join("\n"), /did not resolve to collected evidence/);
 });
 
-test("keeps explicit PR references strict instead of coercing them to numeric SHAs", () => {
+test("does not count an unresolved wrapped SHA as evidence-backed normalization", () => {
   const commit = {
-    short_sha: "10786401",
-    sha: "10786401abcdef0123456789abcdef0123456789",
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
     subject: "fix(plugin): stabilize memory recovery",
   };
   const topic = {
@@ -638,29 +649,65 @@ test("keeps explicit PR references strict instead of coercing them to numeric SH
     source_refs: [commit.short_sha],
     subjects: [commit.subject],
   };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["sha:deadbeef"],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
 
-  for (const sourceRef of [
-    "PR #10786401",
-    "pull request: 10786401",
-    "https://github.com/MemTensor/MemOS/pull/10786401",
-  ]) {
-    const processed = postprocessDraftFromEvidence(
-      {
-        ok: true,
-        needs_review: false,
-        release_items: [{
-          category: "Fixed",
-          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
-          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-          source_refs: [sourceRef],
-        }],
-        coverage: {},
-      },
-      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
-    );
-    assert.equal(processed.ok, false, sourceRef);
-    assert.equal(processed.coverage.invalid_item_refs.length, 1, sourceRef);
-  }
+  assert.equal(processed.ok, false);
+  assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 0);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, ["sha:deadbeef"]);
+  assert.deepEqual(processed.coverage.invalid_item_refs.map((item) => item.ref), ["deadbeef"]);
+});
+
+test("keeps explicit PR references strict instead of coercing them to numeric SHAs", () => {
+  const commit = {
+    short_sha: "10786401",
+    sha: "10786401abcdef0123456789abcdef0123456789",
+    subject: "fix(plugin): stabilize memory recovery (#10786401)",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+
+  withGitHubRepository(evidence.repo, () => {
+    for (const sourceRef of [
+      "PR #10786401",
+      "pull request: 10786401",
+      "https://github.com/MemTensor/MemOS/pull/10786401",
+    ]) {
+      const processed = postprocessDraftFromEvidence(
+        {
+          ok: true,
+          needs_review: false,
+          release_items: [{
+            category: "Fixed",
+            text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+            text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+            source_refs: [sourceRef],
+          }],
+          coverage: {},
+        },
+        { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+      );
+      assert.equal(processed.ok, false, sourceRef);
+      assert.equal(processed.coverage.missing_required_count, 1, sourceRef);
+      assert.equal(processed.coverage.invalid_item_refs.length, 0, sourceRef);
+    }
+  });
 });
 
 test("accepts an evidence PR URL and retains its linked commit alias", () => {
@@ -675,7 +722,7 @@ test("accepts an evidence PR URL and retains its linked commit alias", () => {
     source_refs: [commit.short_sha, "#10786401"],
     subjects: [commit.subject],
   };
-  const processed = postprocessDraftFromEvidence(
+  const processed = withGitHubRepository(evidence.repo, () => postprocessDraftFromEvidence(
     {
       ok: true,
       needs_review: false,
@@ -688,7 +735,7 @@ test("accepts an evidence PR URL and retains its linked commit alias", () => {
       coverage: {},
     },
     { commits: [commit], release_note_guidance: { release_topics: [topic] } },
-  );
+  ));
 
   assert.equal(processed.ok, true);
   // The URL is replaced, not retained alongside the canonical evidence aliases.
@@ -711,27 +758,29 @@ test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
     subjects: [commit.subject],
   };
 
-  for (const sourceRef of [
-    `https://github.com/another/repository/commit/${commit.sha}`,
-    "https://github.com/another/repository/pull/1234",
-  ]) {
-    const processed = postprocessDraftFromEvidence(
-      {
-        ok: true,
-        needs_review: false,
-        release_items: [{
-          category: "Fixed",
-          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
-          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-          source_refs: [sourceRef],
-        }],
-        coverage: {},
-      },
-      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
-    );
-    assert.equal(processed.ok, false, sourceRef);
-    assert.equal(processed.postprocess.dropped_invalid_items, 1, sourceRef);
-  }
+  withGitHubRepository(evidence.repo, () => {
+    for (const sourceRef of [
+      `https://github.com/another/repository/commit/${commit.sha}`,
+      "https://github.com/another/repository/pull/1234",
+    ]) {
+      const processed = postprocessDraftFromEvidence(
+        {
+          ok: true,
+          needs_review: false,
+          release_items: [{
+            category: "Fixed",
+            text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+            text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+            source_refs: [sourceRef],
+          }],
+          coverage: {},
+        },
+        { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+      );
+      assert.equal(processed.ok, false, sourceRef);
+      assert.equal(processed.postprocess.dropped_invalid_items, 1, sourceRef);
+    }
+  });
 });
 
 test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
@@ -739,12 +788,12 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
   const commit = {
     short_sha: "abcdef12",
     sha: "abcdef12".padEnd(40, "0"),
-    subject: "fix(plugin): stabilize memory recovery",
+    subject: "fix(plugin): stabilize memory recovery (#1234)",
   };
   const topic = {
     key: "memory-recovery",
     category: "Fixed",
-    source_refs: [commit.short_sha],
+    source_refs: [commit.short_sha, "#1234"],
     subjects: [commit.subject],
   };
   try {
@@ -764,7 +813,30 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
       { commits: [commit], release_note_guidance: { release_topics: [topic] } },
     );
     assert.equal(processed.ok, true);
-    assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
+    assert.deepEqual(
+      [...processed.release_items[0].source_refs].sort(),
+      [commit.short_sha, "#1234"].sort(),
+    );
+
+    const acceptedPull = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: ["https://github.com/ForkOwner/ForkRepo/pull/1234"],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(acceptedPull.ok, true);
+    assert.deepEqual(
+      [...acceptedPull.release_items[0].source_refs].sort(),
+      [commit.short_sha, "#1234"].sort(),
+    );
 
     const rejected = postprocessDraftFromEvidence(
       {
@@ -782,6 +854,23 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
     );
     assert.equal(rejected.ok, false);
     assert.equal(rejected.postprocess.dropped_invalid_items, 1);
+
+    const rejectedPull = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: ["https://github.com/MemTensor/MemOS/pull/1234"],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(rejectedPull.ok, false);
+    assert.equal(rejectedPull.postprocess.dropped_invalid_items, 1);
   } finally {
     if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
     else process.env.GITHUB_REPOSITORY = previousRepository;
@@ -857,6 +946,70 @@ test("keeps ambiguous SHA prefixes fail-closed", () => {
   assert.equal(processed.coverage.missing_required_count, 2);
   assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["1078640"]);
   assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/);
+});
+
+test("deduplicates repeated evidence commits before resolving SHA prefixes", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["abcdef1"],
+      }],
+      coverage: {},
+    },
+    { commits: [commit, { ...commit }], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.deepEqual(processed.release_items[0].source_refs, [commit.short_sha]);
+  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, []);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, []);
+});
+
+test("initializes warnings when a valid draft omits the field", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: [commit.short_sha],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.deepEqual(processed.warnings, []);
 });
 
 test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
@@ -1644,7 +1797,10 @@ test("writes failure diagnostics when final postprocessing remains invalid", () 
     const report = JSON.parse(readFileSync(join(directory, "quality-report.json"), "utf8"));
     assert.equal(report.ok, false);
     assert.equal(report.invalid_item_ref_count, 1);
-    assert.match(readFileSync(join(directory, "release-notes-draft.json"), "utf8"), /#10786401/);
+    const diagnosticDraft = JSON.parse(
+      readFileSync(join(directory, "release-notes-draft.json"), "utf8"),
+    );
+    assert.deepEqual(diagnosticDraft.release_items[0].source_refs, ["#10786401"]);
   } finally {
     if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
     else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
@@ -1660,6 +1816,29 @@ test("returns a fully validated draft without writing failure diagnostics", () =
     const validDraft = { ok: true, needs_review: false, release_items: [] };
     assert.strictEqual(requireValidatedDraft({ evidence, draft: validDraft }), validDraft);
     assert.deepEqual(readdirSync(directory), []);
+  } finally {
+    if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects ok drafts that still require review", () => {
+  const previousFailureDir = process.env.RELEASE_NOTES_FAILURE_DIR;
+  const directory = mkdtempSync(join(tmpdir(), "local-plugin-needs-review-"));
+  try {
+    process.env.RELEASE_NOTES_FAILURE_DIR = directory;
+    assert.throws(
+      () => requireValidatedDraft({
+        evidence,
+        draft: { ok: true, needs_review: true, release_items: [] },
+      }),
+      /Postprocessed release notes require review/,
+    );
+    assert.deepEqual(
+      readdirSync(directory).sort(),
+      ["README.md", "evidence.json", "quality-report.json", "release-notes-draft.json"],
+    );
   } finally {
     if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
     else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -1265,6 +1265,15 @@ test("postprocesses duplicate source refs into the best evidence category", () =
     processed.release_items.find((item) => item.text_cn.includes("记忆恢复"))?.text_cn.includes("XML"),
     false,
   );
+  assert.match(
+    processed.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /Vector Scan Performance/,
+  );
+  assert.doesNotMatch(
+    processed.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /向量扫描性能优化/,
+  );
+  assert.match(processed.release_notes_markdown, /向量扫描性能优化/);
   assert.match(processed.release_notes_markdown, /doc-agent-release-notes-json/);
 });
 
@@ -1469,6 +1478,14 @@ test("repairs postprocessed language validation issues with exact context", asyn
     ["text_cn", "text_en"],
   );
   assert.equal(requests[1].release_notes_repair_context.previous_release_items[0].source_refs[0], "abc1234");
+  assert.match(
+    result.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /Plugin Health Dashboard/,
+  );
+  assert.doesNotMatch(
+    result.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /插件健康看板/,
+  );
   assert.match(result.release_notes_markdown, /插件健康看板/);
   assert.match(result.release_notes_markdown, /doc-agent-release-notes-json/);
 });
@@ -1533,6 +1550,10 @@ test("standalone latest draft validation allows one initial response plus three 
   assert.equal(result.needs_review, false);
   assert.equal(result.validation_attempt_count, 4);
   assert.equal(result.repair_attempt_count, 3);
+  assert.match(
+    result.release_notes_markdown.split("<!-- doc-agent-release-notes-json")[0],
+    /Plugin Health Dashboard/,
+  );
   assert.match(result.release_notes_markdown, /插件健康看板/);
 });
 
@@ -1834,6 +1855,34 @@ test("writes failure diagnostics when final postprocessing remains invalid", () 
     if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
     else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
     rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("writes default failure diagnostics under RUNNER_TEMP for artifact upload", () => {
+  const previousFailureDir = process.env.RELEASE_NOTES_FAILURE_DIR;
+  const previousRunnerTemp = process.env.RUNNER_TEMP;
+  const runnerTemp = mkdtempSync(join(tmpdir(), "local-plugin-runner-temp-"));
+  const expectedDirectory = join(runnerTemp, "memos-local-plugin-release-notes-failure");
+  try {
+    delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    process.env.RUNNER_TEMP = runnerTemp;
+    assert.throws(
+      () => requireValidatedDraft({
+        evidence,
+        draft: { ok: false, needs_review: true, release_items: [], coverage: {} },
+      }),
+      /Postprocessed release notes require review/,
+    );
+    assert.deepEqual(
+      readdirSync(expectedDirectory).sort(),
+      ["README.md", "evidence.json", "quality-report.json", "release-notes-draft.json"],
+    );
+  } finally {
+    if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
+    if (previousRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+    else process.env.RUNNER_TEMP = previousRunnerTemp;
+    rmSync(runnerTemp, { recursive: true, force: true });
   }
 });
 

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -515,6 +515,8 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     source_refs: [commit.short_sha],
     subjects: [commit.subject],
   };
+  // This fixture has one commit, so the seven-character SHA prefix is unique. The
+  // numeric and hexadecimal ambiguity tests below cover the multi-match rejection path.
   const variants = [
     "10786401",
     "#10786401",
@@ -587,7 +589,7 @@ test("keeps explicit PR references strict instead of coercing them to numeric SH
   }
 });
 
-test("accepts an explicit PR reference only when that PR is present in evidence", () => {
+test("accepts an evidence PR URL and retains its linked commit alias", () => {
   const commit = {
     short_sha: "abcdef12",
     sha: "abcdef12".padEnd(40, "0"),
@@ -715,6 +717,7 @@ test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
   );
 
   assert.equal(processed.ok, false);
+  assert.equal(processed.needs_review, true);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.equal(processed.coverage.missing_required_count, 2);
 });
@@ -1436,7 +1439,7 @@ test("writes a redacted failure artifact without endpoint or token details", () 
 });
 
 test("writes failure diagnostics when final postprocessing remains invalid", () => {
-  const previous = { ...process.env };
+  const previousFailureDir = process.env.RELEASE_NOTES_FAILURE_DIR;
   const directory = mkdtempSync(join(tmpdir(), "local-plugin-postprocess-failure-"));
   try {
     process.env.RELEASE_NOTES_FAILURE_DIR = directory;
@@ -1472,7 +1475,8 @@ test("writes failure diagnostics when final postprocessing remains invalid", () 
     assert.equal(report.invalid_item_ref_count, 1);
     assert.match(readFileSync(join(directory, "release-notes-draft.json"), "utf8"), /#10786401/);
   } finally {
-    process.env = previous;
+    if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
+    else process.env.RELEASE_NOTES_FAILURE_DIR = previousFailureDir;
     rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -416,6 +416,92 @@ test("compacts future topic growth below the hard item limit without losing evid
   assert.ok(compacted.every((topic) => ["Added", "Improved", "Fixed"].includes(topic.category)));
 });
 
+test("repairs a numeric SHA that the draft formats as a PR reference", () => {
+  const commit = {
+    short_sha: "10786401",
+    sha: "10786401".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    title_hint: "Memory recovery",
+    reason: "user-visible recovery fix",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: ["#10786401"],
+        },
+      ],
+      coverage: {},
+      warnings: [],
+    },
+    {
+      commits: [commit],
+      release_note_guidance: { release_topics: [topic] },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.needs_review, false);
+  assert.deepEqual(processed.release_items[0].source_refs, ["10786401"]);
+  assert.equal(processed.coverage.invalid_item_refs.length, 0);
+  assert.equal(processed.coverage.missing_required_count, 0);
+  assert.equal(processed.postprocess.normalized_ambiguous_numeric_sha_refs, 1);
+});
+
+test("preserves an evidence-backed numeric PR reference", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery (#10786401)",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    title_hint: "Memory recovery",
+    reason: "user-visible recovery fix",
+    source_refs: [commit.short_sha, "#10786401"],
+    subjects: [commit.subject],
+  };
+
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [
+        {
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: ["#10786401"],
+        },
+      ],
+      coverage: {},
+      warnings: [],
+    },
+    {
+      commits: [commit],
+      release_note_guidance: { release_topics: [topic] },
+    },
+  );
+
+  assert.equal(processed.ok, true);
+  assert.equal(processed.needs_review, false);
+  assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
+  assert.equal(processed.postprocess.normalized_ambiguous_numeric_sha_refs, 0);
+});
+
 test("redacts full diff and prompt guidance from inspection evidence", () => {
   const inspection = evidenceForInspection({
     ...evidence,

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -291,6 +291,7 @@ test("uses subject fallback for in-range reverts but keeps rollbacks of older re
 });
 
 test("aggregates the v2.0.18 high-commit release into evidence-complete user topics", () => {
+  const numericShaCommit = "10786401";
   const commits = [
     ["602f60ff", "fix(plugin): make free-form config paths explicit"],
     ["e1530908", "fix(plugin): scope secret environment fallbacks"],
@@ -301,7 +302,7 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
     ["763ca1fc", "fix(skill): auto-generate crystallizer summary/steps instead of rejecting"],
     ["2b726985", "fix(plugin): default headers {} on l3Llm/skillEvolver slots; maxTokens floor 100"],
     ["5fd49171", "fix(core): bound startup recovery wait in shutdown to 15s"],
-    ["10786401", "fix(plugin): wire l3Llm/skillEvolver maxTokens+headers; raise dedicated-slot defaults to 4096"],
+    [numericShaCommit, "fix(plugin): wire l3Llm/skillEvolver maxTokens+headers; raise dedicated-slot defaults to 4096"],
     ["d59fe83a", "fix(plugin): add l3Llm.maxTokens default (shares SkillEvolverSchema)"],
     ["70646de3", "fix(plugin): declare llm.maxTokens and llm.headers as first-class config keys"],
     ["1f28c8c5", "fix(config): apply OCR review to secret env resolver"],
@@ -341,11 +342,11 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
     "the v2.0.18 test-only commits must not be required release-note evidence",
   );
   assert.equal(
-    topics.flatMap((topic) => topic.source_refs).includes("#10786401"),
+    topics.flatMap((topic) => topic.source_refs).includes(`#${numericShaCommit}`),
     false,
     "a numeric hexadecimal SHA must not be rewritten as a PR number",
   );
-  assert.ok(topics.flatMap((topic) => topic.source_refs).includes("10786401"));
+  assert.ok(topics.flatMap((topic) => topic.source_refs).includes(numericShaCommit));
 
   const processed = postprocessDraftFromEvidence(
     {
@@ -355,7 +356,9 @@ test("aggregates the v2.0.18 high-commit release into evidence-complete user top
         category: topic.category,
         text_cn: `**主题 ${index + 1}**：汇总同一用户影响下的本地插件改进。`,
         text_en: `**Topic ${index + 1}**: Groups related local-plugin changes by user impact.`,
-        source_refs: [topic.source_refs.includes("10786401") ? "#10786401" : topic.source_refs[0]],
+        source_refs: [
+          topic.source_refs.includes(numericShaCommit) ? `#${numericShaCommit}` : topic.source_refs[0],
+        ],
       })),
       coverage: {},
       warnings: [],
@@ -784,7 +787,6 @@ test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
 });
 
 test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
-  const previousRepository = process.env.GITHUB_REPOSITORY;
   const commit = {
     short_sha: "abcdef12",
     sha: "abcdef12".padEnd(40, "0"),
@@ -796,8 +798,7 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
     source_refs: [commit.short_sha, "#1234"],
     subjects: [commit.subject],
   };
-  try {
-    process.env.GITHUB_REPOSITORY = "ForkOwner/ForkRepo";
+  withGitHubRepository("ForkOwner/ForkRepo", () => {
     const processed = postprocessDraftFromEvidence(
       {
         ok: true,
@@ -871,14 +872,10 @@ test("uses GITHUB_REPOSITORY as the source URL trust boundary", () => {
     );
     assert.equal(rejectedPull.ok, false);
     assert.equal(rejectedPull.postprocess.dropped_invalid_items, 1);
-  } finally {
-    if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
-    else process.env.GITHUB_REPOSITORY = previousRepository;
-  }
+  });
 });
 
 test("fails closed for repository URLs when GITHUB_REPOSITORY is unavailable", () => {
-  const previousRepository = process.env.GITHUB_REPOSITORY;
   const commit = {
     short_sha: "abcdef12",
     sha: "abcdef12".padEnd(40, "0"),
@@ -890,8 +887,7 @@ test("fails closed for repository URLs when GITHUB_REPOSITORY is unavailable", (
     source_refs: [commit.short_sha],
     subjects: [commit.subject],
   };
-  try {
-    delete process.env.GITHUB_REPOSITORY;
+  withGitHubRepository(undefined, () => {
     const processed = postprocessDraftFromEvidence(
       {
         ok: true,
@@ -908,10 +904,7 @@ test("fails closed for repository URLs when GITHUB_REPOSITORY is unavailable", (
     );
     assert.equal(processed.ok, false);
     assert.equal(processed.postprocess.dropped_invalid_items, 1);
-  } finally {
-    if (previousRepository === undefined) delete process.env.GITHUB_REPOSITORY;
-    else process.env.GITHUB_REPOSITORY = previousRepository;
-  }
+  });
 });
 
 test("keeps ambiguous SHA prefixes fail-closed", () => {
@@ -1012,7 +1005,7 @@ test("initializes warnings when a valid draft omits the field", () => {
   assert.deepEqual(processed.warnings, []);
 });
 
-test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
+test("keeps bare and explicit ambiguous hexadecimal SHA prefixes fail-closed", () => {
   const commits = [
     { short_sha: "abcdef1a", sha: "abcdef1a".padEnd(40, "0"), subject: "fix(plugin): recovery A" },
     { short_sha: "abcdef1b", sha: "abcdef1b".padEnd(40, "0"), subject: "fix(plugin): recovery B" },
@@ -1023,27 +1016,29 @@ test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
     source_refs: [commit.short_sha],
     subjects: [commit.subject],
   }));
-  const processed = postprocessDraftFromEvidence(
-    {
-      ok: true,
-      needs_review: false,
-      release_items: [{
-        category: "Fixed",
-        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
-        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
-        source_refs: ["abcdef1"],
-      }],
-      coverage: {},
-    },
-    { commits, release_note_guidance: { release_topics: topics } },
-  );
+  for (const sourceRef of ["abcdef1", "sha:abcdef1"]) {
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [sourceRef],
+        }],
+        coverage: {},
+      },
+      { commits, release_note_guidance: { release_topics: topics } },
+    );
 
-  assert.equal(processed.ok, false);
-  assert.equal(processed.needs_review, true);
-  assert.equal(processed.coverage.invalid_item_refs.length, 1);
-  assert.equal(processed.coverage.missing_required_count, 2);
-  assert.deepEqual(processed.postprocess.ambiguous_sha_refs, ["abcdef1"]);
-  assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/);
+    assert.equal(processed.ok, false, sourceRef);
+    assert.equal(processed.needs_review, true, sourceRef);
+    assert.equal(processed.coverage.invalid_item_refs.length, 1, sourceRef);
+    assert.equal(processed.coverage.missing_required_count, 2, sourceRef);
+    assert.deepEqual(processed.postprocess.ambiguous_sha_refs, [sourceRef], sourceRef);
+    assert.match(processed.warnings.join("\n"), /ambiguous SHA source_refs/, sourceRef);
+  }
 });
 
 test("fails closed when every draft item is malformed", () => {
@@ -1814,7 +1809,9 @@ test("returns a fully validated draft without writing failure diagnostics", () =
   try {
     process.env.RELEASE_NOTES_FAILURE_DIR = directory;
     const validDraft = { ok: true, needs_review: false, release_items: [] };
-    assert.strictEqual(requireValidatedDraft({ evidence, draft: validDraft }), validDraft);
+    const result = requireValidatedDraft({ evidence, draft: validDraft });
+    assert.strictEqual(result, validDraft);
+    assert.deepEqual(result, { ok: true, needs_review: false, release_items: [] });
     assert.deepEqual(readdirSync(directory), []);
   } finally {
     if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;
@@ -1855,7 +1852,11 @@ test("preserves the validation error when failure diagnostics cannot be written"
     process.env.RELEASE_NOTES_FAILURE_DIR = filePath;
     assert.throws(
       () => requireValidatedDraft({ evidence, draft: { ok: false, needs_review: true } }),
-      /Postprocessed release notes require review/,
+      (error) => {
+        assert.match(error.message, /Postprocessed release notes require review/);
+        assert.doesNotMatch(error.message, /ENOTDIR|ENOENT/);
+        return true;
+      },
     );
   } finally {
     if (previousFailureDir === undefined) delete process.env.RELEASE_NOTES_FAILURE_DIR;

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -616,7 +616,44 @@ test("accepts an explicit PR reference only when that PR is present in evidence"
 
   assert.equal(processed.ok, true);
   assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
+  // A topic is evidence-complete only when its linked commit alias is retained too.
   assert.ok(processed.release_items[0].source_refs.includes("abcdef12"));
+});
+
+test("rejects source URLs from repositories outside MemTensor/MemOS", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery (#1234)",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha, "#1234"],
+    subjects: [commit.subject],
+  };
+
+  for (const sourceRef of [
+    `https://github.com/another/repository/commit/${commit.sha}`,
+    "https://github.com/another/repository/pull/1234",
+  ]) {
+    const processed = postprocessDraftFromEvidence(
+      {
+        ok: true,
+        needs_review: false,
+        release_items: [{
+          category: "Fixed",
+          text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+          text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+          source_refs: [sourceRef],
+        }],
+        coverage: {},
+      },
+      { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+    );
+    assert.equal(processed.ok, false, sourceRef);
+    assert.equal(processed.postprocess.dropped_invalid_items, 1, sourceRef);
+  }
 });
 
 test("keeps ambiguous SHA prefixes fail-closed", () => {
@@ -647,6 +684,37 @@ test("keeps ambiguous SHA prefixes fail-closed", () => {
 
   assert.equal(processed.ok, false);
   assert.equal(processed.needs_review, true);
+  assert.equal(processed.coverage.invalid_item_refs.length, 1);
+  assert.equal(processed.coverage.missing_required_count, 2);
+});
+
+test("keeps ambiguous hexadecimal SHA prefixes fail-closed", () => {
+  const commits = [
+    { short_sha: "abcdef1a", sha: "abcdef1a".padEnd(40, "0"), subject: "fix(plugin): recovery A" },
+    { short_sha: "abcdef1b", sha: "abcdef1b".padEnd(40, "0"), subject: "fix(plugin): recovery B" },
+  ];
+  const topics = commits.map((commit, index) => ({
+    key: `recovery-${index}`,
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  }));
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["abcdef1"],
+      }],
+      coverage: {},
+    },
+    { commits, release_note_guidance: { release_topics: topics } },
+  );
+
+  assert.equal(processed.ok, false);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.equal(processed.coverage.missing_required_count, 2);
 });
@@ -687,6 +755,8 @@ test("fails closed when every draft item is malformed", () => {
   assert.deepEqual(processed.release_items, []);
   assert.equal(processed.coverage.missing_required_count, 1);
   assert.equal(processed.postprocess.dropped_invalid_items, 1);
+  // Structurally invalid items are dropped before evidence coverage checks.
+  assert.equal(processed.coverage.invalid_item_refs.length, 0);
 });
 
 test("redacts full diff and prompt guidance from inspection evidence", () => {
@@ -1405,6 +1475,11 @@ test("writes failure diagnostics when final postprocessing remains invalid", () 
     process.env = previous;
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test("returns a fully validated draft without writing failure diagnostics", () => {
+  const validDraft = { ok: true, needs_review: false, release_items: [] };
+  assert.strictEqual(requireValidatedDraft({ evidence, draft: validDraft }), validDraft);
 });
 
 test("reports once after three transient failures", async () => {

--- a/.github/scripts/draft-local-plugin-release-notes.test.mjs
+++ b/.github/scripts/draft-local-plugin-release-notes.test.mjs
@@ -38,7 +38,8 @@ const evidence = {
   target_version: "v2.0.10",
 };
 
-// URL trust tests use the canonical repository when run outside GitHub Actions.
+// URL trust tests use the canonical repository outside Actions. Production reads
+// this variable lazily per call so individual tests can still remove or replace it.
 process.env.GITHUB_REPOSITORY ||= evidence.repo;
 
 function response(status, body) {
@@ -485,6 +486,7 @@ test("does not coerce a numeric PR-like prefix into an evidence SHA", () => {
         category: "Fixed",
         text_cn: "**记忆恢复**：修复异常数据恢复问题。",
         text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        // This 7-digit prefix intentionally differs from the 8-character evidence SHA.
         source_refs: ["#1234567"],
       }],
       coverage: {},
@@ -495,6 +497,7 @@ test("does not coerce a numeric PR-like prefix into an evidence SHA", () => {
   assert.equal(processed.ok, false);
   assert.equal(processed.coverage.invalid_item_refs.length, 1);
   assert.deepEqual(processed.postprocess.ambiguous_sha_refs, []);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, ["#1234567"]);
 });
 
 test("preserves an evidence-backed numeric PR reference", () => {
@@ -535,7 +538,10 @@ test("preserves an evidence-backed numeric PR reference", () => {
 
   assert.equal(processed.ok, true);
   assert.equal(processed.needs_review, false);
-  assert.ok(processed.release_items[0].source_refs.includes("#10786401"));
+  assert.deepEqual(
+    [...processed.release_items[0].source_refs].sort(),
+    ["#10786401", "abcdef12"].sort(),
+  );
   assert.equal(processed.postprocess.normalized_evidence_backed_source_refs, 0);
 });
 
@@ -565,7 +571,6 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     "commit: 1078640",
     "sha 10786401",
     "SHA: 10786401",
-    "https://github.com/MemTensor/MemOS/commit/10786401abcdef0123456789abcdef0123456789",
   ];
 
   for (const sourceRef of variants) {
@@ -586,6 +591,39 @@ test("normalizes explicit wrappers and a unique evidence-backed SHA prefix", () 
     assert.equal(processed.ok, true, sourceRef);
     assert.deepEqual(processed.release_items[0].source_refs, ["10786401"], sourceRef);
   }
+});
+
+test("rejects a well-formed short SHA absent from collected evidence", () => {
+  const commit = {
+    short_sha: "abcdef12",
+    sha: "abcdef12".padEnd(40, "0"),
+    subject: "fix(plugin): stabilize memory recovery",
+  };
+  const topic = {
+    key: "memory-recovery",
+    category: "Fixed",
+    source_refs: [commit.short_sha],
+    subjects: [commit.subject],
+  };
+  const processed = postprocessDraftFromEvidence(
+    {
+      ok: true,
+      needs_review: false,
+      release_items: [{
+        category: "Fixed",
+        text_cn: "**记忆恢复**：修复异常数据恢复问题。",
+        text_en: "**Memory Recovery**: Fixed abnormal data recovery.",
+        source_refs: ["deadbeef"],
+      }],
+      coverage: {},
+    },
+    { commits: [commit], release_note_guidance: { release_topics: [topic] } },
+  );
+
+  assert.equal(processed.ok, false);
+  assert.equal(processed.coverage.invalid_item_refs.length, 1);
+  assert.deepEqual(processed.postprocess.unresolved_sha_refs, ["deadbeef"]);
+  assert.match(processed.warnings.join("\n"), /did not resolve to collected evidence/);
 });
 
 test("keeps explicit PR references strict instead of coercing them to numeric SHAs", () => {


### PR DESCRIPTION
## Summary

- canonicalize evidence-backed SHA aliases before final release-note validation
- repair the exact `#10786401` numeric-SHA formatting failure from the v2.0.18 dry-run
- support short/full/unique-prefix SHA forms plus explicit commit/PR wrappers and GitHub URLs
- preserve real PR references and keep explicit unknown PRs, ambiguous SHAs, foreign-repository URLs, and unknown references fail-closed
- deduplicate repeated evidence commits so one real SHA cannot become spuriously ambiguous
- fail closed when every generated item becomes invalid during normalization
- write sanitized failure diagnostics on a best-effort basis without masking the original validation error
- place failure diagnostics under `RUNNER_TEMP` so the existing Action upload step always finds them
- render every stable public GitHub Release body in English, including evidence-bound manual input, while retaining bilingual text and evidence refs in the hidden Doc Agent payload
- normalize a single GitHub URL `source_refs` value consistently with array inputs and tolerate evidence producers that omit either SHA alias

## Root cause

The v2.0.18 dry-run covered all 9 required evidence groups, but the draft returned `#10786401` for the real short SHA `10786401`. Final postprocessing treated that value as an unknown PR number. The prior fix protected evidence generation, but not equivalent source-ref formats returned by the draft service.

## Safety boundaries

A bare numeric `#ref` is repaired only when it exactly equals a short or full SHA already present in collected evidence; numeric prefixes are never coerced. Bare SHA values and explicit `sha:` wrappers may use a unique evidence prefix. Explicit commit wrappers and same-repository commit URLs are resolved as SHAs. Explicit PR wrappers and same-repository pull URLs are accepted only when that PR is present in evidence. Repository URLs are trusted only when they match `GITHUB_REPOSITORY`; absent repository context and foreign-repository URLs fail closed. Invented PRs, ambiguous SHA prefixes, invented refs, missing refs, and missing required commit coverage still stop the workflow.

Duplicate evidence commit rows are collapsed by full SHA before prefix matching. Only references that actually resolve to collected evidence increment `normalized_evidence_backed_source_refs`; unresolved and ambiguous references remain visible in diagnostics and fail validation.

Failure-diagnostic I/O or a non-serializable validation report can no longer replace the real release-note validation error; an artifact-write failure is still visible as a CI warning. By default the files are now written under `$RUNNER_TEMP/memos-local-plugin-release-notes-failure`, matching the workflow upload path. `{ ok: true, needs_review: true }` is explicitly tested and rejected.

The public GitHub Release body is always re-rendered from validated `text_en`, including the manual-notes path. The hidden `doc-agent-release-notes-json` payload continues to carry `text_cn`, `text_en`, and `source_refs`, so the Chinese website output and the 106 evidence contract remain unchanged. Package-only prerelease notes were already English.

This PR changes only the MemOS local-plugin release-note caller and tests. It does not modify 106 Doc Agent, CLI, cloud-plugin, weekly release notifications, npm publication, tag creation, or Release creation.

## Verification

- targeted release-note tests: `57/57`
- complete release automation script tests: `186/186`
- real v2.0.18 evidence replay (`memos-local-plugin-v2.0.17..bc9ccd1e`): 35 path commits and 57 changed files compacted into 9 topics, 9/9 covered, 0 missing, 0 invalid; injected `#10786401` normalized once; 7 final items
- replayed public body contains no CJK text, while the hidden payload retains Chinese text for docs generation
- manual stable input with a Chinese visible bullet is re-rendered to English after evidence validation; its hidden bilingual payload remains intact
- explicit unknown PR, foreign/similarly-named repository URL, missing repository boundary, numeric/hex ambiguous SHA-prefix, duplicate commit rows, malformed-all-items, and unwritable-diagnostic tests remain fail-closed
- exact evidence short-SHA aliases resolve even when supplied by a nonstandard evidence producer that does not make them a full-SHA prefix
- fork/canonical repository commit and PR URLs are tested independently
- final postprocess rejection produces a sanitized failure artifact at the exact workflow upload path and always preserves the original validation failure
