### PR TITLE
fix(scheduler): keep unrelated filtering for a single memory in combined filter

### DIFF
--- a/src/memos/mem_scheduler/memory_manage_modules/memory_filter.py
+++ b/src/memos/mem_scheduler/memory_manage_modules/memory_filter.py
@@ -234,10 +234,6 @@ class MemoryFilter(BaseSchedulerModule):
             logger.info("No query history provided - keeping all memories")
             return memories, True
 
-        if len(memories) <= 1:
-            logger.info("Only one memory - no filtering needed")
-            return memories, True
-
         logger.info(
             f"Starting combined unrelated and redundant filtering for {len(memories)} memories against {len(query_history)} queries"
         )

--- a/tests/mem_scheduler/test_retriever.py
+++ b/tests/mem_scheduler/test_retriever.py
@@ -360,6 +360,7 @@ class TestSchedulerRetriever(unittest.TestCase):
         # Should return all memories
         self.assertEqual(result, memories)
         self.assertTrue(success_flag)
+        self.assertTrue(self.llm.generate.called)
 
     def test_combined_filtering_still_filters_a_single_unrelated_memory(self):
         """A lone memory must still go through unrelated filtering.

--- a/tests/mem_scheduler/test_retriever.py
+++ b/tests/mem_scheduler/test_retriever.py
@@ -360,3 +360,53 @@ class TestSchedulerRetriever(unittest.TestCase):
         # Should return all memories
         self.assertEqual(result, memories)
         self.assertTrue(success_flag)
+
+    def test_combined_filtering_still_filters_a_single_unrelated_memory(self):
+        """A lone memory must still go through unrelated filtering.
+
+        The combined filter used to return early on `len(memories) <= 1`, a
+        guard that only makes sense for redundancy (one memory cannot be
+        redundant with itself). Unrelated filtering is per-memory, so skipping
+        it left an off-topic memory sitting in working memory.
+        """
+        query_history = ["What is my deployment pipeline?"]
+        memories = [TextualMemoryItem(memory="The user's cat is named Whiskers")]
+
+        self.llm.generate.return_value = json.dumps(
+            {
+                "kept_memories": [],
+                "unrelated_removed_count": 1,
+                "redundant_removed_count": 0,
+                "reasoning": "No semantic connection to the deployment query",
+            }
+        )
+
+        result, success_flag = self.retriever.filter_unrelated_and_redundant_memories(
+            query_history=query_history, memories=memories
+        )
+
+        self.assertEqual(result, [])
+        self.assertTrue(success_flag)
+        # The LLM must actually be consulted, not short-circuited.
+        self.assertTrue(self.llm.generate.called)
+
+    def test_combined_filtering_keeps_a_single_relevant_memory(self):
+        """The counterpart: one on-topic memory must survive the filter."""
+        query_history = ["What is my deployment pipeline?"]
+        memories = [TextualMemoryItem(memory="Deployment uses a blue-green pipeline")]
+
+        self.llm.generate.return_value = json.dumps(
+            {
+                "kept_memories": [0],
+                "unrelated_removed_count": 0,
+                "redundant_removed_count": 0,
+                "reasoning": "Directly answers the deployment query",
+            }
+        )
+
+        result, success_flag = self.retriever.filter_unrelated_and_redundant_memories(
+            query_history=query_history, memories=memories
+        )
+
+        self.assertEqual(result, memories)
+        self.assertTrue(success_flag)


### PR DESCRIPTION
## What's wrong

`MemoryFilter.filter_unrelated_and_redundant_memories` starts with three early
returns. The third one is wrong:

```python
if len(memories) <= 1:
    logger.info("Only one memory - no filtering needed")
    return memories, True
```

This method is responsible for **two** filtering steps, and they have different
arity requirements:

| step | needs 2+ memories? |
|---|---|
| redundancy removal — "keep the most informative of several similar memories" | yes, one memory cannot be redundant with itself |
| unrelated removal — "drop memories with no semantic connection to any query" | **no, this is per-memory** |

The guard skips both. With a single memory, unrelated filtering never runs and
the LLM is never called.

## The two paths disagree on the same input

`filter_unrelated_memories` (line 18), which performs only the unrelated step,
has **no** `len(memories) <= 1` guard — it filters a single memory correctly.
`filter_redundant_memories` (line 105) has the guard, and there it is right.

So for one off-topic memory the two code paths return opposite results.
Reproduced against the real `MemoryFilter` with a mocked LLM:

```
memory  = "The user's cat is named Whiskers."
queries = ["what is my deployment pipeline?", "how do I roll back a release?"]

filter_unrelated_and_redundant_memories -> ["The user's cat is named Whiskers."]   LLM called: False
filter_unrelated_memories               -> []                                     LLM called: True
```

## Why this looks like a copy that was not adjusted

The log messages preserve the history:

- `memory_filter.py:139` (redundancy filter) — `"Only one memory - no redundancy to filter"` — accurate.
- `memory_filter.py:238` (combined filter) — `"Only one memory - no filtering needed"` — not accurate; unrelated filtering was still needed.

The guard was carried over from the redundancy-only method without widening its
condition, and the log text was softened rather than re-derived.

`MEMORY_COMBINED_FILTERING_PROMPT`
(`src/memos/templates/mem_scheduler_prompts.py:279`) states the intent
explicitly — it asks for two steps, the first being:

> **Unrelated Memory Removal**: Remove memories that are completely unrelated to
> the user's query history … Has no semantic connection to any query in the history

Nothing there requires a second memory to be present.

## Impact

The combined filter runs on the working-memory replacement path,
`OptimizedScheduler.replace_working_memory`
(`src/memos/mem_scheduler/optimized_scheduler.py:318`). When reranking leaves a
single candidate, an unrelated memory survives into working memory and is then
carried into subsequent prompts.

## The fix

Delete the guard. Behaviour that is deliberately preserved:

- `not memories` → `([], True)` unchanged.
- `not query_history` → keep everything unchanged (no relevance signal available).
- LLM failure → still conservatively returns all memories with `success_flag=False`.

## Tests

Two cases added to `tests/mem_scheduler/test_retriever.py`, following the
existing convention in that file (`self.retriever`, `MagicMock(spec=BaseLLM)`,
`json.dumps(...)` for the mocked response):

- `test_combined_filtering_still_filters_a_single_unrelated_memory` — one
  off-topic memory must be dropped, and asserts `llm.generate.called` so the
  guard cannot come back as a silent short-circuit.
- `test_combined_filtering_keeps_a_single_relevant_memory` — the counterpart, so
  the fix cannot pass by simply discarding lone memories.

Note the mocked response uses `kept_memories`, which is the key this method
actually reads (`memory_filter.py:264`) — not `relevant_memories`, which is the
unrelated-only filter's schema.

## Verification

Environment note: the repo uses poetry; poetry was unavailable locally, so the
venv was built with `uv` (`uv pip install -e .`). `pika` had to be installed
separately — without it `tests/mem_scheduler/` fails to import via
`src/memos/dependency.py:47`. `uv.lock` was left untouched.

```
tests/mem_scheduler/test_retriever.py                      18 passed
tests/mem_scheduler/                                       67 passed, 1 skipped, 1 failed
ruff 0.11.8 check  (version pinned in .pre-commit-config.yaml)   All checks passed
ruff 0.11.8 format --check                                 2 files already formatted
```

The one failure, `test_scheduler.py::TestGeneralScheduler::test_dynamic_cache_layers_access`,
is pre-existing: it fails identically on an unmodified `dev-v2.0.34`.

Wider suite, excluding two files that need `torch`
(`tests/llms/test_hf.py`, `tests/memories/activation/test_kv.py`) — identical
before and after this change, so no regression:

```
baseline:   11 failed, 763 passed, 8 skipped, 25 errors
with fix:   11 failed, 763 passed, 8 skipped, 25 errors
```

Those remaining failures/errors are missing optional dependencies in my local
environment, not related to this change.

Reverse-verified: with the source change stashed and the new tests kept,
`test_combined_filtering_still_filters_a_single_unrelated_memory` fails and the
other 17 pass — so the test pins this specific behaviour rather than passing
incidentally.

## AI disclosure

This change was prepared with AI assistance. The defect was found by auditing
the three filter methods against each other, then confirmed by executing the
real `MemoryFilter` class; every claim above (log line numbers, prompt text,
call site, test counts, baseline comparison) was verified by running the code
rather than inferred.
