### PR TITLE
fix: stop activation KV cache from growing every turn

### DIFF
--- a/src/memos/llms/hf.py
+++ b/src/memos/llms/hf.py
@@ -82,7 +82,14 @@ class HFLLM(BaseLLM):
         if past_key_values is None:
             return self._generate_full(prompt, **kwargs)
         else:
-            return self._generate_with_cache(prompt, past_key_values, **kwargs)
+            from memos.memories.activation.kv import clone_dynamic_cache
+
+            # The model appends new K/V tensors to the cache it receives, so
+            # hand it a clone and keep the caller's cache (e.g. a stored
+            # activation memory) unchanged by this call.
+            return self._generate_with_cache(
+                prompt, clone_dynamic_cache(past_key_values), **kwargs
+            )
 
     def generate_stream(
         self, messages: MessageList, past_key_values: DynamicCache | None = None, **kwargs
@@ -102,7 +109,11 @@ class HFLLM(BaseLLM):
         if past_key_values is None:
             yield from self._generate_full_stream(prompt)
         else:
-            yield from self._generate_with_cache_stream(prompt, past_key_values)
+            from memos.memories.activation.kv import clone_dynamic_cache
+
+            yield from self._generate_with_cache_stream(
+                prompt, clone_dynamic_cache(past_key_values)
+            )
 
     def _generate_full(self, prompt: str, **kwargs) -> str:
         """

--- a/src/memos/memories/activation/kv.py
+++ b/src/memos/memories/activation/kv.py
@@ -206,7 +206,10 @@ class KVCacheMemory(BaseActMemory):
 
         assert caches, "Need at least one cache"
         if len(caches) == 1:
-            return caches[0]
+            # Return a copy: the stored cache must never be handed out by
+            # reference, because generation appends new K/V tensors to the
+            # cache object it receives and would grow the store every turn.
+            return clone_dynamic_cache(caches[0])
 
         merged = DynamicCache()
 
@@ -253,6 +256,34 @@ class KVCacheMemory(BaseActMemory):
             )
 
         return merged
+
+
+def clone_dynamic_cache(cache: DynamicCache) -> DynamicCache:
+    """
+    Return an independent copy of a DynamicCache with cloned K/V tensors.
+
+    Generation mutates the cache object it receives in place, so a stored cache
+    must never be handed to a model by reference — hand out a clone instead.
+    Compatible with both old (key_cache/value_cache) and new (layers) structures.
+    """
+    cloned = DynamicCache()
+
+    if hasattr(cache, "layers"):
+        if not hasattr(cloned, "layers"):
+            cloned.layers = []
+
+        for layer in cache.layers:
+            new_layer = type(layer)()
+            if getattr(layer, "keys", None) is not None:
+                new_layer.keys = layer.keys.clone()
+                new_layer.values = layer.values.clone()
+            cloned.layers.append(new_layer)
+    elif hasattr(cache, "key_cache"):
+        for keys, values in zip(cache.key_cache, cache.value_cache):
+            cloned.key_cache.append(keys.clone() if keys is not None else None)
+            cloned.value_cache.append(values.clone() if values is not None else None)
+
+    return cloned
 
 
 def move_dynamic_cache_htod(dynamic_cache: DynamicCache, device: str) -> DynamicCache:

--- a/src/memos/memories/activation/kv.py
+++ b/src/memos/memories/activation/kv.py
@@ -276,6 +276,7 @@ def clone_dynamic_cache(cache: DynamicCache) -> DynamicCache:
             new_layer = type(layer)()
             if getattr(layer, "keys", None) is not None:
                 new_layer.keys = layer.keys.clone()
+            if getattr(layer, "values", None) is not None:
                 new_layer.values = layer.values.clone()
             cloned.layers.append(new_layer)
     elif hasattr(cache, "key_cache"):

--- a/src/memos/memories/activation/kv.py
+++ b/src/memos/memories/activation/kv.py
@@ -274,10 +274,18 @@ def clone_dynamic_cache(cache: DynamicCache) -> DynamicCache:
 
         for layer in cache.layers:
             new_layer = type(layer)()
+            # transformers>=4.56 layers expose keys/values, but some versions
+            # instead carry per-layer key_cache/value_cache (see
+            # move_dynamic_cache_htod); a clone that skips one shape would
+            # silently return a content-empty layer.
             if getattr(layer, "keys", None) is not None:
                 new_layer.keys = layer.keys.clone()
             if getattr(layer, "values", None) is not None:
                 new_layer.values = layer.values.clone()
+            if getattr(layer, "key_cache", None) is not None:
+                new_layer.key_cache = layer.key_cache.clone()
+            if getattr(layer, "value_cache", None) is not None:
+                new_layer.value_cache = layer.value_cache.clone()
             cloned.layers.append(new_layer)
     elif hasattr(cache, "key_cache"):
         for keys, values in zip(cache.key_cache, cache.value_cache):

--- a/tests/llms/test_hf.py
+++ b/tests/llms/test_hf.py
@@ -182,3 +182,38 @@ class TestHFLLM(unittest.TestCase):
         kv_cache = DynamicCache()
         resp = llm.generate([{"role": "user", "content": "Sampling"}], past_key_values=kv_cache)
         self.assertEqual(resp, self.standard_response)
+
+    def test_generate_with_cache_does_not_mutate_caller_cache(self):
+        """Regression for issue #2301: generation must not append K/V tensors
+        into the caller's stored cache (activation memory grew every turn)."""
+        config = HFLLMConfig(
+            model_name_or_path="qwen3:0.6b",
+            temperature=0.7,
+            max_tokens=3,
+            do_sample=True,
+            add_generation_prompt=True,
+        )
+        llm = self._create_llm(config)
+
+        kv_cache = DynamicCache()
+        kv_cache.key_cache = [torch.zeros(1, 2, 3)]
+        kv_cache.value_cache = [torch.zeros(1, 2, 3)]
+
+        def forward(*args, **kwargs):
+            # transformers appends the new tokens' K/V to the cache in place.
+            kv = kwargs["past_key_values"]
+            kv.key_cache[0] = torch.cat([kv.key_cache[0], torch.ones(1, 1, 3)], dim=-2)
+            kv.value_cache[0] = torch.cat([kv.value_cache[0], torch.ones(1, 1, 3)], dim=-2)
+            out = MagicMock()
+            out.logits = torch.ones(1, 1, 100)
+            out.past_key_values = kv
+            return out
+
+        self.mock_model.side_effect = forward
+        try:
+            llm.generate([{"role": "user", "content": "Hi"}], past_key_values=kv_cache)
+        finally:
+            self.mock_model.side_effect = None
+
+        self.assertEqual(kv_cache.key_cache[0].shape, (1, 2, 3))
+        self.assertEqual(kv_cache.value_cache[0].shape, (1, 2, 3))

--- a/tests/llms/test_hf.py
+++ b/tests/llms/test_hf.py
@@ -201,9 +201,10 @@ class TestHFLLM(unittest.TestCase):
 
         def forward(*args, **kwargs):
             # transformers appends the new tokens' K/V to the cache in place.
+            # _prefill always passes the cache by keyword; .get keeps the mock
+            # resilient to an explicit-None caller without inventing a
+            # positional call shape.
             kv = kwargs.get("past_key_values")
-            if kv is None and len(args) > 1:
-                kv = args[1]
             kv.key_cache[0] = torch.cat([kv.key_cache[0], torch.ones(1, 1, 3)], dim=-2)
             kv.value_cache[0] = torch.cat([kv.value_cache[0], torch.ones(1, 1, 3)], dim=-2)
             out = MagicMock()

--- a/tests/llms/test_hf.py
+++ b/tests/llms/test_hf.py
@@ -201,11 +201,17 @@ class TestHFLLM(unittest.TestCase):
 
         def forward(*args, **kwargs):
             # transformers appends the new tokens' K/V to the cache in place.
-            kv = kwargs["past_key_values"]
+            kv = kwargs.get("past_key_values")
+            if kv is None and len(args) > 1:
+                kv = args[1]
             kv.key_cache[0] = torch.cat([kv.key_cache[0], torch.ones(1, 1, 3)], dim=-2)
             kv.value_cache[0] = torch.cat([kv.value_cache[0], torch.ones(1, 1, 3)], dim=-2)
             out = MagicMock()
-            out.logits = torch.ones(1, 1, 100)
+            # Deterministic non-EOS argmax so the loop runs all max_tokens turns
+            # instead of sometimes sampling eos_token_id (2) on the first step.
+            logits = torch.full((1, 1, 100), -1e9)
+            logits[0, 0, 10] = 0.0
+            out.logits = logits
             out.past_key_values = kv
             return out
 

--- a/tests/memories/activation/test_kv.py
+++ b/tests/memories/activation/test_kv.py
@@ -121,6 +121,12 @@ def test_clone_dynamic_cache_copies_legacy_tensors():
     cloned.key_cache[0] = torch.ones(1, 5, 3)
     assert cache.key_cache[0].shape == (1, 2, 3)
 
+    # In-place mutation must not leak either: catches a clone that shares
+    # tensor storage instead of copying.
+    cloned.key_cache[0].fill_(99.0)
+    assert not torch.all(cache.key_cache[0] == 99.0), "clone shares storage with original"
+    assert cache.key_cache[0].shape == (1, 2, 3)
+
 
 def test_clone_dynamic_cache_handles_layers_structure():
     # transformers >= 4.56 exposes DynamicCache.layers with per-layer keys/values.
@@ -145,3 +151,34 @@ def test_clone_dynamic_cache_handles_layers_structure():
 
     cloned.layers[0].keys = torch.ones(2, 2, 3)
     assert cache.layers[0].keys.shape == (1, 2, 3)
+
+    # In-place mutation must not leak either: catches a clone that shares
+    # tensor storage instead of copying.
+    cloned.layers[0].keys.fill_(99.0)
+    assert not torch.all(cache.layers[0].keys == 99.0), "clone shares tensor storage with original"
+    assert cache.layers[0].keys.shape == (1, 2, 3)
+
+
+def test_clone_dynamic_cache_layers_guard_keys_and_values_independently():
+    # A layer may legitimately have only one side populated; the clone must
+    # not crash on the missing side nor fabricate a value for it.
+    class FakeLayer:
+        def __init__(self):
+            self.keys = None
+            self.values = None
+
+    class FakeLayeredCache:
+        pass
+
+    cache = FakeLayeredCache()
+    keys_only = FakeLayer()
+    keys_only.keys = torch.zeros(1, 2, 3)
+    values_only = FakeLayer()
+    values_only.values = torch.zeros(1, 2, 4)
+    cache.layers = [keys_only, values_only]
+
+    cloned = clone_dynamic_cache(cache)
+    assert torch.equal(cloned.layers[0].keys, keys_only.keys)
+    assert cloned.layers[0].values is None
+    assert cloned.layers[1].keys is None
+    assert torch.equal(cloned.layers[1].values, values_only.values)

--- a/tests/memories/activation/test_kv.py
+++ b/tests/memories/activation/test_kv.py
@@ -7,7 +7,7 @@ from transformers import DynamicCache
 
 from memos.configs.memory import KVCacheMemoryConfig
 from memos.memories.activation.item import KVCacheItem
-from memos.memories.activation.kv import KVCacheMemory
+from memos.memories.activation.kv import KVCacheMemory, clone_dynamic_cache
 
 
 @pytest.fixture
@@ -84,3 +84,64 @@ def test_from_textual_memory(kv_memory):
     item = kv_memory.from_textual_memory(DummyTextualMemory())
     assert isinstance(item, KVCacheItem)
     assert item.metadata["bar"] == 1
+
+def test_get_cache_single_item_returns_independent_copy(kv_memory):
+    # Regression for issue #2301: with a single cache, get_cache used to hand
+    # out the stored object, so generation appended new K/V tensors into the
+    # store and the activation memory grew every turn.
+    item = KVCacheItem(memory=make_filled_cache())
+    kv_memory.add([item])
+
+    merged = kv_memory.get_cache([item.id])
+    assert merged is not item.memory
+
+    # Simulate generation appending to the handed-out cache.
+    merged.key_cache[0] = torch.cat([merged.key_cache[0], torch.ones(1, 1, 3)], dim=-2)
+    assert item.memory.key_cache[0].shape == (1, 2, 3)
+
+
+def test_get_cache_multi_item_merge_does_not_alias_inputs(kv_memory):
+    item1 = KVCacheItem(memory=make_filled_cache())
+    item2 = KVCacheItem(memory=make_filled_cache())
+    kv_memory.add([item1, item2])
+
+    merged = kv_memory.get_cache([item1.id, item2.id])
+    assert merged is not item1.memory
+    assert merged is not item2.memory
+
+
+def test_clone_dynamic_cache_copies_legacy_tensors():
+    cache = make_filled_cache()
+    cloned = clone_dynamic_cache(cache)
+
+    assert cloned is not cache
+    assert cloned.key_cache[0] is not cache.key_cache[0]
+    assert torch.equal(cloned.key_cache[0], cache.key_cache[0])
+
+    cloned.key_cache[0] = torch.ones(1, 5, 3)
+    assert cache.key_cache[0].shape == (1, 2, 3)
+
+
+def test_clone_dynamic_cache_handles_layers_structure():
+    # transformers >= 4.56 exposes DynamicCache.layers with per-layer keys/values.
+    class FakeLayer:
+        def __init__(self):
+            self.keys = None
+            self.values = None
+
+    class FakeLayeredCache:
+        pass
+
+    cache = FakeLayeredCache()
+    cache.layers = [FakeLayer()]
+    cache.layers[0].keys = torch.zeros(1, 2, 3)
+    cache.layers[0].values = torch.zeros(1, 2, 4)
+
+    cloned = clone_dynamic_cache(cache)
+    assert isinstance(cloned, DynamicCache)
+    assert len(cloned.layers) == 1
+    assert cloned.layers[0].keys is not cache.layers[0].keys
+    assert torch.equal(cloned.layers[0].keys, cache.layers[0].keys)
+
+    cloned.layers[0].keys = torch.ones(2, 2, 3)
+    assert cache.layers[0].keys.shape == (1, 2, 3)

--- a/tests/memories/activation/test_kv.py
+++ b/tests/memories/activation/test_kv.py
@@ -99,6 +99,12 @@ def test_get_cache_single_item_returns_independent_copy(kv_memory):
     merged.key_cache[0] = torch.cat([merged.key_cache[0], torch.ones(1, 1, 3)], dim=-2)
     assert item.memory.key_cache[0].shape == (1, 2, 3)
 
+    # In-place mutation must not leak either: a clone sharing tensor storage
+    # would surface here even though the reference swap above passes.
+    merged.key_cache[0].fill_(99.0)
+    assert not torch.all(item.memory.key_cache[0] == 99.0), "get_cache shares storage with store"
+    assert item.memory.key_cache[0].shape == (1, 2, 3)
+
 
 def test_get_cache_multi_item_merge_does_not_alias_inputs(kv_memory):
     item1 = KVCacheItem(memory=make_filled_cache())
@@ -182,3 +188,27 @@ def test_clone_dynamic_cache_layers_guard_keys_and_values_independently():
     assert cloned.layers[0].values is None
     assert cloned.layers[1].keys is None
     assert torch.equal(cloned.layers[1].values, values_only.values)
+
+
+def test_clone_dynamic_cache_handles_per_layer_key_value_cache():
+    # Some transformers versions carry per-layer key_cache/value_cache
+    # instead of keys/values (mirrors move_dynamic_cache_htod); the clone
+    # must copy those tensors too instead of returning an empty layer.
+    class FakeLayer:
+        pass
+
+    class FakeLayeredCache:
+        pass
+
+    cache = FakeLayeredCache()
+    layer = FakeLayer()
+    layer.key_cache = torch.zeros(1, 2, 3)
+    layer.value_cache = torch.zeros(1, 2, 3)
+    cache.layers = [layer]
+
+    cloned = clone_dynamic_cache(cache)
+    assert torch.equal(cloned.layers[0].key_cache, layer.key_cache)
+    assert torch.equal(cloned.layers[0].value_cache, layer.value_cache)
+
+    cloned.layers[0].key_cache.fill_(99.0)
+    assert not torch.all(layer.key_cache == 99.0), "clone shares tensor storage with original"


### PR DESCRIPTION
Fixes #2301.

## Root cause

The stored activation cache and the cache handed to generation were the same object, so every turn permanently grew the store (and the re-dumped memory file):

1. `MemOS.chat` (`mem_os/core.py`), `mem_os/main.py`, `mem_chat/simple.py` and `mos_for_test_scheduler.py` pass the stored `kv_cache.memory` straight into `HFLLM.generate(past_key_values=...)`;
2. `HFLLM._prefill` forwards it to `model(past_key_values=...)`, and transformers appends the new tokens' K/V **in place** (`DynamicLayer.update` rebinds `keys`/`values` on the same object; identity is preserved);
3. `KVCacheMemory._concat_caches` returns `caches[0]` unchanged for a single id, so the `get_cache()` merge path hands out the stored object as well.

No caller reads the cache back expecting it to have grown — the growth is only observable as leaked state (which `ActivationMemoryManager` then re-dumps to disk).

## Fix

Treat stored caches as read-only by construction, at the two boundaries where a cache leaves the store or enters the model:

- **`clone_dynamic_cache()`** (new, `memories/activation/kv.py`): independent copy with cloned K/V tensors, compatible with both the legacy `key_cache`/`value_cache` structure (transformers <= 4.55, per `poetry.lock`) and the newer `layers` structure (>= 4.56, still < 5.0.0 in the supported range);
- **`KVCacheMemory._concat_caches`**: the single-cache case now returns a clone instead of the stored object;
- **`HFLLM.generate` / `generate_stream`**: clone the incoming `past_key_values` once at the boundary. This fixes all four call sites without touching them; the cost is one cache copy per generate call, the same order as the prefill work itself.

## Tests

- `test_generate_with_cache_does_not_mutate_caller_cache` (tests/llms/test_hf.py): mocks a model forward that appends K/V in place, asserts the caller's cache is unchanged — **fails on current `main`, passes with this fix**;
- `test_get_cache_single_item_returns_independent_copy` + `test_get_cache_multi_item_merge_does_not_alias_inputs` (tests/memories/activation/test_kv.py): `get_cache()` never aliases the store;
- `test_clone_dynamic_cache_copies_legacy_tensors` + `test_clone_dynamic_cache_handles_layers_structure`: cover both cache structures;
- full `tests/memories/` + `tests/llms/`: **117 passed (+4 subtests)**, no regressions (Python 3.13, torch 2.14 CPU, transformers 4.53.2 per `poetry.lock`).

cc @issue reporter — thanks for the exceptionally detailed write-up; the line-level analysis made this straightforward to confirm and fix.