### PR TITLE
docs: repoint all 18 leaked claude.ai chat links to real targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,19 +429,19 @@ Questions, ideas, showing off what you built — pick whichever channe
 | [Discord](https://discord.gg/Txbx3gebZR) | Real-time chat, mostly English-speaking community |
 | [WeChat Group](https://statics.memtensor.com.cn/memos/qr-code.png) | 中文实时交流，国内用户首选 |
 
-For sensitive issues (security vulnerabilities, Code of Conduct concerns), please contact the maintainers privately rather than using public channels. See our [Code of Conduct](https://claude.ai/chat/CODE_OF_CONDUCT.md) for the reporting email.
+For sensitive issues (security vulnerabilities, Code of Conduct concerns), please contact the maintainers privately rather than using public channels. See our [Code of Conduct](CODE_OF_CONDUCT.md) for the reporting email.
 
 ---
 
 ## Code of Conduct
 
-By participating in this project, you agree to abide by our [Code of Conduct](https://claude.ai/chat/CODE_OF_CONDUCT.md). We're committed to making MemOS a welcoming, harassment-free community for everyone.
+By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md). We're committed to making MemOS a welcoming, harassment-free community for everyone.
 
 ---
 
 ## License
 
-MemOS is licensed under the [Apache License 2.0](https://claude.ai/chat/LICENSE). By contributing, you agree that your contributions will be licensed under the same license.
+MemOS is licensed under the [Apache License 2.0](LICENSE). By contributing, you agree that your contributions will be licensed under the same license.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,31 +8,31 @@ MemOS is a Memory Operating System for LLMs and AI agents, maintained
 
 ## Table of Contents
 
-*   [Ways to Contribute](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#ways-to-contribute)
+*   [Ways to Contribute](#ways-to-contribute)
 
-*   [Before You Start](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#before-you-start)
+*   [Before You Start](#before-you-start)
 
-*   [Setting Up Your Development Environment](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#setting-up-your-development-environment)
+*   [Setting Up Your Development Environment](#setting-up-your-development-environment)
 
-*   [Development Workflow](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#development-workflow)
+*   [Development Workflow](#development-workflow)
 
-*   [Commit Message Guidelines](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#commit-message-guidelines)
+*   [Commit Message Guidelines](#commit-message-guidelines)
 
-*   [What Makes a Good PR](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#what-makes-a-good-pr)
+*   [What Makes a Good PR](#what-makes-a-good-pr)
 
-*   [Review Process](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#review-process)
+*   [Review Process](#review-process)
 
-*   [Writing Tests](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#writing-tests)
+*   [Writing Tests](#writing-tests)
 
-*   [Writing Documentation](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#writing-documentation)
+*   [Writing Documentation](#writing-documentation)
 
-*   [Community](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#community)
+*   [Community](#community)
 
-*   [Code of Conduct](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#code-of-conduct)
+*   [Code of Conduct](#code-of-conduct)
 
-*   [License](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#license)
+*   [License](#license)
 
-*   [Recognition](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#recognition)
+*   [Recognition](#recognition)
 
 
 ---
@@ -257,7 +257,7 @@ make test
 
 ```
 
-All tests should pass before you open a PR. If you've added new functionality, please add tests for it (see [Writing Tests](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#writing-tests) below).
+All tests should pass before you open a PR. If you've added new functionality, please add tests for it (see [Writing Tests](#writing-tests) below).
 
 ### 5. Rebase onto the latest `dev`
 
@@ -270,7 +270,7 @@ git rebase upstream/dev
 
 ### 6. Commit your changes
 
-Follow the [Commit Message Guidelines](https://claude.ai/chat/4504392b-b48f-484a-b284-09624e7f1147#commit-message-guidelines) below.
+Follow the [Commit Message Guidelines](#commit-message-guidelines) below.
 
 ### 7. Push to your fork
 


### PR DESCRIPTION
CONTRIBUTING.md's entire Table of Contents, an inline test-docs link, the Code of Conduct references, and the license link pointed at `https://claude.ai/chat/<conversation-id>#anchor` — a private AI chat session that leaked into the file, so every TOC entry 404'd.

- All 15 TOC/inline entries now use the in-file anchors that already exist in the document
- The Code of Conduct references point at `CODE_OF_CONDUCT.md` and the license link at `LICENSE` (both in-repo)

Docs-only.