### PR TITLE
fix(plugin): reject conversational acts in L2 policy induction (v3)

### DIFF
--- a/apps/memos-local-plugin/core/llm/prompts/l2-induction.ts
+++ b/apps/memos-local-plugin/core/llm/prompts/l2-induction.ts
@@ -17,6 +17,7 @@ import type { PromptDef } from "./index.js";
  * v3 history: adds a negative list for conversational acts (clarify /
  * confirm-with-user / notify / reporting status). 2026-08-28 audit: those
  * crystallized into dead skills nobody can invoke.
+ * Bumping the version to v3 captures that change.
  */
 export const L2_INDUCTION_PROMPT: PromptDef = {
   id: "l2.induction",

--- a/apps/memos-local-plugin/core/llm/prompts/l2-induction.ts
+++ b/apps/memos-local-plugin/core/llm/prompts/l2-induction.ts
@@ -14,10 +14,13 @@ import type { PromptDef } from "./index.js";
  * belongs to the L3 world model, not here. The system prompt explicitly
  * rejects environment-fact drift to keep the two layers semantically
  * orthogonal. Bumping the version to v2 captures that change.
+ * v3 history: adds a negative list for conversational acts (clarify /
+ * confirm-with-user / notify / reporting status). 2026-08-28 audit: those
+ * crystallized into dead skills nobody can invoke.
  */
 export const L2_INDUCTION_PROMPT: PromptDef = {
   id: "l2.induction",
-  version: 2,
+  version: 3,
   description:
     "Distill an L2 policy (procedural sub-task strategy) from a cluster of similar L1 traces, with explicit boundaries against L3 world-model drift.",
   system: `You induce reusable **procedural policies** from agent experience.
@@ -69,6 +72,22 @@ check, not as a standalone description. Example:
                '<lib> not found' or 'header not found'"
     caveats:  ["if first apk add still fails, also check musl-vs-glibc
                wheel compatibility before retrying"]
+
+──────────────────── Conversational acts are not policies ────────────────────
+
+Do NOT write a policy whose core ACTION is talking to the user: asking
+a clarifying question, requesting confirmation, notifying, or reporting
+status. Those are one-off dialogue behaviours, not reusable procedures —
+they later crystallize into dead "skills" no agent can invoke.
+
+If the underlying trace really contains a reusable check, express the
+CHECK itself as the action:
+
+  Wrong (conversational act):
+    action: "ask the user to confirm the skill name before viewing it"
+  Right (reusable check):
+    action: "resolve the skill id via skill list search before invoking
+    it; on miss, fall back to keyword search instead of prompting"
 
 ──────────────────── Same fact, two framings ─────────────────────
 

--- a/apps/memos-local-plugin/tests/unit/memory/l2/induce.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/induce.test.ts
@@ -44,7 +44,7 @@ describe("memory/l2/induce", () => {
   it("returns {ok:true, draft} and fills support_trace_ids when the LLM omits them", async () => {
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": {
+        "l2.l2.induction.v3": {
           title: "install system libs first",
           trigger: "pip install fails in container with missing system library",
           procedure: "1. detect missing lib 2. apk/apt-get install 3. retry pip",
@@ -75,7 +75,7 @@ describe("memory/l2/induce", () => {
   it("cleans unsafe markup from LLM-derived policy fields", async () => {
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": {
+        "l2.l2.induction.v3": {
           title: "<img src=x onerror=alert(1)> install system libs",
           trigger: "<script>alert(1)</script>pip fails [bad](javascript:alert(1))",
           procedure: "Use [safe](https://example.com), ignore [bad](javascript:alert(1))",
@@ -149,7 +149,7 @@ describe("memory/l2/induce", () => {
   it("reason=llm_failed when the LLM draft is malformed (missing title)", async () => {
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": { trigger: "no title", procedure: "..." },
+        "l2.l2.induction.v3": { trigger: "no title", procedure: "..." },
       },
     });
     const res = await induceDraft(

--- a/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/l2.integration.test.ts
@@ -112,7 +112,7 @@ describe("memory/l2/integration", () => {
 
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": {
+        "l2.l2.induction.v3": {
           title: "install missing system libs in container",
           trigger: "pip install fails in container with MODULE_NOT_FOUND due to missing system lib",
           procedure: "1. detect lib 2. use distro pkg manager 3. retry pip",
@@ -367,7 +367,7 @@ describe("memory/l2/integration", () => {
         repos: handle.repos,
         llm: fakeLlm({
           completeJson: {
-            "l2.l2.induction.v2": {
+            "l2.l2.induction.v3": {
               title: " 闲聊场景下避免使用emoji ",
               trigger: "用户发起非任务性闲聊，且未明确要求使用emoji",
               procedure: "以简洁、自然的文字回应，但不添加任何emoji或表情符号",
@@ -457,7 +457,7 @@ describe("memory/l2/integration", () => {
         repos: handle.repos,
         llm: fakeLlm({
           completeJson: {
-            "l2.l2.induction.v2": {
+            "l2.l2.induction.v3": {
               title: "结构化呈现外部数据查询结果",
               trigger: "agent通过工具调用获取到外部数据源的原始响应（搜索结果、API返回、数据库查询等），需要向用户呈现信息",
               procedure: "1) 从原始数据中提取关键信息要素；2) 按逻辑分类组织信息（时间、地点、数值、状态等）；3) 使用结构化格式呈现（分类标题、列表、表格等）；4) 可选：基于数据添加简短的实用性总结或建议",
@@ -548,7 +548,7 @@ describe("memory/l2/integration", () => {
         repos: handle.repos,
         llm: fakeLlm({
           completeJson: {
-            "l2.l2.induction.v2": {
+            "l2.l2.induction.v3": {
               ...shared,
               boundary: "仅适用于数据库事务和写入操作，不适用于天气API或公开搜索结果",
               rationale: "边界不同，不能复用天气呈现经验",
@@ -630,7 +630,7 @@ describe("memory/l2/integration", () => {
         repos: handle.repos,
         llm: fakeLlm({
           completeJson: {
-            "l2.l2.induction.v2": {
+            "l2.l2.induction.v3": {
               title: "工具全部失效时坦诚说明并回退到已有知识",
               trigger: "连续尝试多个同类工具（如多个搜索引擎、多个新闻源）后全部因反爬、封禁或网络错误失效，且用户问题需要实时信息",
               procedure: "1) 明确告知用户所有尝试过的工具都已失效（列出具体工具名）；2) 基于训练数据中的已有知识提供最接近的答案；3) 明确标注该信息的时间戳或来源时间，并提醒用户可能存在时效性差异；4) 建议用户通过其他渠道（如直接搜索、官方网站）验证",
@@ -663,7 +663,7 @@ describe("memory/l2/integration", () => {
 
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": {
+        "l2.l2.induction.v3": {
           title: "t",
           trigger: "tr",
           procedure: "pr",


### PR DESCRIPTION
## Summary

Conversational acts — asking clarifying questions, requesting confirmation,
notifying, reporting status — are one-off dialogue behaviours, not reusable
procedures. When the L2 induction LLM writes them as a policy `action` anyway,
they later crystallize into dead skills that no agent can invoke. This PR adds
an explicit negative list to the induction system prompt and bumps the prompt
to v3 so the re-induction pass rewrites affected policies.

## Problem

An internal 25-day production audit (2026-08-28) of the crystallized-skill
pool identified conversational-act policies as a recurring failure mode: they
are induced and stored like any other policy, but no agent can ever invoke
them, so they accumulate as dead weight. In the same window the pool received
207 fresh generations of which 98% of candidates were never invoked — the
quality of what enters the pool is the upstream half of that problem, and the
induction prompt had no guidance separating reusable checks from dialogue.

## Change

- `core/llm/prompts/l2-induction.ts` — new "Conversational acts are not
  policies" section: a negative list (clarify / confirm-with-user / notify /
  report status) plus a wrong/right example pair steering the model to express
  a reusable CHECK as the action instead (e.g. resolve the skill id via list
  search rather than ask the user to confirm it). Doc comment records the v3
  history. `version: 2` → `3` — induction op names embed the prompt version
  (`l2.${id}.v${version}`), so the bump drives re-induction onto the new
  prompt on the next pass.
- `tests/unit/memory/l2/induce.test.ts`,
  `tests/unit/memory/l2/l2.integration.test.ts` — `fakeLlm` mock keys
  `l2.l2.induction.v2` → `.v3` (9 occurrences). Without this the fake LLM has
  no mock for the new op and 8 induction tests fail with `llm_failed` —
  which doubles as confirmation the version bump takes effect.

## Tests

- `npx vitest run tests/unit/llm/prompts.test.ts tests/unit/memory/l2/` → **57 passed (10 files)**
- `npx vitest run tests/unit/` → **1549 passed, 2 skipped, 0 failed**
- `npx tsc --noEmit` → clean (exit 0)

## Related

- PR #2253 hardened the crystallizer validator against malformed LLM drafts;
  this PR addresses an upstream cause — the induction prompt steering the LLM
  toward conversational acts in the first place.
- Fixes #2318.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, lint)
- [ ] Documentation update

## How Has This Been Tested?

- [x] Unit tests (`npx vitest run tests/unit/llm/prompts.test.ts tests/unit/memory/l2/` — 57 passed, 10 files)
- [x] Full unit suite (`npx vitest run tests/unit/` — 1549 passed, 0 failed)
- [x] Type-check (`tsc --noEmit` clean)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [ ] I have linked the issue to this PR (if applicable)
- [ ] I have mentioned the person who will review this PR
