### PR TITLE
docs: fix a dead API-doc link and a doubled 'the' in eval docs

### DIFF
--- a/docs/en/open_source/evaluation/overview.md
+++ b/docs/en/open_source/evaluation/overview.md
@@ -85,6 +85,6 @@ get `questions_32k.csv` and `shared_contexts_32k.jsonl` from https://huggingface
 ```bash
 # Edit the configuration in evaluation/scripts/run_pm_eval.sh
 # Specify the model and memory backend you want to use (e.g., mem0, zep, etc.)
-# If you want to use MIRIX, edit the the configuration in evaluation/scripts/personamem/config.yaml
+# If you want to use MIRIX, edit the configuration in evaluation/scripts/personamem/config.yaml
 evaluation/scripts/run_pm_eval.sh
 ```

--- a/docs/en/open_source/open_source_api/core/get_memory_by_id.md
+++ b/docs/en/open_source/open_source_api/core/get_memory_by_id.md
@@ -19,7 +19,7 @@ This interface uses the standard RESTful path parameter format:
 
 | Parameter | Location | Type | Required | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| **`memory_id`** | Path | `str` | Yes | The unique identifier (UUID) of the memory. You can obtain this ID from the results of the [**Get Memory List**](./get_memory_list.md) or [**Search**](./search_memory.md) interfaces. |
+| **`memory_id`** | Path | `str` | Yes | The unique identifier (UUID) of the memory. You can obtain this ID from the results of the [**Memory Search**](./search_memory.md) or [**Search**](./search_memory.md) interfaces. |
 
 ## 3. How It Works (MemoryHandler)
 


### PR DESCRIPTION
- `open_source_api/core/get_memory_by_id.md`: linked `./get_memory_list.md`, which doesn't exist in `core/` — repointed at `./search_memory.md` (the search page named in the same sentence)
- `evaluation/overview.md`: "edit **the the** configuration"

Docs-only.