### PR TITLE
fix: restore OpenClaw installation and automatic memory hooks

### DIFF
--- a/apps/memos-local-plugin/README.md
+++ b/apps/memos-local-plugin/README.md
@@ -120,6 +120,28 @@ npm pack
 bash install.sh --version ./memtensor-memos-local-plugin-1.0.0-beta.1.tgz
 ```
 
+For OpenClaw, use the installer for local archives too:
+
+```bash
+bash install.sh --agent openclaw --version ./memtensor-memos-local-plugin-2.0.16-beta.1.tgz
+```
+
+Do not substitute `openclaw plugins install ./package.tgz` for this command:
+that raw-archive path can resolve development-only DeepSeek peer dependencies
+and fail with `ERESOLVE`, including on OpenClaw 2026.9.1 and 2026.9.2.
+The installer stages production dependencies and rebuilds `better-sqlite3`.
+OpenClaw's newer `npm-pack:` path avoids the peer-resolution conflict, but a
+successful managed install alone does not verify native bindings or initialize
+MemOS runtime configuration; the installer above remains the supported setup.
+
+When upgrading OpenClaw itself, migrate retired host configuration with
+`openclaw doctor --fix` before installing MemOS. The MemOS installer removes its
+own legacy `plugins.installs` records, preserves other plugins' old-host records,
+and uses the host CLI for capability consent when available. It does not rewrite
+the host's internal installation database. See
+[the compatibility test results](docs/OPENCLAW-COMPATIBILITY.md) for tested versions
+and limits.
+
 On Windows, run `install.ps1` from PowerShell instead of `install.sh` for
 OpenClaw or Hermes. The DSH one-command target currently supports macOS/Linux;
 Windows users can use DSH's lower-level `dsh plugin` flow.

--- a/apps/memos-local-plugin/adapters/openclaw/index.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/index.ts
@@ -310,36 +310,12 @@ function isDiagnosticMode(): boolean {
   return false;
 }
 
-function register(api: OpenClawPluginApi): void {
-  const diagnosticMode = isDiagnosticMode();
-
-  let runtimeLock: OpenClawRuntimeLockHandle;
-  try {
-    runtimeLock = acquireOpenClawRuntimeLock({
-      home: resolveHome("openclaw"),
-      pluginId: PLUGIN_ID,
-      version: PLUGIN_VERSION,
-      viewerPort: OPENCLAW_VIEWER_PORT,
-      skipLock: diagnosticMode,
-    });
-
-    if (diagnosticMode) {
-      api.logger.info("memos-local: running in diagnostic mode (lock acquisition skipped)");
-    }
-  } catch (err) {
-    const duplicate = err instanceof DuplicateOpenClawRuntimeError;
-    api.logger.error("memos-local: duplicate OpenClaw runtime blocked", {
-      err: err instanceof Error ? err.message : String(err),
-      code: duplicate ? err.code : (err as { code?: unknown }).code,
-    });
-    throw err;
-  }
-
-  // OpenClaw publishes its clean, command-facing inbound body before
-  // prompt construction. Keep this store independent of core bootstrap
-  // so early messages are not lost while SQLite/providers initialize.
-  const inboundUserText = createOpenClawInboundTextStore();
-
+function registerRuntimeBindings(
+  api: OpenClawPluginApi,
+  ensureRuntime: () => Promise<PluginRuntime | null>,
+  inboundUserText: ReturnType<typeof createOpenClawInboundTextStore>,
+  currentRuntime: () => PluginRuntime | null,
+): void {
   // 1. Memory capability (prompt prelude) — register synchronously so the
   //    host immediately knows who owns the memory slot, even if bootstrap
   //    fails later.
@@ -391,31 +367,6 @@ function register(api: OpenClawPluginApi): void {
       return lines;
     },
   });
-
-  // 2. Kick off core bootstrap. OpenClaw only accepts tool / hook
-  //    registration during the synchronous `register(api)` window, so
-  //    tools register a shell now and wait for runtime inside execute().
-  let runtime: PluginRuntime | null = null;
-  let bootstrapError: Error | null = null;
-  const bootstrapPromise = createRuntime(api, runtimeLock, inboundUserText)
-    .then((r) => {
-      runtime = r;
-      api.logger.info("memos-local: plugin ready");
-    })
-    .catch((err) => {
-      bootstrapError = err instanceof Error ? err : new Error(String(err));
-      const duplicate = err instanceof DuplicateOpenClawRuntimeError;
-      api.logger.error("memos-local: bootstrap failed", {
-        err: bootstrapError.message,
-        code: duplicate ? err.code : (err as { code?: unknown }).code,
-      });
-    });
-
-  const ensureRuntime = async (): Promise<PluginRuntime | null> => {
-    if (runtime) return runtime;
-    await bootstrapPromise;
-    return runtime;
-  };
 
   /**
    * Helper for **void / fire-and-forget** hooks: dispatch `fn` against the
@@ -520,6 +471,7 @@ function register(api: OpenClawPluginApi): void {
   // already sync, so we can invoke it directly when the runtime is
   // ready and return undefined otherwise.
   api.on("tool_result_persist", (event, ctx) => {
+    const runtime = currentRuntime();
     if (!runtime) return; // bootstrap not finished — nothing to inject
     return runtime.bridge.handleToolResultPersist(event, ctx);
   });
@@ -542,6 +494,101 @@ function register(api: OpenClawPluginApi): void {
     void runWhenReady((r) => r.bridge.handleSubagentEnded(event, ctx), "subagent_ended");
   });
 
+}
+
+// OpenClaw may build a separate tool registry in the same process. That
+// registry borrows the full registration's core and never owns its lifecycle.
+interface SharedRuntime {
+  ensureRuntime: () => Promise<PluginRuntime | null>;
+  registerBindings: (api: OpenClawPluginApi) => void;
+}
+// Host registries can reload the module. Keep ownership process-wide while
+// retaining the filesystem lock against genuinely separate gateway processes.
+const runtimeKey = Symbol.for("memos.openclaw.activeRuntimes.v1");
+const processState = globalThis as typeof globalThis & {
+  [runtimeKey]?: Map<string, SharedRuntime>;
+};
+const activeRuntimes = processState[runtimeKey] ??= new Map<string, SharedRuntime>();
+
+function register(api: OpenClawPluginApi): void {
+  const home = resolveHome("openclaw");
+  if (api.registrationMode === "tool-discovery") {
+    registerOpenClawTools(api, {
+      agent: "openclaw",
+      getCore: async () => (await activeRuntimes.get(home.root)?.ensureRuntime())?.core ?? null,
+      log: api.logger,
+    });
+    return;
+  }
+  const existing = activeRuntimes.get(home.root);
+  if (existing) {
+    existing.registerBindings(api);
+    api.logger.info("memos-local: reused active runtime for host registry");
+    return;
+  }
+  const diagnosticMode = isDiagnosticMode();
+
+  let runtimeLock: OpenClawRuntimeLockHandle;
+  try {
+    runtimeLock = acquireOpenClawRuntimeLock({
+      home,
+      pluginId: PLUGIN_ID,
+      version: PLUGIN_VERSION,
+      viewerPort: OPENCLAW_VIEWER_PORT,
+      skipLock: diagnosticMode,
+    });
+
+    if (diagnosticMode) {
+      api.logger.info("memos-local: running in diagnostic mode (lock acquisition skipped)");
+    }
+  } catch (err) {
+    const duplicate = err instanceof DuplicateOpenClawRuntimeError;
+    api.logger.error("memos-local: duplicate OpenClaw runtime blocked", {
+      err: err instanceof Error ? err.message : String(err),
+      code: duplicate ? err.code : (err as { code?: unknown }).code,
+    });
+    throw err;
+  }
+
+  // OpenClaw publishes its clean, command-facing inbound body before
+  // prompt construction. Keep this store independent of core bootstrap
+  // so early messages are not lost while SQLite/providers initialize.
+  const inboundUserText = createOpenClawInboundTextStore();
+
+  // 2. Kick off core bootstrap. OpenClaw only accepts tool / hook
+  //    registration during the synchronous `register(api)` window, so
+  //    tools register a shell now and wait for runtime inside execute().
+  let runtime: PluginRuntime | null = null;
+  let bootstrapError: Error | null = null;
+  const bootstrapPromise = createRuntime(api, runtimeLock, inboundUserText)
+    .then((r) => {
+      runtime = r;
+      api.logger.info("memos-local: plugin ready");
+    })
+    .catch((err) => {
+      if (activeRuntimes.get(home.root) === sharedRuntime) activeRuntimes.delete(home.root);
+      bootstrapError = err instanceof Error ? err : new Error(String(err));
+      const duplicate = err instanceof DuplicateOpenClawRuntimeError;
+      api.logger.error("memos-local: bootstrap failed", {
+        err: bootstrapError.message,
+        code: duplicate ? err.code : (err as { code?: unknown }).code,
+      });
+    });
+
+  const ensureRuntime = async (): Promise<PluginRuntime | null> => {
+    if (runtime) return runtime;
+    await bootstrapPromise;
+    return runtime;
+  };
+
+  const sharedRuntime: SharedRuntime = {
+    ensureRuntime,
+    registerBindings: (target) => registerRuntimeBindings(target, ensureRuntime, inboundUserText, () => runtime),
+  };
+  activeRuntimes.set(home.root, sharedRuntime);
+
+  sharedRuntime.registerBindings(api);
+
   // 4. Service — lets the host flush + wait for ready and shut us down.
   //
   // OpenClaw's current loader (≥ 2026.4) keys the service registry by
@@ -559,6 +606,8 @@ function register(api: OpenClawPluginApi): void {
       if (bootstrapError) throw bootstrapError;
     },
     async stop() {
+      await bootstrapPromise;
+      if (activeRuntimes.get(home.root) === sharedRuntime) activeRuntimes.delete(home.root);
       if (runtime) await runtime.shutdown();
     },
   });

--- a/apps/memos-local-plugin/adapters/openclaw/openclaw-api.ts
+++ b/apps/memos-local-plugin/adapters/openclaw/openclaw-api.ts
@@ -330,6 +330,8 @@ export interface ServiceDescriptor {
 // ─── The façade we register against ───────────────────────────────────────
 
 export interface OpenClawPluginApi {
+  /** Older hosts omit this; tool discovery must not start a second runtime. */
+  registrationMode?: "full" | "discovery" | "tool-discovery" | "setup-only" | "setup-runtime" | "cli-metadata";
   /** Plugin id + metadata the host injected. */
   id: string;
   name: string;

--- a/apps/memos-local-plugin/docs/OPENCLAW-COMPATIBILITY.md
+++ b/apps/memos-local-plugin/docs/OPENCLAW-COMPATIBILITY.md
@@ -1,0 +1,133 @@
+# OpenClaw installation and automatic-memory compatibility
+
+Verified on 2026-09-08 against `main` commit `78a372a4`, using MemOS Local
+2.0.16-beta.1. The npm `latest` tag resolved to OpenClaw **2026.9.2**.
+
+## Changes
+
+- The shell installer no longer writes MemOS records into `plugins.installs`,
+  which 2026.9.1/2026.9.2 reject. It removes only MemOS-owned legacy records;
+  unrelated older records are preserved. Modern installation indexes remain
+  managed by OpenClaw.
+- Both installers detect noninteractive `gateway stop --force` support, validate
+  configuration, and accept capabilities through the host CLI when supported.
+  The shell installer additionally detects launchd `--disable`. Plugin help is
+  probed with plugins disabled to avoid bootstrapping a runtime from old CLIs.
+  The shell restart fallback now requires successful gateway health, rather
+  than treating any process listening on the gateway port as healthy.
+- Multiple full plugin registries in one process share one MemOS runtime, even
+  when the module is reloaded. Each registry gets conversation hooks and tools;
+  only the original service owns startup/shutdown. `tool-discovery` gets tool
+  factories without starting another runtime or registering conversation hooks.
+  The filesystem lock still prevents separate processes owning the same data.
+
+Automatic recall runs through `before_prompt_build` and logs
+`memos.onTurnStart`; capture runs through `agent_end` and logs
+`memos.agent_end.received` followed by `memos.onTurnEnd`. These are automatic
+hooks, not tool calls named `memory_search` or `memory_add`.
+
+## Verified behavior
+
+macOS tests used Node 22.23.1/npm 10.9.8; Windows x64 tests used Node 24.19.0,
+npm 11.17.0 and PowerShell 5.1.26100.8875. Separate host versions used isolated
+configurations, workspaces and databases. Gateways ran sequentially because
+MemOS uses port 18799. Normal services were restored and verified afterward.
+
+| Platform / OpenClaw | Config, startup, tool invocation | Automatic capture and cross-session recall |
+| --- | --- | --- |
+| macOS 2026.4.24 | Pass | Gateway path passes with client-only workaround; standard agent CLI fails (see below) |
+| macOS 2026.7.1-2 | Pass | Pass without workaround |
+| macOS 2026.9.1 | Pass | Pass |
+| macOS 2026.9.2 | Pass | Not independently exercised on macOS |
+| Windows 2026.4.24 | Config passes; gateway readiness times out | Not reached |
+| Windows 2026.7.1-2 | Pass | Pass without workaround |
+| Windows 2026.9.2 | Pass | Pass |
+
+The full shell installer completed on macOS 2026.9.1. The full patched
+PowerShell installer completed on Windows 2026.9.2; the previous PowerShell
+installer failed because stopping the gateway required `--force`.
+
+For older-host conversation tests, a local OpenAI-compatible model fixture
+returned fixed text without tools. Two different session IDs were used. The
+second prompt omitted the first session's unique test code; verification checked
+that the code appeared in the second model request. Successful runs produced:
+
+```text
+model_requests: 2
+traces: 2
+distinct_trace_sessions: 2
+cross_session_memory_in_model_prompt: true
+turn_start_count: 2
+turn_end_count: 2
+bootstrap_count: 1
+tool_ok: true
+duplicate_runtime_error: false
+```
+
+macOS 2026.9.1 and Windows 2026.9.2 also completed synthetic conversations with
+their configured models. SQLite contained the test traces; subsequent recall
+logged `hits=1` and `injected=yes` without requiring model tool calls.
+
+## Known limits
+
+- **2026.4.24 macOS agent CLI:** the CLI preloads a full plugin registry in a
+  separate process (`ensureCliPluginRegistryLoaded`). With the gateway running,
+  this triggers `DuplicateOpenClawRuntimeError` before sending the turn. A
+  diagnostic client configuration with plugins disabled let the unchanged
+  gateway complete capture/recall, but the standard CLI remains incompatible.
+- **2026.4.24 Windows startup:** the initial health RPC timed out after 10 seconds.
+  A fresh isolated retry exhausted 120 readiness attempts (about four minutes).
+  Sampling showed synchronous filesystem work in OpenClaw's
+  `prepareBundledPluginRuntimeDistMirror` / `writeRuntimeModuleWrapper`. Neither
+  attempt reached a conversation. This does not establish hook compatibility.
+- **Raw archive installation:** on 2026.9.1 and 2026.9.2,
+  `openclaw plugins install ./package.tgz --force` failed with npm `ERESOLVE`:
+  DSH development dependencies at rc.6 conflict with a transitive rc.8 peer.
+  `npm-pack:./package.tgz` installation succeeded but did not build native
+  SQLite. Use the MemOS installer, which installs production dependencies and
+  rebuilds native modules. This patch does not repair every host installation
+  path or change DSH dependencies.
+- Windows host upgrades can separately require migration of retired OpenClaw
+  configuration and Scheduled Task ownership repair. The plugin installer does
+  not rewrite unrelated host settings. One test stop failed its ownership check;
+  that run was discarded, the actual gateway process was verified and stopped,
+  and tests restarted only after ports were free. A task-start acknowledgement
+  alone is not a readiness check.
+
+No claim is made for every intervening or historical OpenClaw release.
+
+## Reproduction and regression checks
+
+```bash
+cd apps/memos-local-plugin
+npm run lint
+npm test
+npm pack
+bash install.sh --agent openclaw --version ./memtensor-memos-local-plugin-2.0.16-beta.1.tgz
+```
+
+On Windows, install the built package through `install.ps1`. The standalone
+PowerShell harness extracts the actual installer helpers and tests old/new CLI
+flags, native exit codes, capability consent and temporary-environment cleanup:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tests/powershell/openclaw-install-compat.ps1
+```
+
+For host verification, use an isolated state and MemOS home, wait for both the
+actual gateway and MemOS health endpoint, invoke `memos_skill_list` through the
+authenticated `/tools/invoke` API, then send two different sessions through
+`openclaw agent --session-id`. Verify SQLite and the second model request, not
+only command exit codes. Do not use `--deliver` for synthetic tests.
+
+Recorded automated results: **184 Vitest files passed, 1569 tests passed,
+3 skipped**; lifecycle/lock subset **17 passed**; real PowerShell harness
+**7 scenarios passed**. Type checking, package build and `git diff --check`
+passed. No Python library code changed. Project formatting used the declared
+Ruff version:
+
+```bash
+uv tool run --from poetry --with ruff==0.11.8 poetry run make format
+```
+
+Output: `All checks passed!` and `624 files left unchanged`.

--- a/apps/memos-local-plugin/install.ps1
+++ b/apps/memos-local-plugin/install.ps1
@@ -59,7 +59,12 @@ function Invoke-OpenClawGatewayChecked {
     $PreviousErrorActionPreference = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     try {
-        $GatewayOutput = @(& cmd.exe /d /c "openclaw gateway $Action" 2>&1)
+        $GatewayCommand = "openclaw gateway $Action"
+        if ($Action -eq "stop") {
+            $StopHelp = @(& cmd.exe /d /c "openclaw gateway stop --help" 2>&1) | Out-String
+            if ($StopHelp -match '--force') { $GatewayCommand += " --force" }
+        }
+        $GatewayOutput = @(& cmd.exe /d /c $GatewayCommand 2>&1)
         $ExitCode = $LASTEXITCODE
     } finally {
         $ErrorActionPreference = $PreviousErrorActionPreference
@@ -69,6 +74,45 @@ function Invoke-OpenClawGatewayChecked {
     }
     if ($ExitCode -ne 0) {
         throw "openclaw gateway $Action failed (exit code $ExitCode)"
+    }
+}
+
+function Enable-OpenClawMemoryPlugin {
+    # Host state formats change independently of the plugin. Let the host own
+    # validation and capability consent; do not edit its SQLite install index.
+    $PreviousErrorActionPreference = $ErrorActionPreference
+    $PreviousStateDir = $env:OPENCLAW_STATE_DIR
+    $PreviousConfigPath = $env:OPENCLAW_CONFIG_PATH
+    $ProbeDir = Join-Path $env:TEMP ("memos-openclaw-help-" + [guid]::NewGuid().ToString("N"))
+    $ErrorActionPreference = "Continue"
+    try {
+        $ConfigHelp = @(& cmd.exe /d /c "openclaw config --help" 2>&1) | Out-String
+        if ($ConfigHelp -match 'validate') {
+            $Output = @(& cmd.exe /d /c "openclaw config validate" 2>&1)
+            $ExitCode = $LASTEXITCODE
+            $Output | ForEach-Object { Write-Host "$_" }
+            if ($ExitCode -ne 0) { throw "OpenClaw config validation failed; run openclaw doctor --fix and retry." }
+        }
+        # Older plugin CLI help can load configured plugins. Probe with plugins
+        # disabled, then restore the real host paths before accepting consent.
+        New-Item -ItemType Directory -Path $ProbeDir -ErrorAction Stop | Out-Null
+        Set-Content -Path (Join-Path $ProbeDir "openclaw.json") -Value '{"plugins":{"enabled":false}}' -Encoding ASCII -ErrorAction Stop
+        $env:OPENCLAW_STATE_DIR = $ProbeDir
+        $env:OPENCLAW_CONFIG_PATH = Join-Path $ProbeDir "openclaw.json"
+        $EnableHelp = @(& cmd.exe /d /c "openclaw plugins enable --help" 2>&1) | Out-String
+        $env:OPENCLAW_STATE_DIR = $PreviousStateDir
+        $env:OPENCLAW_CONFIG_PATH = $PreviousConfigPath
+        if ($EnableHelp -match '--accept-capabilities') {
+            $Output = @(& cmd.exe /d /c "openclaw plugins enable memos-local-plugin --accept-capabilities" 2>&1)
+            $ExitCode = $LASTEXITCODE
+            $Output | ForEach-Object { Write-Host "$_" }
+            if ($ExitCode -ne 0) { throw "OpenClaw could not enable the MemOS plugin (exit code $ExitCode)." }
+        }
+    } finally {
+        $env:OPENCLAW_STATE_DIR = $PreviousStateDir
+        $env:OPENCLAW_CONFIG_PATH = $PreviousConfigPath
+        $ErrorActionPreference = $PreviousErrorActionPreference
+        if (Test-Path $ProbeDir) { Remove-Item -Recurse -Force $ProbeDir -ErrorAction SilentlyContinue }
     }
 }
 
@@ -662,6 +706,7 @@ fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
         Write-Success "openclaw.json patched"
 
         if ($OcBin) {
+            Enable-OpenClawMemoryPlugin
             Write-Info "Starting OpenClaw gateway"
             try {
                 Invoke-OpenClawGatewayChecked -Action "start"

--- a/apps/memos-local-plugin/install.sh
+++ b/apps/memos-local-plugin/install.sh
@@ -501,7 +501,14 @@ install_openclaw() {
   GATEWAY_RECOVERY_STATE="inactive"
   if oc_bin="$(find_openclaw_cli)"; then
     step "Stopping OpenClaw gateway"
-    "${oc_bin}" gateway stop >/dev/null 2>&1 || true
+    local stop_help
+    local -a stop_args=(gateway stop)
+    stop_help="$("${oc_bin}" gateway stop --help 2>/dev/null || true)"
+    # New hosts require an explicit non-interactive stop; suppress launchd
+    # respawn during the package swap when the host supports it.
+    if grep -q -- '--force' <<< "${stop_help}"; then stop_args+=(--force); fi
+    if grep -q -- '--disable' <<< "${stop_help}"; then stop_args+=(--disable); fi
+    "${oc_bin}" "${stop_args[@]}" >/dev/null 2>&1 || true
     sleep 1
     success "Gateway stopped"
     GATEWAY_RECOVERY_BIN="${oc_bin}"
@@ -556,18 +563,12 @@ EOF
 
   step "Patching ${config_path}"
   PLUGIN_ID="${PLUGIN_ID}" \
-  INSTALL_PATH="${prefix}" \
-  SOURCE_KIND="${SOURCE_KIND}" \
-  SOURCE_SPEC="${SOURCE_SPEC}" \
-  PLUGIN_VERSION="${plugin_version}" \
   LEGACY_JSON="$(printf '%s,' "${LEGACY_PLUGIN_IDS[@]}")" \
   CONFIG_PATH="${config_path}" \
   node - <<'NODE'
 const fs = require('fs');
 const {
-  CONFIG_PATH: configPath, PLUGIN_ID: pluginId, INSTALL_PATH: installPath,
-  SOURCE_KIND: sourceKind, SOURCE_SPEC: sourceSpec,
-  PLUGIN_VERSION: pluginVersion, LEGACY_JSON: legacyCsv,
+  CONFIG_PATH: configPath, PLUGIN_ID: pluginId, LEGACY_JSON: legacyCsv,
 } = process.env;
 const legacyIds = (legacyCsv || '').split(',').filter(Boolean);
 const MEMOS_TOOL_NAMES = [
@@ -615,7 +616,6 @@ if (!config.plugins.allow.includes(pluginId)) config.plugins.allow.push(pluginId
 // can delete it themselves if desired.
 for (const legacyId of legacyIds) {
   if (config.plugins.entries?.[legacyId]) delete config.plugins.entries[legacyId];
-  if (config.plugins.installs?.[legacyId]) delete config.plugins.installs[legacyId];
   if (Array.isArray(config.plugins.allow)) {
     config.plugins.allow = config.plugins.allow.filter((x) => x !== legacyId);
   }
@@ -646,20 +646,24 @@ if (
 }
 config.plugins.entries[pluginId].hooks.allowConversationAccess = true;
 
-if (!config.plugins.installs || typeof config.plugins.installs !== 'object') config.plugins.installs = {};
-const installsEntry = {
-  source: sourceKind === 'path' ? 'path' : 'npm',
-  installPath,
-  version: pluginVersion,
-  resolvedVersion: pluginVersion,
-  installedAt: new Date().toISOString(),
-};
-if (sourceKind !== 'path') {
-  installsEntry.spec = sourceSpec;
-  installsEntry.resolvedName = '@memtensor/memos-local-plugin';
-  installsEntry.resolvedSpec = sourceSpec;
+// Older OpenClaw releases allow `plugins.installs`; current hosts keep that
+// metadata in machine-managed state instead. The extension already lives
+// in OpenClaw's standard discovery directory, so neither generation requires a
+// hand-written MemOS install record. Remove only records owned by this installer
+// so older OpenClaw releases retain metadata for unrelated plugins.
+if (
+  config.plugins.installs &&
+  typeof config.plugins.installs === 'object' &&
+  !Array.isArray(config.plugins.installs)
+) {
+  delete config.plugins.installs[pluginId];
+  for (const legacyId of legacyIds) delete config.plugins.installs[legacyId];
+  if (Object.keys(config.plugins.installs).length === 0) delete config.plugins.installs;
+} else if (Object.prototype.hasOwnProperty.call(config.plugins, 'installs')) {
+  // A malformed legacy value is invalid on old hosts and cannot carry records
+  // worth preserving.
+  delete config.plugins.installs;
 }
-config.plugins.installs[pluginId] = installsEntry;
 
 fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
 NODE
@@ -669,6 +673,26 @@ NODE
     warn "openclaw CLI not on PATH — restart manually: openclaw gateway start"
     return 1
   fi
+  # Validate before accepting an already-running process: an old process may
+  # still answer while the newly written configuration is invalid.
+  if "${oc_bin}" config --help 2>/dev/null | grep -q 'validate'; then
+    "${oc_bin}" config validate || die "OpenClaw config validation failed; run openclaw doctor --fix and retry."
+  fi
+  # Recent hosts persist capability consent outside openclaw.json. Let their
+  # CLI own that state; older hosts do not expose this flag.
+  # Some older CLIs load configured plugins even for subcommand help. Probe
+  # against an empty, disabled plugin configuration to avoid starting a runtime.
+  local probe_dir enable_help
+  probe_dir="$(mktemp -d)"
+  printf '%s\n' '{"plugins":{"enabled":false}}' > "${probe_dir}/openclaw.json"
+  enable_help="$(OPENCLAW_STATE_DIR="${probe_dir}" OPENCLAW_CONFIG_PATH="${probe_dir}/openclaw.json" \
+    "${oc_bin}" plugins enable --help 2>/dev/null || true)"
+  rm -rf -- "${probe_dir}"
+  if grep -q -- '--accept-capabilities' <<< "${enable_help}"; then
+    step "Enabling MemOS memory tools and conversation hooks"
+    "${oc_bin}" plugins enable "${PLUGIN_ID}" --accept-capabilities \
+      || die "OpenClaw could not enable the MemOS plugin."
+  fi
   step "Starting OpenClaw gateway"
   local start_out
   if ! start_out="$("${oc_bin}" gateway start 2>&1)"; then
@@ -676,8 +700,7 @@ NODE
     # the stop above, making "gateway start" fail with a kickstart
     # conflict. Check if the gateway is actually running before
     # treating this as a real error.
-    if curl -fsS --max-time 2 "http://127.0.0.1:18789" >/dev/null 2>&1 \
-       || (command -v lsof >/dev/null 2>&1 && lsof -i ":18789" -t >/dev/null 2>&1); then
+    if "${oc_bin}" health >/dev/null 2>&1; then
       success "OpenClaw gateway already running"
     else
       # The intended final start already ran and failed; do not repeat the same

--- a/apps/memos-local-plugin/tests/powershell/openclaw-install-compat.ps1
+++ b/apps/memos-local-plugin/tests/powershell/openclaw-install-compat.ps1
@@ -1,0 +1,90 @@
+param([string]$Installer = (Join-Path $PSScriptRoot '..\..\install.ps1'))
+$ErrorActionPreference = 'Stop'
+$Tokens = $null
+$ParseErrors = $null
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    (Resolve-Path $Installer), [ref]$Tokens, [ref]$ParseErrors)
+if ($ParseErrors.Count) { throw ($ParseErrors | Out-String) }
+$Definition = $Ast.Find({ param($Node)
+    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $Node.Name -eq 'Invoke-OpenClawGatewayChecked'
+}, $true)
+Invoke-Expression $Definition.Extent.Text
+$Policy = $Ast.Find({ param($Node)
+    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $Node.Name -eq 'Enable-OpenClawMemoryPlugin'
+}, $true)
+if (-not $Policy) { throw 'Missing host policy helper' }
+Invoke-Expression $Policy.Extent.Text
+
+# Exercise the real PowerShell helper with a fake native command boundary.
+function cmd.exe {
+    param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Arguments)
+    $Command = [string]$Arguments[-1]
+    $script:Calls.Add($Command)
+    $global:LASTEXITCODE = 0
+    if ($Command -eq 'openclaw gateway stop --help') {
+        if ($script:Modern) { return 'Options: --force  Allow stop from a non-interactive shell' }
+        return 'Options: --json'
+    }
+    if ($Command -eq 'openclaw config --help') {
+        if ($script:Modern) { return 'validate' }
+        return 'get set'
+    }
+    if ($Command -eq 'openclaw plugins enable --help') {
+        $Probe = Get-Content $env:OPENCLAW_CONFIG_PATH -Raw | ConvertFrom-Json
+        if ($Probe.plugins.enabled -ne $false) { throw 'Help probe can start plugins' }
+        $script:ProbeDir = $env:OPENCLAW_STATE_DIR
+        if ($script:Modern) { return '--accept-capabilities' }
+        return 'enable <id>'
+    }
+    if ($Command -eq $script:FailPolicy) { $global:LASTEXITCODE = 19; return 'simulated policy failure' }
+    if ($script:Fail) { $global:LASTEXITCODE = 17; return 'simulated service failure' }
+    if ($script:Modern -and $Command -eq 'openclaw gateway stop') {
+        $global:LASTEXITCODE = 1
+        return 'Re-run with --force from a non-interactive shell'
+    }
+    return 'Service action completed'
+}
+
+foreach ($Modern in @($false, $true)) {
+    $script:Modern = $Modern
+    $script:Fail = $false
+    $script:Calls = New-Object 'System.Collections.Generic.List[string]'
+    Invoke-OpenClawGatewayChecked -Action stop
+    $Expected = if ($Modern) { 'openclaw gateway stop --force' } else { 'openclaw gateway stop' }
+    if ($script:Calls[-1] -ne $Expected) { throw "Wrong stop command: $($script:Calls[-1])" }
+    Invoke-OpenClawGatewayChecked -Action start
+    if ($script:Calls[-1] -ne 'openclaw gateway start') { throw 'Start received stop-only arguments' }
+    Write-Output "PASS gateway stop/start (modern=$Modern)"
+}
+$script:Fail = $true
+$Caught = $false
+try { Invoke-OpenClawGatewayChecked -Action start } catch { $Caught = $true }
+if (-not $Caught) { throw 'Native service failure was ignored' }
+Write-Output 'PASS native failure propagation'
+
+$script:Fail = $false
+$OriginalState = $env:OPENCLAW_STATE_DIR
+$OriginalConfig = $env:OPENCLAW_CONFIG_PATH
+foreach ($Modern in @($false, $true)) {
+    $script:Modern = $Modern
+    $script:FailPolicy = ''
+    $script:Calls.Clear()
+    Enable-OpenClawMemoryPlugin
+    $Accepted = $script:Calls.Contains('openclaw plugins enable memos-local-plugin --accept-capabilities')
+    if ($Accepted -ne $Modern) { throw 'Capability consent feature detection failed' }
+    if ($env:OPENCLAW_STATE_DIR -ne $OriginalState -or $env:OPENCLAW_CONFIG_PATH -ne $OriginalConfig) { throw 'Host paths not restored' }
+    if (Test-Path $script:ProbeDir) { throw 'Temporary help configuration leaked' }
+    Write-Output "PASS host policy (modern=$Modern)"
+}
+$script:Modern = $true
+foreach ($Failure in @('openclaw config validate', 'openclaw plugins enable memos-local-plugin --accept-capabilities')) {
+    $script:FailPolicy = $Failure
+    $Caught = $false
+    try { Enable-OpenClawMemoryPlugin } catch { $Caught = $true }
+    if (-not $Caught) { throw 'Host policy failure was ignored' }
+    if ($env:OPENCLAW_STATE_DIR -ne $OriginalState -or $env:OPENCLAW_CONFIG_PATH -ne $OriginalConfig) { throw 'Host paths not restored after failure' }
+    if (Test-Path $script:ProbeDir) { throw 'Temporary help configuration leaked after failure' }
+    Write-Output "PASS failure propagation: $Failure"
+}

--- a/apps/memos-local-plugin/tests/unit/adapters/openclaw-runtime.test.ts
+++ b/apps/memos-local-plugin/tests/unit/adapters/openclaw-runtime.test.ts
@@ -128,7 +128,56 @@ function deferred<T>() {
 }
 
 describe("OpenClaw adapter runtime lifecycle", () => {
-  it("blocks a duplicate register before the second runtime bootstraps", async () => {
+  it("reuses the active core for tool discovery without bootstrapping or registering hooks twice", async () => {
+    const home = useTempMemosHome();
+    const core = { ...makeCore(), listSkills: vi.fn(async () => []) };
+    const boot = vi.fn(async () => ({ core, config: DEFAULT_CONFIG, home }));
+    const close = vi.fn(async () => {});
+    const server = vi.fn(async () => ({ url: "http://127.0.0.1:18799", port: 18799, closed: false, close }));
+    const plugin = await loadPluginWithMocks(boot, server);
+    const owner = makeApi();
+    plugin.register(owner);
+    await owner.services[0].start();
+    try {
+      const discovery = Object.assign(makeApi(), { registrationMode: "tool-discovery" as const });
+      expect(() => plugin.register(discovery)).not.toThrow();
+      expect(discovery.on).not.toHaveBeenCalled();
+      expect(discovery.services).toHaveLength(0);
+      const registrations = vi.mocked(discovery.registerTool).mock.calls;
+      const entry = registrations.find(([, options]) => options?.name === "memos_skill_list");
+      expect(entry).toBeDefined();
+      const factory = entry![0];
+      if (typeof factory !== "function") throw new Error("Expected a tool factory");
+      const tool = factory({ agentId: "main", sessionKey: "main" });
+      if (!tool || Array.isArray(tool)) throw new Error("Expected a single tool");
+      await tool.execute("compat-test", {});
+      expect(core.listSkills).toHaveBeenCalledOnce();
+      expect(boot).toHaveBeenCalledOnce();
+      expect(server).toHaveBeenCalledOnce();
+    } finally {
+      await owner.services[0].stop();
+    }
+  });
+
+  it("keeps tool discovery inert when there is no full runtime", async () => {
+    useTempMemosHome();
+    const boot = vi.fn();
+    const server = vi.fn();
+    const plugin = await loadPluginWithMocks(boot, server);
+    const discovery = Object.assign(makeApi(), { registrationMode: "tool-discovery" as const });
+    plugin.register(discovery);
+    expect(boot).not.toHaveBeenCalled();
+    expect(server).not.toHaveBeenCalled();
+    expect(discovery.services).toHaveLength(0);
+    expect(discovery.on).not.toHaveBeenCalled();
+    const factory = vi.mocked(discovery.registerTool).mock.calls[0][0];
+    if (typeof factory !== "function") throw new Error("Expected a tool factory");
+    const tool = factory({ agentId: "main" });
+    if (!tool || Array.isArray(tool)) throw new Error("Expected a single tool");
+    await expect(tool.execute("compat-test", { query: "test" })).rejects.toThrow("runtime is not ready");
+  });
+
+  it("reuses the runtime and registers conversation hooks in another host registry", async () => {
     const home = useTempMemosHome();
     const firstCore = makeCore();
     const boot = deferred<{ core: ReturnType<typeof makeCore>; config: typeof DEFAULT_CONFIG; home: ResolvedHome }>();
@@ -139,21 +188,37 @@ describe("OpenClaw adapter runtime lifecycle", () => {
       closed: false,
       close: vi.fn(async () => {}),
     }));
-    const plugin = await loadPluginWithMocks(bootstrapMemoryCoreFull, startHttpServer);
+    const bridge = {
+      handleBeforePrompt: vi.fn(async () => ({ prependContext: "recalled test memory" })),
+      handleAgentEnd: vi.fn(async () => {}),
+    };
+    const plugin = await loadPluginWithMocks(bootstrapMemoryCoreFull, startHttpServer, vi.fn(() => bridge));
 
     const api1 = makeApi();
     plugin.register(api1);
     expect(bootstrapMemoryCoreFull).toHaveBeenCalledTimes(1);
 
     const api2 = makeApi();
-    expect(() => plugin.register(api2)).toThrow(/already active/);
+    vi.resetModules();
+    const reloaded = (await import("../../../adapters/openclaw/index.js")).default;
+    expect(() => reloaded.register(api2)).not.toThrow();
     expect(bootstrapMemoryCoreFull).toHaveBeenCalledTimes(1);
-    expect(api2.registerTool).not.toHaveBeenCalled();
-    expect(api2.on).not.toHaveBeenCalled();
+    expect(api2.registerTool).toHaveBeenCalled();
+    expect(api2.hooks.has("before_prompt_build")).toBe(true);
+    expect(api2.hooks.has("agent_end")).toBe(true);
+    expect(api2.services).toHaveLength(0);
 
     boot.resolve({ core: firstCore, config: DEFAULT_CONFIG, home });
     await api1.services[0]!.start?.();
+    const beforePrompt = api2.hooks.get("before_prompt_build") as OpenClawHookHandlerMap["before_prompt_build"];
+    await expect(beforePrompt({ prompt: "synthetic test", messages: [] }, { agentId: "main" }))
+      .resolves.toEqual({ prependContext: "recalled test memory" });
+    const agentEnd = api2.hooks.get("agent_end") as OpenClawHookHandlerMap["agent_end"];
+    agentEnd({ messages: [], success: true }, { agentId: "main" });
+    await vi.waitFor(() => expect(bridge.handleAgentEnd).toHaveBeenCalledOnce());
+    expect(bridge.handleBeforePrompt).toHaveBeenCalledOnce();
     await api1.services[0]!.stop?.();
+    expect(firstCore.shutdown).toHaveBeenCalledOnce();
 
     expect(fs.existsSync(path.join(home.daemonDir, "openclaw-runtime.lock"))).toBe(false);
   });

--- a/apps/memos-local-plugin/tests/unit/install/install-gateway-recovery.test.ts
+++ b/apps/memos-local-plugin/tests/unit/install/install-gateway-recovery.test.ts
@@ -66,6 +66,12 @@ if [[ "$*" == "gateway start" ]]; then
   fi
   exit "\${FAKE_GATEWAY_START_EXIT:-0}"
 fi
+if [[ "$*" == "health" ]]; then exit "\${FAKE_GATEWAY_HEALTH_EXIT:-1}"; fi
+if [[ "$*" == "gateway stop --help" && "\${FAKE_MODERN_HOST:-0}" == "1" ]]; then echo "--force --disable"; fi
+if [[ "$*" == "config --help" && "\${FAKE_MODERN_HOST:-0}" == "1" ]]; then echo validate; fi
+if [[ "$*" == "config validate" ]]; then exit "\${FAKE_CONFIG_EXIT:-0}"; fi
+if [[ "$*" == "plugins enable --help" && "\${FAKE_MODERN_HOST:-0}" == "1" ]]; then echo --accept-capabilities; fi
+if [[ "$*" == "plugins enable memos-local-plugin --accept-capabilities" ]]; then exit "\${FAKE_ENABLE_EXIT:-0}"; fi
 exit 0`,
   );
   writeExecutable(path.join(bin, "sleep"), "exit 0");
@@ -150,6 +156,7 @@ describe.skipIf(process.platform === "win32")(
 
         expect(result.status).toBe(1);
         expect(gatewayCalls(fixture)).toEqual([
+          "gateway stop --help",
           "gateway stop",
           "gateway start",
         ]);
@@ -171,6 +178,7 @@ describe.skipIf(process.platform === "win32")(
 
         expect(result.status).toBe(1);
         expect(gatewayCalls(fixture)).toEqual([
+          "gateway stop --help",
           "gateway stop",
           "gateway start",
         ]);
@@ -194,11 +202,73 @@ describe.skipIf(process.platform === "win32")(
 
         expect(result.status).not.toBe(0);
         expect(gatewayCalls(fixture)).toEqual([
+          "gateway stop --help",
           "gateway stop",
+          "config --help",
+          "plugins enable --help",
           "gateway start",
+          "health",
         ]);
         expect(result.stderr).toContain("openclaw gateway start failed");
         expectTemporaryDirectoriesCleaned(fixture);
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    });
+
+    it("does not mistake an occupied port for a healthy gateway after start failure", () => {
+      const fixture = createFixture();
+      try {
+        const tarball = createValidPackage(fixture);
+        writeExecutable(path.join(fixture.bin, "lsof"), "echo 12345; exit 0");
+        const result = runInstaller(fixture, tarball, {
+          FAKE_CURL_EXIT: "0", FAKE_GATEWAY_START_EXIT: "17", FAKE_GATEWAY_HEALTH_EXIT: "1",
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stdout).not.toContain("OpenClaw gateway already running");
+        expect(result.stderr).toContain("openclaw gateway start failed");
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    });
+
+    it("validates configuration and lets modern hosts record capability consent", () => {
+      const fixture = createFixture();
+      try {
+        const result = runInstaller(fixture, createValidPackage(fixture), { FAKE_MODERN_HOST: "1" });
+        expect(result.status, result.stderr).toBe(0);
+        expect(gatewayCalls(fixture)).toEqual([
+          "gateway stop --help", "gateway stop --force --disable", "config --help", "config validate", "plugins enable --help",
+          "plugins enable memos-local-plugin --accept-capabilities", "gateway start",
+        ]);
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    });
+
+    it.each([
+      { FAKE_CONFIG_EXIT: "1" }, { FAKE_ENABLE_EXIT: "1" },
+    ])("does not report success after host validation or enablement fails: %j", (failure) => {
+      const fixture = createFixture();
+      try {
+        const result = runInstaller(fixture, createValidPackage(fixture), { FAKE_MODERN_HOST: "1", ...failure });
+        expect(result.status).not.toBe(0);
+        expect(result.stdout).not.toContain("OpenClaw install complete");
+        expect(gatewayCalls(fixture).filter((call) => call === "gateway start")).toHaveLength(1);
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts a successful authenticated health probe after a service start race", () => {
+      const fixture = createFixture();
+      try {
+        const result = runInstaller(fixture, createValidPackage(fixture), {
+          FAKE_GATEWAY_START_EXIT: "17", FAKE_GATEWAY_HEALTH_EXIT: "0",
+        });
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("OpenClaw gateway already running");
+        expect(gatewayCalls(fixture)).toContain("health");
       } finally {
         rmSync(fixture.root, { recursive: true, force: true });
       }
@@ -213,7 +283,10 @@ describe.skipIf(process.platform === "win32")(
 
         expect(result.status).toBe(0);
         expect(gatewayCalls(fixture)).toEqual([
+          "gateway stop --help",
           "gateway stop",
+          "config --help",
+          "plugins enable --help",
           "gateway start",
         ]);
         expectTemporaryDirectoriesCleaned(fixture);

--- a/apps/memos-local-plugin/tests/unit/install/openclaw-config-compat.test.ts
+++ b/apps/memos-local-plugin/tests/unit/install/openclaw-config-compat.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../../..");
+
+// Execute the actual embedded patch, including the curl | bash distribution path.
+function patch(input: unknown): Record<string, any> {
+  const dir = mkdtempSync(path.join(tmpdir(), "memos-openclaw-config-"));
+  try {
+    const config = path.join(dir, "openclaw.json");
+    writeFileSync(config, JSON.stringify(input));
+    const script = readFileSync(path.join(root, "install.sh"), "utf8");
+    const source = script.match(/  node - <<'NODE'\n([\s\S]*?)\nNODE/)?.[1];
+    expect(source).toBeDefined();
+    const result = spawnSync(process.execPath, ["-e", source!], {
+      encoding: "utf8",
+      env: { ...process.env, CONFIG_PATH: config, PLUGIN_ID: "memos-local-plugin",
+        INSTALL_PATH: path.join(dir, "plugin"), SOURCE_KIND: "path", SOURCE_SPEC: "test.tgz",
+        PLUGIN_VERSION: "test", LEGACY_JSON: "memos-local-openclaw-plugin," },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return JSON.parse(readFileSync(config, "utf8"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("OpenClaw installer config compatibility", () => {
+  it("installs into current hosts without creating retired install records", () => {
+    const result = patch({});
+    expect(result.plugins.installs).toBeUndefined();
+    expect(result.plugins.slots.memory).toBe("memos-local-plugin");
+    expect(result.plugins.allow).toContain("memos-local-plugin");
+  });
+
+  it.each([null, [], "invalid", { "memos-local-plugin": { source: "path" } }])(
+    "cleans obsolete installer records and malformed legacy values: %j", (installs) => {
+      expect(patch({ plugins: { installs } }).plugins.installs).toBeUndefined();
+    },
+  );
+
+  it("preserves unrelated old-host records and existing hook settings across reinstallation", () => {
+    const other = { source: "npm", spec: "another-plugin@1.0.0" };
+    const input = { plugins: {
+      installs: { "another-plugin": other, "memos-local-plugin": { source: "path" },
+        "memos-local-openclaw-plugin": { source: "path" } },
+      entries: { "memos-local-plugin": { hooks: { customHostSetting: "keep" } } },
+    } };
+    const result = patch(input);
+    expect(result.plugins.installs).toEqual({ "another-plugin": other });
+    expect(result.plugins.entries["memos-local-plugin"].hooks).toEqual({
+      customHostSetting: "keep", allowConversationAccess: true,
+    });
+    expect(patch(result)).toEqual(result);
+  });
+});


### PR DESCRIPTION
## Description

OpenClaw 2026.9.1/2026.9.2 reject the shell installer’s legacy `plugins.installs` records. Rebuilding a plugin registry in the gateway process can also trigger MemOS’s duplicate-runtime guard, leaving conversation hooks unavailable even though the Viewer and tools work.

This change removes only MemOS-owned legacy install records, detects supported stop/validation/capability-consent commands in both installers, and requires actual gateway health for the shell restart fallback. Plugin CLI help is probed with plugins disabled.

The adapter shares one runtime across full registries and module reloads while registering hooks in each host registry. Tool discovery borrows the existing core without owning a server or service. Cross-process locking remains in place. No dependency or package-version changes.

Related issue: #1873 (runtime-ownership context; this PR addresses same-process registry rebuilding, not that already-closed doctor issue).

## Type of change

- [x] Bug fix
- [x] Documentation update

## How Has This Been Tested?

- [x] `npm test`: **184 files passed; 1569 passed, 3 skipped**. Added configuration, gateway recovery, module reload and tool-discovery regressions.
- [x] `npm run lint` passed.
- [x] Real Windows PowerShell 5.1 harness: **7 scenarios passed** (`tests/powershell/openclaw-install-compat.ps1`).
- [x] `make format` with pinned Ruff 0.11.8: `All checks passed!`, `624 files left unchanged`.
- [x] Pre-commit checks on all changed files and `git diff --check` passed.
- [x] Actual macOS host binaries: configuration/startup/authenticated tool invocation passed on 2026.4.24, 2026.7.1-2, 2026.9.1 and 2026.9.2. Full installers passed on macOS 2026.9.1 and Windows 2026.9.2.
- [x] Automatic capture and subsequent recall passed on macOS 2026.9.1 and Windows 2026.9.2. Both platforms also passed 2026.7.1-2 tests with two separate sessions: two SQLite traces, the first turn’s unique code present in the second model request, and exactly one runtime bootstrap.

See `apps/memos-local-plugin/docs/OPENCLAW-COMPATIBILITY.md` for reproduction steps and platform-specific results. No Python library code or API contracts changed.

### Known limitations

- **2026.4.24 macOS:** standard `openclaw agent` preloads the plugin in a separate CLI process and still hits the runtime lock. Gateway capture/recall passed only with a client-only plugin-preloading workaround.
- **2026.4.24 Windows:** two isolated attempts failed gateway readiness; automatic capture/recall was not reached. Sampling showed synchronous file work in the old host’s plugin loader.

## Checklist

- [x] Self-reviewed the final changes.
- [x] Commented runtime ownership and host-version compatibility logic.
- [x] Added regression tests proving the relevant fixes.
- [x] Updated documentation in this PR; a separate MemOS-Docs change is not applicable.
- [x] Linked related issue context without claiming to close an unrelated issue.
- [x] Mentioned @MLittleprince, a recent local-plugin contributor, for review.

Maintainer review and GitHub CI results remain pending; the checks above describe completed local and machine tests.