### PR TITLE
Fix #2335: l3.abstraction hard-fails entire world-model generation on empty LLM title (no r

### DIFF
--- a/apps/memos-local-plugin/core/memory/l2/induce.ts
+++ b/apps/memos-local-plugin/core/memory/l2/induce.ts
@@ -146,6 +146,7 @@ export async function induceDraft(
       log.warn("induce.title_fallback", {
         signatureLabel: input.signatureLabel,
         synthesisedTitle: draft.title,
+        rawTitleType: typeof rawTitle,
       });
     }
     if (deps.validate) deps.validate(draft);
@@ -285,7 +286,7 @@ function normaliseDraft(
  * throwing away the trigger/procedure that we did get.
  */
 function synthesiseTitle(signatureLabel: string): string {
-  const clean = signatureLabel.trim();
-  if (clean.length > 0) return clean.slice(0, 120);
+  const clean = sanitizeDerivedText(signatureLabel);
+  if (clean.length > 0) return truncate(clean, 120);
   return "Untitled policy";
 }

--- a/apps/memos-local-plugin/core/memory/l2/induce.ts
+++ b/apps/memos-local-plugin/core/memory/l2/induce.ts
@@ -110,14 +110,17 @@ export async function induceDraft(
         schemaHint: `{"title":"...","trigger":"...","procedure":"...","verification":"...","rationale":"...","caveats":["..."],"confidence":0..1,"support_trace_ids":["tr_..."]}`,
         validate: (v) => {
           const o = v as Record<string, unknown>;
-          for (const k of ["title", "trigger"]) {
-            if (typeof o[k] !== "string" || !(o[k] as string).trim()) {
-              throw new MemosError(
-                ERROR_CODES.LLM_OUTPUT_MALFORMED,
-                `l2.induction: '${k}' must be a non-empty string`,
-                { got: o[k] },
-              );
-            }
+          // `trigger` is load-bearing — a policy without a trigger has
+          // no matching semantics. `title` is a display attribute; if
+          // empty, `normaliseDraft` synthesises a fallback from the
+          // pattern signature so a single flaky LLM response doesn't
+          // discard an otherwise-usable draft.
+          if (typeof o.trigger !== "string" || !(o.trigger as string).trim()) {
+            throw new MemosError(
+              ERROR_CODES.LLM_OUTPUT_MALFORMED,
+              `l2.induction: 'trigger' must be a non-empty string`,
+              { got: o.trigger },
+            );
           }
           if (
             typeof o.procedure !== "string" &&
@@ -133,7 +136,18 @@ export async function induceDraft(
       },
     );
 
-    const draft = normaliseDraft(rsp.value, input.evidenceTraces.map((t) => t.id));
+    const draft = normaliseDraft(
+      rsp.value,
+      input.evidenceTraces.map((t) => t.id),
+      input.signatureLabel,
+    );
+    const rawTitle = (rsp.value as { title?: unknown }).title;
+    if (typeof rawTitle !== "string" || rawTitle.trim().length === 0) {
+      log.warn("induce.title_fallback", {
+        signatureLabel: input.signatureLabel,
+        synthesisedTitle: draft.title,
+      });
+    }
     if (deps.validate) deps.validate(draft);
     return { ok: true, draft };
   } catch (err) {
@@ -230,7 +244,11 @@ function truncate(s: string, n: number): string {
   return s.slice(0, n - 1) + "…";
 }
 
-function normaliseDraft(value: Record<string, unknown>, traceIds: readonly TraceId[]): InductionDraft {
+function normaliseDraft(
+  value: Record<string, unknown>,
+  traceIds: readonly TraceId[],
+  signatureLabel: string,
+): InductionDraft {
   const procedure =
     typeof value.procedure === "string"
       ? (value.procedure as string)
@@ -244,8 +262,12 @@ function normaliseDraft(value: Record<string, unknown>, traceIds: readonly Trace
   const supportTraceIds = Array.isArray(value.support_trace_ids)
     ? (value.support_trace_ids as unknown[]).filter((x): x is string => typeof x === "string")
     : [];
+  const cleanedTitle = sanitizeDerivedText(value.title);
+  const title = cleanedTitle.length > 0
+    ? cleanedTitle
+    : synthesiseTitle(signatureLabel);
   return {
-    title: sanitizeDerivedText(value.title),
+    title,
     trigger: sanitizeDerivedMarkdown(value.trigger),
     procedure: sanitizeDerivedMarkdown(procedure),
     verification: typeof value.verification === "string" ? sanitizeDerivedMarkdown(value.verification) : "",
@@ -255,4 +277,15 @@ function normaliseDraft(value: Record<string, unknown>, traceIds: readonly Trace
     confidence: Math.max(0, Math.min(1, confidence)),
     supportTraceIds: supportTraceIds.length > 0 ? (supportTraceIds as TraceId[]) : Array.from(traceIds),
   };
+}
+
+/**
+ * Build a display-quality title from the pattern signature when the LLM
+ * returns an empty `title`. Keeps the whole draft usable instead of
+ * throwing away the trigger/procedure that we did get.
+ */
+function synthesiseTitle(signatureLabel: string): string {
+  const clean = signatureLabel.trim();
+  if (clean.length > 0) return clean.slice(0, 120);
+  return "Untitled policy";
 }

--- a/apps/memos-local-plugin/core/memory/l3/abstract.ts
+++ b/apps/memos-local-plugin/core/memory/l3/abstract.ts
@@ -124,10 +124,12 @@ export async function abstractDraft(
     );
 
     const draft = normaliseDraft(rsp.value);
-    if (isEmptyString((rsp.value as Record<string, unknown>).title)) {
+    const rawTitle = (rsp.value as { title?: unknown }).title;
+    if (typeof rawTitle !== "string" || rawTitle.trim().length === 0) {
       log.warn("abstract.title_fallback", {
         clusterKey: input.cluster.key,
         synthesisedTitle: draft.title,
+        rawTitleType: typeof rawTitle,
       });
     }
     if (deps.validate) deps.validate(draft);
@@ -285,14 +287,10 @@ function normaliseDraft(value: Record<string, unknown>): L3AbstractionDraft {
   };
 }
 
-function isEmptyString(v: unknown): boolean {
-  return typeof v !== "string" || v.trim().length === 0;
-}
-
 /**
  * Build a display-quality title from whatever structure the draft carries.
  * The abstractor's `title` is a display attribute; a missing one shouldn't
- * lose the whole world model. See `docs/openspec/changes/…-2335-…/design.md`.
+ * lose the whole world model.
  */
 function synthesiseTitle(
   domainTags: readonly string[],
@@ -300,17 +298,20 @@ function synthesiseTitle(
 ): string {
   if (domainTags.length > 0) {
     const joined = domainTags.slice(0, 3).map(titleCaseTag).join(" · ");
-    if (joined.trim().length > 0) return joined.slice(0, 160);
+    return [...joined].slice(0, 160).join("");
   }
   for (const e of environment) {
-    if (e.label && e.label.trim().length > 0) return e.label.slice(0, 160);
+    if (e.label && e.label.trim().length > 0) {
+      return [...e.label].slice(0, 160).join("");
+    }
   }
   return "Untitled world model";
 }
 
 function titleCaseTag(tag: string): string {
   if (tag.length === 0) return tag;
-  return tag.charAt(0).toUpperCase() + tag.slice(1);
+  const chars = [...tag];
+  return chars[0].toUpperCase() + chars.slice(1).join("");
 }
 
 function pickTriple(value: Record<string, unknown>): {

--- a/apps/memos-local-plugin/core/memory/l3/abstract.ts
+++ b/apps/memos-local-plugin/core/memory/l3/abstract.ts
@@ -104,13 +104,11 @@ export async function abstractDraft(
         schemaHint: `{"title":"...","domain_tags":["..."],"environment":[{"label":"...","description":"...","evidenceIds":["..."]}],"inference":[...],"constraints":[...],"body":"markdown","confidence":0..1,"supersedes_world_ids":[]}`,
         validate: (v) => {
           const o = v as Record<string, unknown>;
-          if (typeof o.title !== "string" || !(o.title as string).trim()) {
-            throw new MemosError(
-              ERROR_CODES.LLM_OUTPUT_MALFORMED,
-              "l3.abstraction: 'title' must be a non-empty string",
-              { got: o.title },
-            );
-          }
+          // Empty `title` is tolerated — `normaliseDraft` synthesises a
+          // fallback from `domain_tags` / first environment label so a
+          // single missing display attribute doesn't abort the entire
+          // world-model. Missing triple, however, means the draft has
+          // no usable payload and must still fail.
           const triple = ["environment", "inference", "constraints"];
           for (const k of triple) {
             if (!Array.isArray(o[k])) {
@@ -126,6 +124,12 @@ export async function abstractDraft(
     );
 
     const draft = normaliseDraft(rsp.value);
+    if (isEmptyString((rsp.value as Record<string, unknown>).title)) {
+      log.warn("abstract.title_fallback", {
+        clusterKey: input.cluster.key,
+        synthesisedTitle: draft.title,
+      });
+    }
     if (deps.validate) deps.validate(draft);
     return { ok: true, draft };
   } catch (err) {
@@ -260,9 +264,14 @@ function packPolicy(
 
 function normaliseDraft(value: Record<string, unknown>): L3AbstractionDraft {
   const triple = pickTriple(value);
+  const domainTags = normaliseTags(value.domain_tags);
+  const rawTitle = sanitizeDerivedText(value.title);
+  const title = rawTitle.length > 0
+    ? rawTitle
+    : synthesiseTitle(domainTags, triple.environment);
   return {
-    title: sanitizeDerivedText(value.title),
-    domainTags: normaliseTags(value.domain_tags),
+    title,
+    domainTags,
     environment: triple.environment,
     inference: triple.inference,
     constraints: triple.constraints,
@@ -274,6 +283,34 @@ function normaliseDraft(value: Record<string, unknown>): L3AbstractionDraft {
           .map((s) => s as WorldModelId)
       : [],
   };
+}
+
+function isEmptyString(v: unknown): boolean {
+  return typeof v !== "string" || v.trim().length === 0;
+}
+
+/**
+ * Build a display-quality title from whatever structure the draft carries.
+ * The abstractor's `title` is a display attribute; a missing one shouldn't
+ * lose the whole world model. See `docs/openspec/changes/…-2335-…/design.md`.
+ */
+function synthesiseTitle(
+  domainTags: readonly string[],
+  environment: readonly L3AbstractionDraftEntry[],
+): string {
+  if (domainTags.length > 0) {
+    const joined = domainTags.slice(0, 3).map(titleCaseTag).join(" · ");
+    if (joined.trim().length > 0) return joined.slice(0, 160);
+  }
+  for (const e of environment) {
+    if (e.label && e.label.trim().length > 0) return e.label.slice(0, 160);
+  }
+  return "Untitled world model";
+}
+
+function titleCaseTag(tag: string): string {
+  if (tag.length === 0) return tag;
+  return tag.charAt(0).toUpperCase() + tag.slice(1);
 }
 
 function pickTriple(value: Record<string, unknown>): {

--- a/apps/memos-local-plugin/tests/unit/memory/l2/induce.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l2/induce.test.ts
@@ -146,10 +146,38 @@ describe("memory/l2/induce", () => {
     expect(res.reason).toBe("llm_failed");
   });
 
-  it("reason=llm_failed when the LLM draft is malformed (missing title)", async () => {
+  it("synthesises a fallback title from the pattern signature when the LLM omits it", async () => {
+    // Regression for #2335 (parity with l3.abstract): the LLM
+    // occasionally returns an empty `title`. That is a display attribute,
+    // not a load-bearing field — the whole draft shouldn't be discarded.
     const llm = fakeLlm({
       completeJson: {
-        "l2.l2.induction.v2": { trigger: "no title", procedure: "..." },
+        "l2.l2.induction.v2": {
+          title: "   ",
+          trigger: "pip install fails in alpine",
+          procedure: "apk add + retry",
+          confidence: 0.6,
+        },
+      },
+    });
+    const res = await induceDraft(
+      {
+        evidenceTraces: [mkTrace("tr_a", "ep_1", vec([1, 0]))],
+        episodeIds: ["ep_1"] as EpisodeId[],
+        signatureLabel: "docker|pip|MODULE_NOT_FOUND",
+        charCap: 1000,
+      },
+      { llm, log },
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.draft.title).toBe("docker|pip|MODULE_NOT_FOUND");
+  });
+
+  it("reason=llm_failed when the LLM draft is malformed (missing trigger)", async () => {
+    const llm = fakeLlm({
+      completeJson: {
+        "l2.l2.induction.v2": { title: "have title", procedure: "..." },
       },
     });
     const res = await induceDraft(

--- a/apps/memos-local-plugin/tests/unit/memory/l3/abstract.test.ts
+++ b/apps/memos-local-plugin/tests/unit/memory/l3/abstract.test.ts
@@ -180,6 +180,79 @@ describe("memory/l3/abstract", () => {
     expect(res.detail).toContain("boom");
   });
 
+  it("synthesises a fallback title from domain_tags when the LLM returns empty title", async () => {
+    const llm = fakeLlm({
+      completeJson: {
+        [OP]: {
+          title: "   ",
+          domain_tags: ["Alpine", "python", "pip"],
+          environment: [{ label: "Alpine", description: "musl libc" }],
+          inference: [{ label: "wheels fail", description: "musl" }],
+          constraints: [{ label: "avoid wheels", description: "no binary" }],
+          body: "body",
+          confidence: 0.6,
+          supersedes_world_ids: [],
+        },
+      },
+    });
+
+    const res = await abstractDraft(
+      { cluster: mkCluster(), evidenceByPolicy: new Map() },
+      { llm, log, config: cfg() },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.draft.title.trim().length).toBeGreaterThan(0);
+    expect(res.draft.title.toLowerCase()).toContain("alpine");
+  });
+
+  it("falls back to environment label when title and domain_tags are empty", async () => {
+    const llm = fakeLlm({
+      completeJson: {
+        [OP]: {
+          title: "",
+          domain_tags: [],
+          environment: [{ label: "Runtime", description: "runtime" }],
+          inference: [{ label: "x", description: "y" }],
+          constraints: [{ label: "z", description: "w" }],
+          body: "",
+          confidence: 0.5,
+        },
+      },
+    });
+    const res = await abstractDraft(
+      { cluster: mkCluster(), evidenceByPolicy: new Map() },
+      { llm, log, config: cfg() },
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.draft.title).toBe("Runtime");
+  });
+
+  it("falls back to a static title when title / tags / environment are all empty", async () => {
+    const llm = fakeLlm({
+      completeJson: {
+        [OP]: {
+          title: "",
+          domain_tags: [],
+          environment: [{ label: "", description: "d" }],
+          inference: [{ label: "x", description: "y" }],
+          constraints: [{ label: "z", description: "w" }],
+          body: "",
+          confidence: 0.5,
+        },
+      },
+    });
+    const res = await abstractDraft(
+      { cluster: mkCluster(), evidenceByPolicy: new Map() },
+      { llm, log, config: cfg() },
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.draft.title).toBe("Untitled world model");
+  });
+
   it("returns llm_failed when the LLM returns missing triple", async () => {
     const llm = fakeLlm({
       completeJson: {


### PR DESCRIPTION
## Description

Fixes issue #2335: `l3.abstraction` no longer aborts a whole cluster's world-model generation when the LLM returns an empty `title`. The `validate` callback still requires the triple (`environment` / `inference` / `constraints`) but no longer throws on empty `title`; `normaliseDraft` synthesises a fallback title from `domain_tags` (title-cased, joined with " · "), the first non-empty `environment[].label`, or a static `"Untitled world model"`. `abstractDraft` emits an `abstract.title_fallback` warn breadcrumb so ops can still spot LLM regressions.

Applied the same softening to `l2.induction`: `title` becomes a display attribute (falls back to `signatureLabel`, else `"Untitled policy"`) while `trigger` and `procedure` remain load-bearing and still fail the draft when missing.

Verified with vitest: the two focused test files run 16 tests (all passing) and the full `tests/unit/memory/l2 + l3` suite runs 89 tests (all passing). `tsc -p tsconfig.json --noEmit` is clean. Changes touch four files under `apps/memos-local-plugin/{core,tests}/memory/{l2,l3}`; opsp task file and openspec change artefacts are staged in `.ai-tasks/` and `openspec/changes/` for scheduler archival.

Related Issue (Required):  Fixes #2335

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Automated tests are pending.

- [ ] Unit Test
- [ ] Test Script Or Test Steps (please provide)
- [ ] Pipeline Automated API Test (please provide)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable)
- [x] I have linked the issue to this PR (if applicable)
- [x] I have mentioned the person who will review this PR

@whipser030, @hijzy please review this PR.

## Reviewer Checklist
- [x] closes #2335
- [ ] Made sure Checks passed
- [ ] Tests have been provided
