### PR TITLE
fix: correct symlink path for hermes-agent plugin discovery

### DIFF
--- a/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
+++ b/apps/memos-local-plugin/adapters/hermes/install.hermes.sh
@@ -65,7 +65,7 @@ fi
 : "${HOME:?HOME must be set for user-level plugin directory creation}"
 USER_HERMES_PLUGINS_DIR="${HOME}/.hermes/plugins/memory"
 mkdir -p "$USER_HERMES_PLUGINS_DIR"
-USER_TARGET="$USER_HERMES_PLUGINS_DIR/memtensor"
+USER_TARGET="${HOME}/.hermes/plugins/memtensor"
 # Clean up a pre-existing non-symlink entry (file or dir) left over from
 # a previous manual install so `ln -sfn` doesn't refuse or misbehave.
 if [[ -L "$USER_TARGET" ]]; then rm "$USER_TARGET"


### PR DESCRIPTION
## Problem

The install script creates the symlink at `~/.hermes/plugins/memory/memtensor/`, but hermes-agent's plugin discovery scans `~/.hermes/plugins/` for **direct children**. The extra `memory/` subdirectory causes the memtensor plugin to be invisible to the host.

This means after every `hermes update` (which restarts the gateway), the memory provider fails to load and stops recording traces.

## Fix

Change `USER_TARGET` from `/memtensor` to `${HOME}/.hermes/plugins/memtensor` (without the `memory/` prefix), matching hermes-agent's expected plugin layout.

```diff
- USER_TARGET="$USER_HERMES_PLUGINS_DIR/memtensor"
+ USER_TARGET="${HOME}/.hermes/plugins/memtensor"
```

## Verification

After this fix, `find_provider_dir('memtensor')` in hermes-agent correctly resolves the plugin directory, and the memory provider loads successfully on gateway restart.