### PR TITLE
fix(llm): double max_tokens on finish_reason=length before retrying JSON

### DIFF
--- a/apps/memos-local-plugin/core/llm/client.ts
+++ b/apps/memos-local-plugin/core/llm/client.ts
@@ -501,16 +501,48 @@ export function createLlmClientWithProvider(
     const messages = normalizeMessages(input);
     const systemHint = buildJsonSystemHint(opts.schemaHint);
     const msgs = ensureJsonWordInUserMessage(inject(messages, systemHint));
-    const call = buildCallInput(opts, true);
+    let call = buildCallInput(opts, true);
     const op = opts.op ?? "complete.json";
     const maxMalformedRetries = Math.max(0, opts.malformedRetries ?? 1);
     let attempt = 0;
     let lastRaw = "";
     let lastErr: unknown = null;
+    // Thinking models share one max_tokens budget between reasoning and the
+    // final answer, so a truncated response arrives as 200 OK with
+    // finish_reason="length". Without an explicit check it looks like plain
+    // malformed JSON and the retry re-sends the same doomed budget. On the
+    // first truncation, log diagnostics and double max_tokens for the next
+    // attempt (capped).
+    const LENGTH_RETRY_MAX_TOKENS_CEILING = 32_768;
+    let truncatedOnce = false;
 
     while (attempt <= maxMalformedRetries) {
       attempt++;
       const { completion } = await callWithFallback(msgs, call, opts, op);
+      if (completion.finishReason === "length") {
+        jsonLog.warn("max_tokens_truncated", {
+          op,
+          attempt,
+          maxTokens: call.maxTokens,
+          completionChars: completion.text.length,
+          usage: completion.usage
+            ? {
+                completionTokens: completion.usage.completionTokens,
+                totalTokens: completion.usage.totalTokens,
+              }
+            : undefined,
+        });
+        if (!truncatedOnce && (call.maxTokens ?? 0) < LENGTH_RETRY_MAX_TOKENS_CEILING) {
+          truncatedOnce = true;
+          call = {
+            ...call,
+            maxTokens: Math.min(
+              LENGTH_RETRY_MAX_TOKENS_CEILING,
+              Math.max(2 * (call.maxTokens ?? DEFAULT_MAX_TOKENS), DEFAULT_MAX_TOKENS),
+            ),
+          };
+        }
+      }
       lastRaw = completion.text;
       try {
         const parsed = opts.parse

--- a/apps/memos-local-plugin/core/llm/client.ts
+++ b/apps/memos-local-plugin/core/llm/client.ts
@@ -45,6 +45,8 @@ import type {
 } from "./types.js";
 
 const DEFAULT_MAX_TOKENS = 1024;
+// Upper bound for the one-shot truncation retry budget (see completeJson).
+const LENGTH_RETRY_MAX_TOKENS_CEILING = 32_768;
 
 // ─── Factory ─────────────────────────────────────────────────────────────────
 
@@ -503,7 +505,7 @@ export function createLlmClientWithProvider(
     const msgs = ensureJsonWordInUserMessage(inject(messages, systemHint));
     let call = buildCallInput(opts, true);
     const op = opts.op ?? "complete.json";
-    const maxMalformedRetries = Math.max(0, opts.malformedRetries ?? 1);
+    let maxMalformedRetries = Math.max(0, opts.malformedRetries ?? 1);
     let attempt = 0;
     let lastRaw = "";
     let lastErr: unknown = null;
@@ -513,7 +515,6 @@ export function createLlmClientWithProvider(
     // malformed JSON and the retry re-sends the same doomed budget. On the
     // first truncation, log diagnostics and double max_tokens for the next
     // attempt (capped).
-    const LENGTH_RETRY_MAX_TOKENS_CEILING = 32_768;
     let truncatedOnce = false;
 
     while (attempt <= maxMalformedRetries) {
@@ -534,6 +535,10 @@ export function createLlmClientWithProvider(
         });
         if (!truncatedOnce && (call.maxTokens ?? 0) < LENGTH_RETRY_MAX_TOKENS_CEILING) {
           truncatedOnce = true;
+          // The upgraded budget is useless without at least one more attempt:
+          // a caller may pass malformedRetries: 0 for fail-fast parsing, and
+          // the truncation retry must not be silently skipped then.
+          if (attempt > maxMalformedRetries) maxMalformedRetries = attempt;
           call = {
             ...call,
             maxTokens: Math.min(

--- a/apps/memos-local-plugin/tests/unit/llm/length-retry-budget.test.ts
+++ b/apps/memos-local-plugin/tests/unit/llm/length-retry-budget.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Truncation retry budget: finish_reason="length" is a budget problem, not
+ * plain malformed output. The retry must double max_tokens (once, capped)
+ * instead of re-sending the same doomed budget.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { MemosError } from "../../../agent-contract/errors.js";
+import { createLlmClientWithProvider } from "../../../core/llm/index.js";
+import { initTestLogger } from "../../../core/logger/index.js";
+import type {
+  LlmConfig,
+  LlmMessage,
+  LlmProvider,
+  LlmProviderCtx,
+  LlmProviderName,
+  ProviderCallInput,
+  ProviderCompletion,
+} from "../../../core/llm/types.js";
+
+beforeAll(async () => {
+  await initTestLogger();
+});
+
+function cfg(partial: Partial<LlmConfig> = {}): LlmConfig {
+  return {
+    provider: "openai_compatible",
+    model: "gpt-test",
+    endpoint: "",
+    apiKey: "X",
+    temperature: 0.3,
+    fallbackToHost: false,
+    timeoutMs: 5_000,
+    maxRetries: 0,
+    ...partial,
+  };
+}
+
+class StubProvider implements LlmProvider {
+  public inputs: ProviderCallInput[] = [];
+  public readonly name: LlmProviderName;
+  constructor(
+    name: LlmProviderName,
+    private readonly responder: (n: number) => ProviderCompletion,
+  ) {
+    this.name = name;
+  }
+  async complete(
+    _messages: LlmMessage[],
+    opts: ProviderCallInput,
+    _ctx: LlmProviderCtx,
+  ): Promise<ProviderCompletion> {
+    this.inputs.push(opts);
+    return this.responder(this.inputs.length);
+  }
+}
+
+const DEFAULT_MAX_TOKENS = 1024;
+
+describe("completeJson truncation retry budget", () => {
+  it("doubles max_tokens after finish_reason=length and parses the retry", async () => {
+    const stub = new StubProvider("openai_compatible", (n) =>
+      n === 1
+        ? { text: "{\"x\":", durationMs: 1, finishReason: "length" as const }
+        : { text: "{\"x\":1}", durationMs: 1, finishReason: "stop" as const },
+    );
+    const client = createLlmClientWithProvider(cfg(), stub);
+    const r = await client.completeJson<{ x: number }>("ask", { malformedRetries: 1 });
+    expect(r.value.x).toBe(1);
+    expect(stub.inputs).toHaveLength(2);
+    expect(stub.inputs[0]!.maxTokens).toBe(DEFAULT_MAX_TOKENS);
+    expect(stub.inputs[1]!.maxTokens).toBe(2 * DEFAULT_MAX_TOKENS);
+  });
+
+  it("caps the doubled budget at 32768", async () => {
+    const stub = new StubProvider("openai_compatible", (n) =>
+      n === 1
+        ? { text: "truncated", durationMs: 1, finishReason: "length" as const }
+        : { text: "{\"y\":2}", durationMs: 1, finishReason: "stop" as const },
+    );
+    const client = createLlmClientWithProvider(cfg({ maxTokens: 16_384 }), stub);
+    const r = await client.completeJson<{ y: number }>("ask", { malformedRetries: 1 });
+    expect(r.value.y).toBe(2);
+    expect(stub.inputs[0]!.maxTokens).toBe(16_384);
+    expect(stub.inputs[1]!.maxTokens).toBe(32_768);
+  });
+
+  it("doubles at most once across consecutive truncations", async () => {
+    const stub = new StubProvider("openai_compatible", () => ({
+      text: "truncated",
+      durationMs: 1,
+      finishReason: "length" as const,
+    }));
+    const client = createLlmClientWithProvider(cfg({ maxTokens: 16_384 }), stub);
+    await expect(
+      client.completeJson("ask", { malformedRetries: 2 }),
+    ).rejects.toBeInstanceOf(MemosError);
+    expect(stub.inputs).toHaveLength(3);
+    expect(stub.inputs[0]!.maxTokens).toBe(16_384);
+    expect(stub.inputs[1]!.maxTokens).toBe(32_768);
+    expect(stub.inputs[2]!.maxTokens).toBe(32_768); // no further doubling
+  });
+
+  it("keeps the budget unchanged when finish_reason is stop", async () => {
+    const stub = new StubProvider("openai_compatible", (n) =>
+      n === 1
+        ? { text: "not json", durationMs: 1, finishReason: "stop" as const }
+        : { text: "{\"z\":3}", durationMs: 1, finishReason: "stop" as const },
+    );
+    const client = createLlmClientWithProvider(cfg(), stub);
+    const r = await client.completeJson<{ z: number }>("ask", { malformedRetries: 1 });
+    expect(r.value.z).toBe(3);
+    expect(stub.inputs[1]!.maxTokens).toBe(stub.inputs[0]!.maxTokens);
+  });
+});

--- a/apps/memos-local-plugin/tests/unit/llm/length-retry-budget.test.ts
+++ b/apps/memos-local-plugin/tests/unit/llm/length-retry-budget.test.ts
@@ -72,6 +72,19 @@ describe("completeJson truncation retry budget", () => {
     expect(stub.inputs[1]!.maxTokens).toBe(2 * DEFAULT_MAX_TOKENS);
   });
 
+  it("still retries once on truncation when malformedRetries is 0", async () => {
+    const stub = new StubProvider("openai_compatible", (n) =>
+      n === 1
+        ? { text: "{\"q\":", durationMs: 1, finishReason: "length" as const }
+        : { text: "{\"q\":2}", durationMs: 1, finishReason: "stop" as const },
+    );
+    const client = createLlmClientWithProvider(cfg(), stub);
+    const r = await client.completeJson<{ q: number }>("ask", { malformedRetries: 0 });
+    expect(r.value.q).toBe(2);
+    expect(stub.inputs).toHaveLength(2);
+    expect(stub.inputs[1]!.maxTokens).toBe(2 * DEFAULT_MAX_TOKENS);
+  });
+
   it("caps the doubled budget at 32768", async () => {
     const stub = new StubProvider("openai_compatible", (n) =>
       n === 1


### PR DESCRIPTION
## Description

Thinking models share one `max_tokens` budget between reasoning and the final
answer, so a truncated completion arrives as **200 OK with
`finish_reason="length"`** — not as an error. `completeJson()` treats it like
any malformed output and retries with **the same budget**, which truncates
again: the retry can never succeed.

On our local deployment this triggered routinely on L3-abstraction calls
(P95 useful output ≈ 4.2k tokens, with reasoning frequently pushing past the
configured budget), burning both attempts of `completeJson` (the initial call plus its one malformed-retry) and producing
`LLM_OUTPUT_MALFORMED` for what is a budget problem, not a formatting problem.

This PR detects the truncation and doubles `max_tokens` once for the retry,
capped at 32768.

Related Issue: Fixes #2320

## Change

- `core/llm/client.ts` — `completeJson()`:
  - after `callWithFallback()`, if `completion.finishReason === "length"`,
    log `max_tokens_truncated` diagnostics (`op`, `attempt`, `maxTokens`,
    completion chars, `usage.completionTokens` / `usage.totalTokens`; the
    usage block is nullable — not every provider normalizes it);
  - on the first truncation only (`truncatedOnce` guard), still granted when the caller passes `malformedRetries: 0` (fail-fast), rebuild the call
    with `maxTokens = min(32768, max(2 × maxTokens, DEFAULT_MAX_TOKENS))`.
    The detection sits **before** JSON parsing so the diagnosis does not
    depend on the parse failing, and the once-only guard keeps retries from
    ratcheting cost upward. If the configured budget is already ≥ 32768
    (the cap), the budget is left untouched — the guard never lowers an
    explicit high budget a caller set via `llm.maxTokens` (#2248).
  - Malformed-only retries (`finish_reason="stop"`) keep the budget
    unchanged.
- `tests/unit/llm/length-retry-budget.test.ts` — new suite (5 tests) driving the
  real retry loop through a stub provider:
  doubling from the default (1024 → 2048) and the retry parses;
  cap at 32768 from 16384;
  at-most-once doubling across consecutive truncations (budget stays at
  32768, ultimately rejects with `MemosError`);
  budget unchanged when the only problem is malformed output
  (`finish_reason="stop"`).

## Tests

- `npx vitest run tests/unit/llm/length-retry-budget.test.ts tests/unit/llm/client.test.ts` → **30 passed** (5 new + 25 existing)
- `npx vitest run tests/unit/llm/` → **86 passed (6 files)**
- `npx tsc -p tsconfig.json --noEmit` → clean (exit 0)

Reproduce: clone `main`, apply this PR, `cd apps/memos-local-plugin`,
`npm install`, run the commands above.

## Related

- Builds on #2248, which made `llm.maxTokens` a first-class config key —
  this covers the retry behavior that PR did not address: with
  `finish_reason="length"`, raising the configured budget up front helps,
  but a completion that still runs out mid-JSON must not burn its retries
  at the same doomed budget.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit Test — `npx vitest run tests/unit/llm/` → 86 passed (6 files), incl. 5 new truncation-budget tests
- [x] Test Script Or Test Steps — see reproduce steps above
- [ ] Pipeline Automated API Test

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in MemOS-Docs (if applicable) — no public-API/config surface changed
- [ ] I have linked the issue to this PR (if applicable) — pending issue; will link once filed
- [ ] I have mentioned the person who will review this PR

## Environment

- **Plugin version:** monorepo main (`28dfb4e`)
- **Runtime:** Node 26 (arm64 macOS), vitest 2.1.9
